### PR TITLE
Fix crash on world reload

### DIFF
--- a/src/wren/Viewport.cpp
+++ b/src/wren/Viewport.cpp
@@ -106,7 +106,7 @@ namespace wren {
     containerutils::removeElementFromVector(mPostProcessingEffects, postProcessingEffect);
     if (mAmbientOcclusionEffect == postProcessingEffect)
       mAmbientOcclusionEffect = NULL;
-    if (mAntiAliasingEffect == postProcessingEffect)
+    else if (mAntiAliasingEffect == postProcessingEffect)
       mAntiAliasingEffect = NULL;
   }
 


### PR DESCRIPTION
Fix #18

Invalid pointers on some post processing effects were wrongly kept.