### PR TITLE
Fix possible bad pointer access

### DIFF
--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -300,7 +300,9 @@ void WbCamera::clearRecognizedObjectsOverlay() {
 WrTexture *WbCamera::getWrenTexture() {
   if (!hasBeenSetup())
     setup();
-  return mWrenCamera->getWrenTexture();
+  if (mWrenCamera)
+    return mWrenCamera->getWrenTexture();
+  return NULL;
 }
 
 void WbCamera::displayRecognizedObjectsInOverlay() {


### PR DESCRIPTION
Fix #19

In case of full shared memory, the wren camera may not be created and returns NULL, causing invalid pointer reference to be tested.