### PR TITLE
Hotfix for Disabling GTAO

### DIFF
--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -1156,7 +1156,7 @@ void WbViewpoint::updatePostProcessingParameters() {
     updateExposure();
 
   if (mWrenGtao) {
-    if (mAmbientOcclusionRadius->value() == 0.0) {
+    if (mAmbientOcclusionRadius->value() == 0.0 || !WbPreferences::instance()->value("OpenGL/GTAO", 2).toInt()) {
       mWrenGtao->detachFromViewport();
       return;
     } else if (!mWrenGtao->hasBeenSetup())


### PR DESCRIPTION
when the "disabled" option is selected, GTAO is actually re-enabled on the next frame due to a missing condition on the parameter update (called every frame).