### PR TITLE
webots.min.js: support texture urls from jsdelivr

### DIFF
--- a/resources/web/wwi/texture_loader.js
+++ b/resources/web/wwi/texture_loader.js
@@ -159,7 +159,7 @@ class _TextureLoaderObject {
   }
 
   loadOrRetrieveImage(name, texture, cubeTextureIndex = undefined, onLoad = undefined) {
-    if (this.texturePathPrefix)
+    if (this.texturePathPrefix && !name.startsWith('http'))
       name = this.texturePathPrefix + name;
     if (this.images[name]) {
       if (typeof onLoad !== 'undefined')

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -14,6 +14,7 @@
 
 #include "WbImageTexture.hpp"
 
+#include "WbApplicationInfo.hpp"
 #include "WbAppearance.hpp"
 #include "WbField.hpp"
 #include "WbFieldChecker.hpp"
@@ -400,6 +401,15 @@ void WbImageTexture::exportNodeFields(WbVrmlWriter &writer) const {
   WbField urlFieldCopy(*findField("url", true));
   for (int i = 0; i < mUrl->size(); ++i) {
     QString texturePath(WbUrl::computePath(this, "url", mUrl, i));
+
+    // TODO: better integration in this mechanism.
+    if (texturePath.startsWith(WbStandardPaths::webotsHomePath())) {
+      texturePath.replace(WbStandardPaths::webotsHomePath(), "");
+        texturePath = QString("https://cdn.jsdelivr.net/gh/omichel/webots@R2019b/%1").arg(texturePath); // TODO: replace "R2019a" by WbApplicationInfo::version().toString(false)
+      dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, texturePath);
+      continue;
+    }
+ 
     if (writer.isWritingToFile()) {
       QString newUrl = WbUrl::exportTexture(this, mUrl, i, writer);
       dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, newUrl);

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -14,8 +14,8 @@
 
 #include "WbImageTexture.hpp"
 
-#include "WbApplicationInfo.hpp"
 #include "WbAppearance.hpp"
+#include "WbApplicationInfo.hpp"
 #include "WbField.hpp"
 #include "WbFieldChecker.hpp"
 #include "WbImage.hpp"
@@ -405,11 +405,12 @@ void WbImageTexture::exportNodeFields(WbVrmlWriter &writer) const {
     // TODO: better integration in this mechanism.
     if (texturePath.startsWith(WbStandardPaths::webotsHomePath())) {
       texturePath.replace(WbStandardPaths::webotsHomePath(), "");
-        texturePath = QString("https://cdn.jsdelivr.net/gh/omichel/webots@R2019b/%1").arg(texturePath); // TODO: replace "R2019a" by WbApplicationInfo::version().toString(false)
+      texturePath = QString("https://cdn.jsdelivr.net/gh/omichel/webots@R2019b/%1")
+                      .arg(texturePath);  // TODO: replace "R2019a" by WbApplicationInfo::version().toString(false)
       dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, texturePath);
       continue;
     }
- 
+
     if (writer.isWritingToFile()) {
       QString newUrl = WbUrl::exportTexture(this, mUrl, i, writer);
       dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, newUrl);


### PR DESCRIPTION
Aim: improve browser cache usage in-between simulations thanks to the use of jsdelivr for the texture assets inside Webots.
