### PR TITLE
Fix handling mouse wheel event while running another mouse event

### DIFF
--- a/resources/web/wwi/mouse_events.js
+++ b/resources/web/wwi/mouse_events.js
@@ -16,7 +16,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
       'wheelTimeout': null,
       'hiddenContextMenu': false
     };
-    this.moveParams = null;
+    this.moveParams = {};
     this.enableNavigation = true;
 
     this.onmousemove = (event) => { this._onMouseMove(event); };
@@ -138,7 +138,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
 
   _onMouseWheel(event) {
     event.preventDefault(); // do not scroll page
-    if (!this.moveParams)
+    if (!('initialCameraPosition' in this.moveParams))
       this._setupMoveParameters(event);
     // else another drag event is already active
 
@@ -340,7 +340,7 @@ class MouseEvents { // eslint-disable-line no-unused-vars
     this.state.initialTimeStamp = null;
     this.state.initialX = null;
     this.state.initialY = null;
-    this.moveParams = null;
+    this.moveParams = {};
   }
 
   _selectAndHandleClick() {


### PR DESCRIPTION
Fix issue https://github.com/omichel/robotbenchmark/issues/351:
the wheel event was overwriting the `MouseEvents.moveParams` and deleting the `scaleFactor` variable. Due to this when moving the mouse the computed `zoomScale` value was NaN and the viewpoint position was broken.

Steps to reproduce:
1. start tilting/zooming the viewpoint by pressing the middle/wheel button
2. move the wheel (without releasing the wheel button)
3. move the mouse (without releasing the wheel button)