### PR TITLE
Fix regular expression pattern for Solid.name

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -33,6 +33,7 @@ Released on XXX YYth, 2019.
     - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
     - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
     - External controllers now wait if started before Webots.
+    - Fixed warnings printed in the terminal if a [Solid](solid.md).name field contains characters with special meaning in regular expressions.
     - Linux: Fixed missing Python3.7 controller API.
     - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll.
 

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -514,7 +514,7 @@ void WbSolid::resolveNameClashIfNeeded(bool automaticallyChange, bool recursive,
       parameterNode = parameterNode->protoParameterNode();
 
     bool found = false;
-    re.setPattern(QString("%1\\((\\d+)\\)").arg(nameWithoutIndex));
+    re.setPattern(QString("%1\\((\\d+)\\)").arg(QRegularExpression::escape(nameWithoutIndex)));
     foreach (WbSolid *s, siblings) {
       if (!s || s == this)
         continue;

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -200,7 +200,8 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
       foreach (WbFieldModel *model, mFieldModels) {
         // condition explanation: if (token contains modelName and not a Lua identifier containing modelName such as
         // "my_awesome_modelName")
-        if (token->word().contains(QRegExp(QString("(^|[^a-zA-Z0-9_])%1($|[^a-zA-Z0-9_])").arg(model->name())))) {
+        if (token->word().contains(
+              QRegExp(QString("(^|[^a-zA-Z0-9_])%1($|[^a-zA-Z0-9_])").arg(QRegExp::escape(model->name()))))) {
           // qDebug() << "TemplateRegenerator" << mName << model->name();
           model->setTemplateRegenerator(true);
         }
@@ -272,8 +273,8 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
         // "%{ a = \"fields.model->name().value.y\" }%"  => false
         // "%{= \"fields.model->name().value.y\" }%"  => false
         // "%{= fields.model->name().value.y }%"  => true
-        if (token->word().contains(
-              QRegularExpression(QString("%{(?:(?!}%|\").)*fields\\.%1(?:(?!}%|\").)*}%").arg(model->name()))))
+        if (token->word().contains(QRegularExpression(
+              QString("%{(?:(?!}%|\").)*fields\\.%1(?:(?!}%|\").)*}%").arg(QRegularExpression::escape(model->name())))))
           model->setTemplateRegenerator(true);
       }
     }


### PR DESCRIPTION
Fix #841: escape characters in Solid.name that have special meaning when used as a regular expression pattern string.