### PR TITLE
Fix crash in Background

### DIFF
--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -241,9 +241,6 @@ void WbBackground::destroySkyBox() {
   if (mSkyboxMaterial)
     wr_material_set_texture_cubemap(mSkyboxMaterial, NULL, 0);
 
-  wr_material_set_texture_cubemap(mSkyboxMaterial, NULL, 0);
-  wr_scene_set_skybox(wr_scene_get_instance(), NULL);
-
   if (mCubeMapTexture) {
     wr_texture_delete(WR_TEXTURE(mCubeMapTexture));
     mCubeMapTexture = NULL;

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -442,6 +442,8 @@ void WbBackground::exportNodeFields(WbVrmlWriter &writer) const {
 
   QString outputFileNames[6];
   for (int i = 0; i < 6; ++i) {
+    if (mUrlFields[i]->size() == 0)
+      continue;
     const QString &url = WbUrl::computePath(this, "textureBaseName", mUrlFields[i]->item(0), false);
     const QFileInfo &cubeInfo(url);
     if (writer.isWritingToFile())
@@ -454,12 +456,16 @@ void WbBackground::exportNodeFields(WbVrmlWriter &writer) const {
 
   if (writer.isX3d()) {
     writer << " ";
-    for (int i = 0; i < 6; ++i)
-      writer << gUrlNames[i] << "='\"" << outputFileNames[i] << "\"' ";
+    for (int i = 0; i < 6; ++i) {
+      if (!outputFileNames[i].isEmpty())
+        writer << gUrlNames[i] << "='\"" << outputFileNames[i] << "\"' ";
+    }
   } else if (writer.isVrml()) {
     for (int i = 0; i < 6; ++i) {
-      writer.indent();
-      writer << gUrlNames[i] << " [ \"" << outputFileNames[i] << "\" ]\n";
+      if (!outputFileNames[i].isEmpty()) {
+        writer.indent();
+        writer << gUrlNames[i] << " [ \"" << outputFileNames[i] << "\" ]\n";
+      }
     }
   } else
     WbNode::exportNodeFields(writer);


### PR DESCRIPTION
- [x] Fix crash visible in the test suite: *the `supervisor_animation` test exports an empty Background causing invalid references*
- [x] Fix potential crash when destroying the Background node.

Stack:

```
5   WbMFString::item(int) const + 124 (WbMFString.hpp:56)
6   WbBackground::exportNodeFields(WbVrmlWriter&) const + 447 (WbBackground.cpp:445)
7   WbNode::exportNodeContents(WbVrmlWriter&) const + 51 (WbNode.cpp:1092)
8   WbNode::writeExport(WbVrmlWriter&) const + 89 (WbNode.cpp:1101)
9   WbNode::write(WbVrmlWriter&) const + 221 (WbNode.cpp:960)
10  WbWorld::write(WbVrmlWriter&) const + 432 (WbWorld.cpp:361)
11  WbWorld::exportAsVrml(QString const&) const + 182 (WbWorld.cpp:338)
12  WbWorld::exportAsHtml(QString const&, bool) const + 448 (WbWorld.cpp:281)
13  WbAnimationRecorder::start(QString const&) + 349 (WbAnimationRecorder.cpp:368)
```