### PR TITLE
Fix travis_unit_only rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         - python -m unittest discover -s docs/tests
         - |
           # in case of planned test or tag test, run complete test
-          if [[ "$TRAVIS_COMMIT_MESSAGE" != travis_* ]] && [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && [[ -z "${TRAVIS_TAG}" ]]
+          if [[ "$TRAVIS_COMMIT_MESSAGE" != "travis_sources" ]] && [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && [[ -z "${TRAVIS_TAG}" ]]
           then
             python docs/generate_thumbnails.py --silent;
             tests/sources/generate_diff.py $TRAVIS_COMMIT $TRAVIS_REPO_SLUG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ jobs:
       script:
         - python -m unittest discover -s docs/tests
         - |
-          # in case of manually triggered test, planned test or tag test, run complete test
-          if [[ "$TRAVIS_COMMIT_MESSAGE" != travis_* ]] && [[ "$TRAVIS_EVENT_TYPE" != "api" ]] && [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && [[ -z "${TRAVIS_TAG}" ]]
+          # in case of planned test or tag test, run complete test
+          if [[ "$TRAVIS_COMMIT_MESSAGE" != travis_* ]] && [[ "$TRAVIS_EVENT_TYPE" != "cron" ]] && [[ -z "${TRAVIS_TAG}" ]]
           then
             python docs/generate_thumbnails.py --silent;
             tests/sources/generate_diff.py $TRAVIS_COMMIT $TRAVIS_REPO_SLUG;


### PR DESCRIPTION
If We trigger a `travis_unit_only` we want to run the short source test.