### PR TITLE
Fix search for objects documentation page

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -110,6 +110,7 @@ Released on June 25th, 2019.
     - Fixed runtime changes of kinematic solid bounding objects not taken into account when colliding with sleeping dynamic solids.
     - Fixed insertion of USE PROTO node into a PROTO field from the Add Node dialog.
     - Fixed native robot windows and physics plugins recompilation on Windows by upgrading from gcc 7.4.0 to gcc 9.1.0.
+    - Fixed link to documentation page for PROTO nodes contained in a folder with underscore symbols in the name.
   - Cleanup
     - Deprecated the Python 2.7 API.
     - Removed the `environmentMap` field of the PBRAppearance node.

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1440,7 +1440,7 @@ void WbSceneTree::help() {
             }
             break;
           }
-          name = dir.dirName();
+          name = dir.dirName().replace('_', '-');
           if (!dir.cdUp())
             break;
         }

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -320,7 +320,7 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
             mDocumentationUrl = "https://cyberbotics.com/doc/guide/object-" + name;
           break;
         }
-        name = dir.dirName();
+        name = dir.dirName().replace('_', '-');
         if (!dir.cdUp())
           break;
       }


### PR DESCRIPTION
For objects in a folder containing underscores in the name, like the ones in the "living_room_furniture" folder, the generic `Solid` documentation page is shown instead of the specific one when selecting the "Help..." item from the context menu.

Steps to reproduce:
1. open the `inverted_pendulum.wbt` benhcmark
2. right click on the sofa to open the context menu
3. select the "Help..." item

-> The `reference/solid.md` documentation page is displayed instead of the `guide/object-living-room-furniture`