### PR TITLE
Use POSIX shared memory instead of SYSV shared memory on Linux and macOS

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -176,23 +176,6 @@ You can pass this warning and install Webots by clicking on the "More info" link
 2. Double click on this file.
 This will mount on the desktop a volume named "Webots" containing the "Webots" folder.
 3. Move this folder to your "/Applications" folder or wherever you would like to install Webots.
-4. It is recommended to increase the size of the system shared memory in order to run simulations with more than 8 camera or display devices (such as the PR2 robot).
-In order to proceed, edit the following file from the Terminal application as administrator: `sudo pico /etc/sysctl.conf`.
-It is likely this file doesn't exist on your system, in which case an empty file will be created.
-Edit this file so that it contains the lines:
-
-    ```
-kern.sysv.shmmax=16777216
-kern.sysv.shmmin=1
-kern.sysv.shmmni=128
-kern.sysv.shmseg=32
-kern.sysv.shmall=4096
-    ```
-
-    These settings increase the amount of shared memory to four times the usual default.
-The current values are provided by the following command line: `sysctl -A | grep sysv.shm`.
-Please refer to the macOS documentation to understand the exact meaning of each value.
-You will have to reboot your computer so that these changes are taken into account.
 
 ### macOS Security
 

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -15,8 +15,6 @@ Released on XXX YYth, 2019.
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
     - Added a `village_center` world.
-  - Dependency Updates
-    - Windows: upgraded to Qt 5.12.4.
   - Enhancements
     - Improved the intensity and color of the bus, truck and car vehicle lights.
     - macOS and Linux: Use POSIX shared memory segments to fix the limit problems on macOS and allow for snap packaging with strict confinement on Linux.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -15,8 +15,11 @@ Released on XXX YYth, 2019.
   - New Samples
     - Added new samples about the [Accelerometer](../guide/samples-devices.md#accelerometer-wbt) and [Brake](../guide/samples-devices.md#brake-wbt) devices.
     - Added a `village_center` world.
+  - Dependency Updates
+    - Windows: upgraded to Qt 5.12.4.
   - Enhancements
     - Improved the intensity and color of the bus, truck and car vehicle lights.
+    - macOS and Linux: Use POSIX shared memory segments to fix the limit problems on macOS and allow for snap packaging with strict confinement on Linux.
     - Improved management of the life cycle of the Webots temporary folder.
   - Bug fixes
     - Webots online 3D viewer (`webots.min.js`)

--- a/src/lib/Controller/Makefile
+++ b/src/lib/Controller/Makefile
@@ -38,7 +38,7 @@ LIB_PNG      = png16
 else
 LIB_PNG      = png12
 endif
-SHARED_LIBS = -ltiff -lm -ljpeg -lpthread -l$(LIB_PNG) -ldl -llzma
+SHARED_LIBS = -ltiff -lm -ljpeg -lpthread -l$(LIB_PNG) -ldl -llzma -lrt
 TARGET      = $(WEBOTS_PATH)/lib/libController.so
 endif
 

--- a/src/lib/Controller/api/abstract_camera.c
+++ b/src/lib/Controller/api/abstract_camera.c
@@ -16,8 +16,10 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#else
-#include <sys/shm.h>
+#else  // POSIX shared memory segments
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,33 +31,27 @@
 static void wb_abstract_camera_cleanup_shm(WbDevice *d) {
   AbstractCamera *c = d->pdata;
 #ifdef _WIN32
-  if (c->shmFile != NULL) {
+  if (c->shm_file != NULL) {
     UnmapViewOfFile(c->image);
-    CloseHandle(c->shmFile);
+    CloseHandle(c->shm_file);
   }
-#else
+#else  // POSIX shared memory
   if (c->shmid > 0) {
-    shmctl(c->shmid, IPC_RMID, NULL);
-    shmdt(c->image);
+    munmap(c->image, 4 * c->height * c->width);
+    shm_unlink(c->shm_key);
   }
 #endif
 }
 
-static void wb_abstract_camera_get_shm(WbDevice *d, shm_key_t shm_key) {
+static void wb_abstract_camera_get_shm(WbDevice *d) {
   AbstractCamera *c = d->pdata;
 #ifdef _WIN32
-  c->shmFile = OpenFileMapping(FILE_MAP_WRITE, FALSE, shm_key);
-  ROBOT_ASSERT(c->shmFile);
-  c->image = MapViewOfFile(c->shmFile, FILE_MAP_WRITE, 0, 0, 0);
-#else
-  // inspired from QSharedMemoryPrivate::attach() with QT_POSIX_IPC = FALSE
-  // grab the shared memory segment id
-  c->shmid = shmget(shm_key, 0, 0400);
-  ROBOT_ASSERT(-1 != c->shmid);
-
-  // grab the memory
-  c->image = (unsigned char *)shmat(c->shmid, NULL, 0);  // not read only, because remote controller need to write
-  ROBOT_ASSERT((void *)-1 != c->image);
+  c->shm_file = OpenFileMapping(FILE_MAP_WRITE, FALSE, c->shm_key);
+  ROBOT_ASSERT(c->shm_file);
+  c->image = MapViewOfFile(c->shm_file, FILE_MAP_WRITE, 0, 0, 0);
+#else  // POSIX shared memory segments
+  c->shmid = shm_open(c->shm_key, O_RDWR, 0400);
+  c->image = (unsigned char *)mmap(0, 4 * c->height * c->width, PROT_READ | PROT_WRITE, MAP_SHARED, c->shmid, 0);
 #endif
 
   ROBOT_ASSERT(c->image);
@@ -69,12 +65,13 @@ void wb_abstract_camera_cleanup(WbDevice *d) {
   free(c);
 }
 
-static void wb_abstract_camera_change_shm(WbDevice *d, shm_key_t shm_key) {
+static void wb_abstract_camera_change_shm(WbDevice *d, char *shm_key) {
   AbstractCamera *c = d->pdata;
   if (c == NULL)
     return;
   wb_abstract_camera_cleanup_shm(d);
-  wb_abstract_camera_get_shm(d, shm_key);
+  c->shm_key = shm_key;
+  wb_abstract_camera_get_shm(d);
 }
 
 void wb_abstract_camera_new(WbDevice *d, unsigned int id, int w, int h, double fov, double camnear, bool spherical) {
@@ -117,16 +114,10 @@ void wb_abstract_camera_update_timestamp(WbDevice *d) {
 bool wb_abstract_camera_handle_command(WbDevice *d, WbRequest *r, unsigned char command) {
   bool command_handled = true;
   AbstractCamera *c = d->pdata;
-  shm_key_t shm_key;
 
   switch (command) {
     case C_CAMERA_SHARED_MEMORY:
-#ifdef _WIN32
-      shm_key = request_read_string(r);
-#else
-      shm_key = request_read_int32(r);
-#endif
-      wb_abstract_camera_change_shm(d, shm_key);
+      wb_abstract_camera_change_shm(d, request_read_string(r));
       break;
 
     case C_CAMERA_GET_IMAGE:

--- a/src/lib/Controller/api/abstract_camera.h
+++ b/src/lib/Controller/api/abstract_camera.h
@@ -25,19 +25,13 @@
 #include <windows.h>
 #endif
 
-#ifdef _WIN32
-typedef char *shm_key_t;
-#else
-typedef int shm_key_t;
-#endif
-
 typedef struct {
   bool enable;
   int sampling_period;
   unsigned int unique_id;  // camera id
   int width;
   int height;
-  char *shm_native_key;
+  char *shm_key;
   int shmid;
   double camnear;
   bool spherical;
@@ -48,7 +42,7 @@ typedef struct {
   double image_update_time;
   void *pdata;
 #ifdef _WIN32
-  HANDLE shmFile;
+  HANDLE shm_file;
 #endif
 } AbstractCamera;
 

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -572,6 +572,9 @@ ifeq ($(OSTYPE),windows)
 OTHER_SOURCES += \
   WbMicrosoftTextToSpeech.cpp \
   WbWindowsRegistry.cpp
+else
+OTHER_SOURCES += \
+  WbPosixSharedMemory.cpp
 endif
 
 MOC_FILES=$(addprefix $(OBJDIR)/,$(notdir $(QT_SOURCES:%.cpp=%.moc.cpp)))

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -121,7 +121,7 @@ TARGET             = $(WEBOTS_PATH)/bin/webots-bin
 CFLAGS             = -fPIC
 CXXFLAGS           = -std=c++11
 MOC                = $(WEBOTS_PATH)/bin/qt/moc
-LIBS              += $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a $(LIB_WREN) -Wl,-rpath $(WEBOTS_PATH)/lib -L$(WEBOTS_PATH)/lib -lQt5Core -lQt5Network -lQt5Gui -lQt5OpenGL -lQt5WebSockets -lQt5Widgets -lQt5PrintSupport -lQt5WebEngine -lQt5WebEngineCore -lQt5WebEngineWidgets -lQt5Multimedia -lQt5MultimediaWidgets -lQt5Sql -lQt5Sensors -lQt5WebChannel -lQt5Xml -lopenal -lGL -lusb -lGLU -ldl -lpci -lOIS -lcrypto -lpico -lfreetype -lassimp
+LIBS              += $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a $(LIB_WREN) -Wl,-rpath $(WEBOTS_PATH)/lib -L$(WEBOTS_PATH)/lib -lQt5Core -lQt5Network -lQt5Gui -lQt5OpenGL -lQt5WebSockets -lQt5Widgets -lQt5PrintSupport -lQt5WebEngine -lQt5WebEngineCore -lQt5WebEngineWidgets -lQt5Multimedia -lQt5MultimediaWidgets -lQt5Sql -lQt5Sensors -lQt5WebChannel -lQt5Xml -lopenal -lGL -lusb -lGLU -ldl -lpci -lOIS -lcrypto -lpico -lfreetype -lassimp -lrt
 LD_FLAGS           = -rdynamic
 EXTRA_CMD          = cp launcher/webots-linux.sh $(WEBOTS_PATH)/webots && chmod 755 $(WEBOTS_PATH)/webots
 FILES_TO_REMOVE    = $(WEBOTS_PATH)/webots

--- a/src/webots/core/WbPosixSharedMemory.cpp
+++ b/src/webots/core/WbPosixSharedMemory.cpp
@@ -1,0 +1,54 @@
+// Copyright 1996-2019 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "WbPosixSharedMemory.hpp"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+WbPosixSharedMemory::WbPosixSharedMemory(const QString &name) :
+#ifdef __APPLE__
+  mName(name),
+#else
+  mName("snap.webots." + name.mid(7)),
+#endif
+  mSize(0),
+  mData(NULL) {
+  // we remove the "Webots_" prefix from name and generate a snap compatible POSIX shared memory segment
+  shm_unlink(mName.toUtf8());  // delete a possibly existing shared memory segment with the same name
+  mFd = shm_open(mName.toUtf8(), O_CREAT | O_RDWR, 0666);  // returns -1 in case of failure
+  mSize = 0;
+  mData = NULL;
+}
+
+WbPosixSharedMemory::~WbPosixSharedMemory() {
+  if (mFd < 0)
+    return;
+  if (mData)
+    munmap(mData, mSize);
+  shm_unlink(mName.toUtf8());
+}
+
+bool WbPosixSharedMemory::create(int size) {
+  if (mFd < 0)
+    return false;
+  if (ftruncate(mFd, size) == -1)
+    return false;
+  mData = mmap(0, size, PROT_WRITE | PROT_READ, MAP_SHARED, mFd, 0);
+  if (mData == MAP_FAILED)
+    return false;
+  mSize = size;
+  return true;
+}

--- a/src/webots/core/WbPosixSharedMemory.hpp
+++ b/src/webots/core/WbPosixSharedMemory.hpp
@@ -1,0 +1,42 @@
+// Copyright 1996-2019 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// On Linux, we need to use POSIX shared memory segments (shm) and name them snap.webots.*
+// to be compliant with the strict confinement policy of snap applications.
+// On macOS, POSIX shared memory segments don't have the low limits of the SYSV shared memory segments.
+// Unfortunately, the Qt implementation of shared memory segment relies only on SYSV shared memory segments.
+// Hence we have to revert to the native POSIX shared memory to be compatible with snap and work around
+// macOS limitation with SYSV shared memory.
+
+#ifndef WB_POSIX_SHARED_MEMORY_HPP
+#define WB_POSIX_SHARED_MEMORY_HPP
+
+class WbPosixSharedMemory {
+public:
+  explicit WbPosixSharedMemory(const QString &name);
+  ~WbPosixSharedMemory();
+  static bool attach() { return false; }
+  static bool detach() { return false; }
+  bool create(int size);
+  void *data() const { return mData; }
+  const QString nativeKey() const { return mName; }
+
+private:
+  int mFd;
+  QString mName;
+  int mSize;
+  void *mData;
+};
+
+#endif

--- a/src/webots/core/WbPosixSharedMemory.hpp
+++ b/src/webots/core/WbPosixSharedMemory.hpp
@@ -22,6 +22,8 @@
 #ifndef WB_POSIX_SHARED_MEMORY_HPP
 #define WB_POSIX_SHARED_MEMORY_HPP
 
+#include <QtCore/QString>
+
 class WbPosixSharedMemory {
 public:
   explicit WbPosixSharedMemory(const QString &name);

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -64,7 +64,14 @@
 // macOS limitation with SYSV shared memory.
 class WbPosixSharedMemory {
 public:
-  explicit WbPosixSharedMemory(const QString &name) : mName("snap.webots." + name.mid(7)), mSize(0), mData(NULL) {
+  explicit WbPosixSharedMemory(const QString &name) :
+#ifdef __APPLE__
+    mName(name),
+#else
+    mName("snap.webots." + name.mid(7)),
+#endif
+    mSize(0),
+    mData(NULL) {
     // we remove the "Webots_" prefix from name and generate a snap compatible POSIX shared memory segment
     shm_unlink(mName.toUtf8());  // delete a possibly existing shared memory segment with the same name
     mFd = shm_open(mName.toUtf8(), O_CREAT | O_RDWR, 0666);  // returns -1 in case of failure

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -40,7 +40,7 @@
 #include <QtCore/QDataStream>
 #include <QtCore/QFile>
 #ifndef _WIN32
-#include "WbSharedMemory.hpp"
+#include "WbPosixSharedMemory.hpp"
 #else
 #include <QtCore/QSharedMemory>
 #endif

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -26,7 +26,12 @@ class WbLens;
 class WbWrenCamera;
 class WbSensor;
 
+#ifdef _WIN32
 class QSharedMemory;
+#else
+class WbPosixSharedMemory;
+#endif
+
 class QDataStream;
 
 class WbAbstractCamera : public WbRenderingDevice {
@@ -82,7 +87,7 @@ protected:
   virtual void addConfigureToStream(QDataStream &stream, bool reconfigure = false);
   bool handleCommand(QDataStream &stream, unsigned char command);
 
-  unsigned char *image() const;
+  unsigned char *image() const { return mImageData; }
   WbLens *lens() const;
 
   virtual WbRgb enabledCameraFrustrumColor() const = 0;
@@ -126,7 +131,12 @@ protected:
   // other stuff
   WbSensor *mSensor;
   short mRefreshRate;
+#ifdef _WIN32
   QSharedMemory *mImageShm;
+#else
+  WbPosixSharedMemory *mImageShm;
+#endif
+  unsigned char *mImageData;
   char mCharType;
   bool mNeedToConfigure;
   bool mHasSharedMemoryChanged;


### PR DESCRIPTION
By default Qt uses SYSV shared memory on Linux and macOS. This has several drawbacks:
- on macOS: the default size of SYSV shared memory segments is very small preventing many camera-based simulation to work out-of-the-box. We ask users to modify their system settings to work around this problem, which is not very user friendly.
- on Linux: the SYSV shared memory segments are not compatible with snap strict confinement, hence preventing us to package Webots as a snap package with strict confinement (which is better than the classic confinement).
