### PR TITLE
webots.min.js: hotfix single node load into existing scene

### DIFF
--- a/resources/web/wwi/texture_loader.js
+++ b/resources/web/wwi/texture_loader.js
@@ -143,6 +143,33 @@ class _TextureLoaderObject {
     return newTexture;
   }
 
+  applyTextureTransform(texture, transformData) {
+    if (transformData !== 'undefined') {
+      texture.matrixAutoUpdate = false;
+      texture.onUpdate = () => {
+        // X3D UV transform matrix differs from THREE.js default one
+        // http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/texturing.html#TextureTransform
+        var c = Math.cos(-transformData.rotation);
+        var s = Math.sin(-transformData.rotation);
+        var sx = transformData.scale.x;
+        var sy = transformData.scale.y;
+        var cx = transformData.center.x;
+        var cy = transformData.center.y;
+        var tx = transformData.translation.x;
+        var ty = transformData.translation.y;
+        texture.matrix.set(
+          sx * c, sx * s, sx * (tx * c + ty * s + cx * c + cy * s) - cx,
+          -sy * s, sy * c, sy * (-tx * s + ty * c - cx * s + cy * c) - cy,
+          0, 0, 1
+        );
+      };
+    } else {
+      texture.matrixAutoUpdate = true;
+      texture.onUpdate = null;
+    }
+    texture.needsUpdate = true;
+  }
+
   loadOrRetrieveImage(name, texture, cubeTextureIndex = undefined, onLoad = undefined) {
     if (this.texturePathPrefix)
       name = this.texturePathPrefix + name;
@@ -334,31 +361,4 @@ function hasJPEGExtension(name) {
 
 function hasHDRExtension(name) {
   return name.search(/\.hdr($|\?)/i) > 0 || name.search(/^data:image\/hdr/) === 0;
-}
-
-function applyTextureTransform(texture, transformData) {
-  if (transformData !== 'undefined') {
-    texture.matrixAutoUpdate = false;
-    texture.onUpdate = () => {
-      // X3D UV transform matrix differs from THREE.js default one
-      // http://www.web3d.org/documents/specifications/19775-1/V3.2/Part01/components/texturing.html#TextureTransform
-      var c = Math.cos(-transformData.rotation);
-      var s = Math.sin(-transformData.rotation);
-      var sx = transformData.scale.x;
-      var sy = transformData.scale.y;
-      var cx = transformData.center.x;
-      var cy = transformData.center.y;
-      var tx = transformData.translation.x;
-      var ty = transformData.translation.y;
-      texture.matrix.set(
-        sx * c, sx * s, sx * (tx * c + ty * s + cx * c + cy * s) - cx,
-        -sy * s, sy * c, sy * (-tx * s + ty * c - cx * s + cy * c) - cy,
-        0, 0, 1
-      );
-    };
-  } else {
-    texture.matrixAutoUpdate = true;
-    texture.onUpdate = null;
-  }
-  texture.needsUpdate = true;
 }

--- a/resources/web/wwi/x3d.js
+++ b/resources/web/wwi/x3d.js
@@ -418,7 +418,7 @@ THREE.X3DLoader = class X3DLoader {
       if (typeof defTexture !== 'undefined')
         transformData = defTexture.userData.transform;
       else
-        transformData = this.parseTextureTransform(textureTransform);
+        transformData = this.parseTextureTransform(textureTransform[0]);
     }
 
     // Map ImageTexture.TextureProperties.anisotropicDegree to THREE.Texture.anisotropy.
@@ -443,10 +443,10 @@ THREE.X3DLoader = class X3DLoader {
 
   parseTextureTransform(textureTransform, textureObject = undefined) {
     var transformData = {
-      'center': convertStringToVec2(getNodeAttribute(textureTransform[0], 'center', '0 0')),
-      'rotation': parseFloat(getNodeAttribute(textureTransform[0], 'rotation', '0')),
-      'scale': convertStringToVec2(getNodeAttribute(textureTransform[0], 'scale', '1 1')),
-      'translation': convertStringToVec2(getNodeAttribute(textureTransform[0], 'translation', '0 0'))
+      'center': convertStringToVec2(getNodeAttribute(textureTransform, 'center', '0 0')),
+      'rotation': parseFloat(getNodeAttribute(textureTransform, 'rotation', '0')),
+      'scale': convertStringToVec2(getNodeAttribute(textureTransform, 'scale', '1 1')),
+      'translation': convertStringToVec2(getNodeAttribute(textureTransform, 'translation', '0 0'))
     };
     if (typeof textureObject !== 'undefined' && textureObject.isTexture)
       TextureLoader.applyTextureTransform(textureObject, transformData);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -188,11 +188,10 @@ class X3dScene { // eslint-disable-line no-unused-vars
     if (parentId && parentId !== 0)
       parentObject = this.getObjectById('n' + parentId);
     var loader = new THREE.X3DLoader(this);
-    var objects = loader.parse(x3dObject);
-    if (typeof parentObject !== 'undefined') {
-      objects.forEach((o) => { parentObject.add(o); });
+    var objects = loader.parse(x3dObject, parentObject);
+    if (typeof parentObject !== 'undefined')
       this._updateUseNodesIfNeeded(parentObject, parentObject.name.split(';'));
-    } else {
+    else {
       console.assert(objects.length <= 1 && typeof this.root === 'undefined'); // only one root object is supported
       objects.forEach((o) => { this.scene.add(o); });
       this.root = objects[0];

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -767,7 +767,8 @@ void WbStreamingServer::propagateNodeAddition(WbNode *node) {
     WbVrmlWriter writer(&nodeString, node->modelName() + ".x3d");
     node->write(writer);
     foreach (QWebSocket *client, mClients)
-      client->sendTextMessage(QString("node:%1:%2").arg(node->parent()->uniqueId()).arg(nodeString));
+      // add root <nodes> element to handle correctly multiple root elements like in case of PBRAppearance node.
+      client->sendTextMessage(QString("node:%1:<nodes>%2</nodes>").arg(node->parent()->uniqueId()).arg(nodeString));
   }
 }
 


### PR DESCRIPTION
Fix #857:
* [x] fix streaming a PBRAppearance node insertion event: PBRAppearance it is currently exported as two siblings nodes for X3D compatibility (Appearance and PBRAppearance) but XML parser doesn't support multiple root nodes
* [x] fix loading new geometry and appearance (and TextureTransform) nodes into an existing three.js scene