### PR TITLE
Fixed warning with libcrypto on Windows package build

### DIFF
--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -23,7 +23,6 @@
 /mingw64/bin/libbz2-1.dll
 /mingw64/bin/libsqlite3-0.dll
 /mingw64/bin/libxslt-1.dll
-/mingw64/bin/libcrypto-1_1-x64.dll
 /mingw64/bin/libdouble-conversion.dll
 /mingw64/bin/libjpeg-8.dll
 /mingw64/bin/libpng16-16.dll


### PR DESCRIPTION
Fixes #842.