### PR TITLE
Fix removing the second node from node_list in libController

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -37,8 +37,9 @@ Released on XXX YYth, 2019.
     - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
     - External controllers now wait if started before Webots.
     - Fixed warnings printed in the terminal if a [Solid](solid.md).name field contains characters with special meaning in regular expressions.
+    - Fixed invalid node references in controllers after deleting nodes from Webots or from the [Supervisor](supervisor.md) API (thanks to @chilaire).
     - Linux: Fixed missing Python3.7 controller API.
-    - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll.
+    - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -39,7 +39,7 @@ Released on XXX YYth, 2019.
     - Fixed warnings printed in the terminal if a [Solid](solid.md).name field contains characters with special meaning in regular expressions.
     - Fixed invalid node references in controllers after deleting nodes from Webots or from the [Supervisor](supervisor.md) API (thanks to @chilaire).
     - Linux: Fixed missing Python3.7 controller API.
-    - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll
+    - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll.
 
 ## [Webots R2019b](../blog/Webots-2019-b-release.md)
 Released on June 25th, 2019.

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -1614,7 +1614,7 @@ void wb_supervisor_node_remove(WbNodeRef node) {
   if (!robot_check_supervisor("wb_supervisor_node_remove"))
     return;
 
-  if (!is_node_ref_valid(node)) {
+  if (!is_node_ref_valid(node) || node->id == 0) {
     if (!robot_is_quitting())
       fprintf(stderr, "Error: wb_supervisor_node_remove() called with NULL or invalid 'node' argument.\n");
     return;

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -165,7 +165,7 @@ static void remove_node_from_list(int uid) {
   WbNodeRef node = find_node_by_id(uid);
   if (node) {  // make sure this node is in the list
     // look for the previous node in the list
-    if (node_list == node)  // the node was the first of the list
+    if (node_list == node)  // the node is the first of the list
       node_list = node->next;
     else {
       WbNodeRef previous_node_in_list = node_list;

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -162,19 +162,22 @@ static bool is_node_ref_valid(WbNodeRef n) {
 }
 
 static void remove_node_from_list(int uid) {
-  WbNodeRef previous_node_in_list = node_list;
   WbNodeRef node = find_node_by_id(uid);
   if (node) {  // make sure this node is in the list
     // look for the previous node in the list
-    while (previous_node_in_list) {
-      previous_node_in_list = previous_node_in_list->next;
-      if (previous_node_in_list && previous_node_in_list->next && previous_node_in_list->next->id == uid)
-        break;
-    }
-    if (previous_node_in_list)  // connect previous and next node in the list
-      previous_node_in_list->next = node->next;
-    else  // the node was the first of the list
+    if (node_list == node)  // the node was the first of the list
       node_list = node->next;
+    else {
+      WbNodeRef previous_node_in_list = node_list;
+      while (previous_node_in_list) {
+        if (previous_node_in_list->next && previous_node_in_list->next->id == uid) {
+          // connect previous and next node in the list
+          previous_node_in_list->next = node->next;
+          break;
+        }
+        previous_node_in_list = previous_node_in_list->next;
+      }
+    }
     // clean the node
     free(node->model_name);
     node->model_name = NULL;

--- a/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
+++ b/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
@@ -70,6 +70,10 @@ int main(int argc, char **argv) {
                       "The number of children of the root node is not correct after the insertion of SPHERE2.");
 
   wb_robot_step(TIME_STEP);
+  
+  // Try to remove root
+  // this is an invalid action: nothing should be applied and Webots should not crash
+  wb_supervisor_node_remove(wb_supervisor_node_get_root());
 
   value0 = wb_distance_sensor_get_value(ds0);
   ts_assert_double_is_bigger(750, value0, "SPHERE2 is not detected");
@@ -78,6 +82,13 @@ int main(int argc, char **argv) {
   ts_assert_pointer_not_null(sphere2_node, "Invalid reference to node 'SPHERE2'");
   wb_supervisor_node_remove(sphere2_node);
 
+  ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), initial_root_children_count,
+                      "The number of children of the root node is not correct after the deletion of SPHERE2.");
+
+  wb_robot_step(TIME_STEP);
+
+  // Remove an already deleted node: invalid action
+  wb_supervisor_node_remove(sphere2_node);
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), initial_root_children_count,
                       "The number of children of the root node is not correct after the deletion of SPHERE2.");
 
@@ -134,6 +145,18 @@ int main(int argc, char **argv) {
 
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), root_children_count + 3,
                       "The number of children of the root node should increase by 1 when importing the *.wrl file.");
+                      
+  // test internal update of libController node_list on node delete
+  wb_supervisor_field_import_mf_node_from_string(root_children_field, -1, "DEF SPHERE4 Solid {}");
+  WbNodeRef sphere4 = wb_supervisor_field_get_mf_node(root_children_field, -1);
+  wb_supervisor_field_import_mf_node_from_string(root_children_field, -1, "DEF SPHERE5 Solid {}");
+  WbNodeRef sphere5 = wb_supervisor_field_get_mf_node(root_children_field, -1);
+  wb_robot_step(TIME_STEP);
+  wb_supervisor_node_remove(sphere4);
+  wb_robot_step(TIME_STEP);
+  ts_assert_boolean_equal(wb_supervisor_field_get_mf_node(root_children_field, -1) == sphere5,
+                      "WbNodeRef instance of SPHERE 5 should not change after deleting SPHERE 4.");
+  
 
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
+++ b/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
                       "The number of children of the root node is not correct after the insertion of SPHERE2.");
 
   wb_robot_step(TIME_STEP);
-  
+
   // Try to remove root
   // this is an invalid action: nothing should be applied and Webots should not crash
   wb_supervisor_node_remove(wb_supervisor_node_get_root());
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), root_children_count + 3,
                       "The number of children of the root node should increase by 1 when importing the *.wrl file.");
-                      
+
   // test internal update of libController node_list on node delete
   wb_supervisor_field_import_mf_node_from_string(root_children_field, -1, "DEF SPHERE4 Solid {}");
   WbNodeRef sphere4 = wb_supervisor_field_get_mf_node(root_children_field, -1);
@@ -155,8 +155,7 @@ int main(int argc, char **argv) {
   wb_supervisor_node_remove(sphere4);
   wb_robot_step(TIME_STEP);
   ts_assert_boolean_equal(wb_supervisor_field_get_mf_node(root_children_field, -1) == sphere5,
-                      "WbNodeRef instance of SPHERE 5 should not change after deleting SPHERE 4.");
-  
+                          "WbNodeRef instance of SPHERE 5 should not change after deleting SPHERE 4.");
 
   ts_send_success();
   return EXIT_SUCCESS;


### PR DESCRIPTION
Fix #883: fix deleting the second node of the `node_list` list in libController `supervisor.c`. 

Previously both the first and second nodes were wrongly removed from the list.