### PR TITLE
Fix CppCheck issues

### DIFF
--- a/src/webots/maths/WbPolygon.cpp
+++ b/src/webots/maths/WbPolygon.cpp
@@ -26,14 +26,16 @@ bool WbPolygon::contains(double x, double y) const {
   if (mSize == 1)
     return (x == value(0).x() && y == value(0).y());
 
-  double dx = x - value(0).x();
-  double dy = y - value(0).y();
-  double sideX = value(1).x() - value(0).x();
-  double sideY = value(1).y() - value(0).y();
-  double det = sideX * dy - sideY * dx;
+  double dx, dy, sideX, sideY, det;
 
-  if (mSize == 2)
+  if (mSize == 2) {
+    dx = x - value(0).x();
+    dy = y - value(0).y();
+    sideX = value(1).x() - value(0).x();
+    sideY = value(1).y() - value(0).y();
+    det = sideX * dy - sideY * dx;
     return (det == 0.0 && dx * sideX + dy * sideY < 0.0);
+  }
 
   if (mSize == 3) {  // In this case, the vertex order is possibly clockwise
     // Side A_0 A_1 of the polygon

--- a/src/webots/nodes/WbPhysics.cpp
+++ b/src/webots/nodes/WbPhysics.cpp
@@ -152,32 +152,30 @@ void WbPhysics::checkInertiaMatrix(bool showInfo) {
     return;
   }
 
-  if (size == 2) {
-    if (showInfo && mCenterOfMass->size() == 0)
-      info(tr("You must also specify the 'centerOfMass' when specifying the 'inertiaMatrix'"));
+  if (showInfo && mCenterOfMass->size() == 0)
+    info(tr("You must also specify the 'centerOfMass' when specifying the 'inertiaMatrix'"));
 
-    if (showInfo && mMass->value() <= 0.0)
-      info(tr("You must also set the 'mass' to a positive value when specifying the 'inertiaMatrix'."));
+  if (showInfo && mMass->value() <= 0.0)
+    info(tr("You must also set the 'mass' to a positive value when specifying the 'inertiaMatrix'."));
 
-    // The principal moment of inertia must be positive
-    // to avoid assertion failure with debug version of ODE
-    const WbVector3 &v0 = mInertiaMatrix->item(0);
-    if (v0[0] <= 0.0 || v0[1] <= 0.0 || v0[2] <= 0.0) {
-      mHasAvalidInertiaMatrix = false;
-      if (showInfo)
-        warn(tr("The first line of 'inertiaMatrix' (principal moments of inertia) must have only positive values."));
-    }
-    const WbVector3 &v1 = mInertiaMatrix->item(1);
-    const dReal I[12] = {v0[0], v1[0], v1[1], 0.0, v1[0], v0[1], v1[2], 0.0, v1[1], v1[2], v0[2], 0.0};
-    if (!dIsPositiveDefinite(I, 3)) {
-      mHasAvalidInertiaMatrix = false;
-      if (showInfo)
-        warn(tr("'inertiaMatrix' must be positive definite."));
-    } else if (mCenterOfMass->size() == 0 && showInfo)
-      warn(tr("'centerOfmass' must also be specified when using an inertia matrix."));
-    else if (mMass->value() < 0.0 && showInfo)
-      warn(tr("'mass' must be positive when using an inertia matrix."));
+  // The principal moment of inertia must be positive
+  // to avoid assertion failure with debug version of ODE
+  const WbVector3 &v0 = mInertiaMatrix->item(0);
+  if (v0[0] <= 0.0 || v0[1] <= 0.0 || v0[2] <= 0.0) {
+    mHasAvalidInertiaMatrix = false;
+    if (showInfo)
+      warn(tr("The first line of 'inertiaMatrix' (principal moments of inertia) must have only positive values."));
   }
+  const WbVector3 &v1 = mInertiaMatrix->item(1);
+  const dReal I[12] = {v0[0], v1[0], v1[1], 0.0, v1[0], v0[1], v1[2], 0.0, v1[1], v1[2], v0[2], 0.0};
+  if (!dIsPositiveDefinite(I, 3)) {
+    mHasAvalidInertiaMatrix = false;
+    if (showInfo)
+      warn(tr("'inertiaMatrix' must be positive definite."));
+  } else if (mCenterOfMass->size() == 0 && showInfo)
+    warn(tr("'centerOfmass' must also be specified when using an inertia matrix."));
+  else if (mMass->value() < 0.0 && showInfo)
+    warn(tr("'mass' must be positive when using an inertia matrix."));
 }
 
 WbDamping *WbPhysics::damping() const {


### PR DESCRIPTION
Cppcheck 1.86 reports:
```
[src/webots/maths/WbPolygon.cpp:33] -> [src/webots/maths/WbPolygon.cpp:87]: (style) Variable 'det' is reassigned a value before the old one has been used.
[src/webots/nodes/WbPhysics.cpp:148] -> [src/webots/nodes/WbPhysics.cpp:155]: (style) Condition 'size==2' is always true
```