### PR TITLE
Improve robustness of cotangentFrame function in pbr shader

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -38,6 +38,7 @@ Released on XXX YYth, 2019.
     - External controllers now wait if started before Webots.
     - Fixed warnings printed in the terminal if a [Solid](solid.md).name field contains characters with special meaning in regular expressions.
     - Fixed invalid node references in controllers after deleting nodes from Webots or from the [Supervisor](supervisor.md) API (thanks to @chilaire).
+    - Fixed rendering issues if multiple texture coordinates of a face are equal.
     - Linux: Fixed missing Python3.7 controller API.
     - Windows: Fixed possible DLL conflict with libssl-1_1-x64.dll and libcrypto-1_1-x64.dll.
 

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -108,7 +108,7 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
 
   // construct a scale-invariant frame
   float scale = max(dot(T, T), dot(B, B));
-  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+  if (scale <= 0.0)  // inversesqrt result is undefined for value <= 0
     return mat3(T, B, N);
   float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -97,8 +97,8 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
-  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
-    return mat3(vec3(0.0), vec3(0.0, 0.0, 0.0), N);
+  if (duv1 == vec2(0.0) && duv2 == vec2(0.0))
+    return mat3(vec3(0.0), vec3(0.0), N);
 
   // solve the linear system
   vec3 dp2perp = cross(dp2, N);

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -97,6 +97,9 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
+  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
+    return mat3(vec3(0.0), vec3(0.0, 0.0, 0.0), N);
+
   // solve the linear system
   vec3 dp2perp = cross(dp2, N);
   vec3 dp1perp = cross(N, dp1);
@@ -104,7 +107,10 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
 
   // construct a scale-invariant frame
-  float invmax = inversesqrt(max(dot(T, T), dot(B, B)));
+  float scale = max(dot(T, T), dot(B, B));
+  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+    return mat3(T, B, N);
+  float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);
 }
 

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -47,6 +47,9 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
+  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
+    return mat3(vec3(0.0), vec3(0.0, 0.0, 0.0), N);
+
   // solve the linear system
   vec3 dp2perp = cross(dp2, N);
   vec3 dp1perp = cross(N, dp1);
@@ -54,7 +57,10 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
 
   // construct a scale-invariant frame
-  float invmax = inversesqrt(max(dot(T, T), dot(B, B)));
+  float scale = max(dot(T, T), dot(B, B));
+  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+    return mat3(T, B, N);
+  float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);
 }
 

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -58,7 +58,7 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
 
   // construct a scale-invariant frame
   float scale = max(dot(T, T), dot(B, B));
-  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+  if (scale <= 0.0)  // inversesqrt result is undefined for value <= 0
     return mat3(T, B, N);
   float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -47,8 +47,8 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
-  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
-    return mat3(vec3(0.0), vec3(0.0, 0.0, 0.0), N);
+  if (duv1 == vec2(0.0) && duv2 == vec2(0.0))
+    return mat3(vec3(0.0), vec3(0.0), N);
 
   // solve the linear system
   vec3 dp2perp = cross(dp2, N);

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -92,7 +92,7 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
-  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
+  if (duv1 == vec2(0.0) && duv2 == vec2(0.0))
     return mat3(vec3(0.0), vec3(0.0), N);
 
   // solve the linear system

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -103,7 +103,7 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
 
   // construct a scale-invariant frame
   float scale = max(dot(T, T), dot(B, B));
-  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+  if (scale <= 0.0)  // inversesqrt result is undefined for value <= 0
     return mat3(T, B, N);
   float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -92,6 +92,9 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec2 duv1 = dFdx(uv);
   vec2 duv2 = dFdy(uv);
 
+  if (duv1 == vec2(0.0, 0.0) && duv2 == vec2(0.0, 0.0))
+    return mat3(vec3(0.0), vec3(0.0), N);
+
   // solve the linear system
   vec3 dp2perp = cross(dp2, N);
   vec3 dp1perp = cross(N, dp1);
@@ -99,7 +102,10 @@ mat3 cotangentFrame(vec3 N, vec3 p, vec2 uv) {
   vec3 B = dp2perp * duv1.y + dp1perp * duv2.y;
 
   // construct a scale-invariant frame
-  float invmax = inversesqrt(max(dot(T, T), dot(B, B)));
+  float scale = max(dot(T, T), dot(B, B));
+  if (scale <= 0.0) // inversesqrt result is undefined for value <= 0
+    return mat3(T, B, N);
+  float invmax = inversesqrt(scale);
   return mat3(T * invmax, B * invmax, N);
 }
 


### PR DESCRIPTION
Fix #891: the case where all the texture coordinates are equal (i.e. `dFdx(uv) == vec2(0) && dFdy(uv) == vec2(0)`) was not handled in `cotangentFrame` function leading to a division by 0.