### PR TITLE
Fix macOS package creation

### DIFF
--- a/src/packaging/webots_distro.c
+++ b/src/packaging/webots_distro.c
@@ -232,14 +232,14 @@ static void copy_file(const char *file) {
       break;
 #ifndef _WIN32
     case MAC:
-      fprintf(fd, "cp -ar $WEBOTS_HOME/%s \"%s/%s/%s/\"\n", protected_filename2, distribution_path, bundle_name, dest2);
+      fprintf(fd, "cp -a $WEBOTS_HOME/%s \"%s/%s/%s/\"\n", protected_filename2, distribution_path, bundle_name, dest2);
       break;
     case DEB:
-      fprintf(fd, "cp -ar $WEBOTS_HOME/%s %s/debian/usr/local/%s/%s\n", protected_filename2, distribution_path,
+      fprintf(fd, "cp -a $WEBOTS_HOME/%s %s/debian/usr/local/%s/%s\n", protected_filename2, distribution_path,
               application_name_lowercase_and_dashes, dest2);
       break;
     case SNAP:
-      fprintf(fd, "cp -ar $WEBOTS_HOME/%s $DESTDIR/usr/share/%s/%s\n", protected_filename2,
+      fprintf(fd, "cp -a $WEBOTS_HOME/%s $DESTDIR/usr/share/%s/%s\n", protected_filename2,
               application_name_lowercase_and_dashes, dest2);
       break;
 #endif
@@ -1165,9 +1165,9 @@ static void create_file(const char *name, int m) {
 
       // copy include directories of libzip and libssh in tarball package
       fprintf(fd, "mkdir debian/usr/local/webots/include/libssh\n");
-      fprintf(fd, "cp -ar /usr/include/libssh debian/usr/local/webots/include/libssh/\n");
+      fprintf(fd, "cp -a /usr/include/libssh debian/usr/local/webots/include/libssh/\n");
       fprintf(fd, "mkdir debian/usr/local/webots/include/libzip\n");
-      fprintf(fd, "cp -ar /usr/include/zip.h debian/usr/local/webots/include/libzip/\n");
+      fprintf(fd, "cp -a /usr/include/zip.h debian/usr/local/webots/include/libzip/\n");
       fprintf(fd, "cp /usr/include/x86_64-linux-gnu/zipconf.h debian/usr/local/webots/include/libzip/\n");
 
       // add the required libraries in order to avoid conflicts on other Linux distributions
@@ -1228,9 +1228,9 @@ static void create_file(const char *name, int m) {
       for (int i = 0; i < sizeof(usr_lib_x68_64_linux_gnu) / sizeof(char *); i++)
         fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/%s $DESTDIR/usr/lib/x86_64-linux-gnu/\n", usr_lib_x68_64_linux_gnu[i]);
       fprintf(fd, "mkdir $DESTDIR/usr/share/webots/include/libssh\n");
-      fprintf(fd, "cp -ar /usr/include/libssh $DESTDIR/usr/share/webots/include/libssh/\n");
+      fprintf(fd, "cp -a /usr/include/libssh $DESTDIR/usr/share/webots/include/libssh/\n");
       fprintf(fd, "mkdir $DESTDIR/usr/share/webots/include/libzip\n");
-      fprintf(fd, "cp -ar /usr/include/zip.h $DESTDIR/usr/share/webots/include/libzip/\n");
+      fprintf(fd, "cp -a /usr/include/zip.h $DESTDIR/usr/share/webots/include/libzip/\n");
       fprintf(fd, "cp /usr/include/x86_64-linux-gnu/zipconf.h $DESTDIR/usr/share/webots/include/libzip/\n");
       fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots.desktop $DESTDIR/usr/share/webots/resources/\n");
       break;


### PR DESCRIPTION
`cp` on travis fails with this warning:

    cp: the -R and -r options may not be specified together.

- [x] Fix `cp` calls. As `-a` is a shortcut to `-pPR` and  `-r` is equivalent to `-R` (but not documented on macOS), `-a` is equivalent to `-ar` and less problematic.
