### PR TITLE
Removed Qt Wayland platform plugin

### DIFF
--- a/src/install_scripts/qt_linux_installer.sh
+++ b/src/install_scripts/qt_linux_installer.sh
@@ -97,7 +97,6 @@ cp $QT_INSTALLATION_PATH/lib/libicuuc.so.$ICU_VERSION.1             lib/
 echo $'[Paths]\nPrefix = ..\n' >                                    lib/qt/libexec/qt.conf
 cp $QT_INSTALLATION_PATH/libexec/QtWebEngineProcess                 lib/qt/libexec/
 cp $QT_INSTALLATION_PATH/plugins/platforms/libqxcb.so               lib/qt/plugins/platforms/
-cp $QT_INSTALLATION_PATH/plugins/platforms/libqwayland-egl.so       lib/qt/plugins/platforms/
 cp $QT_INSTALLATION_PATH/plugins/platformthemes/libqgtk3.so         lib/qt/plugins/platformthemes/
 cp $QT_INSTALLATION_PATH/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.so lib/qt/plugins/platforminputcontexts/
 cp $QT_INSTALLATION_PATH/plugins/platforminputcontexts/libibusplatforminputcontextplugin.so    lib/qt/plugins/platforminputcontexts/

--- a/src/packaging/files_core.txt
+++ b/src/packaging/files_core.txt
@@ -157,7 +157,7 @@ lib/qt/plugins/platforminputcontexts/libcomposeplatforminputcontextplugin.so [li
 lib/qt/plugins/platforminputcontexts/libibusplatforminputcontextplugin.so [linux]
 lib/qt/plugins/platforms/ [linux,mac]
 lib/qt/plugins/platforms/libqcocoa.dylib [mac]
-lib/qt/plugins/platforms/lib*.so [linux]
+lib/qt/plugins/platforms/libqxcb.so [linux]
 lib/qt/plugins/platformthemes/ [linux]
 lib/qt/plugins/platformthemes/libqgtk3.so [linux]
 lib/qt/plugins/printsupport/ [linux,mac]


### PR DESCRIPTION
Wayland is not needed as we can disable it from an environment variable in the snap environment.

👍