### PR TITLE
macOS : Remove warning when building a controller in a directory containing spaces

### DIFF
--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -363,8 +363,8 @@ ifeq ($(OSTYPE),darwin)
  ifdef WEBOTS_LIBRARY
   LFLAGS += -Xlinker -rpath -Xlinker @loader_path/.. -install_name @rpath/lib/$(MAIN_TARGET)
  else
-  CALLING_MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-  WEBOTS_RELATIVE_PATH = $(call computeRelativePath,$(WEBOTS_HOME_PATH),$(CALLING_MAKEFILE_DIR))
+  CALLING_MAKEFILE_DIR := $(shell dirname "$(realpath $(firstword $(MAKEFILE_LIST)))")
+  WEBOTS_RELATIVE_PATH = $(call computeRelativePath,"$(WEBOTS_HOME_PATH)","$(CALLING_MAKEFILE_DIR)")
   ifneq (,$(findstring ..,$(WEBOTS_RELATIVE_PATH)))
    DYNAMIC_LINK_FLAGS += -Xlinker -rpath -Xlinker @loader_path/$(WEBOTS_RELATIVE_PATH)
    ifdef BUILD_SHARED_LIBRARY


### PR DESCRIPTION
When compiling a controller contained in a directory with spaces, it produces the following warning:

![Capture d’écran 2019-10-01 à 16 47 39](https://user-images.githubusercontent.com/866788/65973223-3eef1400-e46b-11e9-9790-84cd7d6293e5.png)
