### PR TITLE
Fix libopenal soft link

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -34,7 +34,7 @@ qt-clean:
 qt: $(WEBOTS_HOME)/lib/libQt5Core.so.$(QT_VERSION)
 
 $(WEBOTS_HOME)/lib/libQt5Core.so.$(QT_VERSION): $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
-	tar xvjfm $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) -C $(WEBOTS_HOME)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE):
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
@@ -43,34 +43,33 @@ $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE):
 
 
 open-al-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)* $(WEBOTS_HOME)/lib/libopenal*
+	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)* $(WEBOTS_HOME)/lib/libopenal.so*
 
-open-al: $(WEBOTS_HOME)/lib/libopenal.so.1
+open-al: $(WEBOTS_HOME)/lib/libopenal.so
 
-$(WEBOTS_HOME)/lib/libopenal.so.1: $(WEBOTS_DEPENDENCY_PATH)/openal
-	cp $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so.1.16.0 $(WEBOTS_HOME)/lib/libopenal.so
-	ln -s -r $(WEBOTS_HOME)/lib/libopenal.so $(WEBOTS_HOME)/lib/libopenal.so.1
+$(WEBOTS_HOME)/lib/libopenal.so: $(WEBOTS_DEPENDENCY_PATH)/openal
+	cp -a $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so* $(WEBOTS_HOME)/lib/
 
 $(WEBOTS_DEPENDENCY_PATH)/openal:
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
 	wget $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xvjfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
 
 
 open-cv-clean:
 	rm -rf $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64 $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)* $(WEBOTS_HOME)/lib/libopencv_* $(WEBOTS_HOME)/include/opencv2
 
-open-cv: $(WEBOTS_HOME)/lib/libopencv_core.so.2.4.3
+open-cv: $(WEBOTS_HOME)/lib/libopencv_core.so
 
-$(WEBOTS_HOME)/lib/libopencv_core.so.2.4.3: $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64
-	cp -ar $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/lib/* $(WEBOTS_HOME)/lib
-	cp -ar $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/include/opencv2/ $(WEBOTS_HOME)/include/ -R
+$(WEBOTS_HOME)/lib/libopencv_core.so: $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64
+	cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/lib/libopencv_* $(WEBOTS_HOME)/lib
+	cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/include/opencv2/ $(WEBOTS_HOME)/include/ -R
 
 $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64:
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
 	wget $(DEPENDENCIES_URL)/$(OPENCV_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar zxvfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
 
 
@@ -80,7 +79,7 @@ ois-clean:
 ois: $(WEBOTS_HOME)/lib/libOIS-1.4.0.so
 
 $(WEBOTS_HOME)/lib/libOIS-1.4.0.so: $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	tar xvjfm $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) -C $(WEBOTS_HOME)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE):
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
@@ -94,7 +93,7 @@ pico-clean:
 pico: $(WEBOTS_HOME)/lib/libpico.so
 
 $(WEBOTS_HOME)/lib/libpico.so: $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	tar xvjfm $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) -C $(WEBOTS_HOME)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
@@ -108,7 +107,7 @@ lua-gd-clean:
 lua-gd: $(WEBOTS_HOME)/resources/lua/modules/gd/gd.so
 
 $(WEBOTS_HOME)/resources/lua/modules/gd/gd.so: $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	tar xvjfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)/resources/lua/modules
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)/resources/lua/modules
 
 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE):
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
@@ -124,7 +123,7 @@ lua: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 	wget http://www.lua.org/ftp/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar zxfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3

--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -49,7 +49,7 @@ open-al: $(WEBOTS_HOME)/lib/libopenal.so.1
 
 $(WEBOTS_HOME)/lib/libopenal.so.1: $(WEBOTS_DEPENDENCY_PATH)/openal
 	cp $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so.1.16.0 $(WEBOTS_HOME)/lib/libopenal.so
-	ln -s $(WEBOTS_HOME)/lib/libopenal.so $(WEBOTS_HOME)/lib/libopenal.so.1
+	ln -s -r $(WEBOTS_HOME)/lib/libopenal.so $(WEBOTS_HOME)/lib/libopenal.so.1
 
 $(WEBOTS_DEPENDENCY_PATH)/openal:
 	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)


### PR DESCRIPTION
Fix #964.

Note that it is not necessary to create a package to check the issue but this can be inspected directly on the development environment by checking that the soft link points to the library with a relative path and not an absolute path.