### PR TITLE
Fixed extern controllers on snap

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -14,32 +14,18 @@ The [chapter](language-setup.md) covers the set up of these tools.
 
 Webots will run on most recent Linux distributions running glibc2.11.1 or earlier.
 This includes fairly recent Ubuntu, Debian, Fedora, SuSE, RedHat, etc.
-Webots comes in two different package types: `.deb` and `.tar.bz2` (tarball).
-The `.deb` package is aimed at the latest LTS Ubuntu Linux distribution whereas the tarball package includes many dependency libraries and it is therefore best suited for installation on other Linux distributions.
-These packages can be downloaded from our [website](https://cyberbotics.com/download).
-
-> **Note**: Some of the following commands requires the `root` privileges.
-You can get these privileges by preceding all the commands by the `sudo` command.
-
-<!-- -->
+Webots comes in three different package types: `.deb` (Debian package), `.tar.bz2` (tarball package) and `.snap` (snap package).
+The Debian package is aimed at the latest LTS Ubuntu Linux distribution whereas the tarball and snap packages includes many dependency libraries and are therefore best suited for installation on other Linux distributions.
+All these packages can be installed from our [website](https://cyberbotics.com/download).
 
 > **Note**: Webots will run much faster if you install an accelerated OpenGL drivers.
 If you have a NVIDIA or AMD graphics card, it is highly recommended that you install the Linux graphics drivers from these manufacturers to take the full advantage of the OpenGL hardware acceleration with Webots.
 Please find instructions in [this section](verifying-your-graphics-driver-installation.md).
 
-<!-- -->
+#### Installing the Debian Package With the Advanced Packaging Tool (APT)
 
-> **Note**: Webots needs the *ffmpeg* program to create MPEG-4 movies that can be installed with *ffmpeg* and *libfdk-aac1* packages and *ubuntu-restricted-extras* for H.264 codec.
-The package names could slightly change on different releases and distributions.
-
-#### Using Advanced Packaging Tool (APT)
-
-The advantage of this solution is that Webots will be updated automatically with system updates.
-This installation requires the `root` privileges which you can acquire from this command:
-
-```sh
-sudo su -
-```
+The advantage of this installation is that Webots will be updated automatically with system updates.
+The installation requires the `root` privileges.
 
 First of all, Webots should be authenticated with the [Cyberbotics.asc](https://www.cyberbotics.com/Cyberbotics.asc) signature file which can be downloaded from the [Webots download page](https://www.cyberbotics.com/download), and installed using this command:
 
@@ -51,8 +37,8 @@ Then, you can configure your APT package manager by adding the Cyberbotics repos
 Simply execute the following lines:
 
 ```sh
-apt-add-repository 'deb https://www.cyberbotics.com/debian/ binary-amd64/'
-apt-get update
+sudo apt-add-repository 'deb https://www.cyberbotics.com/debian/ binary-amd64/'
+sudo apt-get update
 ```
 
 As an alternative, you can easily add the Cyberbotics repository from the `Software and Updates` application.
@@ -66,18 +52,39 @@ When you close the window, the APT packages list should be automatically updated
 Otherwise you can manually execute the following command:
 
 ```sh
-apt-get update
+sudo apt-get update
 ```
 
 Then proceed to the installation of Webots using:
 
 ```sh
-apt-get install webots
+sudo apt-get install webots
 ```
 
 > **Note**: Although only the command line procedure is documented here, it is also possible to use any APT front-end tool, such as the Synaptic Package Manager, to proceed with the APT installation of Webots.
 
-#### From the "tarball" Package
+#### Installing the Debian Package Directly
+
+This procedure explains how to install Webots directly from the Debian package (having the `.deb` extension), without using the APT system.
+Unlike with the APT system, you will have to repeat this operation manually each time you want to upgrade to a newer version of Webots.
+
+On Ubuntu, double-click on the Debian package file to open it with the Ubuntu Software App and click on the `Install` button.
+If a previous version of Webots is already installed, then the text on the button could be different, like `Upgrade` or `Reinstall`.
+Note that GNOME Software App distributed in the first release of Ubuntu 16.04 contains a bug preventing the installation of third-party packages.
+
+Alternatively, the Debian package can also be installed using `apt` or `gdebi` with the `root` privileges:
+
+```sh
+sudo apt install ./webots_{{ webots.version.debian_package }}_amd64.deb
+```
+
+Or:
+
+```sh
+sudo gdebi webots_{{ webots.version.debian_package }}_amd64.deb
+```
+
+#### Installing the "tarball" Package
 
 This section explains how to install Webots from the tarball package (having the `.tar.bz2` extension).
 This package can be installed without the `root` privileges.
@@ -96,41 +103,43 @@ export WEBOTS_HOME=/home/username/webots
 
 The export line should however be included in a configuration script like "/etc/profile", so that it is set properly for every session.
 
-Some additional libraries are needed in order to properly run Webots.
-In particular *make*, *g++*, *libjpeg8-dev* and *ffmpeg* have to be installed on the system.
+> **Note**: Webots needs the *ffmpeg* and *libfdk-aac1* (from *ubuntu-restricted-extras* for H.264 codec) packages to create MPEG-4 movies.
+You will also need to install *make*, *g++*, *libjpeg8-dev* to compile your own robot controllers.
 Other particular libraries could also be required to recompile some of the distributed binary files.
 In this case an error message will be printed in the Webots console mentioning the missing dependency.
+The package names could slightly change on different releases and distributions.
 
-> **Note**: On old versions of Ubuntu or other linux distributions the library names and versions could be slightly different.
 
-#### From the DEB Package
+#### Installing the Snap Package
 
-This procedure explains how to install Webots from the DEB package (having the `.deb` extension).
+Snap packaging is a modern alternative to older packaging systems.
+It runs software in a sand-boxed environment to guarantee the security of the operating system.
+The snap package of Webots combines the advantages of the Debian package installed with APT and the tarball package.
+It is very simple to install, automatically updates, runs on a large variety of Linux distributions and has no dependency.
+Moreover, it is available from the official [snap store](https://snapcraft.io/webots) and software center of Ubuntu.
+However, the sand-boxing constraints of snaps yield the following limitations:
 
-On Ubuntu, double-click on the DEB package file to open it with the Ubuntu Software App and click on the `Install` button.
-If a previous version of Webots is already installed, then the text on the button could be different, like `Upgrade` or `Reinstall`.
-Note that GNOME Software App distributed in the first release of Ubuntu 16.04 contains a bug preventing the installation of third-party packages.
+- **Download size**:
+The download is significantly bigger as it includes all the dependencies of Webots (ffmpeg, python, C++ and java compilers, etc.).
+For Webots R2019b revision 1, the download size of the snap is 1.8GB compared to 1.3GB of the Debian and tarball packages.
 
-Alternatively, the DEB package can also be installed using `apt` or `gdebi` with the `root` privileges:
+- **extern controllers**:
+It is not possible to change the built-in dependencies of the snap package (Python interpreter, C/C++/Java compilers, JRE, etc.) or install any extra dependencies (libraries, Python modules).
+However, when developing robot controllers, it is often useful to use various components such as a different version of Python, some Python module (pip), or a native shared library.
+If such components are needed, users can install them on their system or local environment to create, compile and link their robot controllers.
+However, because of the snap sand-boxing, Webots will be unable to launch these controller itself.
+To work around this problem, such controllers should be launched as extern controllers from outside of Webots.
 
-```sh
-apt install ./webots_{{ webots.version.debian_package }}_amd64.deb
-```
-
-Or:
-
-```sh
-gdebi webots_{{ webots.version.debian_package }}_amd64.deb
-```
+To install the snap package of Webots, simply follow the instructions from the [snap store](https://snapcraft.io/webots).
 
 #### Server Edition
 
-Webots requires some graphical features that are usually not available by default on a linux server edition and additional packages needs to be available to make it work:
+Webots requires some graphical features that are usually not available by default on a Linux server edition and additional packages needs to be available to make it work:
 
 - `xserver-xorg-core`
 - `libpulse0`
 
-These packages are automatically installed when using the DEB package, but in case of the tarball package the user has to manually install them.
+These packages are automatically installed when using the Debian package, but in case of the tarball package the user has to manually install them.
 
 Additionally, it is also necessary to install an OS GUI, for example the Unity desktop `ubuntu-desktop` package.
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -22,7 +22,7 @@ All these packages can be installed from our [website](https://cyberbotics.com/d
 If you have a NVIDIA or AMD graphics card, it is highly recommended that you install the Linux graphics drivers from these manufacturers to take the full advantage of the OpenGL hardware acceleration with Webots.
 Please find instructions in [this section](verifying-your-graphics-driver-installation.md).
 
-#### Installing the Debian Package With the Advanced Packaging Tool (APT)
+#### Installing the Debian Package with the Advanced Packaging Tool (APT)
 
 The advantage of this installation is that Webots will be updated automatically with system updates.
 The installation requires the `root` privileges.

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -131,6 +131,7 @@ However, when developing robot controllers, it is often useful to use various co
 If such components are needed, users can install them on their system or local environment to create, possibly compile and link their robot controllers.
 However, because of the snap sand-boxing, Webots will be unable to launch these controller itself.
 To work around this problem, such controllers should be launched as extern controllers from outside of Webots.
+Before launching extern controllers, you should set the `WEBOTS_HOME` environment variable to point to `/snap/webots/current/usr/share/webots` and add `$WEBOTS_HOME/lib` to your `LD_LIBRARY_PATH` environment variable, so that your controllers will find the necessary shared libraries.
 The chapter entitled [running extern robot controllers](running-extern-robot-controllers.md) details how to run extern controllers, including with the snap version of Webots.
 
 

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -70,6 +70,17 @@ If that simulation has more than one extern controller, you may also set the `WE
 
 > **Note**: the environment variables can be set inside the controller program, before calling the `wb_robot_init()` function.
 
+### Running Extern Robot Controller with the Snap Version of Webots
+
+Running extern controllers with the snap version of Webots should work out the box.
+However, behind the scene, this mechanism relies on some special settings that are automatically managed for you by the Webots launcher and the libController.
+Because of the snap sand-boxing system, Webots has to use a special temporary folder to share information with robot controllers.
+When you launch the snap version of Webots, the launcher computes the `WEBOTS_TMPDIR` environment variable if it is not already set.
+This variable is computed from the `SNAP_USER_COMMON` environment variable which typically points to `/home/username/snap/webots/common`, a folder accessible by both Webots and your own programs.
+Similarly, the libController will automatically check this folder and its contents to determine if it should use it to communicate with Webots.
+It is recommended that you do not override this `WEBOTS_TMPDIR` environment variable, unless you want to experiment a different mechanism.
+
+
 ## Example Usage
 
 1. Open for example the "WEBOTS\_HOME/projects/robots/softbank/nao/worlds/nao_demo.wbt" world file.

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -72,8 +72,12 @@ If that simulation has more than one extern controller, you may also set the `WE
 
 ### Running Extern Robot Controller with the Snap Version of Webots
 
-Running extern controllers with the snap version of Webots should work out the box.
-However, behind the scene, this mechanism relies on some special settings that are automatically managed for you by the Webots launcher and the libController.
+In order to compile and execute extern controllers, the following environment variables should be set:
+```
+export WEBOTS_HOME=/snap/webots/current/usr/share/webots
+export LD_LIBRARY_PATH=$WEBOTS_HOME/lib
+```
+
 Because of the snap sand-boxing system, Webots has to use a special temporary folder to share information with robot controllers.
 When you launch the snap version of Webots, the launcher computes the `WEBOTS_TMPDIR` environment variable if it is not already set.
 This variable is computed from the `SNAP_USER_COMMON` environment variable which typically points to `/home/username/snap/webots/common`, a folder accessible by both Webots and your own programs.

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -104,9 +104,9 @@ static const char *wbu_system_tmpdir() {
   // use it as the tmpdir, otherwise fallback to /tmp
   const char *HOME = getenv("HOME");
   if (HOME && HOME[0]) {
-    const size_t len = strlen(HOME) + strlen("/.WEBOTS_TMPDIR") + 1;
+    const size_t len = strlen(HOME) + strlen("/snap/webots/common/tmp") + 1;
     char *path = malloc(len);
-    snprintf(path, len, "%s/.WEBOTS_TMPDIR", HOME);
+    snprintf(path, len, "%s/snap/webots/common/tmp", HOME);
     DIR *dir = opendir(path);
     if (dir) {
       struct dirent *entry;

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -83,7 +83,8 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
   mEditorFontEdit->setText(prefs->value("Editor/font").toString());
   mNumberOfThreads = prefs->value("General/numberOfThreads", 1).toInt();
   mNumberOfThreadsCombo->setCurrentIndex(mNumberOfThreads - 1);
-  mPythonCommand->setText(prefs->value("General/pythonCommand").toString());
+  if (mPythonCommand)
+    mPythonCommand->setText(prefs->value("General/pythonCommand").toString());
   mExtraProjectsPath->setText(prefs->value("General/extraProjectsPath").toString());
   mTelemetryCheckBox->setChecked(prefs->value("General/telemetry").toBool());
   mCheckWebotsUpdateCheckBox->setChecked(prefs->value("General/checkWebotsUpdateOnStartup").toBool());
@@ -140,7 +141,8 @@ void WbPreferencesDialog::accept() {
   prefs->setValue("General/language", languageKey);
   prefs->setValue("General/theme", mValidThemeFilenames.at(mThemeCombo->currentIndex()));
   prefs->setValue("General/numberOfThreads", mNumberOfThreadsCombo->currentIndex() + 1);
-  prefs->setValue("General/pythonCommand", mPythonCommand->text());
+  if (mPythonCommand)
+    prefs->setValue("General/pythonCommand", mPythonCommand->text());
   prefs->setValue("General/extraProjectsPath", mExtraProjectsPath->text());
   prefs->setValue("General/telemetry", mTelemetryCheckBox->isChecked());
   prefs->setValue("General/checkWebotsUpdateOnStartup", mCheckWebotsUpdateCheckBox->isChecked());
@@ -244,7 +246,6 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   }
 
   mEditorFontEdit = new WbLineEdit(this);
-  mPythonCommand = new WbLineEdit(this);
   mExtraProjectsPath = new WbLineEdit(this);
   mExtraProjectsPath->setToolTip(
     tr("Extra projects may include PROTOs, controllers, plugins, etc. that you can use in your current project."));
@@ -277,8 +278,15 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
 
   // row 5
   layout->addWidget(new QLabel(tr("Python command:"), this), 5, 0);
-  layout->addWidget(mPythonCommand, 5, 1);
-
+#ifdef __linux__
+  if (qgetenv("SNAP") == "webots") {
+    QLabel *label = new QLabel(tr("built-in python (snap), see <a href=\"https://cyberbotics.com/doc/guide/running-extern-robot-controllers\">extern controllers</a> for alternatives."), this);
+    layout->addWidget(label, 5, 1);
+    connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
+    mPythonCommand = NULL;
+  } else
+#endif
+  layout->addWidget(mPythonCommand = new WbLineEdit(this), 5, 1);
   // row 6
   layout->addWidget(new QLabel(tr("Extra projects path:"), this), 6, 0);
   layout->addWidget(mExtraProjectsPath, 6, 1);

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -280,13 +280,16 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   layout->addWidget(new QLabel(tr("Python command:"), this), 5, 0);
 #ifdef __linux__
   if (qgetenv("SNAP") == "webots") {
-    QLabel *label = new QLabel(tr("built-in python (snap), see <a href=\"https://cyberbotics.com/doc/guide/running-extern-robot-controllers\">extern controllers</a> for alternatives."), this);
+    QLabel *label = new QLabel(
+      tr("built-in python (snap), see <a href=\"https://cyberbotics.com/doc/guide/running-extern-robot-controllers\">extern "
+         "controllers</a> for alternatives."),
+      this);
     layout->addWidget(label, 5, 1);
     connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
     mPythonCommand = NULL;
   } else
 #endif
-  layout->addWidget(mPythonCommand = new WbLineEdit(this), 5, 1);
+    layout->addWidget(mPythonCommand = new WbLineEdit(this), 5, 1);
   // row 6
   layout->addWidget(new QLabel(tr("Extra projects path:"), this), 6, 0);
   layout->addWidget(mExtraProjectsPath, 6, 1);

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -279,7 +279,7 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   // row 5
   layout->addWidget(new QLabel(tr("Python command:"), this), 5, 0);
 #ifdef __linux__
-  if (qgetenv("SNAP") == "webots") {
+  if (qgetenv("SNAP_NAME") == "webots") {
     QLabel *label = new QLabel(
       tr("built-in python (snap), see <a href=\"https://cyberbotics.com/doc/guide/running-extern-robot-controllers\">extern "
          "controllers</a> for alternatives."),

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # get the location of the Webots binary, even if defined into a relative symlinks
-webotsHome="$(dirname "$(readlink -f "$0")")"
+webots_home="$(dirname "$(readlink -f "$0")")"
 
 # remove wrong a desktop file if needed
 if [ -e ~/.local/share/applications/webots-bin.desktop ]; then
@@ -14,8 +14,8 @@ if [ ! -e /usr/share/applications/webots.desktop ] && [ ! -e ~/.local/share/appl
   echo "[Desktop Entry]" > $FILE
   echo "Name=Webots" >> $FILE
   echo "Comment=Webots mobile robot simulator" >> $FILE
-  echo "Exec="$webotsHome"/webots" >> $FILE
-  echo "Icon="$webotsHome"/resources/icons/core/webots.png" >> $FILE
+  echo "Exec="$webots_home"/webots" >> $FILE
+  echo "Icon="$webots_home"/resources/icons/core/webots.png" >> $FILE
   echo "Terminal=false" >> $FILE
   echo "Type=Application" >> $FILE
 fi
@@ -27,21 +27,39 @@ mkdir -p "$XDG_RUNTIME_DIR"
 export QTCOMPOSE=$SNAP/usr/share/X11/locale
 fi
 
+if [[ -z "$TMPDIR" ]]
+then
+TMPDIR=/tmp
+fi
+
+if [[ -z "$WEBOTS_TMPDIR" ]]
+then
+if [[ ! -z "$SNAP" ]]
+then
+WEBOTS_TMPDIR=~/.WEBOTS_TMPDIR
+mkdir -p $WEBOTS_TMPDIR
+else
+WEBOTS_TMPDIR=$TMPDIR
+fi
+fi
+
+export TMPDIR=$WEBOTS_TMPDIR
+
 # create temporary lib directory
-TMP_LIB_DIR="/tmp/webots-$$/lib"
+TMP_LIB_DIR="$TMPDIR/webots-$$/lib"
 if [ ! -d $TMP_LIB_DIR ]; then
   mkdir -p $TMP_LIB_DIR
 fi
-export WEBOTS_TMP_PATH="/tmp/webots-$$/"
+export WEBOTS_TMP_PATH="$TMPDIR/webots-$$/"
 
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
-export LD_LIBRARY_PATH="$webotsHome/lib/":$TMP_LIB_DIR:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH="$webots_home/lib/":$TMP_LIB_DIR:$LD_LIBRARY_PATH
 
 # execute the real Webots binary in a child process
 if command -v primusrun >/dev/null 2>&1; then
-  primusrun "$webotsHome/bin/webots-bin" "$@" &
+  primusrun "$webots_home/bin/webots-bin" "$@" &
 else
-  "$webotsHome/bin/webots-bin" "$@" &
+  "$webots_home/bin/webots-bin" "$@" &
 fi
 
 webots_pid=$!
@@ -50,5 +68,9 @@ trap 'kill $webots_pid &> /dev/null' EXIT
 
 wait $webots_pid
 webots_return_code=$?
+
+# clean-up tmp folder and pipe files in case webots crashed without clean-up
+rm -rf $WEBOTS_TMP_PATH
+rm -f ${TMPDIR}/webots_${webots_pid}_*
 
 exit $webots_return_code

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -36,7 +36,7 @@ if [[ -z "$WEBOTS_TMPDIR" ]]
 then
 if [[ ! -z "$SNAP" ]]
 then
-WEBOTS_TMPDIR=~/.WEBOTS_TMPDIR
+WEBOTS_TMPDIR="$SNAP_USER_DATA/tmp"
 mkdir -p $WEBOTS_TMPDIR
 else
 WEBOTS_TMPDIR=$TMPDIR

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -36,7 +36,7 @@ if [[ -z "$WEBOTS_TMPDIR" ]]
 then
 if [[ ! -z "$SNAP" ]]
 then
-WEBOTS_TMPDIR="$SNAP_USER_DATA/tmp"
+WEBOTS_TMPDIR="$SNAP_USER_COMMON/tmp"
 mkdir -p $WEBOTS_TMPDIR
 else
 WEBOTS_TMPDIR=$TMPDIR


### PR DESCRIPTION
Fixes #950.

This PR makes it easy to run extern controllers with the snap package (no need to be administrator). Basically, the webots launcher and libController were modified so that the snap version of webots can run extern controllers without any special setup. The user may override the `WEBOTS_TMPDIR` and/or `TMPDIR` environment variables before launching webots and the extern controllers if needed. Otherwise, they will be automatically setup to a default value (`$SNAP_USER_COMMON/tmp` = `~/snap/webots/common/tmp` for the snap version or `/tmp` for the non-snap version) that guarantees it will work smoothly with both the snap and non-snap versions of webots.

Additionally, the launcher now cleans-up the temporary folder and pipe files in case webots crashed without cleaning them up.

The new documentation page is available here for review: https://cyberbotics.com/doc/guide/installation-procedure?version=fix-extern-controller-on-snap

Finally, once this PR is merged, the https://cyberbotics.com/download page should be updated to add a link to the [Webots page](https://snapcraft.io/webots) on the snap store.

Also, as soon as we get an answer from https://lauchpad.net, we will be able to change the snap author from "Olivier Michel" to "Cyberbotics".