### PR TITLE
Qt5 update on Windows

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -1,5 +1,11 @@
 # Webots R2019b Changelog
 
+## Webots R2019b Revision 2
+Released on ???
+
+  - Dependency Updates
+    - Windows: upgraded to Qt 5.13.1.
+
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.
 


### PR DESCRIPTION
MSYS2 updated Qt over the week-end.

You should run again the `src/install_scripts/qt_windows_installer.sh` script that will proceed automatically to the update.
I tested this update and it caused no compilation warning and Webots seems happy with it (we already used this version of Qt on Linux).

👍