### PR TITLE
Fix Extern Controller Synchronization

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -16,7 +16,7 @@ For example, it may run it within a debugging environment, like *gdb*, a command
 Also, the standard output and error streams (`stdout` and `stderr`) remain under the user control and are not sent to the Webots console.
 It is even possible to read the standard input stream (`stdin`) like with any standard program.
 
-> **Note**: If the `robot.synchronization` field is set to `TRUE` Webots will wait for the external controller to be launched, otherwise the simulation will run whether the controller is started or not.
+> **Note**: If the `robot.synchronization` field is set to `TRUE` Webots will wait for the extern controller to be launched, otherwise the simulation will run whether the controller is started or not.
 
 ## Environment Variables
 
@@ -51,12 +51,12 @@ Different use cases are detailed here from the most simple to the most complex:
 
 ### Single Simulation and Single Extern Robot Controller
 
-You are running a single Webots simulation simultaneously on the same machine and this simulation has only one robot that you want to control from an external controller.
+You are running a single Webots simulation simultaneously on the same machine and this simulation has only one robot that you want to control from an extern controller.
 In this case, you simply need to set the `controller` field of this robot to `<extern>` and to launch the controller program from a console or from your favorite IDE.
 
 ### Single Simulation and Multiple Extern Robot Controllers
 
-You are running a single Webots simulation simultaneously on the same machine and this simulation has several robots that you want to control from external controllers.
+You are running a single Webots simulation simultaneously on the same machine and this simulation has several robots that you want to control from extern controllers.
 In this case, for each robot that you want to control externally, you should set their `controller` field to `<extern>`.
 Then, in the environment from which you are going to launch the extern controller, you should define an environment variable named `WEBOTS_ROBOT_NAME` and set it to match the `name` field of the [Robot](../reference/robot.md) node you want to control.
 Once this environment variable is set, you can launch your controller and it will connect to the extern robot whose `name` matches the one provided in the environment variable.

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -16,6 +16,8 @@ For example, it may run it within a debugging environment, like *gdb*, a command
 Also, the standard output and error streams (`stdout` and `stderr`) remain under the user control and are not sent to the Webots console.
 It is even possible to read the standard input stream (`stdin`) like with any standard program.
 
+> **Note**: If the `robot.synchronization` field is set to `TRUE` Webots will wait for the external controller to be launched, otherwise the simulation will run whether the controller is started or not.
+
 ## Environment Variables
 
 In order to be able to run an extern Webots controller, a number of environment variables should be set or extended.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -1,5 +1,11 @@
 # Webots R2019b Changelog
 
+## Webots R2019b Revision 2
+Released on ???
+
+  - Enhancements
+    - Webots now wait for external controllers if the `Robot.synchronization` field is set to `TRUE`.
+
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.
 

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -4,7 +4,7 @@
 Released on ???
 
   - Enhancements
-    - Webots now wait for external controllers if the `Robot.synchronization` field is set to `TRUE`.
+    - Webots now wait for extern controllers if the `Robot.synchronization` field is set to `TRUE`.
 
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.
@@ -47,9 +47,9 @@ Released on October 3rd, 2019.
     - Fixed the insertion of a PROTO containing a [BallJoint](balljoint.md).
     - Fixed ros controller not publishing the `/connector/presence` topic.
     - Fixed crash when using an `infra-red` [DistanceSensors](distancesensor.md) pointing to a texture without repetition.
-    - Fixed external controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another external controller.
+    - Fixed extern controllers, now when a controller exits, the simulation keeps running and it is possible to re-start another extern controller.
     - Webots now reads the Python shebang of controller programs to determine which version of Python to execute.
-    - External controllers now wait if started before Webots.
+    - Extern controllers now wait if started before Webots.
     - Fixed warnings printed in the terminal if a [Solid](solid.md).name field contains characters with special meaning in regular expressions.
     - Fixed invalid node references in controllers after deleting nodes from Webots or from the [Supervisor](supervisor.md) API (thanks to @chilaire).
     - Fixed rendering issues if multiple texture coordinates of a face are equal.

--- a/projects/robots/k-team/khepera3/controllers/khepera3_gripper/khepera3_gripper.c
+++ b/projects/robots/k-team/khepera3/controllers/khepera3_gripper/khepera3_gripper.c
@@ -92,13 +92,10 @@ void step(double seconds) {
 }
 
 void braitenberg() {
-  while (1) {
+  while (wb_robot_step(time_step) != -1) {  // Run simulation
     int i, j;
     double speed[2];
     double sensors_value[num_sensors];
-
-    /* Run simulation */
-    wb_robot_step(time_step);
 
     for (i = 0; i < num_sensors; i++)
       sensors_value[i] = wb_distance_sensor_get_value(sensors[i]);
@@ -189,5 +186,6 @@ int main() {
   turn(-10.7);
   step(1.0);
   braitenberg();
+  wb_robot_cleanup();
   return 0;
 }

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -129,7 +129,7 @@ void WbControlledWorld::startController(WbRobot *robot) {
 
 void WbControlledWorld::startControllerFromSocket(WbRobot *robot, QLocalSocket *socket) {
   if (robot->controllerName().isEmpty() || (socket == NULL && robot->controllerName() == "<extern>")) {
-    mRobotsWaitingExternalController.append(robot);
+    mRobotsWaitingExternController.append(robot);
     connect(robot, &WbRobot::controllerChanged, this, &WbControlledWorld::updateCurrentRobotController, Qt::UniqueConnection);
     return;
   }
@@ -163,7 +163,7 @@ void WbControlledWorld::startControllerFromSocket(WbRobot *robot, QLocalSocket *
   }
   mControllers.append(controller);
   if (socket && robot->controllerName() == "<extern>") {
-    mRobotsWaitingExternalController.removeAll(robot);
+    mRobotsWaitingExternController.removeAll(robot);
     controller->setSocket(socket);
     robot->setControllerStarted(true);
     return;
@@ -220,7 +220,7 @@ void WbControlledWorld::addControllerConnection() {
         continue;
       if ((robotName == robot->name() || robotName.isEmpty()) && robot->controllerName() == "<extern>") {
         WbLog::info(tr("Starting extern controller for robot \"%1\".").arg(robot->name()));
-        mRobotsWaitingExternalController.append(robot);
+        mRobotsWaitingExternController.append(robot);
         startControllerFromSocket(robot, socket);
         return;
       }
@@ -346,8 +346,8 @@ void WbControlledWorld::step() {
 }
 
 bool WbControlledWorld::needToWait() {
-  if (!mRobotsWaitingExternalController.isEmpty()) {
-    foreach (WbRobot *const robot, mRobotsWaitingExternalController) {
+  if (!mRobotsWaitingExternController.isEmpty()) {
+    foreach (WbRobot *const robot, mRobotsWaitingExternController) {
       if (robot->synchronization())
         return true;
     }
@@ -381,7 +381,7 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
   bool paused = WbSimulationState::instance()->isPaused();
   const QString &newControllerName = robot->controllerName();
 
-  mRobotsWaitingExternalController.removeAll(robot);
+  mRobotsWaitingExternController.removeAll(robot);
 
   // restart the controller if needed
   for (int i = 0; i < size; ++i) {
@@ -395,13 +395,13 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
       if (newControllerName.isEmpty() || newControllerName == "<extern>") {
         if (controller->name() == "<extern>") {
           WbLog::info(tr("Terminating extern controller for robot \"%1\".").arg(controller->robot()->name()));
-          mRobotsWaitingExternalController.append(robot);
+          mRobotsWaitingExternController.append(robot);
         } else
           WbLog::info(tr("Terminating controller \"%1\".").arg(controller->name()));
       }
       delete controller;
       if (newControllerName == "<extern>")
-        mRobotsWaitingExternalController.append(robot);
+        mRobotsWaitingExternController.append(robot);
       if (newControllerName.isEmpty() || newControllerName == "<extern>") {
         robot->setControllerStarted(false);
         return;
@@ -417,7 +417,7 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
   }
 
   if (newControllerName == "<extern>")
-    mRobotsWaitingExternalController.append(robot);
+    mRobotsWaitingExternController.append(robot);
 
   if (newControllerName.isEmpty() || newControllerName == "<extern>")
     return;
@@ -434,7 +434,7 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
 void WbControlledWorld::handleRobotRemoval(WbBaseNode *node) {
   WbRobot *robot = static_cast<WbRobot *>(node);
   assert(robot);
-  mRobotsWaitingExternalController.removeAll(robot);
+  mRobotsWaitingExternController.removeAll(robot);
 }
 
 QStringList WbControlledWorld::activeControllersNames() const {

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -74,8 +74,10 @@ WbControlledWorld::WbControlledWorld(WbProtoList *protos, WbTokenizer *tokenizer
     stream << mServer->fullServerName().toUtf8() << endl;
     file.close();
   }
-  foreach (WbRobot *const robot, robots())
+  foreach (WbRobot *const robot, robots()) {
     connect(robot, &WbRobot::startControllerRequest, this, &WbControlledWorld::startController);
+    connect(robot, &WbRobot::isBeingDestroyed, this, &WbControlledWorld::handleRobotRemoval);
+  }
 }
 
 WbControlledWorld::~WbControlledWorld() {
@@ -104,6 +106,7 @@ void WbControlledWorld::setUpControllerForNewRobot(WbRobot *robot) {
     return;
 
   connect(robot, &WbRobot::startControllerRequest, this, &WbControlledWorld::startController);
+  connect(robot, &WbRobot::isBeingDestroyed, this, &WbControlledWorld::handleRobotRemoval);
 
   if (mFirstStep && !mRetryEnabled)
     // simulation not started yet, controller will be created at first step() call
@@ -126,6 +129,7 @@ void WbControlledWorld::startController(WbRobot *robot) {
 
 void WbControlledWorld::startControllerFromSocket(WbRobot *robot, QLocalSocket *socket) {
   if (robot->controllerName().isEmpty() || (socket == NULL && robot->controllerName() == "<extern>")) {
+    mRobotsWaitingExternalController.append(robot);
     connect(robot, &WbRobot::controllerChanged, this, &WbControlledWorld::updateCurrentRobotController, Qt::UniqueConnection);
     return;
   }
@@ -159,6 +163,7 @@ void WbControlledWorld::startControllerFromSocket(WbRobot *robot, QLocalSocket *
   }
   mControllers.append(controller);
   if (socket && robot->controllerName() == "<extern>") {
+    mRobotsWaitingExternalController.removeAll(robot);
     controller->setSocket(socket);
     robot->setControllerStarted(true);
     return;
@@ -215,6 +220,7 @@ void WbControlledWorld::addControllerConnection() {
         continue;
       if ((robotName == robot->name() || robotName.isEmpty()) && robot->controllerName() == "<extern>") {
         WbLog::info(tr("Starting extern controller for robot \"%1\".").arg(robot->name()));
+        mRobotsWaitingExternalController.append(robot);
         startControllerFromSocket(robot, socket);
         return;
       }
@@ -340,12 +346,19 @@ void WbControlledWorld::step() {
 }
 
 bool WbControlledWorld::needToWait() {
-  foreach (WbController *const controller, mControllers)
+  if (!mRobotsWaitingExternalController.isEmpty()) {
+    foreach (WbRobot *const robot, mRobotsWaitingExternalController) {
+      if (robot->synchronization())
+        return true;
+    }
+  }
+  foreach (WbController *const controller, mControllers) {
     if (!controller->isRequestPending() || controller->isIncompleteRequest()) {
       mNeedToYield = true;
       if (controller->synchronization())
         return true;
     }
+  }
   return false;
 }
 
@@ -368,6 +381,8 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
   bool paused = WbSimulationState::instance()->isPaused();
   const QString &newControllerName = robot->controllerName();
 
+  mRobotsWaitingExternalController.removeAll(robot);
+
   // restart the controller if needed
   for (int i = 0; i < size; ++i) {
     WbController *controller = mControllers[i];
@@ -378,12 +393,15 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
       mWaitingControllers.removeOne(controller);
       mControllers.removeOne(controller);
       if (newControllerName.isEmpty() || newControllerName == "<extern>") {
-        if (controller->name() == "<extern>")
+        if (controller->name() == "<extern>") {
           WbLog::info(tr("Terminating extern controller for robot \"%1\".").arg(controller->robot()->name()));
-        else
+          mRobotsWaitingExternalController.append(robot);
+        } else
           WbLog::info(tr("Terminating controller \"%1\".").arg(controller->name()));
       }
       delete controller;
+      if (newControllerName == "<extern>")
+        mRobotsWaitingExternalController.append(robot);
       if (newControllerName.isEmpty() || newControllerName == "<extern>") {
         robot->setControllerStarted(false);
         return;
@@ -398,6 +416,9 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
     }
   }
 
+  if (newControllerName == "<extern>")
+    mRobotsWaitingExternalController.append(robot);
+
   if (newControllerName.isEmpty() || newControllerName == "<extern>")
     return;
 
@@ -408,6 +429,12 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
   else  // step executing
     mNewControllers << controller;
   connect(controller, &WbController::hasTerminatedByItself, this, &WbControlledWorld::deleteController);
+}
+
+void WbControlledWorld::handleRobotRemoval(WbBaseNode *node) {
+  WbRobot *robot = static_cast<WbRobot *>(node);
+  assert(robot);
+  mRobotsWaitingExternalController.removeAll(robot);
 }
 
 QStringList WbControlledWorld::activeControllersNames() const {

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -346,11 +346,9 @@ void WbControlledWorld::step() {
 }
 
 bool WbControlledWorld::needToWait() {
-  if (!mRobotsWaitingExternController.isEmpty()) {
-    foreach (WbRobot *const robot, mRobotsWaitingExternController) {
-      if (robot->synchronization())
-        return true;
-    }
+  foreach (WbRobot *const robot, mRobotsWaitingExternController) {
+    if (robot->synchronization())
+      return true;
   }
   foreach (WbController *const controller, mControllers) {
     if (!controller->isRequestPending() || controller->isIncompleteRequest()) {

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -56,12 +56,14 @@ protected:
 private:
   void startControllerFromSocket(WbRobot *robot, QLocalSocket *socket);
   void updateRobotController(WbRobot *robot);
+  void handleRobotRemoval(WbBaseNode *node);
 
   QLocalServer *mServer;
   QList<WbController *> mControllers;
   QList<WbController *> mWaitingControllers;  // controllers inserted in previous step and waiting to be started in current step
   QList<WbController *> mNewControllers;      // controllers inserted in current step mode and waiting next step to start
-  QList<WbController *> mTerminatingControllers;  // controllers waiting to be deleted
+  QList<WbController *> mTerminatingControllers;      // controllers waiting to be deleted
+  QList<WbRobot *> mRobotsWaitingExternalController;  // robots with external controller not started
   QList<double> mRequests;
   bool mNeedToYield;
   bool mFirstStep;

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -62,8 +62,8 @@ private:
   QList<WbController *> mControllers;
   QList<WbController *> mWaitingControllers;  // controllers inserted in previous step and waiting to be started in current step
   QList<WbController *> mNewControllers;      // controllers inserted in current step mode and waiting next step to start
-  QList<WbController *> mTerminatingControllers;      // controllers waiting to be deleted
-  QList<WbRobot *> mRobotsWaitingExternalController;  // robots with external controller not started
+  QList<WbController *> mTerminatingControllers;    // controllers waiting to be deleted
+  QList<WbRobot *> mRobotsWaitingExternController;  // robots with external controller not started
   QList<double> mRequests;
   bool mNeedToYield;
   bool mFirstStep;

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -63,7 +63,7 @@ private:
   QList<WbController *> mWaitingControllers;  // controllers inserted in previous step and waiting to be started in current step
   QList<WbController *> mNewControllers;      // controllers inserted in current step mode and waiting next step to start
   QList<WbController *> mTerminatingControllers;    // controllers waiting to be deleted
-  QList<WbRobot *> mRobotsWaitingExternController;  // robots with external controller not started
+  QList<WbRobot *> mRobotsWaitingExternController;  // robots with extern controller not started
   QList<double> mRequests;
   bool mNeedToYield;
   bool mFirstStep;

--- a/tests/api/controllers/extern/extern.c
+++ b/tests/api/controllers/extern/extern.c
@@ -13,6 +13,7 @@ int main(int argc, char **argv) {
     putenv("WEBOTS_SERVER=");  // clear environment variables set by Webots
     putenv("WEBOTS_ROBOT_ID=");
     putenv("WEBOTS_TMP_PATH=");
+    putenv("WEBOTS_ROBOT_NAME=extern1");
 #ifdef _WIN32
     STARTUPINFO si;
     PROCESS_INFORMATION pi;
@@ -44,7 +45,8 @@ int main(int argc, char **argv) {
   }
   ts_setup(argv[0]);
   ts_assert_int_equal(argc, 2, "Wrong number of arguments on the command line for starting extern controller.");
-  ts_assert_string_equal(argv[1], "2", "Wrong argument for the extern controller: got \"%s\" instead of \"2\"");
+  ts_assert_string_equal(argv[1], "2", "Wrong argument for the extern controller: got \"%s\" instead of \"2\".");
+  ts_assert_string_equal(wb_robot_get_name(), "extern1", "External controller connected to wrong robot.");
   wb_robot_step(TIME_STEP);
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/controllers/extern/extern.c
+++ b/tests/api/controllers/extern/extern.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
   ts_setup(argv[0]);
   ts_assert_int_equal(argc, 2, "Wrong number of arguments on the command line for starting extern controller.");
   ts_assert_string_equal(argv[1], "2", "Wrong argument for the extern controller: got \"%s\" instead of \"2\".");
-  ts_assert_string_equal(wb_robot_get_name(), "extern1", "External controller connected to wrong robot.");
+  ts_assert_string_equal(wb_robot_get_name(), "extern1", "Extern controller connected to wrong robot.");
   wb_robot_step(TIME_STEP);
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/worlds/extern.wbt
+++ b/tests/api/worlds/extern.wbt
@@ -16,12 +16,21 @@ PointLight {
   intensity 0
 }
 Robot {
-  name "extern controller"
   children [
     TestSuiteEmitter {
     }
   ]
+  name "extern0"
+  controller "<extern>"
   synchronization FALSE
+}
+Robot {
+  translation 0.1 0 0.1
+  children [
+    TestSuiteEmitter {
+    }
+  ]
+  name "extern1"
   controller "<extern>"
 }
 Robot {


### PR DESCRIPTION
Extern controller should block the simulation while not started if the 'synchronization' field is set to `TRUE`.