### PR TITLE
Fix better scene tree naming

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -5,6 +5,7 @@ Released on ???
 
   - Enhancements
     - Webots now wait for extern controllers if the `Robot.synchronization` field is set to `TRUE`.
+    - Device names are displayed in the scene tree next to the node name.
   - Dependency Updates
     - Windows: upgraded to Qt 5.13.1.
 

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -21,6 +21,7 @@
 #include "WbMultipleValue.hpp"
 #include "WbNode.hpp"
 #include "WbNodeModel.hpp"
+#include "WbNodeUtilities.hpp"
 #include "WbSFNode.hpp"
 #include "WbSFRotation.hpp"
 #include "WbSFVector2.hpp"
@@ -125,8 +126,17 @@ QString WbTreeItem::data() const {
     return QString();
 
   switch (mType) {
-    case NODE:
-      return mNode->fullName();
+    case NODE: {
+      QString fullName = mNode->fullName();
+      if (!fullName.startsWith("DEF ") && !fullName.startsWith("USE ")) {
+        if (WbNodeUtilities::isDeviceTypeName(mNode->nodeModelName())) {
+          WbSFString *name = mNode->findSFString("name");
+          if (name)
+            fullName += " \"" + name->value() + "\"";
+        }
+      }
+      return fullName;
+    }
     case FIELD: {
       if (mField->isSingle())
         return QString("%1 %2").arg(mField->name(), mField->value()->toString(WbPrecision::GUI_LOW));


### PR DESCRIPTION
Following-up on the good idea from @HefnySco proposed in #985, this implementation takes care of displaying only device names to avoid over-cluttering the scene tree.