### PR TITLE
Check MD5 for dependencies

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -29,119 +29,160 @@ clean:
 cleanse: $(PACKAGES_CLEAN)
 
 qt-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/webots-qt-*-linux64-release.tar.bz2 $(WEBOTS_HOME)/$(QT_PACKAGE)* $(WEBOTS_HOME)/lib/libQt* $(WEBOTS_HOME)/lib/libicu* $(WEBOTS_HOME)/lib/qt $(WEBOTS_HOME)/include/qt $(WEBOTS_HOME)/bin/qt/lrelease $(WEBOTS_HOME)/bin/qt/lupdate $(WEBOTS_HOME)/bin/qt/moc $(WEBOTS_HOME)/resources/web/local/qwebchannel.js
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/webots-qt-*-linux64-release.tar.bz2 $(WEBOTS_HOME)/$(QT_PACKAGE)* $(WEBOTS_HOME)/lib/libQt* $(WEBOTS_HOME)/lib/libicu* $(WEBOTS_HOME)/lib/qt $(WEBOTS_HOME)/include/qt $(WEBOTS_HOME)/bin/qt/lrelease $(WEBOTS_HOME)/bin/qt/lupdate $(WEBOTS_HOME)/bin/qt/moc $(WEBOTS_HOME)/resources/web/local/qwebchannel.js
 
 qt: $(WEBOTS_HOME)/lib/libQt5Core.so.$(QT_VERSION)
 
 $(WEBOTS_HOME)/lib/libQt5Core.so.$(QT_VERSION): $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(QT_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(QT_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
+	@echo "# downloading $(QT_PACKAGE)"
+	@wget -qq $(DEPENDENCIES_URL)/$(QT_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "e004cc3d47fd359131fb931303214c9d  $(QT_PACKAGE)" > $(QT_PACKAGE).md5
+	@md5sum -c --status $(QT_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(QT_PACKAGE)"; exit 1; fi
+	@rm $(QT_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
 
 
 open-al-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)* $(WEBOTS_HOME)/lib/libopenal.so*
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)* $(WEBOTS_HOME)/lib/libopenal.so*
 
 open-al: $(WEBOTS_HOME)/lib/libopenal.so
 
 $(WEBOTS_HOME)/lib/libopenal.so: $(WEBOTS_DEPENDENCY_PATH)/openal
-	cp -a $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so* $(WEBOTS_HOME)/lib/
+	@cp -a $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so* $(WEBOTS_HOME)/lib/
 
 $(WEBOTS_DEPENDENCY_PATH)/openal:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
+	@echo "# downloading $(OPENAL_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "6c7c9a77dec67f42c51d0f035a94a090  $(OPENAL_PACKAGE)" > $(OPENAL_PACKAGE).md5
+	@md5sum -c --status $(OPENAL_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENAL_PACKAGE)"; exit 1; fi
+	@rm $(OPENAL_PACKAGE).md5
+	@echo "# uncompressing $(OPENAL_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
 
 
 open-cv-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64 $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)* $(WEBOTS_HOME)/lib/libopencv_* $(WEBOTS_HOME)/include/opencv2
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64 $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)* $(WEBOTS_HOME)/lib/libopencv_* $(WEBOTS_HOME)/include/opencv2
 
 open-cv: $(WEBOTS_HOME)/lib/libopencv_core.so
 
 $(WEBOTS_HOME)/lib/libopencv_core.so: $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64
-	cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/lib/libopencv_* $(WEBOTS_HOME)/lib
-	cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/include/opencv2/ $(WEBOTS_HOME)/include/ -R
+	@cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/lib/libopencv_* $(WEBOTS_HOME)/lib
+	@cp -a $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64/include/opencv2/ $(WEBOTS_HOME)/include/ -R
 
 $(WEBOTS_DEPENDENCY_PATH)/opencv-lin64:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENCV_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
+	@echo "# downloading $(OPENCV_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENCV_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "b67e51be5ac4b7b65c557b97a906859c  $(OPENCV_PACKAGE)" > $(OPENCV_PACKAGE).md5
+	@md5sum -c --status $(OPENCV_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENCV_PACKAGE)"; exit 1; fi
+	@rm $(OPENCV_PACKAGE).md5
+	@echo "# uncompressing $(OPENCV_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
 
 
 ois-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_HOME)/lib/libOIS* $(WEBOTS_HOME)/include/libOIS
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_HOME)/lib/libOIS* $(WEBOTS_HOME)/include/libOIS
 
 ois: $(WEBOTS_HOME)/lib/libOIS-1.4.0.so
 
 $(WEBOTS_HOME)/lib/libOIS-1.4.0.so: $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(OIS_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OIS_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
+	@echo "# downloading $(OIS_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OIS_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "06888b7c92bd160b402268f47fb5e850  $(OIS_PACKAGE)" > $(OIS_PACKAGE).md5
+	@md5sum -c --status $(OIS_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OIS_PACKAGE)"; exit 1; fi
+	@rm $(OIS_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
 
 
 pico-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) $(WEBOTS_HOME)/lib/libpico.so $(WEBOTS_HOME)/resources/pico $(WEBOTS_HOME)/include/libpico
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) $(WEBOTS_HOME)/lib/libpico.so $(WEBOTS_HOME)/resources/pico $(WEBOTS_HOME)/include/libpico
 
 pico: $(WEBOTS_HOME)/lib/libpico.so
 
 $(WEBOTS_HOME)/lib/libpico.so: $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(PICO_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
+	@echo "# downloading $(PICO_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "be91bf0479f160d2e7ca3f737eebc29b  $(PICO_PACKAGE)" > $(PICO_PACKAGE).md5
+	@md5sum -c --status $(PICO_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@rm $(PICO_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 
 
 lua-gd-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME)/resources/lua/modules/gd
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME)/resources/lua/modules/gd
 
 lua-gd: $(WEBOTS_HOME)/resources/lua/modules/gd/gd.so
 
 $(WEBOTS_HOME)/resources/lua/modules/gd/gd.so: $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)/resources/lua/modules
+	@echo "# uncompressing $(LUA_GD_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)/resources/lua/modules
 
 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
+	@echo "# downloading $(LUA_GD_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "9c1a6f7904b3c52e9d8435e275f48ef6  $(LUA_GD_PACKAGE)" > $(LUA_GD_PACKAGE).md5
+	@md5sum -c --status $(LUA_GD_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_GD_PACKAGE)"; exit 1; fi
+	@rm $(LUA_GD_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
 
 
 lua-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
 lua: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
-	wget http://www.lua.org/ftp/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@echo "# downloading $(LUA_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@wget -qq http://www.lua.org/ftp/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "dc7f94ec6ff15c985d2d6ad0f1b35654  $(LUA_PACKAGE)" > $(LUA_PACKAGE).md5
+	@md5sum -c --status $(LUA_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_PACKAGE)"; exit 1; fi
+	@rm $(LUA_PACKAGE).md5
+	@echo "# uncompressing $(LUA_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3
-	+make -C $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 linux
+	@echo "# compiling lua"
+	+@make --silent -C $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 linux 2> /dev/null
 
 
 open-ssl-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openssl $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE) $(WEBOTS_HOME)/lib/libcrypto.so* $(WEBOTS_HOME)/lib/libssl.so*
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/openssl $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE) $(WEBOTS_HOME)/lib/libcrypto.so* $(WEBOTS_HOME)/lib/libssl.so*
 
 open-ssl: $(WEBOTS_HOME)/lib/libcrypto.so
 
 $(WEBOTS_HOME)/lib/libcrypto.so: $(WEBOTS_DEPENDENCY_PATH)/openssl
-	cp -a $(WEBOTS_DEPENDENCY_PATH)/openssl/libcrypto.so* $(WEBOTS_HOME)/lib
-	cp -a $(WEBOTS_DEPENDENCY_PATH)/openssl/libssl.so* $(WEBOTS_HOME)/lib
+	@cp -a $(WEBOTS_DEPENDENCY_PATH)/openssl/libcrypto.so* $(WEBOTS_HOME)/lib
+	@cp -a $(WEBOTS_DEPENDENCY_PATH)/openssl/libssl.so* $(WEBOTS_HOME)/lib
 
 $(WEBOTS_DEPENDENCY_PATH)/openssl:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENSSL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
+	@echo "# downloading $(OPENSSL_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENSSL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "dc7f94ec6ff15c985d2d6ad0f1b35654  $(OPENSSL_PACKAGE)" > $(OPENSSL_PACKAGE).md5
+	@md5sum -c --status $(OPENSSL_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENSSL_PACKAGE)"; exit 1; fi
+	@rm $(OPENSSL_PACKAGE).md5
+	@echo "# uncompressing $(OPENSSL_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)

--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -179,7 +179,7 @@ $(WEBOTS_DEPENDENCY_PATH)/openssl:
 	@echo "# downloading $(OPENSSL_PACKAGE)"
 	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
 	@wget -qq $(DEPENDENCIES_URL)/$(OPENSSL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	@echo "dc7f94ec6ff15c985d2d6ad0f1b35654  $(OPENSSL_PACKAGE)" > $(OPENSSL_PACKAGE).md5
+	@echo "4be3d9987533fad1f4ac776be62decee  $(OPENSSL_PACKAGE)" > $(OPENSSL_PACKAGE).md5
 	@md5sum -c --status $(OPENSSL_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENSSL_PACKAGE)"; exit 1; fi
 	@rm $(OPENSSL_PACKAGE).md5
 	@echo "# uncompressing $(OPENSSL_PACKAGE)"

--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -32,253 +32,338 @@ clean:
 cleanse: $(PACKAGES_CLEAN)
 
 qt-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) $(WEBOTS_HOME)/Contents/Frameworks/Qt* $(WEBOTS_HOME)/lib/qt $(WEBOTS_HOME)/include/qt $(WEBOTS_HOME)/bin/qt/lrelease $(WEBOTS_HOME)/bin/qt/lupdate $(WEBOTS_HOME)/bin/qt/moc $(WEBOTS_HOME)/resources/web/local/qwebchannel.js
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE) $(WEBOTS_HOME)/Contents/Frameworks/Qt* $(WEBOTS_HOME)/lib/qt $(WEBOTS_HOME)/include/qt $(WEBOTS_HOME)/bin/qt/lrelease $(WEBOTS_HOME)/bin/qt/lupdate $(WEBOTS_HOME)/bin/qt/moc $(WEBOTS_HOME)/resources/web/local/qwebchannel.js
 
 qt: $(WEBOTS_HOME)/resources/web/local/qwebchannel.js
 
 $(WEBOTS_HOME)/resources/web/local/qwebchannel.js: $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
-	tar xvjfm $(QT_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(QT_PACKAGE)"
+	@tar xfm $(QT_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(QT_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
+	@echo "# downloading $(QT_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(QT_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "6344f08a792f78c6198730a0b6073fa3  $(QT_PACKAGE)" > $(QT_PACKAGE).md5
+	@md5sum -c --status $(QT_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(QT_PACKAGE)"; exit 1; fi
+	@rm $(QT_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE)
 
 
 assimp-clean:
-	rm -fr $(WEBOTS_DEPENDENCY_PATH)/assimp $(WEBOTS_HOME)/lib/libassimp.dylib
+	@rm -fr $(WEBOTS_DEPENDENCY_PATH)/assimp $(WEBOTS_HOME)/lib/libassimp.dylib
 
 assimp: $(WEBOTS_HOME)/lib/libassimp.dylib
 
 $(WEBOTS_HOME)/lib/libassimp.dylib: $(WEBOTS_DEPENDENCY_PATH)/assimp
-	cp $(WEBOTS_DEPENDENCY_PATH)/assimp/build/code/libassimp.dylib $(WEBOTS_HOME)/lib
+	@cp $(WEBOTS_DEPENDENCY_PATH)/assimp/build/code/libassimp.dylib $(WEBOTS_HOME)/lib
 
 $(WEBOTS_DEPENDENCY_PATH)/assimp:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(ASSIMP_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xvjfm $(ASSIMP_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)
+	@echo "# downloading $(ASSIMP_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(ASSIMP_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "669b02481e4409cbdf1a5d3c94aecff9  $(ASSIMP_PACKAGE)" > $(ASSIMP_PACKAGE).md5
+	@md5sum -c --status $(ASSIMP_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(ASSIMP_PACKAGE)"; exit 1; fi
+	@rm $(ASSIMP_PACKAGE).md5
+	@echo "# uncompressing $(ASSIMP_PACKAGE)"
+	@tar xfm $(ASSIMP_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)
 
 
 freetype-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/freetype-2.9
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/freetype-2.9
 
 freetype: $(WEBOTS_DEPENDENCY_PATH)/freetype-2.9/objs/.libs/libfreetype.a
 
 $(WEBOTS_DEPENDENCY_PATH)/freetype-2.9/objs/.libs/libfreetype.a:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FREETYPE_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(FREETYPE_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar jxf $(FREETYPE_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FREETYPE_PACKAGE)
+	@echo "# downloading $(FREETYPE_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FREETYPE_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(FREETYPE_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "44e72be43f677dedd0c547cb9a029178  $(FREETYPE_PACKAGE)" > $(FREETYPE_PACKAGE).md5
+	@md5sum -c --status $(FREETYPE_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(FREETYPE_PACKAGE)"; exit 1; fi
+	@rm $(FREETYPE_PACKAGE).md5
+	@echo "# uncompressing $(FREETYPE_PACKAGE)"
+	@tar xfm $(FREETYPE_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FREETYPE_PACKAGE)
 
 
 ffmpeg-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE) $(WEBOTS_HOME)/util/ffmpeg
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE) $(WEBOTS_HOME)/util/ffmpeg
 
 ffmpeg: $(WEBOTS_HOME)/util/ffmpeg
 
 $(WEBOTS_HOME)/util/ffmpeg: $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE)
-	tar xvjfm $(FFMPEG_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(FFMPEG_PACKAGE)"
+	@tar xfm $(FFMPEG_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(FFMPEG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE)
+	@echo "# downloading $(FFMPEG_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(FFMPEG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "258df72f03ef92526dab46ca0fede187  $(FFMPEG_PACKAGE)" > $(FFMPEG_PACKAGE).md5
+	@md5sum -c --status $(FFMPEG_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(FFMPEG_PACKAGE)"; exit 1; fi
+	@rm $(FFMPEG_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE)
 
 
 jpeg-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b $(WEBOTS_HOME)/include/libjpeg
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b $(WEBOTS_HOME)/include/libjpeg
 
 jpeg: $(WEBOTS_HOME)/include/libjpeg/jconfig.h
 
 $(WEBOTS_HOME)/include/libjpeg/jconfig.h: $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b
-	mkdir -p $(WEBOTS_HOME)/include/libjpeg
-	cp $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b/*.h $(WEBOTS_HOME)/include/libjpeg/
-	cp $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b/build-x86_64/jconfig.h $(WEBOTS_HOME)/include/libjpeg/
+	@mkdir -p $(WEBOTS_HOME)/include/libjpeg
+	@cp $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b/*.h $(WEBOTS_HOME)/include/libjpeg/
+	@cp $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b/build-x86_64/jconfig.h $(WEBOTS_HOME)/include/libjpeg/
 
 $(WEBOTS_DEPENDENCY_PATH)/jpeg-9b:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(JPEG_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(JPEG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar jxfm $(JPEG_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(JPEG_PACKAGE)
+	@echo "# downloading $(JPEG_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(JPEG_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(JPEG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "c210af14f1aaa5797956298894d59507  $(JPEG_PACKAGE)" > $(JPEG_PACKAGE).md5
+	@md5sum -c --status $(JPEG_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(JPEG_PACKAGE)"; exit 1; fi
+	@rm $(JPEG_PACKAGE).md5
+	@echo "# uncompressing $(JPEG_PACKAGE)"
+	@tar xfm $(JPEG_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(JPEG_PACKAGE)
 
 
 lua-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 $(WEBOTS_HOME)/lib/liblua.dylib
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 $(WEBOTS_HOME)/lib/liblua.dylib
 
 lua: $(WEBOTS_HOME)/lib/liblua.dylib
 
 $(WEBOTS_HOME)/lib/liblua.dylib: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3
-	cp $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.dylib $(WEBOTS_HOME)/lib/liblua.dylib
-	install_name_tool -id @rpath/lib/liblua.dylib $(WEBOTS_HOME)/lib/liblua.dylib
+	@cp $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.dylib $(WEBOTS_HOME)/lib/liblua.dylib
+	@install_name_tool -id @rpath/lib/liblua.dylib $(WEBOTS_HOME)/lib/liblua.dylib
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar jxfm $(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@echo "# downloading $(LUA_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "cf55c9efdf835998a7b22c916ece1854  $(LUA_PACKAGE)" > $(LUA_PACKAGE).md5
+	@md5sum -c --status $(LUA_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_PACKAGE)"; exit 1; fi
+	@rm $(LUA_PACKAGE).md5
+	@echo "# uncompressing $(LUA_PACKAGE)"
+	@tar xfm $(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
 
 lua-gd-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME)/lib/libgd.3.dylib $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME)/lib/libgd.3.dylib $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib
 
 lua-gd: $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib
 
 $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	tar xvjfm $(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(LUA_GD_PACKAGE)"
+	@tar xfm $(LUA_GD_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
+	@echo "# downloading $(LUA_GD_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "745929d98829f1bddf0d47ddadb6fd0a  $(LUA_GD_PACKAGE)" > $(LUA_GD_PACKAGE).md5
+	@md5sum -c --status $(LUA_GD_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_GD_PACKAGE)"; exit 1; fi
+	@rm $(LUA_GD_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
 
 
 miniglu-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0
 
 miniglu: $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0/libminiglu.a
 
 $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0/libminiglu.a:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(MINIGLU_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(MINIGLU_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar zxvf $(MINIGLU_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(MINIGLU_PACKAGE)
+	@echo "# downloading $(MINIGLU_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(MINIGLU_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(MINIGLU_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "504316e92609b37c8b749025e1dcf481  $(MINIGLU_PACKAGE)" > $(MINIGLU_PACKAGE).md5
+	@md5sum -c --status $(MINIGLU_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(MINIGLU_PACKAGE)"; exit 1; fi
+	@rm $(MINIGLU_PACKAGE).md5
+	@echo "# uncompressing $(MINIGLU_PACKAGE)"
+	@tar xfm $(MINIGLU_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(MINIGLU_PACKAGE)
 
 
 ois-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0
 
 ois: $(WEBOTS_HOME)/lib/libOIS.dylib
 
 $(WEBOTS_HOME)/lib/libOIS.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	tar xvjfm $(OIS_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(OIS_PACKAGE)"
+	@tar xfm $(OIS_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OIS_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
+	@echo "# downloading $(OIS_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OIS_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "2f3963da739fdba15f183e056b4aa85a  $(OIS_PACKAGE)" > $(OIS_PACKAGE).md5
+	@md5sum -c --status $(OIS_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OIS_PACKAGE)"; exit 1; fi
+	@rm $(OIS_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
 
 
 openal-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_HOME)/lib/libopenal*.dylib
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_HOME)/lib/libopenal*.dylib
 
 openal: $(WEBOTS_HOME)/lib/libopenal.dylib
 
 $(WEBOTS_HOME)/lib/libopenal.dylib: $(WEBOTS_DEPENDENCY_PATH)/openal
-	cp $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.1.16.0.dylib $(WEBOTS_HOME)/lib
-	mv $(WEBOTS_HOME)/lib/libopenal.1.16.0.dylib $(WEBOTS_HOME)/lib/libopenal.dylib
-	install_name_tool -id @rpath/lib/libopenal.dylib $(WEBOTS_HOME)/lib/libopenal.dylib
+	@cp $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.1.16.0.dylib $(WEBOTS_HOME)/lib
+	@mv $(WEBOTS_HOME)/lib/libopenal.1.16.0.dylib $(WEBOTS_HOME)/lib/libopenal.dylib
+	@install_name_tool -id @rpath/lib/libopenal.dylib $(WEBOTS_HOME)/lib/libopenal.dylib
 
 $(WEBOTS_DEPENDENCY_PATH)/openal:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xvjfm $(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
+	@echo "# downloading $(OPENAL_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "4604766ee64f01c596e12445b2e20f96  $(OPENAL_PACKAGE)" > $(OPENAL_PACKAGE).md5
+	@md5sum -c --status $(OPENAL_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENAL_PACKAGE)"; exit 1; fi
+	@rm $(OPENAL_PACKAGE).md5
+	@echo "# uncompressing $(OPENAL_PACKAGE)"
+	@tar xfm $(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
 
 
 opencv-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) $(WEBOTS_HOME)/lib/libopencv_* $(WEBOTS_HOME)/include/opencv2
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) $(WEBOTS_HOME)/lib/libopencv_* $(WEBOTS_HOME)/include/opencv2
 
 opencv: $(WEBOTS_HOME)/lib/libopencv_core.2.4.3.dylib
 
 $(WEBOTS_HOME)/lib/libopencv_core.2.4.3.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
-	tar xvjf $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(OPENCV_PACKAGE)"
+	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENCV_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
+	@echo "# downloading $(OPENCV_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENCV_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "a17da7ccec8ab70ee2a20dab0a575e78  $(OPENCV_PACKAGE)" > $(OPENCV_PACKAGE).md5
+	@md5sum -c --status $(OPENCV_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENCV_PACKAGE)"; exit 1; fi
+	@rm $(OPENCV_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(OPENCV_PACKAGE)
 
 
 openssl-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2 $(WEBOTS_HOME)/lib/libcrypto* $(WEBOTS_HOME)/lib/libssl*
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2 $(WEBOTS_HOME)/lib/libcrypto* $(WEBOTS_HOME)/lib/libssl*
 
 openssl: $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib
 
 $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib: $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2
-	cp $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2/lib*dylib $(WEBOTS_HOME)/lib
-	install_name_tool -id @rpath/lib/libcrypto.dylib $(WEBOTS_HOME)/lib/libcrypto.dylib
-	install_name_tool -id @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libcrypto.1.0.0.dylib
-	install_name_tool -id @rpath/lib/libssl.dylib $(WEBOTS_HOME)/lib/libssl.dylib
-	install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libssl.dylib
-	install_name_tool -id @rpath/lib/libssl.dylib $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib
-	install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib
+	@cp $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2/lib*dylib $(WEBOTS_HOME)/lib
+	@install_name_tool -id @rpath/lib/libcrypto.dylib $(WEBOTS_HOME)/lib/libcrypto.dylib
+	@install_name_tool -id @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libcrypto.1.0.0.dylib
+	@install_name_tool -id @rpath/lib/libssl.dylib $(WEBOTS_HOME)/lib/libssl.dylib
+	@install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libssl.dylib
+	@install_name_tool -id @rpath/lib/libssl.dylib $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib
+	@install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/libcrypto.1.0.0.dylib $(WEBOTS_HOME)/lib/libssl.1.0.0.dylib
 
 $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2:
-	cd $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(OPENSSL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar jxfm $(OPENSSL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
+	@echo "# downloading $(OPENSSL_PACKAGE)"
+	@cd $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(OPENSSL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "1ec23830cd8f32f10c83f0e0eb027032  $(OPENSSL_PACKAGE)" > $(OPENSSL_PACKAGE).md5
+	@md5sum -c --status $(OPENSSL_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPENSSL_PACKAGE)"; exit 1; fi
+	@rm $(OPENSSL_PACKAGE).md5
+	@echo "# uncompressing $(OPENSSL_PACKAGE)"
+	@tar xfm $(OPENSSL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_PACKAGE)
 
 
 pico-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) $(WEBOTS_HOME)/include/libpico $(WEBOTS_HOME)/lib/libpico.dylib $(WEBOTS_HOME)/resources/pico
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE) $(WEBOTS_HOME)/include/libpico $(WEBOTS_HOME)/lib/libpico.dylib $(WEBOTS_HOME)/resources/pico
 
 pico: $(WEBOTS_HOME)/lib/libpico.dylib
 
 $(WEBOTS_HOME)/lib/libpico.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	tar xvjfm $(PICO_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(PICO_PACKAGE)"
+	@tar xfm $(PICO_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
+	@echo "# downloading $(PICO_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "ebde4a56e12b21cc2adb7a3f56ec1999  $(PICO_PACKAGE)" > $(PICO_PACKAGE).md5
+	@md5sum -c --status $(PICO_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@rm $(PICO_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 
 
 png-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/libpng-1.0.12
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/libpng-1.0.12
 
 png: $(WEBOTS_DEPENDENCY_PATH)/libpng-1.0.12/libpng.a
 
 $(WEBOTS_DEPENDENCY_PATH)/libpng-1.0.12/libpng.a: $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE)
-	tar jxfm $(PNG_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@echo "# uncompressing $(PNG_PACKAGE)"
+	@tar xfm $(PNG_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(PNG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE)
+	@echo "# downloading $(PNG_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(PNG_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "0caa0cfb7d735b4a098635c808b1da4c  $(PNG_PACKAGE)" > $(PNG_PACKAGE).md5
+	@md5sum -c --status $(PNG_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(PNG_PACKAGE)"; exit 1; fi
+	@rm $(PNG_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PNG_PACKAGE)
 
 
 ssh-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE) $(WEBOTS_HOME)/lib/libssh* $(WEBOTS_HOME)/libssh/include/libssh
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE) $(WEBOTS_HOME)/lib/libssh* $(WEBOTS_HOME)/libssh/include/libssh
 
 ssh: $(WEBOTS_HOME)/lib/libssh.4.dylib
 
 $(WEBOTS_HOME)/lib/libssh.4.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE)
-	tar xvjfm $(SSH_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(SSH_PACKAGE)"
+	@tar xfm $(SSH_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(SSH_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE)
+	@echo "# downloading $(SSH_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(SSH_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "aa79f5bb1ee6ce12fb47db0c85d736c6  $(SSH_PACKAGE)" > $(SSH_PACKAGE).md5
+	@md5sum -c --status $(SSH_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(SSH_PACKAGE)"; exit 1; fi
+	@rm $(SSH_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE)
 
 
 tiff-clean:
-	rm -rf $(WEBOTS_HOME)/include/libtiff $(WEBOTS_DEPENDENCY_PATH)/libtiff
+	@rm -rf $(WEBOTS_HOME)/include/libtiff $(WEBOTS_DEPENDENCY_PATH)/libtiff
 
 tiff: $(WEBOTS_HOME)/include/libtiff/tiff.h
 
 $(WEBOTS_HOME)/include/libtiff/tiff.h: $(WEBOTS_DEPENDENCY_PATH)/libtiff
-	mkdir -p $(WEBOTS_HOME)/include/libtiff
-	cp $(WEBOTS_DEPENDENCY_PATH)/libtiff/libtiff/*.h $(WEBOTS_HOME)/include/libtiff
+	@mkdir -p $(WEBOTS_HOME)/include/libtiff
+	@cp $(WEBOTS_DEPENDENCY_PATH)/libtiff/libtiff/*.h $(WEBOTS_HOME)/include/libtiff
 
 $(WEBOTS_DEPENDENCY_PATH)/libtiff:
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(TIFF_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(TIFF_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	tar xvjfm $(TIFF_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(TIFF_PACKAGE)
+	@echo "# downloading $(TIFF_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(TIFF_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(TIFF_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "c660e3d9b9e72ee8252f884282551cd2  $(TIFF_PACKAGE)" > $(TIFF_PACKAGE).md5
+	@md5sum -c --status $(TIFF_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(TIFF_PACKAGE)"; exit 1; fi
+	@rm $(TIFF_PACKAGE).md5
+	@echo "# uncompressing $(TIFF_PACKAGE)"
+	@tar xfm $(TIFF_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(TIFF_PACKAGE)
 
 
 zip-clean:
-	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE) $(WEBOTS_HOME)/lib/libzip* $(WEBOTS_HOME)/libzip/include/libzip
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE) $(WEBOTS_HOME)/lib/libzip* $(WEBOTS_HOME)/libzip/include/libzip
 
 zip: $(WEBOTS_HOME)/lib/libnihzip.dylib
 
 $(WEBOTS_HOME)/lib/libnihzip.dylib: $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE)
-	tar xvjfm $(ZIP_PACKAGE) -C $(WEBOTS_HOME)
+	@echo "# uncompressing $(ZIP_PACKAGE)"
+	@tar xfm $(ZIP_PACKAGE) -C $(WEBOTS_HOME)
 
 $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE):
-	rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE)
-	wget $(DEPENDENCIES_URL)/$(ZIP_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	touch $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE)
+	@echo "# downloading $(ZIP_PACKAGE)"
+	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE)
+	@wget -qq $(DEPENDENCIES_URL)/$(ZIP_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
+	@echo "4b9dd2d465b76b179443241bf5ec9d3e  $(ZIP_PACKAGE)" > $(ZIP_PACKAGE).md5
+	@md5sum -c --status $(ZIP_PACKAGE).md5 ; if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(ZIP_PACKAGE)"; exit 1; fi
+	@rm $(ZIP_PACKAGE).md5
+	@touch $(WEBOTS_DEPENDENCY_PATH)/$(ZIP_PACKAGE)

--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -24,8 +24,8 @@ release debug distrib profile: msys64 $(PACKAGES)
 clean:
 
 cleanse: $(PACKAGES_CLEAN)
-	rm -f $(TARGET_PATH)/zlib1.dll
-	rm -f $(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest
+	@rm -f $(TARGET_PATH)/zlib1.dll
+	@rm -f $(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest
 
 .ONESHELL:
 msys64: $(TARGET_PATH) \
@@ -36,103 +36,137 @@ msys64: $(TARGET_PATH) \
 	$(WEBOTS_HOME_PATH)/msys64/mingw32/lib
 
 $(TARGET_PATH)/zlib1.dll: $(TARGET_PATH)
-	cp /mingw64/bin/zlib1.dll $(TARGET_PATH)/
+	@cp /mingw64/bin/zlib1.dll $(TARGET_PATH)/
 
 $(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest: $(TARGET_PATH)
-	cp Cyberbotics.Webots.Mingw64.Libraries.manifest $(TARGET_PATH)/
+	@cp Cyberbotics.Webots.Mingw64.Libraries.manifest $(TARGET_PATH)/
 
 $(WEBOTS_HOME_PATH)/msys64/mingw64/lib:
-	mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw64/lib
+	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw64/lib
 
 $(WEBOTS_HOME_PATH)/msys64/mingw32/bin:
-	mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/bin
+	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/bin
 
 $(WEBOTS_HOME_PATH)/msys64/mingw32/lib:
-	mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/lib
+	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/lib
 
 $(TARGET_PATH):
-	mkdir -p $(TARGET_PATH)
+	@mkdir -p $(TARGET_PATH)
 
 open-vr-clean:
-	rm -rf "$(WEBOTS_HOME_PATH)/include/openvr" $(TARGET_PATH)/openvr_api.dll "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
+	@rm -rf "$(WEBOTS_HOME_PATH)/include/openvr" $(TARGET_PATH)/openvr_api.dll "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
 
 open-vr: $(TARGET_PATH)/openvr_api.dll $(WEBOTS_HOME_PATH)/include/openvr
 
 $(WEBOTS_HOME_PATH)/include/openvr: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
-	mkdir "$(WEBOTS_HOME_PATH)/include/openvr"
-	cp -f "$(WEBOTS_DEPENDENCY_PATH)"/openvr-1.0.7/headers/* "$(WEBOTS_HOME_PATH)/include/openvr"
+	@mkdir -p "$(WEBOTS_HOME_PATH)/include/openvr"
+	@cp -f "$(WEBOTS_DEPENDENCY_PATH)"/openvr-1.0.7/headers/* "$(WEBOTS_HOME_PATH)/include/openvr"
 
 $(TARGET_PATH)/openvr_api.dll: $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7
-	mkdir -p $(TARGET_PATH)
-	cp "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7/bin/win64/openvr_api.dll" "$@"
+	@mkdir -p $(TARGET_PATH)
+	@cp "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7/bin/win64/openvr_api.dll" "$@"
 
 $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7:
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)"
-	wget "$(DEPENDENCIES_URL)/$(OPEN_VR_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
-	unzip -o "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)" -d "$(WEBOTS_DEPENDENCY_PATH)"
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)"
-	touch "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
+	@echo "# downloading $(OPEN_VR_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)"
+	@wget -qq "$(DEPENDENCIES_URL)/$(OPEN_VR_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "5aa5208fdf403ab64a2ccdb7abc1f789 *$(OPEN_VR_PACKAGE)" > $(OPEN_VR_PACKAGE).md5
+	@md5sum -c --status $(OPEN_VR_PACKAGE).md5
+	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OPEN_VR_PACKAGE)"; exit 1; fi
+	@rm $(OPEN_VR_PACKAGE).md5
+	@echo "# uncompressing $(OPEN_VR_PACKAGE)"
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)" -d "$(WEBOTS_DEPENDENCY_PATH)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OPEN_VR_PACKAGE)"
+	@touch "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
 
 lua-clean:
-	rm -rf $(TARGET_PATH)/lua52.dll "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3"
+	@rm -rf $(TARGET_PATH)/lua52.dll "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3"
 
-lua: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll
-	mkdir -p $(TARGET_PATH)
-	cp "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll" "$(TARGET_PATH)/"
+lua: $(TARGET_PATH)/lua52.dll
+
+$(TARGET_PATH)/lua52.dll: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll
+	@echo "# copying lua dll"
+	@mkdir -p $(TARGET_PATH)
+	@cp "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll" "$(TARGET_PATH)/"
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
-	wget "http://www.lua.org/ftp/$(LUA_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
-	cd "$(WEBOTS_DEPENDENCY_PATH)"; tar zxfm $(LUA_PACKAGE) -C "$(WEBOTS_DEPENDENCY_PATH)"
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
+	@echo "# downloading $(LUA_PACKAGE)"
+	@wget -qq "http://www.lua.org/ftp/$(LUA_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "dc7f94ec6ff15c985d2d6ad0f1b35654 *$(LUA_PACKAGE)" > $(LUA_PACKAGE).md5
+	@md5sum -c --status $(LUA_PACKAGE).md5
+	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_PACKAGE)"; exit 1; fi
+	@rm $(LUA_PACKAGE).md5
+	@echo "# uncompressing $(LUA_PACKAGE)"
+	@cd "$(WEBOTS_DEPENDENCY_PATH)"; tar xfm $(LUA_PACKAGE) -C "$(WEBOTS_DEPENDENCY_PATH)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
 
 $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3
-	+make -C "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3" mingw
+	@echo "# compiling lua"
+	+@make --silent -C "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3" mingw
 
 ois-clean:
-	rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)" $(TARGET_PATH)/OIS.dll $(TARGET_PATH)/XInput9_1_0.dll "$(WEBOTS_HOME_PATH)/include/libOIS"
+	@rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)" $(TARGET_PATH)/OIS.dll $(TARGET_PATH)/XInput9_1_0.dll "$(WEBOTS_HOME_PATH)/include/libOIS"
 
 ois: $(TARGET_PATH)/OIS.dll
 
 $(TARGET_PATH)/OIS.dll: $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)
-	mkdir -p $(TARGET_PATH)
-	unzip -o "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
-	mv "$(WEBOTS_HOME_PATH)/OIS.dll" "$(TARGET_PATH)/"
-	mv "$(WEBOTS_HOME_PATH)/XInput9_1_0.dll" "$(TARGET_PATH)/"
-	touch "$@"
+	@echo "# uncompressing $(OIS_PACKAGE)"
+	@mkdir -p $(TARGET_PATH)
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
+	@mv "$(WEBOTS_HOME_PATH)/OIS.dll" "$(TARGET_PATH)/"
+	@mv "$(WEBOTS_HOME_PATH)/XInput9_1_0.dll" "$(TARGET_PATH)/"
+	@touch "$@"
 
 $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE):
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)"
-	wget "$(DEPENDENCIES_URL)/$(OIS_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "# downloading $(OIS_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)"
+	@wget -qq "$(DEPENDENCIES_URL)/$(OIS_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "32c0b9a81ac3a27fe313598c4f8daad1 *$(OIS_PACKAGE)" > $(OIS_PACKAGE).md5
+	@md5sum -c --status $(OIS_PACKAGE).md5
+	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(OIS_PACKAGE)"; exit 1; fi
+	@rm $(OIS_PACKAGE).md5
 	touch "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)"
 
 pico-clean:
-	rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)" "$(WEBOTS_HOME_PATH)/include/libpico" $(TARGET_PATH)/libpico.dll "$(WEBOTS_HOME_PATH)/resources/pico"
+	@rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)" "$(WEBOTS_HOME_PATH)/include/libpico" $(TARGET_PATH)/libpico.dll "$(WEBOTS_HOME_PATH)/resources/pico"
 
 pico: $(TARGET_PATH)/libpico.dll
 
 $(TARGET_PATH)/libpico.dll: $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
-	mkdir -p $(TARGET_PATH)
-	unzip -o "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
-	mv "$(WEBOTS_HOME_PATH)/libpico.dll" "$(TARGET_PATH)/"
-	touch "$@"
+	@echo "# uncompressing $(PICO_PACKAGE)"
+	@mkdir -p $(TARGET_PATH)
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
+	@mv "$(WEBOTS_HOME_PATH)/libpico.dll" "$(TARGET_PATH)/"
+	@touch "$@"
 
 $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
-	wget "$(DEPENDENCIES_URL)/$(PICO_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
-	touch "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
+	@echo "# downloading $(PICO_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
+	@wget -qq "$(DEPENDENCIES_URL)/$(PICO_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "60a412e55d54bb8bf95c7cd728fb4d9a *$(PICO_PACKAGE)" > $(PICO_PACKAGE).md5
+	@md5sum -c --status $(PICO_PACKAGE).md5
+	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@rm $(PICO_PACKAGE).md5
+	@touch "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
 
 lua-gd-clean:
-	rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)" $(TARGET_PATH)/gd.dll
+	@rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)" $(TARGET_PATH)/gd.dll
 
 lua-gd: $(TARGET_PATH)/gd.dll
 
 $(TARGET_PATH)/gd.dll: $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)
-	mkdir -p $(TARGET_PATH)
-	unzip -o "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)" -d "$(WEBOTS_HOME_PATH)/msys64/mingw64/bin"
-	touch "$(TARGET_PATH)/gd.dll"
+	@echo "# uncompressing $(LUA_GD_PACKAGE)"
+	@mkdir -p $(TARGET_PATH)
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)" -d "$(WEBOTS_HOME_PATH)/msys64/mingw64/bin"
+	@touch "$(TARGET_PATH)/gd.dll"
 
 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE):
-	rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)"
-	wget "$(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
-	touch "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)"
+	@echo "# downloading $(LUA_GD_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)"
+	@wget -qq "$(DEPENDENCIES_URL)/$(LUA_GD_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@echo "0a54dcc518d331a853f77fb66ebf75e9 *$(LUA_GD_PACKAGE)" > $(LUA_GD_PACKAGE).md5
+	@md5sum -c --status $(LUA_GD_PACKAGE).md5
+	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_GD_PACKAGE)"; exit 1; fi
+	@rm $(LUA_GD_PACKAGE).md5
+	@touch "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)"


### PR DESCRIPTION
Fixes #965.
In this PR, the dependencies Makefile checks the MD5 sum of each Webots dependency and fails if the check fails. The output of the Makefile was also cleaned-up, so that it is now much more readable.