### PR TITLE
Fix possible crash with external controllers.

### DIFF
--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -82,6 +82,7 @@ WbControlledWorld::WbControlledWorld(WbProtoList *protos, WbTokenizer *tokenizer
 
 WbControlledWorld::~WbControlledWorld() {
   WbController *controller = NULL;
+  mRobotsWaitingExternController.clear();
   while (!mNewControllers.isEmpty()) {
     controller = mNewControllers.takeFirst();
     delete controller;


### PR DESCRIPTION
At the destruction of the world, it happens that the robots are removed, and therefore the controllers also which causes issues with the `mRobotsWaitingExternController` list which is then referring to non-existing robot anymore which causes issues when removing them from the list due to connects.

No changelog entry as this was never released.