### PR TITLE
Fix snap external controllers

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -77,7 +77,7 @@ If that simulation has more than one extern controller, you may also set the `WE
 In order to compile and execute extern controllers, the following environment variables should be set:
 ```
 export WEBOTS_HOME=/snap/webots/current/usr/share/webots
-export LD_LIBRARY_PATH=$WEBOTS_HOME/lib
+export LD_LIBRARY_PATH=$WEBOTS_HOME/lib:/snap/webots/current/usr/lib/x86_64-linux-gnu
 ```
 
 Because of the snap sand-boxing system, Webots has to use a special temporary folder to share information with robot controllers.

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -77,7 +77,13 @@ If that simulation has more than one extern controller, you may also set the `WE
 In order to compile and execute extern controllers, the following environment variables should be set:
 ```
 export WEBOTS_HOME=/snap/webots/current/usr/share/webots
-export LD_LIBRARY_PATH=$WEBOTS_HOME/lib:/snap/webots/current/usr/lib/x86_64-linux-gnu
+export LD_LIBRARY_PATH=$WEBOTS_HOME/lib
+```
+
+Additionally, on Ubuntu 16.04 the following environment variables should be set:
+```
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/snap/webots/current/usr/lib/x86_64-linux-gnu
+export LD_PRELOAD=/snap/webots/current/usr/lib/x86_64-linux-gnu/libz.so
 ```
 
 Because of the snap sand-boxing system, Webots has to use a special temporary folder to share information with robot controllers.


### PR DESCRIPTION
On Ubuntu 16.04 the system libraries are not the same that the one distributed within the snap package which causes conflicts when running external controllers.

Problematic libraries:
  - lipng16 VS 12
  - /lib/x86_64-linux-gnu/libz.so.1: version `ZLIB_1.2.9' not found (required by /snap/webots/current/usr/lib/x86_64-linux-gnu/libpng16.so.16)

https://www.cyberbotics.com/doc/guide/running-extern-robot-controllers?version=fix-snap-external-controllers#running-extern-robot-controller-with-the-snap-version-of-webots