### PR TITLE
Implemented tornado on_message function

### DIFF
--- a/resources/web/server/session_server.py
+++ b/resources/web/server/session_server.py
@@ -140,6 +140,10 @@ class ClientWebSocketHandler(tornado.websocket.WebSocketHandler):
         self.write_message(message)
         logging.info('[' + self.request.host + '] New client')
 
+    def on_message(self, message):
+        # self.write_message(message)
+        logging.info(message)
+
     def on_close(self):
         """Close connection after client leaves."""
         logging.info('[' + self.request.host + '] Client disconnected')


### PR DESCRIPTION
Solving this error

```
2019-10-14 08:42:56,855 [ERROR  ]  Uncaught exception GET / (172.20.0.1)
HTTPServerRequest(protocol='http', host='localhost:1999', method='GET', uri='/', version='HTTP/1.1', remote_ip='172.20.0.1')
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/tornado/websocket.py", line 649, in _run_callback
    result = callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/tornado/websocket.py", line 427, in on_message
    raise NotImplementedError
NotImplementedError
```