### PR TITLE
Fix exporting first translation/rotation field change

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -9,7 +9,8 @@ Released on ???
   - Dependency Updates
     - Windows: upgraded to Qt 5.13.1.
   - Bug fixes
-    - Fix `simulation_server.py` script to work with Python3.
+    - Fixed `simulation_server.py` script to work with Python3.
+    - Fixed exporting first translation and rotation fields change during animation recording and simulation streaming.
 
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -55,6 +55,8 @@ WbAnimationCommand::WbAnimationCommand(const WbNode *n, const QStringList &field
                      .arg(ROUND(sfVector3->x(), 0.0001))
                      .arg(ROUND(sfVector3->y(), 0.0001))
                      .arg(ROUND(sfVector3->z(), 0.0001));
+          mLastTranslation =
+            WbVector3(ROUND(sfVector3->x(), 0.001), ROUND(sfVector3->y(), 0.001), ROUND(sfVector3->z(), 0.001));
         } else if (sfRotation && fieldName.compare("rotation") == 0) {
           // special rotation case
           state += QString("%1 %2 %3 %4")
@@ -62,6 +64,8 @@ WbAnimationCommand::WbAnimationCommand(const WbNode *n, const QStringList &field
                      .arg(ROUND(sfRotation->y(), 0.0001))
                      .arg(ROUND(sfRotation->z(), 0.0001))
                      .arg(ROUND(sfRotation->angle(), 0.0001));
+          mLastRotation = WbRotation(ROUND(sfRotation->x(), 0.001), ROUND(sfRotation->y(), 0.001),
+                                     ROUND(sfRotation->z(), 0.001), ROUND(sfRotation->angle(), 0.001));
         } else  // generic case
           state += field->value()->toString(WbPrecision::FLOAT_MAX);
         state += "\"";


### PR DESCRIPTION
Fix issue with digit translation export described in #829.

Bug Description:
The initial translation( and rotation) field value is not explicitly set and thus it is automatically set to `[0, 0, 0]`.
So if an object, whose initial position was different from `[0, 0, 0]`, is moved to the position `[0, 0, 0]` the change is not detected and not exported.