### PR TITLE
Fix Clang Format Clean

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -27,7 +27,7 @@ endif
 release debug distrib profile: ../.clang-format $(PACKAGES)
 clean:
 cleanse: $(PACKAGES_CLEAN)
-	@rm ../.clang-format
+	@rm -f ../.clang-format
 
 ../.clang-format:
 	@echo "# copying clang-format configuration file"

--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -30,7 +30,7 @@ PACKAGES_CLEAN = $(addsuffix -clean, $(PACKAGES))
 release debug distrib profile: ../.clang-format $(PACKAGES)
 clean:
 cleanse: $(PACKAGES_CLEAN)
-	@rm ../.clang-format
+	@rm -f ../.clang-format
 
 ../.clang-format:
 	@echo "# copying clang-format configuration file"

--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -26,7 +26,7 @@ clean:
 cleanse: $(PACKAGES_CLEAN)
 	@rm -f $(TARGET_PATH)/zlib1.dll
 	@rm -f $(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest
-	@rm ../.clang-format
+	@rm -f ../.clang-format
 
 .ONESHELL:
 


### PR DESCRIPTION
The `make cleanse` command was failing because of this.