### PR TITLE
Fix logging messages in the console before GUI initialization

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -11,6 +11,7 @@ Released on ???
   - Bug fixes
     - Fixed `simulation_server.py` script to work with Python3.
     - Fixed exporting first translation and rotation fields change during animation recording and simulation streaming.
+    - Fixed displaying streaming server initialization errors in the Webots console.
 
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.

--- a/src/webots/core/WbLog.cpp
+++ b/src/webots/core/WbLog.cpp
@@ -23,6 +23,7 @@ static WbLog *gInstance = NULL;
 
 void WbLog::cleanup() {
   gInstance->mPostponedPopUpMessageQueue.clear();
+  gInstance->mPendingConsoleMessages.clear();
   delete gInstance;
   gInstance = NULL;
 }
@@ -40,49 +41,58 @@ WbLog *WbLog::instance() {
 
 void WbLog::debug(const QString &message, bool popup) {
   if (popup && instance()->mPopUpMessagesPostponed) {
-    instance()->enqueuePopUpMessage(message, DEBUG);
+    instance()->enqueueMessage(instance()->mPostponedPopUpMessageQueue, message, DEBUG);
     return;
   }
 
   fprintf(stderr, "DEBUG: %s\n", qPrintable(message));
   fflush(stderr);
-  instance()->emitLog(DEBUG, "DEBUG: " + message, popup);
+  if (instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool))))
+    instance()->emitLog(DEBUG, "DEBUG: " + message, popup);
+  else
+    instance()->enqueueMessage(instance()->mPendingConsoleMessages, "DEBUG: " + message, DEBUG);
 }
 
 void WbLog::info(const QString &message, bool popup) {
   if (popup && instance()->mPopUpMessagesPostponed) {
-    instance()->enqueuePopUpMessage(message, INFO);
+    instance()->enqueueMessage(instance()->mPostponedPopUpMessageQueue, message, INFO);
     return;
   }
 
   if (instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool))))
     instance()->emitLog(INFO, "INFO: " + message, popup);
-  else
+  else {
     printf("INFO: %s\n", qPrintable(message));
+    instance()->enqueueMessage(instance()->mPendingConsoleMessages, "INFO: " + message, INFO);
+  }
 }
 
 void WbLog::warning(const QString &message, bool popup) {
   if (popup && instance()->mPopUpMessagesPostponed) {
-    instance()->enqueuePopUpMessage(message, WARNING);
+    instance()->enqueueMessage(instance()->mPostponedPopUpMessageQueue, message, WARNING);
     return;
   }
 
   if (instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool))))
     instance()->emitLog(WARNING, "WARNING: " + message, popup);
-  else
+  else {
     fprintf(stderr, "WARNING: %s\n", qPrintable(message));
+    instance()->enqueueMessage(instance()->mPendingConsoleMessages, "WARNING: " + message, WARNING);
+  }
 }
 
 void WbLog::error(const QString &message, bool popup) {
   if (popup && instance()->mPopUpMessagesPostponed) {
-    instance()->enqueuePopUpMessage(message, ERROR);
+    instance()->enqueueMessage(instance()->mPostponedPopUpMessageQueue, message, ERROR);
     return;
   }
 
   if (instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool))))
     instance()->emitLog(ERROR, "ERROR: " + message, popup);
-  else
+  else {
     fprintf(stderr, "ERROR: %s\n", qPrintable(message));
+    instance()->enqueueMessage(instance()->mPendingConsoleMessages, "ERROR: " + message, ERROR);
+  }
 }
 
 void WbLog::fatal(const QString &message) {
@@ -128,17 +138,17 @@ void WbLog::clear() {
   emit instance()->cleared();
 }
 
-void WbLog::enqueuePopUpMessage(const QString &message, Level level) {
-  PostponedPopUpMessage msg;
+void WbLog::enqueueMessage(QList<PostponedMessage> &list, const QString &message, Level level) {
+  PostponedMessage msg;
   msg.text = message;
   msg.level = level;
-  instance()->mPostponedPopUpMessageQueue.append(msg);
+  list.append(msg);
 }
 
 void WbLog::showPostponedPopUpMessages() {
   bool tmp = instance()->mPopUpMessagesPostponed;
   setPopUpPostponed(false);
-  foreach (PostponedPopUpMessage msg, instance()->mPostponedPopUpMessageQueue) {
+  foreach (PostponedMessage msg, instance()->mPostponedPopUpMessageQueue) {
     switch (msg.level) {
       case DEBUG:
         debug(msg.text, true);
@@ -159,4 +169,10 @@ void WbLog::showPostponedPopUpMessages() {
   setPopUpPostponed(tmp);
 
   instance()->mPostponedPopUpMessageQueue.clear();
+}
+
+void WbLog::showPendingConsoleMessages() {
+  foreach (PostponedMessage msg, instance()->mPendingConsoleMessages)
+    emit instance()->logEmitted(msg.level, msg.text, false);
+  instance()->mPendingConsoleMessages.clear();
 }

--- a/src/webots/core/WbLog.hpp
+++ b/src/webots/core/WbLog.hpp
@@ -62,6 +62,8 @@ public:
   // queue pop up messages to be shown later
   static void setPopUpPostponed(bool postponed) { instance()->mPopUpMessagesPostponed = postponed; }
   static void showPostponedPopUpMessages();
+  // show messages in console emitted before WbConsole was listening
+  static void showPendingConsoleMessages();
 
 signals:
   // the above function emit this signal that can be connected to a message sink (console)
@@ -77,14 +79,14 @@ private:
   void emitLog(Level level, const QString &message, bool popup);
   static void cleanup();
 
-  struct PostponedPopUpMessage {
+  struct PostponedMessage {
     QString text;
     Level level;
   };
-
   bool mPopUpMessagesPostponed;
-  QVector<PostponedPopUpMessage> mPostponedPopUpMessageQueue;
-  void enqueuePopUpMessage(const QString &message, Level level);
+  QList<PostponedMessage> mPostponedPopUpMessageQueue;
+  QList<PostponedMessage> mPendingConsoleMessages;
+  void enqueueMessage(QList<PostponedMessage> &list, const QString &message, Level level);
 };
 
 #endif

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -204,6 +204,8 @@ WbMainWindow::WbMainWindow(bool minimizedOnStart, QWidget *parent) :
           &WbMainWindow::discardNodeRegeneration);
   connect(WbTemplateManager::instance(), &WbTemplateManager::postNodeRegeneration, this,
           &WbMainWindow::finalizeNodeRegeneration);
+
+  WbLog::instance()->showPendingConsoleMessages();
 }
 
 WbMainWindow::~WbMainWindow() {

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -168,7 +168,7 @@ void WbStreamingServer::start(int port) {
   try {
     create(port);
   } catch (const QString &e) {
-    WbLog::error(tr("Error when creating the TCP streaming server: %1").arg(e));
+    WbLog::error(tr("Error when creating the TCP streaming server on port %1: %2").arg(port).arg(e));
     return;
   }
   WbLog::info(tr("Streaming server listening on port %1.").arg(port));


### PR DESCRIPTION
Fix #825: store log messages emitted before WbConsole instance and print them when the GUI initialization is over.