### PR TITLE
Update Travis to Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
     - &unit_tests_staging
       stage: Unit Tests
       if: type = cron OR commit_message IN (travis_unit, travis_distrib, travis_unit_only) OR (NOT tag =~ ^nightly_ AND tag IS present)
-      name: Ubuntu 16.04 / Python 3.7 / openjdk 8 / ROS kinetic
+      name: Ubuntu 16.04 / Python 3.8 / openjdk 8 / ROS kinetic
       git: &compilation_git
         depth: 3
         submodules: true
@@ -83,7 +83,7 @@ jobs:
       dist: xenial
       install: skip  # bundle install is not required
       language: python
-      python: 3.7
+      python: 3.8
       jdk: openjdk8
       addons: &apt_packages
         apt:
@@ -123,7 +123,7 @@ jobs:
       before_install:
         - sudo add-apt-repository ppa:deadsnakes/ppa -y
         - sudo apt update
-        - sudo apt install -y python3.6-dev python3.7-dev
+        - sudo apt install -y python3.6-dev python3.7-dev python3.8-dev
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - export ROS_DISTRO=kinetic
@@ -140,7 +140,7 @@ jobs:
         - python tests/test_suite.py --no-ansi-escape --nomake
         - ./tests/ros.sh
     - <<: *unit_tests_staging
-      name: Ubuntu 18.04 / Python 3.7 / openjdk 11 / ROS melodic
+      name: Ubuntu 18.04 / Python 3.8 / openjdk 11 / ROS melodic
       dist: bionic
       jdk: openjdk11
       before_install:
@@ -184,6 +184,7 @@ jobs:
             - npm
             - python3.6-dev
             - python3.7-dev
+            - python3.8-dev
             - openjdk-11-jdk
             - curl
             - fakeroot
@@ -192,19 +193,19 @@ jobs:
     - &distribution_staging
       stage: Distribution
       if: type = cron OR commit_message IN (travis_distrib, travis_distrib_only) OR (NOT tag =~ ^nightly_ AND tag IS present)
-      name: Ubuntu 16.04 / Python 3.7 / openjdk 8
+      name: Ubuntu 16.04 / Python 3.8 / openjdk 8
       git: *compilation_git
       os: linux
       dist: xenial
       install: skip  # bundle install is not required
       language: python
-      python: 3.7
+      python: 3.8
       jdk: openjdk8
       addons: *apt_packages
       before_install:
         - sudo add-apt-repository ppa:deadsnakes/ppa -y
         - sudo apt update
-        - sudo apt install python3.6-dev python3.7-dev
+        - sudo apt install python3.6-dev python3.7-dev python3.8-dev
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - pip install PyGithub # used to upload packages to Github releases
@@ -214,7 +215,7 @@ jobs:
         - if [[ "$(ls -l distribution | grep -v ^l | wc -l)" -ne "4" ]]; then echo Wrong number of files in the distribution folder; exit -1; fi  # make sure all the required files are generated
         - if [ "$TRAVIS_BRANCH" != "master" ]; then src/packaging/publish_release.py --key=$GITHUB_API_KEY --repo=$TRAVIS_REPO_SLUG --branch=$TRAVIS_BRANCH --commit=$TRAVIS_COMMIT --tag=$TRAVIS_TAG; fi
     - <<: *distribution_staging
-      name: Ubuntu 18.04 / Python 3.7 / openjdk 11 (no release upload)
+      name: Ubuntu 18.04 / Python 3.8 / openjdk 11 (no release upload)
       dist: bionic  # on Ubuntu 18.04 we just test the package creation but do not upload it
       jdk: openjdk11
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,9 @@ jobs:
       dist: bionic
       jdk: openjdk11
       before_install:
+        - sudo add-apt-repository ppa:deadsnakes/ppa -y
+        - sudo apt update
+        - sudo apt install -y python3.8-dev
         - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - export ROS_DISTRO=melodic
@@ -184,7 +187,6 @@ jobs:
             - npm
             - python3.6-dev
             - python3.7-dev
-            - python3.8-dev
             - openjdk-11-jdk
             - curl
             - fakeroot
@@ -205,7 +207,7 @@ jobs:
       before_install:
         - sudo add-apt-repository ppa:deadsnakes/ppa -y
         - sudo apt update
-        - sudo apt install python3.6-dev python3.7-dev python3.8-dev
+        - sudo apt install python3.6-dev python3.7-dev
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - pip install PyGithub # used to upload packages to Github releases
@@ -219,6 +221,9 @@ jobs:
       dist: bionic  # on Ubuntu 18.04 we just test the package creation but do not upload it
       jdk: openjdk11
       before_install:
+        - sudo add-apt-repository ppa:deadsnakes/ppa -y
+        - sudo apt update
+        - sudo apt install -y python3.8-dev
         - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
       addons: *bionic_apt_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ jobs:
   include:
     - &source_tests_staging
       stage: Sources Tests
-      name: Ubuntu 16.04 / Python 3.7
+      name: Ubuntu 16.04 / Python 3.8
       git:
         depth: 3
         submodules: false
       os: linux
       dist: xenial
       language: python
-      python: '3.7'
+      python: '3.8'
       addons:
         apt:
           packages:
@@ -49,7 +49,7 @@ jobs:
       python: '2.7'
     - <<: *source_tests_staging
       if: type = cron OR commit_message IN (travis_sources, travis_unit, travis_distrib) OR (NOT tag =~ ^nightly_ AND tag IS present)
-      name: Ubuntu 18.04 / Python 3.7
+      name: Ubuntu 18.04 / Python 3.8
       dist: bionic
     - <<: *source_tests_staging
       if: type = cron OR commit_message IN (travis_sources, travis_unit, travis_distrib) OR (NOT tag =~ ^nightly_ AND tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -207,7 +207,7 @@ jobs:
       before_install:
         - sudo add-apt-repository ppa:deadsnakes/ppa -y
         - sudo apt update
-        - sudo apt install python3.6-dev python3.7-dev
+        - sudo apt install python3.6-dev python3.7-dev python3.8-dev
         - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - export PATH=$JAVA_HOME/bin:$PATH
         - pip install PyGithub # used to upload packages to Github releases

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -32,7 +32,7 @@ Please refer to the documentation of your operating system to set environment va
 | Linux            | all                  | LD\_LIBRARY\_PATH        | add `${WEBOTS_HOME}/lib`                         |
 | macOS            | all                  | DYLD\_LIBRARY\_PATH      | add `${WEBOTS_HOME}/lib`                         |
 | all              | Python 2.7           | PYTHONPATH               | add `${WEBOTS_HOME}/lib/python27`                |
-| all              | Python 3.7           | PYTHONPATH               | add `${WEBOTS_HOME}/lib/python37`                |
+| all              | Python 3.X           | PYTHONPATH               | add `${WEBOTS_HOME}/lib/python3X`                |
 | all              | Python               | PYTHONIOENCODING         | `UTF-8`                                          |
 | all              | MATLAB               | WEBOTS\_PROJECT          | `/my_folder/my_webots_project`                   |
 | all              | MATLAB               | WEBOTS\_CONTROLLER\_NAME | `my_robot_controller.m`                          |

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -9,7 +9,7 @@ The classes are either representations of a node of the scene tree (such as Robo
 A complete description of these functions can be found in the reference guide while the instructions about the common way to program a Python controller can be found in [this chapter](programming-fundamentals.md).
 
 The Python API of Webots supports both Python 3.7 and Python 2.7.
-On Ubuntu 18.04, it also supports Python 3.6 and on Ubuntu 16.04, it also supports Python 3.5.
+On Ubuntu 18.04 adn 16.04 it also supports Python 3.6 and Python 3.8, and Python 3.5 Ubuntu 16.04.
 
 Alternatively to the Webots built-in editor, [PyCharm](https://www.jetbrains.com/pycharm) can be used to edit and launch Python controllers, see the [Using PyCharm with Webots](using-pycharm-with-webots.md) chapter for a step-by-step procedure.
 
@@ -40,7 +40,7 @@ To check the versions of Python installed on your system, you can type in a term
 
 Python 2.7 installed by default.
 You can install Python 3.7 from the [Python web site](https://www.python.org).
-To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.7 --version`, `python2.7 --version`, `python3 --version`, etc.
+To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python2.7 --version`, `python3 --version`, etc.
 
 #### Windows Installation
 

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -9,7 +9,7 @@ The classes are either representations of a node of the scene tree (such as Robo
 A complete description of these functions can be found in the reference guide while the instructions about the common way to program a Python controller can be found in [this chapter](programming-fundamentals.md).
 
 The Python API of Webots supports both Python 3.7 and Python 2.7.
-On Ubuntu 18.04 adn 16.04 it also supports Python 3.6 and Python 3.8, and Python 3.5 Ubuntu 16.04.
+On Ubuntu 18.04 and 16.04 it also supports Python 3.6 and Python 3.8, and Python 3.5 Ubuntu 16.04.
 
 Alternatively to the Webots built-in editor, [PyCharm](https://www.jetbrains.com/pycharm) can be used to edit and launch Python controllers, see the [Using PyCharm with Webots](using-pycharm-with-webots.md) chapter for a step-by-step procedure.
 

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -3,6 +3,8 @@
 ## Webots R2019b Revision 2
 Released on ???
 
+  - New Features
+    - Linux: Add support for Python 3.8.
   - Enhancements
     - Webots now wait for extern controllers if the `Robot.synchronization` field is set to `TRUE`.
     - Device names are displayed in the scene tree next to the node name.

--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -4,7 +4,7 @@
 Released on ???
 
   - New Features
-    - Linux: Add support for Python 3.8.
+    - Linux: Added support for Python 3.8.
   - Enhancements
     - Webots now wait for extern controllers if the `Robot.synchronization` field is set to `TRUE`.
     - Device names are displayed in the scene tree next to the node name.

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -6,4 +6,5 @@
 /python35
 /python36
 /python37
+/python38
 /qt

--- a/projects/default/libraries/vehicle/Makefile
+++ b/projects/default/libraries/vehicle/Makefile
@@ -37,6 +37,8 @@ endif
 	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.8;
+	+PYTHON_COMMAND=python3.8 make -s -C python $(MAKECMDGOALS)
 endif
 ifeq ($(OSTYPE),windows)
 	@echo "# make" $@ python3.7;

--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -52,6 +52,8 @@ endif
 	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
+	@echo "# make" $@ python3.8;
+	+PYTHON_COMMAND=python3.8 make -s -C python $(MAKECMDGOALS)
 endif
 ifeq ($(OSTYPE),windows)
 	@echo "# make" $@ python3.7;

--- a/projects/robots/robotis/darwin-op/libraries/python38/.gitignore
+++ b/projects/robots/robotis/darwin-op/libraries/python38/.gitignore
@@ -1,0 +1,2 @@
+/managers.py
+/_managers.pyd

--- a/resources/languages/Makefile
+++ b/resources/languages/Makefile
@@ -33,6 +33,8 @@ endif
 	+PYTHON_COMMAND=python3.6 make -s -C python $@
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $@
+	@echo "# make" $@ python3.8;
+	+PYTHON_COMMAND=python3.8 make -s -C python $@
 endif
 ifeq ($(OSTYPE),windows)
 	@echo "# make" $@ python3.7;

--- a/src/packaging/files_core.txt
+++ b/src/packaging/files_core.txt
@@ -197,6 +197,10 @@ lib/python37/*.py
 lib/python37/_*.so [linux,mac]
 lib/python37/_*.pyd [windows]
 
+lib/python38/ [linux]
+lib/python38/*.py [linux]
+lib/python38/_*.so [linux]
+
 lib/matlab/
 lib/matlab/allincludes.h
 lib/matlab/*.m


### PR DESCRIPTION
Use Python 3.8 (already available on Travis) for source test.

Wiki edit: https://github.com/cyberbotics/webots/wiki/Linux-Optional-Dependencies/_compare/04e9983883a1a70422bf47ecd50d33b7483dbf58...f46061464a05a0a72885a0d5a34ef716a1459a6b