### PR TITLE
Preferences cleaner script: Minor improvements

### DIFF
--- a/scripts/preferences_cleaner/preferences_cleaner.py
+++ b/scripts/preferences_cleaner/preferences_cleaner.py
@@ -16,6 +16,7 @@
 
 '''Cleanup all the Webots preferences.'''
 
+from __future__ import print_function  # To display a correct error message when running from Python 2.
 import platform
 import sys
 
@@ -42,9 +43,9 @@ def cleanupMacOSPreferences():
         preferencesPath = Path(preferencesPath)
         preferenceReference = preferencesPath.stem
         print('Clearing the "%s" preferences...' % preferenceReference)
-        feedback = subprocess.run(['defaults', 'remove', preferenceReference])
-        assert feedback.returncode == 0, 'Issue occured when removing the "%s" preference.'
-        preferencesPath.unlink(missing_ok=True)
+        subprocess.run(['defaults', 'remove', preferenceReference])
+        if preferencesPath.exists():
+            preferencesPath.unlink()
 
 
 def cleanupWindowsPreferences():


### PR DESCRIPTION
- [x] When running in Python2, a cryptic message was displayed because of a syntax error (about stderr).
- [x] On macOS:
    - [x] `unlink.missing_ok` argument was only available since Python 3.8.
    - [x] the assert was causing issue in case the preference file has been removed, but not applied by the system. Ignoring this is more robust.
