### PR TITLE
webots.min.js: compile library as module

### DIFF
--- a/resources/web/wwi/.gitignore
+++ b/resources/web/wwi/.gitignore
@@ -3,7 +3,7 @@
 /node_modules
 /package-lock.json
 /webots.min.js
-/webots-module.min.js
+/webots.lib.js
 /webots.debug.js
 /adapter.js
 janus.nojquery.js

--- a/resources/web/wwi/.gitignore
+++ b/resources/web/wwi/.gitignore
@@ -3,6 +3,7 @@
 /node_modules
 /package-lock.json
 /webots.min.js
+/webots-module.min.js
 /webots.debug.js
 /adapter.js
 janus.nojquery.js

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -79,7 +79,7 @@ release debug profile update:
 	@echo "# Please install nodejs to build 'webots.min.js' using the instructions on the GitHub wiki."
 	@echo -e "# \033[0;33mnpm not installed, skipping webots.min.js\033[0m"
 else
-release profile update: webots.min.js webots-module.js
+release profile update: webots.min.js webots.lib.js
 debug: webots.debug.js
 endif
 
@@ -96,8 +96,8 @@ webots.debug.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE
 
 # JS module intended to be included in another module.
 # webots.lib.js is not processed with babel or minify and does not include three.js.
-webots-module.js:
-	@echo "# compressing webots-module.js"
+webots.lib.js:
+	@echo "# compressing webots.lib.js"
 	@cat $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) > $@
 
 $(THREEJS_SOURCE):
@@ -124,4 +124,4 @@ ifeq ($(NPM_EXISTS),)
 endif
 
 clean:
-	@rm -fr *.min.js webots.debug.js webots-module.js $(DEPENDENCIES_PATH)
+	@rm -fr *.min.js webots.debug.js webots.lib.js $(DEPENDENCIES_PATH)

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -79,7 +79,7 @@ release debug profile update:
 	@echo "# Please install nodejs to build 'webots.min.js' using the instructions on the GitHub wiki."
 	@echo -e "# \033[0;33mnpm not installed, skipping webots.min.js\033[0m"
 else
-release profile update: webots.min.js
+release profile update: webots.min.js webots-module.js
 debug: webots.debug.js
 endif
 
@@ -93,6 +93,12 @@ webots.min.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE) 
 webots.debug.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE) $(INSTALL_TOKEN)
 	@echo "# creating webots.debug.js"
 	@cat $(THREEJS_SOURCE) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) $(BABEL_JS_SOURCES) > $@
+
+# JS module intended to be included in another module.
+# webots.lib.js is not processed with babel or minify and does not include three.js.
+webots-module.js:
+	@echo "# compressing webots-module.js"
+	@cat $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) > $@
 
 $(THREEJS_SOURCE):
 	@echo "# downloading $(THREEJS_URL)"
@@ -118,4 +124,4 @@ ifeq ($(NPM_EXISTS),)
 endif
 
 clean:
-	@rm -fr *.min.js $(DEPENDENCIES_PATH)
+	@rm -fr *.min.js webots.debug.js webots-module.js $(DEPENDENCIES_PATH)


### PR DESCRIPTION
`webots.min.js` is a standalone library (including three.js, minified, including babel resources, etc.).
But to include it in another JS application (like the robot designer) we just need to concatenate together all the files.