### PR TITLE
Cleaner fix for the npm dependency issue

### DIFF
--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -96,8 +96,6 @@ $(LOCAL_THREEJS_EXAMPLE_SOURCES):
 $(INSTALL_TOKEN): package.json
 	@echo "# installing npm dependencies"
 	@npm --silent install 1> /dev/null
-	# The following patch is about to hotfix this issue: https://github.com/babel/minify/issues/967
-	@sed 's/path.get("body")[0].inList = false;/node.body[0].inList = false;/g' node_modules/babel-plugin-minify-simplify/lib/index.js > node_modules/babel-plugin-minify-simplify/lib/index.js
 	@touch $(INSTALL_TOKEN)
 
 cleanse: clean

--- a/resources/web/wwi/package.json
+++ b/resources/web/wwi/package.json
@@ -2,11 +2,11 @@
   "name": "webots.min.js",
   "version": "1.0.0",
   "devDependencies": {
-    "@babel/cli": "^7.4.3",
-    "@babel/core": "^7.4.3",
-    "babel-minify": "^0.5.0",
-    "@babel/preset-env": "^7.4.3",
-    "@babel/polyfill": "^7.4.3"
+    "@babel/cli": "^7.7.0",
+    "@babel/core": "^7.7.2",
+    "babel-minify": "^0.5.1",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/polyfill": "^7.7.0"
   },
   "babel": {
     "presets": [],


### PR DESCRIPTION
We merged yesterday https://github.com/cyberbotics/webots/pull/1069 to fix this issue:
https://github.com/babel/minify/issues/967

Meanwhile, `@babel/core 7.7.2` has been released to fix this issue.

The present patch removes the previous hotfix and updates the npm dependencies to a new stable state.