### PR TITLE
improve IK world: use a "none" controller for the root robot

### DIFF
--- a/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
+++ b/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
@@ -93,6 +93,7 @@ Robot {
       ]
     }
   ]
+  controller ""
 }
 DEF TABLE_WITH_PAPER_SHEET Transform {
   translation 1.1 0 5.8


### PR DESCRIPTION
Thanks to https://github.com/cyberbotics/webots/pull/1060 fix.