### PR TITLE
Fix qt platform plugin trouble

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -360,8 +360,6 @@ void WbController::setProcessEnvironment() {
 #else
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "usr/bin", false, true);
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "mingw64/bin", false, true);
-  addPathEnvironmentVariable(env, "QT_QPA_PLATFORM_PLUGIN_PATH",
-                             WbStandardPaths::webotsMsys64Path() + "mingw64/share/qt5/plugins", true);
 #endif
 
   if (QFile::exists(mControllerPath + "runtime.ini")) {

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -357,8 +357,6 @@ void WbController::setProcessEnvironment() {
   // in order to be able to add easily dynamic libraries there
   // Note: on windows, this is the default behavior
   addPathEnvironmentVariable(env, ldEnvironmentVariable, mControllerPath, false, true);
-  // FIXME: on the develop branch, we should remove the setting of the QT_QPA_PLATFORM_PLUGIN_PATH environment variable from
-  // this file, as it is done in main.cpp now.
 #else
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "usr/bin", false, true);
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "mingw64/bin", false, true);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -357,6 +357,8 @@ void WbController::setProcessEnvironment() {
   // in order to be able to add easily dynamic libraries there
   // Note: on windows, this is the default behavior
   addPathEnvironmentVariable(env, ldEnvironmentVariable, mControllerPath, false, true);
+  // FIXME: on the develop branch, we should remove the setting of the QT_QPA_PLATFORM_PLUGIN_PATH environment variable from
+  // this file, as it is done in main.cpp now.
 #else
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "usr/bin", false, true);
   addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "mingw64/bin", false, true);

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -1,4 +1,3 @@
-#include <QtCore/QDebug>
 // Copyright 1996-2019 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -1,3 +1,4 @@
+#include <QtCore/QDebug>
 // Copyright 1996-2019 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,29 +112,32 @@ int main(int argc, char *argv[]) {
   setvbuf(stderr, NULL, _IONBF, 0);
 #endif
 #endif
-  const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
-  if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
-    const QString platformPluginPath =
-#ifdef _WIN32
-      WbStandardPaths::webotsMsys64Path() + "mingw64/share/qt5/plugins";
-#else
-      WbStandardPaths::webotsLibPath() + "qt/plugins";
-#endif
-    qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());
-  }
   QLocale::setDefault(QLocale::c());
   QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));  // so that all QTextStream use UTF-8 encoding by default
 
 #ifdef __linux__
   // on Linux, the webots binary is located in $WEBOTS_HOME/bin/webots-bin
-  const QString webotsDirPath(QFileInfo(argv[0]).absolutePath() + "/..");
+  const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/..").canonicalPath();
 #elif defined(__APPLE__)
   // on macOS, the webots binary is located in $WEBOTS_HOME/Contents/MacOS/webots-bin
-  const QString webotsDirPath(QFileInfo(argv[0]).absolutePath() + "/../..");
+  const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../..").canonicalPath();
 #else
   // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
-  const QString webotsDirPath(QFileInfo(argv[0]).absolutePath() + "/../../..");
+  const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../../..").canonicalPath();
 #endif
+
+  const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
+  if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
+    const QString platformPluginPath =
+#ifdef _WIN32
+      webotsDirPath + "/msys64/mingw64/share/qt5/plugins";
+#else
+      // FIXME: the following line works only on the revision branch, on the develop branch it should be changed to:
+      // webotsDirPath + "/lib/webots/qt/plugins"
+      webotsDirPath + "/lib/qt/plugins";
+#endif
+    qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());
+  }
 
   // load qt warning filters from file
   QString qtFiltersFilePath = QDir::fromNativeSeparators(webotsDirPath + "/resources/qt_warning_filters.conf");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -14,6 +14,7 @@
 
 #include "WbApplication.hpp"
 #include "WbGuiApplication.hpp"
+#include "WbStandardPaths.hpp"
 
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
@@ -110,6 +111,16 @@ int main(int argc, char *argv[]) {
   setvbuf(stderr, NULL, _IONBF, 0);
 #endif
 #endif
+  const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
+  if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
+    const QString platformPluginPath =
+#ifdef _WIN32
+      WbStandardPaths::webotsMsys64Path() + "mingw64/share/qt5/plugins";
+#else
+      WbStandardPaths::webotsLibPath() + "qt/plugins";
+#endif
+    qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());
+  }
   QLocale::setDefault(QLocale::c());
   QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));  // so that all QTextStream use UTF-8 encoding by default
 

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -131,8 +131,6 @@ int main(int argc, char *argv[]) {
 #ifdef _WIN32
       webotsDirPath + "/msys64/mingw64/share/qt5/plugins";
 #else
-      // FIXME: the following line works only on the revision branch, on the develop branch it should be changed to:
-      // webotsDirPath + "/lib/webots/qt/plugins"
       webotsDirPath + "/lib/qt/plugins";
 #endif
     qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());


### PR DESCRIPTION
In some cases, Webots was unable to start because of a different version of the platform plugins. A typical case is the following:

1. I install Webots R2019b.
2. I update MSYS2 and get a new version of qt5.
3. I compile and start Webots from MSYS2.
4. I start my installed version of Webots.
5. Webots fails to start complaining it cannot load the qt platform plugin. This is because it attempts to load the new ones which were somehow cached by Qt when I launched Webots from MSYS2.

The solution is to set the `QT_QPA_PLATFORM_PLUGIN_PATH` in `main.cpp` to point to the correct location of the platform plugins (the ones compatible with the current Webots binary), before the initialization of Qt.

Once this PR is merged into the revision branch, the revision branch should be merged very carefully in the develop branch (see FIXME comments about it).