### PR TITLE
Fix determism in cameras rendering order

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -14,6 +14,7 @@ Released on ???
   - Dependency Updates
     - Upgraded to Qt 5.13.1 on Windows and macOS.
   - Bug fixes
+    - Fixed determinism in camera rendering order.
     - Fixed `simulation_server.py` script to work with Python3.
     - Fixed exporting first translation and rotation fields change during animation recording and simulation streaming.
     - Fixed displaying streaming server initialization errors in the Webots console.

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -240,7 +240,12 @@ void WbSimulationWorld::step() {
     log->stopMeasure(WbPerformanceLog::POST_PHYSICS_STEP);
 
   // update camera textures before main rendering
-  emit cameraRenderingStarted();
+  const QList<WbRobot *> robotList = robots();
+  for (int i = 0; i < robots().size(); ++i) {
+    WbRobot *robot = robotList[i];
+    if (robot->isControllerStarted())
+      robot->renderCameras();
+  }
 
   if (!mSimulationHasRunAfterSave) {
     mSimulationHasRunAfterSave = true;

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -23,9 +23,7 @@
 #include "WbPreferences.hpp"
 #include "WbProtoModel.hpp"
 #include "WbRgb.hpp"
-#include "WbRobot.hpp"
 #include "WbSFNode.hpp"
-#include "WbSensor.hpp"
 #include "WbSimulationState.hpp"
 #include "WbViewpoint.hpp"
 #include "WbWorld.hpp"
@@ -352,12 +350,7 @@ bool WbAbstractCamera::handleCommand(QDataStream &stream, unsigned char command)
       // update motion blur factor
       applyMotionBlurToWren();
 
-      if (mSensor->isEnabled())
-        connect(WbSimulationState::instance(), &WbSimulationState::cameraRenderingStarted, this,
-                &WbAbstractCamera::updateCameraTexture, Qt::UniqueConnection);
-      else
-        disconnect(WbSimulationState::instance(), &WbSimulationState::cameraRenderingStarted, this,
-                   &WbAbstractCamera::updateCameraTexture);
+      emit enabled(this, mSensor->isEnabled());
 
       if (!hasBeenSetup()) {
         setup();

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -16,6 +16,7 @@
 #define WB_ABSTRACT_CAMERA_HPP
 
 #include "WbRenderingDevice.hpp"
+#include "WbSensor.hpp"
 
 struct WrTransform;
 struct WrStaticMesh;
@@ -24,7 +25,6 @@ struct WrMaterial;
 
 class WbLens;
 class WbWrenCamera;
-class WbSensor;
 
 #ifdef _WIN32
 class QSharedMemory;
@@ -52,7 +52,11 @@ public:
   void writeConfigure(QDataStream &) override;
   void reset() override;
 
+  void updateCameraTexture();
+
   void setNodeVisibility(WbBaseNode *node, bool visible);
+
+  bool isEnabled() { return mSensor ? mSensor->isEnabled() : false; }
 
   // external window
   void enableExternalWindow(bool enabled) override;
@@ -71,6 +75,9 @@ public:
   static void resetStaticCounters() { cCameraNumber = 0; }
 
   const unsigned char *constImage() const { return image(); }
+
+signals:
+  void enabled(WbAbstractCamera *camera, bool isActive);
 
 protected:
   void setup() override;
@@ -170,8 +177,6 @@ protected slots:
   void updateLens();
   void applyLensToWren();
   void removeInvisibleNodeFromList(QObject *node);
-
-  void updateCameraTexture();
 
   virtual void updateFrustumDisplayIfNeeded(int optionalRendering) {}
 

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -241,12 +241,7 @@ void WbLidar::handleMessage(QDataStream &stream) {
 
     mSensor->setRefreshRate(mRefreshRate);
 
-    if (mSensor->isEnabled())
-      connect(WbSimulationState::instance(), &WbSimulationState::cameraRenderingStarted, this, &WbLidar::updateCameraTexture,
-              Qt::UniqueConnection);
-    else
-      disconnect(WbSimulationState::instance(), &WbSimulationState::cameraRenderingStarted, this,
-                 &WbLidar::updateCameraTexture);
+    emit enabled(this, mSensor->isEnabled());
 
     if (!hasBeenSetup()) {
       setup();

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -25,6 +25,7 @@
 #include <QtCore/QVarLengthArray>
 #include <QtCore/QVector>
 
+class WbAbstractCamera;
 class WbDevice;
 class WbJoystickInterface;
 class WbKinematicDifferentialWheels;
@@ -90,6 +91,8 @@ public:
 
   // update sensors in case of no answer needs to be written at this step
   virtual void updateSensors();
+
+  void renderCameras();
 
   // field accessors
   const QString &controllerName() const { return mController->value(); }
@@ -237,6 +240,7 @@ private:
   // other variables
   QList<WbDevice *> mDevices;
   QList<WbRenderingDevice *> mRenderingDevices;
+  QList<WbAbstractCamera *> mActiveCameras;
 
   QList<int> mPressedKeys;
 
@@ -254,6 +258,7 @@ private:
 
 private slots:
   void updateDevicesAfterDestruction();
+  void updateActiveCameras(WbAbstractCamera *camera, bool isActive);
   void updateWindow();
   void updateRemoteControl();
   void updateSimulationMode();


### PR DESCRIPTION
Try to fix `mirror` test error.

Change the way the cameras are rendered by looping through the robots so that the order is always the same.
Previously the order was determined by the order in which the set sampling period command was received from the controllers.
