### PR TITLE
webots.min.js: fix texture animation in webots.min.js

### DIFF
--- a/resources/web/wwi/texture_loader.js
+++ b/resources/web/wwi/texture_loader.js
@@ -124,7 +124,8 @@ class _TextureLoaderObject {
 
     newTexture.userData = {
       'isTransparent': textureData.transparent,
-      'url': filename
+      'url': filename,
+      'transform': textureData.transform
     };
     newTexture.wrapS = textureData.wrap.s === 'true' ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
     newTexture.wrapT = textureData.wrap.t === 'true' ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;


### PR DESCRIPTION
Fix issue #1086 introduced in  #751 preventing to animate the textures by changing the transform values.