### PR TITLE
Proposal to improve nightly build publishing rules

### DIFF
--- a/src/packaging/publish_release.py
+++ b/src/packaging/publish_release.py
@@ -35,6 +35,9 @@ g = Github(options.key)
 repo = g.get_repo(options.repo)
 releaseExists = False
 now = datetime.datetime.now()
+if now.hour <= 5:
+    # Publish nightly build with previous day date even if it completes in the morning
+    now = now - datetime.timedelta(hours=6)
 if now.weekday() >= 5:
     print('Skipping nightly build for Saturday and Sunday.')
     exit(0)


### PR DESCRIPTION
Proposal to try to ensure that the revision and develop nightly builds are always published with the "yesterday" date.