### PR TITLE
webots.min.js: restore video streaming code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
   include:
     - &source_tests_staging
       stage: Sources Tests
+      if: type = cron OR NOT commit_message IN (travis_distrib_only)
       name: Ubuntu 16.04 / Python 3.8
       git:
         depth: 3

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -6,14 +6,49 @@
     <title>Streaming viewer</title>
     <link rel='stylesheet' href='https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css'/>
     <link type="text/css" rel="stylesheet" href='https://www.cyberbotics.com/jquery-ui-layout/1.4.4/layout-default.css' />
-    <link type="text/css" rel="stylesheet" href='https://www.cyberbotics.com/wwi/R2020a/wwi.css' />
+    <link type="text/css" rel="stylesheet" href='../wwi/wwi.css' />
     <link type="text/css" rel="stylesheet" href='style.css' />
     <script src='https://code.jquery.com/jquery-3.1.1.min.js' integrity='sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=' crossorigin='anonymous'></script>
     <script src='https://code.jquery.com/ui/1.12.1/jquery-ui.min.js' integrity='sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=' crossorigin='anonymous'></script>
     <script src='https://www.cyberbotics.com/jquery-ui-layout/1.4.4/jquery.layout.js'></script>
     <script src='https://www.cyberbotics.com/jquery-dialogextend/2.0.4/jquery.dialogextend.min.js'></script>
-    <script src='https://cdn.jsdelivr.net/ace/1.2.6/min/ace.js'></script>
-    <script src="https://www.cyberbotics.com/wwi/R2020a/webots.min.js"></script>
+    <script src='https://cdn.jsdelivr.net/ace/1.2.6/min/ace.js'></script><script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/104/three.js"></script>
+    <script src="../wwi/dependencies/loaders/RGBELoader.js"></script>
+    <script src="../wwi/dependencies/pmrem/PMREMCubeUVPacker.js"></script>
+    <script src="../wwi/dependencies/pmrem/PMREMGenerator.js"></script>
+    <script src="../wwi/dependencies/shaders/CopyShader.js"></script>
+    <script src="../wwi/dependencies/shaders/FXAAShader.js"></script>
+    <script src="../wwi/dependencies/postprocessing/EffectComposer.js"></script>
+    <script src="../wwi/dependencies/postprocessing/RenderPass.js"></script>
+    <script src="../wwi/dependencies/postprocessing/ShaderPass.js"></script>
+    <script src="../wwi/passes/bloom.js"></script>
+    <script src="../wwi/shaders/blend_bloom.js"></script>
+    <script src="../wwi/shaders/bright_pass.js"></script>
+    <script src="../wwi/shaders/gaussian_blur_13_tap.js"></script>
+    <script src="../wwi/shaders/hdr_resolve.js"></script>
+    <script src="../wwi/equirectangular_to_cube_generator.js"></script>
+    <script src="../wwi/gpu_picker.js"></script>
+    <script src="../wwi/util.js"></script>
+    <script src="../wwi/dialog_window.js"></script>
+    <script src="../wwi/console.js"></script>
+    <script src="../wwi/help_window.js"></script>
+    <script src="../wwi/robot_window.js"></script>
+    <script src="../wwi/toolbar.js"></script>
+    <script src="../wwi/editor.js"></script>
+    <script src="../wwi/context_menu.js"></script>
+    <script src="../wwi/viewpoint.js"></script>
+    <script src="../wwi/selector.js"></script>
+    <script src="../wwi/system_info.js"></script>
+    <script src="../wwi/mouse_events.js"></script>
+    <script src="../wwi/texture_loader.js"></script>
+    <script src="../wwi/default_url.js"></script>
+    <script src="../wwi/server.js"></script>
+    <script src="../wwi/stream.js"></script>
+    <script src="../wwi/video.js"></script>
+    <script src="../wwi/x3d.js"></script>
+    <script src="../wwi/x3d_scene.js"></script>
+    <script src="../wwi/animation.js"></script>
+    <script src="../wwi/webots.js"></script>
     <script src="setup_viewer.js"></script>
   </head>
   <body>

--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -33,8 +33,8 @@ function init() {
 function connect() {
   var playerDiv = document.getElementById('playerDiv');
   view = new webots.View(playerDiv, mobileDevice);
-  view.broadcast = true;
-  view.open('ws://' + ipInput.value + ':' + portInput.value);
+  view.broadcast = false;
+  view.open('ws://' + ipInput.value + ':' + portInput.value, 'video');
   connectButton.value = 'Disconnect';
   connectButton.onclick = disconnect;
   ipInput.disabled = true;

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -105,15 +105,6 @@ class Stream { // eslint-disable-line no-unused-vars
       var currentWorld = data.substring(0, data.indexOf(':')).trim();
       data = data.substring(data.indexOf(':') + 1).trim();
       this.view.updateWorldList(currentWorld, data.split(';'));
-    } else if (data.startsWith('video: ')) {
-      console.log('Received data = ' + data);
-      let list = data.split(' ');
-      let url = list[1];
-      this.view.toolBar.setMode(list[2]);
-      this.view.video.domElement.src = url;
-      console.log('Video streamed on ' + url);
-      if (typeof this.onready === 'function')
-        this.onready();
     } else if (data.startsWith('set controller:')) {
       var slash = data.indexOf('/', 15);
       var dirname = data.substring(15, slash);
@@ -171,6 +162,18 @@ class Stream { // eslint-disable-line no-unused-vars
         x: labelProperties[3],
         y: labelProperties[4]
       });
+    } else if (data.startsWith('video: ')) {
+      console.log('Received data = ' + data);
+      let list = data.split(' ');
+      let url = list[1];
+      this.view.toolBar.setMode(list[2]);
+      this.view.video.domElement.src = url;
+      console.log('Video streamed on ' + url);
+      if (typeof this.onready === 'function')
+        this.onready();
+    } else if (data.startsWith('time: ')) {
+      this.view.time = parseFloat(data.substring(data.indexOf(':') + 1).trim());
+      $('#webotsClock').html(webots.parseMillisecondsIntoReadableTime(this.view.time));
     } else
       console.log('WebSocket error: Unknown message received: "' + data + '"');
   }

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -7,7 +7,6 @@ class Stream { // eslint-disable-line no-unused-vars
     this.view = view;
     this.onready = onready;
     this.socket = null;
-    this.videoStream = null;
   }
 
   connect() {
@@ -25,15 +24,12 @@ class Stream { // eslint-disable-line no-unused-vars
   close() {
     if (this.socket)
       this.socket.close();
-    if (this.videoStream)
-      this.videoStream.close();
   }
 
   onSocketOpen(event) {
     var mode = this.view.mode;
     if (mode === 'video')
-      mode += ': 800x600'; // TODO
-      // mode += ': ' + this.view.video.width + 'x' + this.view.video.height;
+      mode += ': ' + this.view.view3D.offsetWidth + 'x' + (this.view.view3D.offsetHeight - 48); // subtract toolbar height
     else if (this.view.broadcast)
       mode += ';broadcast';
     this.socket.send(mode);

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -32,7 +32,8 @@ class Stream { // eslint-disable-line no-unused-vars
   onSocketOpen(event) {
     var mode = this.view.mode;
     if (mode === 'video')
-      mode += ': ' + this.view.video.width + 'x' + this.view.video.height;
+      mode += ': 800x600'; // TODO
+      // mode += ': ' + this.view.video.width + 'x' + this.view.video.height;
     else if (this.view.broadcast)
       mode += ';broadcast';
     this.socket.send(mode);
@@ -113,8 +114,8 @@ class Stream { // eslint-disable-line no-unused-vars
       var list = data.split(' ');
       var url = list[1];
       var streamId = list[2];
+      this.view.video.domElement.src = url;
       console.log('Received video message on ' + url + ' stream = ' + streamId);
-      this.videoStream = new webots.VideoStream(url, this.view.video, document.getElementById('BitrateViewer'), streamId);
       if (typeof this.onready === 'function')
         this.onready();
     } else if (data.startsWith('set controller:')) {

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -111,11 +111,11 @@ class Stream { // eslint-disable-line no-unused-vars
       this.view.updateWorldList(currentWorld, data.split(';'));
     } else if (data.startsWith('video: ')) {
       console.log('Received data = ' + data);
-      var list = data.split(' ');
-      var url = list[1];
-      var streamId = list[2];
+      let list = data.split(' ');
+      let url = list[1];
+      this.view.toolBar.setMode(list[2]);
       this.view.video.domElement.src = url;
-      console.log('Received video message on ' + url + ' stream = ' + streamId);
+      console.log('Video streamed on ' + url);
       if (typeof this.onready === 'function')
         this.onready();
     } else if (data.startsWith('set controller:')) {
@@ -140,7 +140,7 @@ class Stream { // eslint-disable-line no-unused-vars
     } else if (data === 'real-time' || data === 'run' || data === 'fast') {
       this.view.toolBar.setMode(data);
       if (this.view.timeout >= 0)
-        this.view.stream.socket.send('timeout:' + this.view.timeout);
+        this.socket.send('timeout:' + this.view.timeout);
     } else if (data.startsWith('loading:')) {
       data = data.substring(data.indexOf(':') + 1).trim();
       var loadingStatus = data.substring(0, data.indexOf(':')).trim();

--- a/resources/web/wwi/video.js
+++ b/resources/web/wwi/video.js
@@ -1,7 +1,8 @@
 'use strict';
 
 class Video { // eslint-disable-line no-unused-vars
-  constructor(parentObject, mouseEvents, stream) {
+  constructor(view, parentObject) {
+    this.view = view;
     this.domElement = document.createElement('img');
     this.domElement.style.background = 'grey';
     this.domElement.id = 'remoteVideo';
@@ -9,8 +10,7 @@ class Video { // eslint-disable-line no-unused-vars
     this.domElement.width = 800;
     this.domElement.height = 600;
     parentObject.appendChild(this.domElement);
-    this.mouseEvents = mouseEvents;
-    this.stream = stream;
+    this.mouseDown = 0;
 
     this.onmousemove = (e) => { this._onMouseMove(e); };
   }
@@ -29,21 +29,37 @@ class Video { // eslint-disable-line no-unused-vars
   }
 
   sendMouseEvent(type, event, wheel) {
-    var socket = this.stream.socket;
+    var socket = this.view.stream.socket;
     if (!socket || socket.readyState !== 1)
       return;
     var modifier = (event.shiftKey ? 1 : 0) + (event.ctrlKey ? 2 : 0) + (event.altKey ? 4 : 0);
-    socket.send('mouse ' + type + ' ' + event.button + ' ' + this.mouseEvents.mouseState.mouseDown + ' ' +
+    socket.send('mouse ' + type + ' ' + event.button + ' ' + this.mouseDown + ' ' +
                 event.offsetX + ' ' + event.offsetY + ' ' + modifier + ' ' + wheel);
   }
 
   resize(width, height) {
     this.domElement.width = width;
     this.domElement.height = height;
-    this.stream.socket.send('resize: ' + width + 'x' + height);
+    this.view.stream.socket.send('resize: ' + width + 'x' + height);
   }
 
   _onMouseDown(event) {
+    this.mouseDown = 0;
+    switch (event.button) {
+      case THREE.MOUSE.LEFT:
+        this.mouseDown |= 1;
+        break;
+      case THREE.MOUSE.MIDDLE:
+        this.mouseDown |= 4;
+        break;
+      case THREE.MOUSE.RIGHT:
+        this.mouseDown |= 2;
+        break;
+    }
+    if (SystemInfo.isMacOS() && 'ctrlKey' in event && event['ctrlKey'] && this.mouseDown === 1)
+      // On macOS, "Ctrl + left click" should be dealt as a right click.
+      this.mouseDown = 2;
+
     event.target.addEventListener('mousemove', this.onmousemove, false);
     this.sendMouseEvent(-1, event, 0);
     event.preventDefault();
@@ -51,7 +67,7 @@ class Video { // eslint-disable-line no-unused-vars
   }
 
   _onMouseMove(event) {
-    if (this.mouseEvents.mouseState.mouseDown === 0) {
+    if (this.mouseDown === 0) {
       event.target.removeEventListener('mousemove', this.onmousemove, false);
       return false;
     }

--- a/resources/web/wwi/video.js
+++ b/resources/web/wwi/video.js
@@ -6,9 +6,6 @@ class Video { // eslint-disable-line no-unused-vars
     this.domElement = document.createElement('img');
     this.domElement.style.background = 'grey';
     this.domElement.id = 'remoteVideo';
-    this.domElement.class = 'rounded centered';
-    this.domElement.width = 800;
-    this.domElement.height = 600;
     parentObject.appendChild(this.domElement);
     this.mouseDown = 0;
 

--- a/resources/web/wwi/video.js
+++ b/resources/web/wwi/video.js
@@ -2,11 +2,10 @@
 
 class Video { // eslint-disable-line no-unused-vars
   constructor(parentObject, mouseEvents, stream) {
-    this.domElement = document.createElement('video');
+    this.domElement = document.createElement('img');
     this.domElement.style.background = 'grey';
     this.domElement.id = 'remoteVideo';
     this.domElement.class = 'rounded centered';
-    this.domElement.autoplay = 'true';
     this.domElement.width = 800;
     this.domElement.height = 600;
     parentObject.appendChild(this.domElement);
@@ -14,6 +13,10 @@ class Video { // eslint-disable-line no-unused-vars
     this.stream = stream;
 
     this.onmousemove = (e) => { this._onMouseMove(e); };
+  }
+
+  disconnect() {
+    this.domElement.src = '';
   }
 
   finalize(onready) {

--- a/resources/web/wwi/wwi.css
+++ b/resources/web/wwi/wwi.css
@@ -331,3 +331,14 @@ button::-moz-focus-inner {
   position: absolute;
   white-space: pre;
 }
+
+#remoteVideo {
+  background: grey;
+  width: 100%;
+  height: calc(100% - 48px);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -38,7 +38,7 @@ WB_USER_COMMANDS_INCLUDE = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INC
 WB_WIDGETS_INCLUDE       = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) -Icore -Imaths -Iuser_commands -Ivrml
 WB_EDITOR_INCLUDE        = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) $(QT_PRINT_SUPPORT_INCLUDE) -Icore -Iwidgets -Imaths -Inodes -Inodes/utils -Iode -Iuser_commands -Ivrml
 WB_PLUGINS_INCLUDE       = $(QT_CORE_INCLUDE) $(ODE_INCLUDE) -Icore -Imaths -Inodes -Inodes/utils -Ivrml
-WB_ENGINE_INCLUDE        = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) $(ODE_INCLUDE) $(WREN_INCLUDE) -Icore -Imaths -Inodes -Inodes/utils -Iplugins -Isound -Iuser_commands -Iutil -Ivrml
+WB_ENGINE_INCLUDE        = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_NETWORK_INCLUDE) $(ODE_INCLUDE) $(WREN_INCLUDE) -Icore -Imaths -Inodes -Inodes/utils -Iplugins -Isound -Iuser_commands -Iutil -Ivrml
 WB_CONTROL_INCLUDE       = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) -Icore -Iengine -Imaths -Inodes -Inodes/utils -Iode -Ivrml -Iutil
 # dependency of NODES on QT_GUI is necessary in WbImageTexture to retrieve the size of a texture before loading it in Wren
 WB_NODES_INCLUDE         = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(ODE_INCLUDE) $(CONTROLLER_INCLUDE) $(OIS_INCLUDE) $(FREETYPE_INCLUDE) $(WREN_INCLUDE) -Iapp -Icore -isystem external/siphash -isystem external/stb_image -Imaths -Inodes -Inodes/utils -Iode -Iplugins -Isound -Iutil -Ivrml

--- a/src/webots/engine/WbMultimediaStreamer.cpp
+++ b/src/webots/engine/WbMultimediaStreamer.cpp
@@ -134,12 +134,13 @@ bool WbMultimediaStreamer::start() {
 }
 
 bool WbMultimediaStreamer::isReady() {
-  return mIsInitialized && mClients->size() > 0;
+  return mIsInitialized && mClients.size() > 0;
 }
 
 #include <QtCore/QDebug>
 bool WbMultimediaStreamer::sendImage(QImage image) {
   mSceneImage = image;
+  // emit imageReady(QByteArray((const char *)mSharedMemoryData, mImageSize));
 
   QByteArray im;
   QBuffer bufferJpeg(&im);

--- a/src/webots/engine/WbMultimediaStreamer.hpp
+++ b/src/webots/engine/WbMultimediaStreamer.hpp
@@ -18,8 +18,9 @@
 #include <QtCore/QObject>
 #include <QtCore/QProcess>
 #include <QtCore/QString>
-#include <QtNetwork/QLocalServer>
-#include <QtNetwork/QLocalSocket>
+#include <QtGui/QImage>
+#include <QtNetwork/QTcpServer>
+#include <QtNetwork/QTcpSocket>
 
 // The WbMultimediaStreamer class allows to send a stream of raw images to a
 // multimedia server, such as Janus for WebRTC broadcasting.
@@ -35,10 +36,11 @@ public:
   void *buffer() const { return mSharedMemoryData; }
   int imageWidth() const { return mImageWidth; }
   int imageHeight() const { return mImageHeight; }
-  bool sendImage();
+  bool sendImage(QImage image);
 
 private slots:
   void treatNewConnection();
+  void onNewTcpData();
 
 private:
   WbMultimediaStreamer();
@@ -51,16 +53,16 @@ private:
   bool mIsInitialized;  // Remember if 'initialize()' was successfully called.
   int mImageWidth;
   int mImageHeight;
+  int mImageSize;
   QString mHostname;
   int mPort;
-  QString mStreamerExecutablePath;
-  QProcess mStreamer;
   int mSharedMemoryKey;
   void *mSharedMemoryData;
-  QLocalServer mLocalServer;
-  QLocalSocket *mLocalSocket;
+  QTcpServer *mTcpServer;
+  QList<QTcpSocket *> mClients;
   enum StreamerState { WAIT, READY, PROCESSING };
   StreamerState mStreamerState;
+  QImage mSceneImage;
 };
 
 #endif  // WB_MULTIMEDIA_STREAMER_HPP

--- a/src/webots/engine/WbMultimediaStreamer.hpp
+++ b/src/webots/engine/WbMultimediaStreamer.hpp
@@ -29,14 +29,19 @@ class WbMultimediaStreamer : public QObject {
   Q_OBJECT
 public:
   static WbMultimediaStreamer *instance();
-  static void reset();
-  bool initialize(int width, int height, const QString &stream);
-  bool start();
-  bool isReady();
+  bool initialize(int width, int height);
+  bool start(int port);
+  bool isInitialized() const { return mIsInitialized; }
+  bool isReady() const { return mIsInitialized && mClients.size() > 0; };
   void *buffer() const { return mSharedMemoryData; }
   int imageWidth() const { return mImageWidth; }
   int imageHeight() const { return mImageHeight; }
   bool sendImage(QImage image);
+
+  QString url() const { return QString("http://localhost:%1").arg(mPort); }
+
+signals:
+  void imageReady(const QByteArray &image);
 
 private slots:
   void treatNewConnection();
@@ -51,11 +56,11 @@ private:
   static WbMultimediaStreamer *sInstance;
 
   bool mIsInitialized;  // Remember if 'initialize()' was successfully called.
+  int mPort;
   int mImageWidth;
   int mImageHeight;
   int mImageSize;
   QString mHostname;
-  int mPort;
   int mSharedMemoryKey;
   void *mSharedMemoryData;
   QTcpServer *mTcpServer;

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -545,10 +545,13 @@ void WbStreamingServer::processTextMessage(QString message) {
     int width = resolution[0].toInt();
     int height = resolution[1].toInt();
     WbLog::info(tr("Streaming server: Client set mode to: VIDEO %1x%2").arg(width).arg(height));
-    gMainWindow->setView3DSize(QSize(width, height));
-    WbMultimediaStreamer::instance()->initialize(width, height, mMultimediaStream);
-    WbMultimediaStreamer::instance()->start();
-    client->sendTextMessage("video: " + mMultimediaServer + " 1");  // 1 is the stream id of the main Webots view
+    if (!WbMultimediaStreamer::instance()->isReady()) {
+      gMainWindow->setView3DSize(QSize(width, height));
+      WbMultimediaStreamer::instance()->initialize(width, height, mMultimediaStream);
+      WbMultimediaStreamer::instance()->start();
+    }
+    // TODO
+    client->sendTextMessage("video: http:/localhost:8089 1");  // 1 is the stream id of the main Webots view
     // this should be fixed when we want to support multiples instance of Webots running on the same multimedia streaming server
   } else if (message.startsWith("resize: ")) {
     QStringList resolution = message.mid(8).split("x");

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -551,7 +551,8 @@ void WbStreamingServer::processTextMessage(QString message) {
       WbMultimediaStreamer::instance()->start();
     }
     // TODO
-    client->sendTextMessage("video: http:/localhost:8089 1");  // 1 is the stream id of the main Webots view
+    client->sendTextMessage(
+      QString("video: http:/localhost:8089 %1").arg(simulationStateString()));  // 1 is the stream id of the main Webots view
     // this should be fixed when we want to support multiples instance of Webots running on the same multimedia streaming server
   } else if (message.startsWith("resize: ")) {
     QStringList resolution = message.mid(8).split("x");

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -86,6 +86,7 @@ private:
 
   static QString simulationStateString();
 
+  int mPort;
   QString mX3dWorld;
   QHash<QString, QString> mX3dWorldTextures;
   double mX3dWorldGenerationTime;

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -107,6 +107,8 @@ private:
   QString mMultimediaServer;
   QString mMultimediaStream;
   double mPauseTimeout;
+
+  bool mIsVideoStreaming;
 };
 
 #endif

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -442,9 +442,10 @@ void WbWrenWindow::feedMultimediaStreamer() {
     skipFirstFrame = false;
   else {
     WbMultimediaStreamer *multimediaStreamer = WbMultimediaStreamer::instance();
-    void *buffer = multimediaStreamer->buffer();
-    readPixels(multimediaStreamer->imageWidth(), multimediaStreamer->imageHeight(), GL_RGB, buffer);
-    multimediaStreamer->sendImage();
+    // TODO
+    // void *buffer = multimediaStreamer->buffer();
+    // readPixels(multimediaStreamer->imageWidth(), multimediaStreamer->imageHeight(), GL_RGB, buffer);
+    multimediaStreamer->sendImage(grabWindowBufferNow());
   }
 }
 


### PR DESCRIPTION
After porting to three.js the video streaming code is no longer working.
Here I'm restoring it while inspecting the MJPEG streaming.