### PR TITLE
Move `Check for updates...` menu

### DIFF
--- a/docs/guide/the-user-interface.md
+++ b/docs/guide/the-user-interface.md
@@ -324,8 +324,6 @@ This editor can be used for editing and compiling controller source code.
 
 - The **Preferences** item pops up a window described in [this section](preferences.md).
 
-- The **Check for updates...** item pops up a window informing if the Webots version in use is the latest one and providing the link to download the latest version if needed.
-
 ### Wizards Menu
 
 The **Wizards** menu makes it easier to create new projects and new controllers.
@@ -349,6 +347,8 @@ The **Help** menu makes it easier to access the documentation, support and gener
 - The **About...** item opens the `About...` window that displays the license information.
 
 - The **Webots Guided Tour...** menu item starts a guided tour that demonstrates Webots capabilies through a series of examples.
+
+- The **Check for updates...** item pops up a window informing if the Webots version in use is the latest one and providing the link to download the latest version if needed.
 
 - The **OpenGL Information...** menu item gives you information about your current OpenGL hardware and driver.
 It can be used to diagnose rendering problems.

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -26,5 +26,6 @@ Released on XXX YYth, 2019.
     - Improved the [Sick LD MRS](../guide/lidar-sensors.md#sick-ld-mrs) PROTO to support the following types: `400001`, `400102`, `400001S01`, `400102S01` and `800001S01`.
     - Split the Webots and controller libraries to avoid possible conflicts with external libraries.
     - Set the [ABB IRB 4600/40](../guide/irb4600-40.md) root node to [Robot](robot.md) instead of [Solid](solid.md) to be able to insert it everywhere.
+    - Windows/Linux: Move the `Check for updates...` menu from `Tools` to `Help` for consistency with other applications.
   - New Samples
     - Added a `complete_apartment` world.

--- a/src/webots/gui/WbGuidedTour.cpp
+++ b/src/webots/gui/WbGuidedTour.cpp
@@ -45,10 +45,6 @@ WbGuidedTour *WbGuidedTour::instance(QWidget *parent) {
   return gInstance;
 }
 
-bool WbGuidedTour::isAvailable() {
-  return QFile::exists(WbStandardPaths::projectsPath() + "guided_tour.txt");
-}
-
 WbGuidedTour::WbGuidedTour(QWidget *parent) :
   QDialog(parent, Qt::Tool) {  // Qt::Tool allows to handle well the z-order. This is mainly advantageous on Mac
   mIndex = -1;

--- a/src/webots/gui/WbGuidedTour.hpp
+++ b/src/webots/gui/WbGuidedTour.hpp
@@ -35,7 +35,6 @@ class WbGuidedTour : public QDialog {
 public:
   // get or create the singleton WbGuidedTour and center on parent
   static WbGuidedTour *instance(QWidget *parent);
-  static bool isAvailable();
   static bool set(const QString &name);
 
 signals:

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -785,13 +785,6 @@ QMenu *WbMainWindow::createToolsMenu() {
   connect(action, &QAction::triggered, this, &WbMainWindow::openPreferencesDialog);
   menu->addAction(action);
 
-  action = new QAction(this);
-  action->setMenuRole(QAction::ApplicationSpecificRole);  // Mac: put the menu respecting the MacOS specifications
-  action->setText(tr("&Check for updates..."));
-  action->setStatusTip(tr("Open the Webots update dialog."));
-  connect(action, &QAction::triggered, this, &WbMainWindow::openWebotsUpdateDialogFromMenu);
-  menu->addAction(action);
-
   return menu;
 }
 
@@ -838,6 +831,15 @@ QMenu *WbMainWindow::createHelpMenu() {
     connect(action, &QAction::triggered, this, &WbMainWindow::showGuidedTour);
     menu->addAction(action);
   }
+
+  menu->addSeparator();
+
+  action = new QAction(this);
+  action->setMenuRole(QAction::ApplicationSpecificRole);  // Mac: put the menu respecting the MacOS specifications
+  action->setText(tr("&Check for updates..."));
+  action->setStatusTip(tr("Open the Webots update dialog."));
+  connect(action, &QAction::triggered, this, &WbMainWindow::openWebotsUpdateDialogFromMenu);
+  menu->addAction(action);
 
   menu->addSeparator();
 

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -824,13 +824,11 @@ QMenu *WbMainWindow::createHelpMenu() {
   connect(action, &QAction::triggered, this, &WbMainWindow::showAboutBox);
   menu->addAction(action);
 
-  if (WbGuidedTour::isAvailable()) {
-    action = new QAction(this);
-    action->setText(tr("Webots &Guided Tour..."));
-    action->setStatusTip(tr("Start a guided tour demonstrating Webots capabilities."));
-    connect(action, &QAction::triggered, this, &WbMainWindow::showGuidedTour);
-    menu->addAction(action);
-  }
+  action = new QAction(this);
+  action->setText(tr("Webots &Guided Tour..."));
+  action->setStatusTip(tr("Start a guided tour demonstrating Webots capabilities."));
+  connect(action, &QAction::triggered, this, &WbMainWindow::showGuidedTour);
+  menu->addAction(action);
 
   menu->addSeparator();
 
@@ -1566,8 +1564,6 @@ void WbMainWindow::showAboutBox() {
 }
 
 void WbMainWindow::showGuidedTour() {
-  if (!WbGuidedTour::isAvailable())
-    return;
   WbGuidedTour *tour = WbGuidedTour::instance(this);
   tour->show();
   tour->raise();


### PR DESCRIPTION
- [x] Linux/Windows: move `Check for updates...` menu from `Tools` to `Help`
- [x] Remove the `WbGuidedTour::isAvailable()` which looks like a vestige of the license system. If the `guided_tour.txt` file is not present, it means that Webots is not installed correctly. In such case, the guided tour box can be open, but shows an "Internal error" label.
