### PR TITLE
Fix Nao.selfCollision

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -21,6 +21,7 @@ Released on ???
     - Fixed exporting first translation and rotation fields change during animation recording and simulation streaming.
     - Fixed displaying streaming server initialization errors in the Webots console.
     - Fixed bugs in Python Display.imageNew() when passing an image array: rearranged image data from column-major order and memory leak (thanks to Inbae Jeong).
+    - Fixed [Nao.selfCollision](../guide/nao.md) due to overlapping bounding objects in feet (thanks to Sheila).
 
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.

--- a/projects/robots/softbank/nao/protos/Nao.proto
+++ b/projects/robots/softbank/nao/protos/Nao.proto
@@ -4058,8 +4058,13 @@ PROTO Nao [
                                                 }
                                               }
                                             }
-                                            boundingObject DEF BUMPER_BO Box {
-                                              size 0.02 0.025 0.01
+                                            boundingObject DEF BUMPER_BO Transform {
+                                              translation 0.0075 0 0
+                                              children [
+                                                Box {
+                                                  size 0.005 0.025 0.01
+                                                }
+                                              ]
                                             }
                                             lookupTable [
                                             ]


### PR DESCRIPTION
Reported here: https://stackoverflow.com/questions/59020010/nao-robot-sinking-into-floor-webots

Fix `Nao.selfCollision`. Internal forces were present due to the feet bounding objects causing weird shrink in floors. The touch sensors bounding objects were overlapping with the foot body.

The present Transform should be equivalent to the previous one.