### PR TITLE
Escape characters before sending message to the robot window

### DIFF
--- a/docs/reference/changelog-r2019.md
+++ b/docs/reference/changelog-r2019.md
@@ -22,6 +22,7 @@ Released on ???
     - Fixed displaying streaming server initialization errors in the Webots console.
     - Fixed bugs in Python Display.imageNew() when passing an image array: rearranged image data from column-major order and memory leak (thanks to Inbae Jeong).
     - Fixed [Nao.selfCollision](../guide/nao.md) due to overlapping bounding objects in feet (thanks to Sheila).
+    - Fixed errors sending messages containing single quote (') and backslash (\) to the robot windows.
 
 ## Webots R2019b Revision 1
 Released on October 3rd, 2019.

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -227,7 +227,7 @@ void WbRobotWindow::runJavaScript(const QString &message) {
 #endif
 
 void WbRobotWindow::sendToJavascript(const QByteArray &string) {
-  QString message(escapeString(string));
+  const QString &message(escapeString(string));
 #ifdef _WIN32
   mFrame->evaluateJavaScript("webots.Window.receive('" + message + "', '" + escapeString(robot()->name()) + "')");
 #else

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -213,22 +213,30 @@ void WbRobotWindow::notifyAckReceived() {
   mRobot->setWaitingForWindow(false);
 }
 
+QString WbRobotWindow::escapeString(const QString &text) {
+  QString escaped(text);
+  escaped.replace("\\", "\\\\\\\\");
+  escaped.replace("'", "\\'");
+  return escaped;
+}
+
 void WbRobotWindow::runJavaScript(const QString &message) {
   mTransportLayer->requestAck();
-  mWebView->page()->runJavaScript("webots.Window.receive('" + message + "', '" + robot()->name() + "')");
+  mWebView->page()->runJavaScript("webots.Window.receive('" + message + "', '" + escapeString(robot()->name()) + "')");
 }
 #endif
 
 void WbRobotWindow::sendToJavascript(const QByteArray &string) {
+  QString message(escapeString(string));
 #ifdef _WIN32
-  mFrame->evaluateJavaScript("webots.Window.receive('" + string + "', '" + robot()->name() + "')");
+  mFrame->evaluateJavaScript("webots.Window.receive('" + message + "', '" + escapeString(robot()->name()) + "')");
 #else
   mRobot->setWaitingForWindow(true);
   if (mLoaded)
-    runJavaScript(string);
+    runJavaScript(message);
   else
     // message will be sent once the robot window loading is completed
-    mWaitingSentMessages << string;
+    mWaitingSentMessages << message;
 #endif
 }
 

--- a/src/webots/gui/WbRobotWindow.hpp
+++ b/src/webots/gui/WbRobotWindow.hpp
@@ -60,6 +60,8 @@ private:
   int mResetCount;
   bool mLoaded;
 
+  static QString escapeString(const QString &text);
+
 private slots:
 #if defined(__APPLE__) || defined(__linux__)
   void notifyLoadCompleted();


### PR DESCRIPTION
Fix #1065:
the single quote `'` and backslash `\` characters need to be escaped before sending a message to the robot window.

The single quote character in the message will interfere with the message delimiters.
The backslash character is interpreted and has to be converted to the corresponding characters to avoid it (we have similar issues when using it in a QRegularExpression).
