### PR TITLE
Fixed PEP8 Test not Ignoring '.git' Folder

### DIFF
--- a/tests/sources/test_pep8.py
+++ b/tests/sources/test_pep8.py
@@ -28,6 +28,7 @@ from pyflakes import checker
 from pyflakes.reporter import Reporter
 
 skippedDirectories = [
+    '.git',
     'dependencies',
     'lib',
     'projects/robots/mobsya/thymio/controllers/thymio2_aseba/aseba',


### PR DESCRIPTION
The PEP8 test is the only test that was looking for files in this folder.
This will allow us to make branches ending with `.py` (I tested on purpose with the name of this branch) and speed up the test.