### PR TITLE
Improve nightly upload failure error message.

### DIFF
--- a/src/packaging/publish_release.py
+++ b/src/packaging/publish_release.py
@@ -99,7 +99,7 @@ for release in repo.get_releases():
             path = os.path.join(os.environ['WEBOTS_HOME'], 'distribution', file)
             if file != '.gitignore' and not os.path.isdir(path):
                 if file in assets:
-                    print('Asset "%s" already present in release' % file)
+                    print('Asset "%s" already present in release "%s".' % (file, title))
                 else:
                     print('Uploading "%s"' % file)
                     release.upload_asset(path)


### PR DESCRIPTION
Hopefully, this will help us understand why the nightly is not uploaded from Windows on revision anymore.