### PR TITLE
Fix clang-format config file used in AppVeyor webots-test-sources

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ install:
   - pacman --noconfirm -S mingw-w64-x86_64-cppcheck
   - pip install -r %APPVEYOR_BUILD_FOLDER%\\tests\\sources\\requirements.txt
   - pip install -r %APPVEYOR_BUILD_FOLDER%\\docs\\tests\\requirements.txt
-  - copy %APPVEYOR_BUILD_FOLDER%\\dependencies\\.clang-format-6 %APPVEYOR_BUILD_FOLDER%\\.clang-format
+  - copy %APPVEYOR_BUILD_FOLDER%\\dependencies\\.clang-format-9 %APPVEYOR_BUILD_FOLDER%\\.clang-format
 
 build: off
 

--- a/include/controller/cpp/webots/Brake.hpp
+++ b/include/controller/cpp/webots/Brake.hpp
@@ -27,7 +27,9 @@ namespace webots {
     typedef enum { ROTATIONAL = 0, LINEAR } Type;
 
     explicit Brake(const std::string &name) :
-      Device(name), motor(NULL), positionSensor(NULL) {}  // Use Robot::getBrake() instead
+      Device(name),
+      motor(NULL),
+      positionSensor(NULL) {}  // Use Robot::getBrake() instead
     virtual ~Brake() {}
     Type getType() const;
     void setDampingConstant(double dampingConstant) const;

--- a/include/controller/cpp/webots/Brake.hpp
+++ b/include/controller/cpp/webots/Brake.hpp
@@ -27,9 +27,7 @@ namespace webots {
     typedef enum { ROTATIONAL = 0, LINEAR } Type;
 
     explicit Brake(const std::string &name) :
-      Device(name),
-      motor(NULL),
-      positionSensor(NULL) {}  // Use Robot::getBrake() instead
+      Device(name), motor(NULL), positionSensor(NULL) {}  // Use Robot::getBrake() instead
     virtual ~Brake() {}
     Type getType() const;
     void setDampingConstant(double dampingConstant) const;


### PR DESCRIPTION
In #1130, when running the AppVeyor "webots-test-sources" on the branch I got again a clang-format test failure due to a wrong style configuration.

Note that when running the "webots-test-sources-revision" the test passes and it is using the `.clang-format-9` config file:
https://github.com/cyberbotics/webots/blob/ae4db5164bd22237bf8c8861698cf12dfaeae09d/.appveyor-test-sources-scheduled.yml#L13