### PR TITLE
SICK LD-MRS: change the way to manage the overlapping layers

### DIFF
--- a/docs/guide/lidar-sensors.md
+++ b/docs/guide/lidar-sensors.md
@@ -154,21 +154,32 @@ The `resolution` field specifies the number of points returned per layer per sca
 #### SICK LD-MRS
 
 The [SICK LD-MRS](https://www.sick.com/us/en/detection-and-ranging-solutions/3d-lidar-sensors/ld-mrs/c/g91913) is a multi-layer lidar designed for harsh outdoor environments.
-It has a range of 300 meters.
-Each layer is separated vertically by 0.8°.
 
-Other parameters depends on its type:
+The `SickLdMrs` PROTO contains internally a [Lidar](../reference/lidar.md) node which covers the main usual cases.
+Its reference name matches directly with the `SickLdMrs.name` field.
+It has the following properties:
 
-| Type | Number of measurement layers (L) | Horizontal field of view | Horizontal Offset |
-| --- | --- | --- | --- | --- |
-| `400001` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
-| `400102` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
-| `400001S01` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
-| `400102S01` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
-| `800001S01` | 4 or 8 | 85° (8L) or 110° (4L) | 7.5° (8L) or 5° (4L) |
+- Its number of layers is 4 except for the `800001S01` type which is 8.
+- Its horizontal scanning range is 85°, shifted by 7,5°.
+- Its maximal range is 300 meters.
+- Each layer is separated vertically by 0.8°.
 
-Layer 0 corresponds to the bottom layer.
-First response values are corresponding to the device right.
+In addition to this main [Lidar](../reference/lidar.md) node, the PROTO contains a second [Lidar](../reference/lidar.md) in order to model the overlapping long-range layers.
+This sensor reference name (to get it from the Webots API) is the `SickLdMrs.name` field concatenated by the ` (long range)` string.
+In addition to the properties of the main lidar, it has the following properties:
+
+- Its horizontal scanning range is 110°, shifted by 5°.
+- Its number of layers is `SickLdMrs.measurementLayers` divided by 2.
+
+The internal Lidars are oriented as follows:
+
+- Layer 0 corresponds to the bottom layer.
+- First response values are corresponding to the device right.
+
+In comparison to the real sensor, the simulated model has the following limitations:
+
+- The scanning range resolution is constant over the entire scan.
+- The vertical azimuth doesn't depend on the horizontal scan angle.
 
 %figure "SICK LD-MRS lidar"
 
@@ -182,7 +193,6 @@ SickLdMrs {
   SFRotation rotation          0 1 0 0
   SFString   name              "Sick LD-MRS"
   SFString   type              "400001"
-  SFInt32    measurementLayers 4
   SFString   angularResolution "0.5 [deg]"
   SFFloat    noise             0.001
   SFBool     physics           TRUE
@@ -190,19 +200,15 @@ SickLdMrs {
 ```
 
 The `type` field specifies the `SICK LD-MRS` type (cf. [specifications](https://www.sick.com/us/en/detection-and-ranging-solutions/3d-lidar-sensors/ld-mrs/c/g91913)).
-Internal parameters are affected by the `type` as described in the table above.
 The value could be one of the following: `400001`, `400102`, `400001S01`, `400102S01` or `800001S01`.
 
 The `noise` field specifies the standard deviation of gaussian image noise in meters.
-
-The `measurementLayers` field specifies the number of horizontal layers.
-Depending on `SickLdMrs.type` some `measurementLayers` values may not be applicable.
-The value could be one of the following: `2`, `4` or `8`.
 
 The `angularResolution` field specifies the vertical angular gap between two measurements.
 From the `SICK LD-MRS` specification, it can be either 0.5, 0.25 or 0.125 degrees.
 Internally, the `Lidar.horizontalResolution` is directly affected by this field.
 The value could be one of the following: `0.5 [deg]`, `0.25 [deg]` or `0.125 [deg]`.
+Unlike the sensor specification, the angular resolution is constant over the entire scan.
 
 The `physics` field specifies if the sensor should be affected by physics (mass = 1 [kg]) or not.
 

--- a/docs/guide/lidar-sensors.md
+++ b/docs/guide/lidar-sensors.md
@@ -155,16 +155,17 @@ The `resolution` field specifies the number of points returned per layer per sca
 
 The [SICK LD-MRS](https://www.sick.com/us/en/detection-and-ranging-solutions/3d-lidar-sensors/ld-mrs/c/g91913) is a multi-layer lidar designed for harsh outdoor environments.
 It has a range of 300 meters.
+Each layer is separated vertically by 0.8°.
 
 Other parameters depends on its type:
 
-| Type | Number of measurement layers (L) | Horizontal field of view | Horizontal Offset | Vertical field of View |
+| Type | Number of measurement layers (L) | Horizontal field of view | Horizontal Offset |
 | --- | --- | --- | --- | --- |
-| `400001` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) | 3.2° |
-| `400102` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) | 3.2° |
-| `400001S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) | 3.2° |
-| `400102S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) | 3.2° |
-| `800001S01` | 4 or 8 | 85° (8L) or 110° (4L) | 9.5° (8L) or 5° (4L) | 6.4° (8L) or 3.2° (4L) |
+| `400001` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
+| `400102` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
+| `400001S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
+| `400102S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
+| `800001S01` | 4 or 8 | 85° (8L) or 110° (4L) | 9.5° (8L) or 5° (4L) |
 
 Layer 0 corresponds to the bottom layer.
 First response values are corresponding to the device right.

--- a/docs/guide/lidar-sensors.md
+++ b/docs/guide/lidar-sensors.md
@@ -161,11 +161,11 @@ Other parameters depends on its type:
 
 | Type | Number of measurement layers (L) | Horizontal field of view | Horizontal Offset |
 | --- | --- | --- | --- | --- |
-| `400001` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
-| `400102` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
-| `400001S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
-| `400102S01` | 2 or 4 | 85° (4L) or 110° (2L) | 9.5° (4L) or 5° (2L) |
-| `800001S01` | 4 or 8 | 85° (8L) or 110° (4L) | 9.5° (8L) or 5° (4L) |
+| `400001` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
+| `400102` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
+| `400001S01` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
+| `400102S01` | 2 or 4 | 85° (4L) or 110° (2L) | 7.5° (4L) or 5° (2L) |
+| `800001S01` | 4 or 8 | 85° (8L) or 110° (4L) | 7.5° (8L) or 5° (4L) |
 
 Layer 0 corresponds to the bottom layer.
 First response values are corresponding to the device right.

--- a/docs/guide/lidar-sensors.md
+++ b/docs/guide/lidar-sensors.md
@@ -155,23 +155,23 @@ The `resolution` field specifies the number of points returned per layer per sca
 
 The [SICK LD-MRS](https://www.sick.com/us/en/detection-and-ranging-solutions/3d-lidar-sensors/ld-mrs/c/g91913) is a multi-layer lidar designed for harsh outdoor environments.
 
-The `SickLdMrs` PROTO contains internally a [Lidar](../reference/lidar.md) node which covers the main usual cases.
-Its reference name matches directly with the `SickLdMrs.name` field.
+The `SickLdMrs` PROTO contains a [Lidar](../reference/lidar.md) node which covers the main usual cases.
+Its reference name (to get it from the Webots API) matches directly with the `SickLdMrs.name` field.
 It has the following properties:
 
 - Its number of layers is 4 except for the `800001S01` type which is 8.
-- Its horizontal scanning range is 85°, shifted by 7,5°.
+- Its horizontal scanning range is 85°, shifted horizontally by 7,5°.
 - Its maximal range is 300 meters.
 - Each layer is separated vertically by 0.8°.
 
 In addition to this main [Lidar](../reference/lidar.md) node, the PROTO contains a second [Lidar](../reference/lidar.md) in order to model the overlapping long-range layers.
-This sensor reference name (to get it from the Webots API) is the `SickLdMrs.name` field concatenated by the ` (long range)` string.
+This sensor reference name is the `SickLdMrs.name` field concatenated by the ` (long range)` string.
 In addition to the properties of the main lidar, it has the following properties:
 
-- Its horizontal scanning range is 110°, shifted by 5°.
+- Its horizontal scanning range is 110°, shifted horizontally by 5°.
 - Its number of layers is `SickLdMrs.measurementLayers` divided by 2.
 
-The internal Lidars are oriented as follows:
+The internal [Lidars](../reference/lidar.md) are oriented as follows:
 
 - Layer 0 corresponds to the bottom layer.
 - First response values are corresponding to the device right.
@@ -179,7 +179,7 @@ The internal Lidars are oriented as follows:
 In comparison to the real sensor, the simulated model has the following limitations:
 
 - The scanning range resolution is constant over the entire scan.
-- The vertical azimuth doesn't depend on the horizontal scan angle.
+- The vertical azimuth is constant over the entire scan.
 
 %figure "SICK LD-MRS lidar"
 
@@ -208,7 +208,6 @@ The `angularResolution` field specifies the vertical angular gap between two mea
 From the `SICK LD-MRS` specification, it can be either 0.5, 0.25 or 0.125 degrees.
 Internally, the `Lidar.horizontalResolution` is directly affected by this field.
 The value could be one of the following: `0.5 [deg]`, `0.25 [deg]` or `0.125 [deg]`.
-Unlike the sensor specification, the angular resolution is constant over the entire scan.
 
 The `physics` field specifies if the sensor should be affected by physics (mass = 1 [kg]) or not.
 

--- a/projects/devices/sick/protos/SickLdMrs.proto
+++ b/projects/devices/sick/protos/SickLdMrs.proto
@@ -47,7 +47,7 @@ PROTO SickLdMrs [
     if type == "800001S01" then
       if measurementLayers == 8 then
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(9.5)
+        offsetAngle = wbmath.degrees2radians(7.5)
       elseif measurementLayers == 4 then
         horizontalFieldOfView = wbmath.degrees2radians(110)
         offsetAngle = wbmath.degrees2radians(5)
@@ -55,12 +55,12 @@ PROTO SickLdMrs [
         -- invalid case: warn and fill with dummy values.
         io.stderr:write("A '" .. type .. "' SickLdMrs can not have " .. measurementLayers .. " measurement layers.")
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(9.5)
+        offsetAngle = wbmath.degrees2radians(7.5)
       end
     else  -- type "400*"
       if measurementLayers == 4 then
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(9.5)
+        offsetAngle = wbmath.degrees2radians(7.5)
       elseif measurementLayers == 2 then
         horizontalFieldOfView = wbmath.degrees2radians(110)
         offsetAngle = wbmath.degrees2radians(5)
@@ -68,7 +68,7 @@ PROTO SickLdMrs [
         -- invalid case: warn and fill with dummy values.
         io.stderr:write("A '" .. type .. "' SickLdMrs can not have " .. measurementLayers .. " measurement layers.")
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(9.5)
+        offsetAngle = wbmath.degrees2radians(7.5)
       end
     end
 

--- a/projects/devices/sick/protos/SickLdMrs.proto
+++ b/projects/devices/sick/protos/SickLdMrs.proto
@@ -40,28 +40,24 @@ PROTO SickLdMrs [
     end
 
     -- Compute geometry constants.
+    local verticalFieldOfView = wbmath.degrees2radians(0.8 * (measurementLayers + 1))  -- +1 because the measurements are taken at the pixel center.
     local horizontalFieldOfView = 0.0
-    local verticalFieldOfView = 0.0
     local offsetAngle = 0.0
 
     if type == "800001S01" then
       if measurementLayers == 8 then
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        verticalFieldOfView = wbmath.degrees2radians(6.4)
         offsetAngle = wbmath.degrees2radians(9.5)
       elseif measurementLayers == 4 then
         horizontalFieldOfView = wbmath.degrees2radians(110)
-        verticalFieldOfView = wbmath.degrees2radians(3.2)
         offsetAngle = wbmath.degrees2radians(5)
       else
         -- invalid case: warn and fill with dummy values.
         io.stderr:write("A '" .. type .. "' SickLdMrs can not have " .. measurementLayers .. " measurement layers.")
         horizontalFieldOfView = wbmath.degrees2radians(85)
-        verticalFieldOfView = wbmath.degrees2radians(6.4)
         offsetAngle = wbmath.degrees2radians(9.5)
       end
     else  -- type "400*"
-      verticalFieldOfView = wbmath.degrees2radians(3.2)
       if measurementLayers == 4 then
         horizontalFieldOfView = wbmath.degrees2radians(85)
         offsetAngle = wbmath.degrees2radians(9.5)

--- a/projects/devices/sick/protos/SickLdMrs.proto
+++ b/projects/devices/sick/protos/SickLdMrs.proto
@@ -13,8 +13,6 @@ PROTO SickLdMrs [
   field SFString   name              "Sick LD-MRS"
   field SFString{"400001", "400102", "400001S01", "400102S01", "800001S01"}
                    type              "400001"
-  field SFInt32{2, 4, 8}
-                   measurementLayers 4
   field SFString{"0.5 [deg]", "0.25 [deg]", "0.125 [deg]"}
                    angularResolution "0.5 [deg]"
   field SFFloat    noise             0.001
@@ -26,11 +24,12 @@ PROTO SickLdMrs [
     local wbmath = require('wbmath')
 
     -- Get and check fields.
-    local measurementLayers = fields.measurementLayers.value
     local type = fields.type.value
 
     local isHD = type == "400102" or type == "400102S01"
     local is8L = type == "800001S01"
+
+    local measurementLayers = is8L and 8 or 4
 
     local angularResolution = wbmath.degrees2radians(0.5)
     if fields.angularResolution.value == "0.25 [deg]" then
@@ -38,44 +37,6 @@ PROTO SickLdMrs [
     elseif fields.angularResolution.value == "0.125 [deg]" then
       angularResolution = angularResolution / 4
     end
-
-    -- Compute geometry constants.
-    local verticalFieldOfView = wbmath.degrees2radians(0.8 * (measurementLayers + 1))  -- +1 because the measurements are taken at the pixel center.
-    local horizontalFieldOfView = 0.0
-    local offsetAngle = 0.0
-
-    if type == "800001S01" then
-      if measurementLayers == 8 then
-        horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(7.5)
-      elseif measurementLayers == 4 then
-        horizontalFieldOfView = wbmath.degrees2radians(110)
-        offsetAngle = wbmath.degrees2radians(5)
-      else
-        -- invalid case: warn and fill with dummy values.
-        io.stderr:write("A '" .. type .. "' SickLdMrs can not have " .. measurementLayers .. " measurement layers.")
-        horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(7.5)
-      end
-    else  -- type "400*"
-      if measurementLayers == 4 then
-        horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(7.5)
-      elseif measurementLayers == 2 then
-        horizontalFieldOfView = wbmath.degrees2radians(110)
-        offsetAngle = wbmath.degrees2radians(5)
-      else
-        -- invalid case: warn and fill with dummy values.
-        io.stderr:write("A '" .. type .. "' SickLdMrs can not have " .. measurementLayers .. " measurement layers.")
-        horizontalFieldOfView = wbmath.degrees2radians(85)
-        offsetAngle = wbmath.degrees2radians(7.5)
-      end
-    end
-
-    local internalRotation = wbrotation.combine(
-      {x = 0, y = 1, z = 0, a = -offsetAngle},
-      {x = 0, y = 0, z = 1, a = math.pi}
-    )
   }%
   Solid {
     translation IS translation
@@ -83,12 +44,39 @@ PROTO SickLdMrs [
     name IS name
     children [
       Lidar {
+        %{
+          local internalRotation = wbrotation.combine(
+            {x = 0, y = 1, z = 0, a = -wbmath.degrees2radians(7.5)},
+            {x = 0, y = 0, z = 1, a = math.pi}
+          )
+          local horizontalFieldOfView = wbmath.degrees2radians(85)
+        }%
         rotation %{= internalRotation.x }% %{= internalRotation.y }% %{= internalRotation.z }% %{= internalRotation.a }%
         name IS name
         model %{= "\"Sick LD-MRS " .. fields.type.value .. "\"" }%
         fieldOfView %{= horizontalFieldOfView }%
         horizontalResolution %{= wbmath.round(horizontalFieldOfView / angularResolution)  }%
-        verticalFieldOfView %{= verticalFieldOfView }%
+        verticalFieldOfView %{= wbmath.degrees2radians(0.8 * (measurementLayers + 1)) }%
+        numberOfLayers %{= measurementLayers }%
+        minRange 0.5
+        maxRange 300
+        noise IS noise
+      }
+      Lidar {
+        %{
+          internalRotation = wbrotation.combine(
+            {x = 0, y = 1, z = 0, a = -wbmath.degrees2radians(5)},
+            {x = 0, y = 0, z = 1, a = math.pi}
+          )
+          horizontalFieldOfView = wbmath.degrees2radians(110)
+          measurementLayers = measurementLayers / 2
+        }%
+        rotation %{= internalRotation.x }% %{= internalRotation.y }% %{= internalRotation.z }% %{= internalRotation.a }%
+        name %{= "\"" .. fields.name.value .. " (long range)\"" }%
+        model %{= "\"Sick LD-MRS " .. fields.type.value .. "\"" }%
+        fieldOfView %{= horizontalFieldOfView }%
+        horizontalResolution %{= wbmath.round(horizontalFieldOfView / angularResolution)  }%
+        verticalFieldOfView %{= wbmath.degrees2radians(0.8 * (measurementLayers + 1)) }%
         numberOfLayers %{= measurementLayers }%
         minRange 0.5
         maxRange 300

--- a/projects/samples/devices/worlds/sick_point_cloud.wbt
+++ b/projects/samples/devices/worlds/sick_point_cloud.wbt
@@ -55,7 +55,6 @@ Robot {
       translation 0 1.2 -0.25
       name "sick"
       type "800001S01"
-      measurementLayers 8
     }
     DEF BODY_SHAPE Transform {
       translation 0 0.7 0


### PR DESCRIPTION
According [these specifications](https://cdn.sick.com/media/docs/3/03/803/Operating_instructions_LD_MRS_3D_LiDAR_sensors_en_IM0032803.PDF), the SICK LD-MRS can has supplementary and overlapping layers with a shifted and bigger range (It was not a mode of operation as I thought at first).
The current PR is about to add another internal Lidar (which can be optionally switched on) to manage this long range case.

- [x] Add a supplementary internal Lidar to manage the long-range case.
- [x] Fix the vertical offset in case of a 85° scan (9.5° to 7.5°)
- [x] Drop the `SickLdMrs.measurementLayer` which becomes pointless (the number of layers can be extracted from the `SickLdMrs.type`
- [x] Update doc accordingly: [Preview](https://cyberbotics.com/doc/guide/lidar-sensors?version=fix-ld-mrs#sick-ld-mrs)
    - [x] Warn about limitations (constant horizontal resolution and constant vertical azimuth)

