### PR TITLE
HDR Reflection Fallback

### DIFF
--- a/resources/web/wwi/x3d.js
+++ b/resources/web/wwi/x3d.js
@@ -8,6 +8,8 @@ THREE.X3DLoader = class X3DLoader {
     this.scene = scene;
     this.parsedObjects = [];
     this.directionalLights = [];
+
+    this.enableHDRReflections = true;
   };
 
   load(url, onLoad, onProgress, onError) {
@@ -989,7 +991,7 @@ THREE.X3DLoader = class X3DLoader {
       cubeTexture.needsUpdate = true;
     }
 
-    if (irradianceEnabled) {
+    if (irradianceEnabled && this.enableHDRReflections) {
       let cubeTexture = new THREE.CubeTexture();
       cubeTexture.format = THREE.RGBFormat;
       cubeTexture.type = THREE.FloatType;

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -201,6 +201,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
     if (parentId && parentId !== 0)
       parentObject = this.getObjectById('n' + parentId);
     var loader = new THREE.X3DLoader(this);
+    loader.enableHDRReflections = this.enableHDRReflections;
     var objects = loader.parse(x3dObject, parentObject);
     if (typeof parentObject !== 'undefined')
       this._updateUseNodesIfNeeded(parentObject, parentObject.name.split(';'));

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -12,6 +12,14 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.sceneModified = false;
     this.useNodeCache = {};
     this.objectsIdCache = {};
+
+    const gl = document.createElement('canvas').getContext('webgl');
+    const glVendor = gl.getParameter(gl.VENDOR);
+    // Mozilla WebGL implementation does not support mimaps on float32 cubes.
+    // cf. https://github.com/cyberbotics/webots/issues/1150
+    this.enableHDRReflections = glVendor !== 'Mozilla';
+    if (!this.enableHDRReflections)
+      console.warn('HDR reflections are not implemented for the current hardware.');
   }
 
   init(texturePathPrefix = '') {
@@ -158,6 +166,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
   loadWorldFile(url, onLoad) {
     this.objectsIdCache = {};
     var loader = new THREE.X3DLoader(this);
+    loader.enableHDRReflections = this.enableHDRReflections;
     loader.load(url, (object3d) => {
       if (object3d.length > 0) {
         this.scene.add(object3d[0]);

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -13,10 +13,14 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.useNodeCache = {};
     this.objectsIdCache = {};
 
+    // Mozilla WebGL implementation does not support mimaps on float32 cube textures.
+    // - Warning (JS console): "Texture at base level is not unsized internal format or is not color-renderable or texture-filterable."
+    // - References:
+    //   - https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glGenerateMipmap.xhtml
+    //   - https://stackoverflow.com/questions/44754479/issue-with-rgba32f-texture-format-and-mipmapping-using-opengl-es-3-0
+    //   - https://stackoverflow.com/questions/56829454/unable-to-generate-mipmap-for-half-float-texture
     const gl = document.createElement('canvas').getContext('webgl');
     const glVendor = gl.getParameter(gl.VENDOR);
-    // Mozilla WebGL implementation does not support mimaps on float32 cubes.
-    // cf. https://github.com/cyberbotics/webots/issues/1150
     this.enableHDRReflections = glVendor !== 'Mozilla';
     if (!this.enableHDRReflections)
       console.warn('HDR reflections are not implemented for the current hardware.');

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -13,9 +13,9 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.useNodeCache = {};
     this.objectsIdCache = {};
 
-    // Mozilla WebGL implementation does not support mimaps on float32 cube textures.
+    // The Mozilla WebGL implementation does not support automatic mimaps generation on float32 cube textures.
     // - Warning (JS console): "Texture at base level is not unsized internal format or is not color-renderable or texture-filterable."
-    // - References:
+    // - The related OpenGL specification is known as cryptic about this topic:
     //   - https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glGenerateMipmap.xhtml
     //   - https://stackoverflow.com/questions/44754479/issue-with-rgba32f-texture-format-and-mipmapping-using-opengl-es-3-0
     //   - https://stackoverflow.com/questions/56829454/unable-to-generate-mipmap-for-half-float-texture


### PR DESCRIPTION
Fix #1150

Unfortunately, the Mozilla implementation of WebGL doesn't support mipmaps generation for cube textures with float 32 type, which is required for the current background algorithm.
I tested it on supported on webkit (safari, chrome, opera) and microsoft (edge) and it's working smoothly.

Removing the HDR reflections is not a big deal on Firefox, the effect is not very big in our featured worlds (robotbenchmark). Only sun reflections are less intense. This is because of the fallback using PNG in case HDR is not present:

<img width="947" alt="Capture d’écran 2019-12-09 à 15 55 22" src="https://user-images.githubusercontent.com/866788/70451023-f96f4880-1aa4-11ea-9201-2e248fbef524.png">

