### PR TITLE
Improve doc about old license system

### DIFF
--- a/docs/guide/general-faq.md
+++ b/docs/guide/general-faq.md
@@ -14,10 +14,16 @@ Please [contact us](mailto:info@cyberbotics.com) for more information about our 
 ### Can I Still Use a Webots Version before the R2019a Release?
 
 Yes, and for free!
+But please, upgrade Webots ;-) !
 
 Download an old Webots version from [this archive page](https://github.com/cyberbotics/webots/releases/tag/R2019a).
 Just log into Webots using this magical password: `webots`.
 Your e-mail doesn't matter (it is not stored anywhere).
+
+#### Limitations
+
+- The license system is still functional for the following versions: Webots 7, 8 and R2018.
+- Webots >= 8.0 and < 8.4 are no more functional.
 
 ### Where to Start?
 


### PR DESCRIPTION
❗️This PR targets `master`.

I have now more information about the supported versions. I think it's important to document this quickly.

=> Webots >= 8.0 and < 8.4 are not supported anymore because the modules packages are currently not restored.