### PR TITLE
macOS: Fix RPATH of openssl

### DIFF
--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -244,9 +244,9 @@ $(WEBOTS_HOME_LIB)/libssl.1.0.0.dylib: $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2
 	@install_name_tool -id @rpath/lib/webots/libcrypto.dylib $(WEBOTS_HOME_LIB)/libcrypto.dylib
 	@install_name_tool -id @rpath/lib/webots/libcrypto.1.0.0.dylib $(WEBOTS_HOME_LIB)/libcrypto.1.0.0.dylib
 	@install_name_tool -id @rpath/lib/webots/libssl.dylib $(WEBOTS_HOME_LIB)/libssl.dylib
-	@install_name_tool -change /usr/local/ssl/lib/webots/libcrypto.1.0.0.dylib @rpath/lib/webots/libcrypto.1.0.0.dylib $(WEBOTS_HOME_LIB)/libssl.dylib
+	@install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/webots/libcrypto.1.0.0.dylib $(WEBOTS_HOME_LIB)/libssl.dylib
 	@install_name_tool -id @rpath/lib/webots/libssl.dylib $(WEBOTS_HOME_LIB)/libssl.1.0.0.dylib
-	@install_name_tool -change /usr/local/ssl/lib/webots/libcrypto.1.0.0.dylib @rpath/lib/webots/libcrypto.1.0.0.dylib $(WEBOTS_HOME_LIB)/libssl.1.0.0.dylib
+	@install_name_tool -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib @rpath/lib/webots/libcrypto.1.0.0.dylib $(WEBOTS_HOME_LIB)/libssl.1.0.0.dylib
 
 $(WEBOTS_DEPENDENCY_PATH)/openssl-1.0.2:
 	@echo "# downloading $(OPENSSL_PACKAGE)"

--- a/src/packaging/check_rpath.py
+++ b/src/packaging/check_rpath.py
@@ -93,3 +93,5 @@ for f in controllerFiles + binaryFiles + qtBinaryFiles:
 if success:
     print('Dylibs dependencies: ok')
     print('Frameworks dependencies: ok')
+else:
+    sys.exit(1)  # Quit the script with an error code.


### PR DESCRIPTION
Not very important, but it's more consistent, and makes the `check_rpath.py` test happy.

Before:

```
➜  packaging git:(develop) ./check_rpath.py 
Dependency error:
- File: ./lib/webots/libssl.dylib
- Dependency: /usr/local/ssl/lib/libcrypto.1.0.0.dylib
Dependency error:
- File: ./lib/webots/libssl.1.0.0.dylib
- Dependency: /usr/local/ssl/lib/libcrypto.1.0.0.dylib
```

After:

```
➜  packaging git:(develop) ./check_rpath.py
Dylibs dependencies: ok
Frameworks dependencies: ok
```
