### PR TITLE
macOS: Fix new clang warnings coming from swig

### DIFF
--- a/resources/languages/python/Makefile
+++ b/resources/languages/python/Makefile
@@ -62,7 +62,7 @@ PYTHON_PYMALLOC = m
 endif
 BREW_PYTHON_PATH = /usr/local/Cellar/python/$(PYTHON_FULL_VERSION)/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
 PYTHON_BIN       = $(PYTHON_PATH)/bin/
-C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-maybe-uninitialized
+C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-uninitialized
 ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
 C_FLAGS        += -Wno-self-assign
 endif


### PR DESCRIPTION
Since the last clang update, `-Wno-maybe-uninitialized` has been replaced by `-Wno-uninitialized`. Lot of warnings are raised with the previous argument.