### PR TITLE
Improved receiver warnings

### DIFF
--- a/src/lib/Controller/api/receiver.c
+++ b/src/lib/Controller/api/receiver.c
@@ -303,7 +303,7 @@ const void *wb_receiver_get_data(WbDeviceTag tag) {
   if (rs && rs->queue)  // if queue not empty
     result = rs->queue->data;
   else if (rs)
-    fprintf(stderr, "Error: wb_receiver_get_data(): the receiver queue length should be get first.\n");
+    fprintf(stderr, "Error: wb_receiver_get_data(): the receiver queue is empty.\n");
   else  // rs->queue == NULL
     fprintf(stderr, "Error: wb_receiver_get_data(): invalid device tag.\n");
   robot_mutex_unlock_step();

--- a/src/lib/Controller/api/receiver.c
+++ b/src/lib/Controller/api/receiver.c
@@ -303,7 +303,7 @@ const void *wb_receiver_get_data(WbDeviceTag tag) {
   if (rs && rs->queue)  // if queue not empty
     result = rs->queue->data;
   else if (rs)
-    fprintf(stderr, "Error: wb_receiver_get_data(): please get the queue length first.\n");
+    fprintf(stderr, "Error: wb_receiver_get_data(): the receiver queue length should be get first.\n");
   else  // rs->queue == NULL
     fprintf(stderr, "Error: wb_receiver_get_data(): invalid device tag.\n");
   robot_mutex_unlock_step();

--- a/src/lib/Controller/api/receiver.c
+++ b/src/lib/Controller/api/receiver.c
@@ -302,7 +302,9 @@ const void *wb_receiver_get_data(WbDeviceTag tag) {
   Receiver *rs = receiver_get_struct(tag);
   if (rs && rs->queue)  // if queue not empty
     result = rs->queue->data;
-  else
+  else if (rs)
+    fprintf(stderr, "Error: wb_receiver_get_data(): please get the queue length first.\n");
+  else  // rs->queue == NULL
     fprintf(stderr, "Error: wb_receiver_get_data(): invalid device tag.\n");
   robot_mutex_unlock_step();
   return result;


### PR DESCRIPTION
It is required to call `wb_receiver_get_queue_length()` before `wb_receiver_get_data()`, but the warning in case this is not fulfilled is cryptic: `invalid device tag`.

The aim of this PR is simply to improve this warning to be self explanatory.