### PR TITLE
Update copyright dates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/generate_thumbnails.py
+++ b/docs/generate_thumbnails.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/guide/generate_objects_doc.py
+++ b/docs/guide/generate_objects_doc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/local_exporter.py
+++ b/docs/local_exporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/src/dia/Makefile
+++ b/docs/src/dia/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/src/math/Makefile
+++ b/docs/src/math/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/src/svg/Makefile
+++ b/docs/src/svg/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/tests/suite.py
+++ b/docs/tests/suite.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/accelerometer.h
+++ b/include/controller/c/webots/accelerometer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/brake.h
+++ b/include/controller/c/webots/brake.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/camera.h
+++ b/include/controller/c/webots/camera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/camera_recognition_object.h
+++ b/include/controller/c/webots/camera_recognition_object.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/compass.h
+++ b/include/controller/c/webots/compass.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/connector.h
+++ b/include/controller/c/webots/connector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/console.h
+++ b/include/controller/c/webots/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/device.h
+++ b/include/controller/c/webots/device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/differential_wheels.h
+++ b/include/controller/c/webots/differential_wheels.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/display.h
+++ b/include/controller/c/webots/display.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/distance_sensor.h
+++ b/include/controller/c/webots/distance_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/emitter.h
+++ b/include/controller/c/webots/emitter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/gps.h
+++ b/include/controller/c/webots/gps.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/gyro.h
+++ b/include/controller/c/webots/gyro.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/inertial_unit.h
+++ b/include/controller/c/webots/inertial_unit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/joystick.h
+++ b/include/controller/c/webots/joystick.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/keyboard.h
+++ b/include/controller/c/webots/keyboard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/led.h
+++ b/include/controller/c/webots/led.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/lidar.h
+++ b/include/controller/c/webots/lidar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/lidar_point.h
+++ b/include/controller/c/webots/lidar_point.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/light_sensor.h
+++ b/include/controller/c/webots/light_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/microphone.h
+++ b/include/controller/c/webots/microphone.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/motor.h
+++ b/include/controller/c/webots/motor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/mouse.h
+++ b/include/controller/c/webots/mouse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/mouse_state.h
+++ b/include/controller/c/webots/mouse_state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/nodes.h
+++ b/include/controller/c/webots/nodes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/pen.h
+++ b/include/controller/c/webots/pen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/position_sensor.h
+++ b/include/controller/c/webots/position_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/radar.h
+++ b/include/controller/c/webots/radar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/radar_target.h
+++ b/include/controller/c/webots/radar_target.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/radio.h
+++ b/include/controller/c/webots/radio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/range_finder.h
+++ b/include/controller/c/webots/range_finder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/receiver.h
+++ b/include/controller/c/webots/receiver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/remote_control.h
+++ b/include/controller/c/webots/remote_control.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/robot.h
+++ b/include/controller/c/webots/robot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/robot_window.h
+++ b/include/controller/c/webots/robot_window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/robot_wwi.h
+++ b/include/controller/c/webots/robot_wwi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/skin.h
+++ b/include/controller/c/webots/skin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/speaker.h
+++ b/include/controller/c/webots/speaker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/supervisor.h
+++ b/include/controller/c/webots/supervisor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/touch_sensor.h
+++ b/include/controller/c/webots/touch_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/types.h
+++ b/include/controller/c/webots/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/utils/default_robot_window.h
+++ b/include/controller/c/webots/utils/default_robot_window.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/utils/motion.h
+++ b/include/controller/c/webots/utils/motion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/utils/system.h
+++ b/include/controller/c/webots/utils/system.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/vehicle/car.h
+++ b/include/controller/c/webots/vehicle/car.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/c/webots/vehicle/driver.h
+++ b/include/controller/c/webots/vehicle/driver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Accelerometer.hpp
+++ b/include/controller/cpp/webots/Accelerometer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Brake.hpp
+++ b/include/controller/cpp/webots/Brake.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Camera.hpp
+++ b/include/controller/cpp/webots/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Compass.hpp
+++ b/include/controller/cpp/webots/Compass.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Connector.hpp
+++ b/include/controller/cpp/webots/Connector.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Device.hpp
+++ b/include/controller/cpp/webots/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/DifferentialWheels.hpp
+++ b/include/controller/cpp/webots/DifferentialWheels.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Display.hpp
+++ b/include/controller/cpp/webots/Display.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/DistanceSensor.hpp
+++ b/include/controller/cpp/webots/DistanceSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Emitter.hpp
+++ b/include/controller/cpp/webots/Emitter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Field.hpp
+++ b/include/controller/cpp/webots/Field.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/GPS.hpp
+++ b/include/controller/cpp/webots/GPS.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Gyro.hpp
+++ b/include/controller/cpp/webots/Gyro.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/ImageRef.hpp
+++ b/include/controller/cpp/webots/ImageRef.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/InertialUnit.hpp
+++ b/include/controller/cpp/webots/InertialUnit.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Joystick.hpp
+++ b/include/controller/cpp/webots/Joystick.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Keyboard.hpp
+++ b/include/controller/cpp/webots/Keyboard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/LED.hpp
+++ b/include/controller/cpp/webots/LED.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Lidar.hpp
+++ b/include/controller/cpp/webots/Lidar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/LightSensor.hpp
+++ b/include/controller/cpp/webots/LightSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Motor.hpp
+++ b/include/controller/cpp/webots/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Mouse.hpp
+++ b/include/controller/cpp/webots/Mouse.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Node.hpp
+++ b/include/controller/cpp/webots/Node.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Pen.hpp
+++ b/include/controller/cpp/webots/Pen.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/PositionSensor.hpp
+++ b/include/controller/cpp/webots/PositionSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Radar.hpp
+++ b/include/controller/cpp/webots/Radar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/RangeFinder.hpp
+++ b/include/controller/cpp/webots/RangeFinder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Receiver.hpp
+++ b/include/controller/cpp/webots/Receiver.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Robot.hpp
+++ b/include/controller/cpp/webots/Robot.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Skin.hpp
+++ b/include/controller/cpp/webots/Skin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Speaker.hpp
+++ b/include/controller/cpp/webots/Speaker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/Supervisor.hpp
+++ b/include/controller/cpp/webots/Supervisor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/TouchSensor.hpp
+++ b/include/controller/cpp/webots/TouchSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/utils/Motion.hpp
+++ b/include/controller/cpp/webots/utils/Motion.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/vehicle/Car.hpp
+++ b/include/controller/cpp/webots/vehicle/Car.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/controller/cpp/webots/vehicle/Driver.hpp
+++ b/include/controller/cpp/webots/vehicle/Driver.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/plugins/physics.h
+++ b/include/plugins/physics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/plugins/radio.h
+++ b/include/plugins/radio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/controller/matlab/mgenerate.py
+++ b/lib/controller/matlab/mgenerate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/Makefile
+++ b/projects/default/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/braitenberg/Makefile
+++ b/projects/default/controllers/braitenberg/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/braitenberg/braitenberg.c
+++ b/projects/default/controllers/braitenberg/braitenberg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosAccelerometer.cpp
+++ b/projects/default/controllers/ros/RosAccelerometer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosAccelerometer.hpp
+++ b/projects/default/controllers/ros/RosAccelerometer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosBatterySensor.cpp
+++ b/projects/default/controllers/ros/RosBatterySensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosBatterySensor.hpp
+++ b/projects/default/controllers/ros/RosBatterySensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosBrake.cpp
+++ b/projects/default/controllers/ros/RosBrake.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosBrake.hpp
+++ b/projects/default/controllers/ros/RosBrake.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosCamera.cpp
+++ b/projects/default/controllers/ros/RosCamera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosCamera.hpp
+++ b/projects/default/controllers/ros/RosCamera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosCompass.cpp
+++ b/projects/default/controllers/ros/RosCompass.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosCompass.hpp
+++ b/projects/default/controllers/ros/RosCompass.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosConnector.cpp
+++ b/projects/default/controllers/ros/RosConnector.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosConnector.hpp
+++ b/projects/default/controllers/ros/RosConnector.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDevice.cpp
+++ b/projects/default/controllers/ros/RosDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDevice.hpp
+++ b/projects/default/controllers/ros/RosDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDisplay.cpp
+++ b/projects/default/controllers/ros/RosDisplay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDisplay.hpp
+++ b/projects/default/controllers/ros/RosDisplay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDistanceSensor.cpp
+++ b/projects/default/controllers/ros/RosDistanceSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosDistanceSensor.hpp
+++ b/projects/default/controllers/ros/RosDistanceSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosEmitter.cpp
+++ b/projects/default/controllers/ros/RosEmitter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosEmitter.hpp
+++ b/projects/default/controllers/ros/RosEmitter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosGPS.cpp
+++ b/projects/default/controllers/ros/RosGPS.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosGPS.hpp
+++ b/projects/default/controllers/ros/RosGPS.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosGyro.cpp
+++ b/projects/default/controllers/ros/RosGyro.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosGyro.hpp
+++ b/projects/default/controllers/ros/RosGyro.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosInertialUnit.cpp
+++ b/projects/default/controllers/ros/RosInertialUnit.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosInertialUnit.hpp
+++ b/projects/default/controllers/ros/RosInertialUnit.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosJoystick.cpp
+++ b/projects/default/controllers/ros/RosJoystick.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosJoystick.hpp
+++ b/projects/default/controllers/ros/RosJoystick.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosKeyboard.cpp
+++ b/projects/default/controllers/ros/RosKeyboard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosKeyboard.hpp
+++ b/projects/default/controllers/ros/RosKeyboard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLED.cpp
+++ b/projects/default/controllers/ros/RosLED.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLED.hpp
+++ b/projects/default/controllers/ros/RosLED.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLidar.cpp
+++ b/projects/default/controllers/ros/RosLidar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLidar.hpp
+++ b/projects/default/controllers/ros/RosLidar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLightSensor.cpp
+++ b/projects/default/controllers/ros/RosLightSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosLightSensor.hpp
+++ b/projects/default/controllers/ros/RosLightSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMathUtils.cpp
+++ b/projects/default/controllers/ros/RosMathUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMathUtils.hpp
+++ b/projects/default/controllers/ros/RosMathUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMotor.cpp
+++ b/projects/default/controllers/ros/RosMotor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMotor.hpp
+++ b/projects/default/controllers/ros/RosMotor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMotorSensor.cpp
+++ b/projects/default/controllers/ros/RosMotorSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMotorSensor.hpp
+++ b/projects/default/controllers/ros/RosMotorSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMouse.cpp
+++ b/projects/default/controllers/ros/RosMouse.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosMouse.hpp
+++ b/projects/default/controllers/ros/RosMouse.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosPen.cpp
+++ b/projects/default/controllers/ros/RosPen.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosPen.hpp
+++ b/projects/default/controllers/ros/RosPen.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosPositionSensor.cpp
+++ b/projects/default/controllers/ros/RosPositionSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosPositionSensor.hpp
+++ b/projects/default/controllers/ros/RosPositionSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosRadar.cpp
+++ b/projects/default/controllers/ros/RosRadar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosRadar.hpp
+++ b/projects/default/controllers/ros/RosRadar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosRangeFinder.cpp
+++ b/projects/default/controllers/ros/RosRangeFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosRangeFinder.hpp
+++ b/projects/default/controllers/ros/RosRangeFinder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosReceiver.cpp
+++ b/projects/default/controllers/ros/RosReceiver.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosReceiver.hpp
+++ b/projects/default/controllers/ros/RosReceiver.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSensor.cpp
+++ b/projects/default/controllers/ros/RosSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSensor.hpp
+++ b/projects/default/controllers/ros/RosSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSkin.cpp
+++ b/projects/default/controllers/ros/RosSkin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSkin.hpp
+++ b/projects/default/controllers/ros/RosSkin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSpeaker.cpp
+++ b/projects/default/controllers/ros/RosSpeaker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSpeaker.hpp
+++ b/projects/default/controllers/ros/RosSpeaker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosSupervisor.hpp
+++ b/projects/default/controllers/ros/RosSupervisor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosTouchSensor.cpp
+++ b/projects/default/controllers/ros/RosTouchSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/RosTouchSensor.hpp
+++ b/projects/default/controllers/ros/RosTouchSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/headersFromMSG.py
+++ b/projects/default/controllers/ros/headersFromMSG.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/headersFromSRV.py
+++ b/projects/default/controllers/ros/headersFromSRV.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/headersGenerator.py
+++ b/projects/default/controllers/ros/headersGenerator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/include/Makefile
+++ b/projects/default/controllers/ros/include/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/include/templateHeader.h
+++ b/projects/default/controllers/ros/include/templateHeader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/include/templateMessage.h
+++ b/projects/default/controllers/ros/include/templateMessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/include/templateRequest.h
+++ b/projects/default/controllers/ros/include/templateRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/include/templateResponse.h
+++ b/projects/default/controllers/ros/include/templateResponse.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/controllers/ros/main.cpp
+++ b/projects/default/controllers/ros/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/controllers/sumo_supervisor/Objects.py
+++ b/projects/default/controllers/sumo_supervisor/Objects.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/sumo_supervisor/SumoDisplay.py
+++ b/projects/default/controllers/sumo_supervisor/SumoDisplay.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/sumo_supervisor/SumoSupervisor.py
+++ b/projects/default/controllers/sumo_supervisor/SumoSupervisor.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/sumo_supervisor/WebotsVehicle.py
+++ b/projects/default/controllers/sumo_supervisor/WebotsVehicle.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/controllers/sumo_supervisor/sumo_supervisor.py
+++ b/projects/default/controllers/sumo_supervisor/sumo_supervisor.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/Makefile
+++ b/projects/default/libraries/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/Makefile
+++ b/projects/default/libraries/vehicle/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/c/car/Makefile
+++ b/projects/default/libraries/vehicle/c/car/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/c/car/src/car.c
+++ b/projects/default/libraries/vehicle/c/car/src/car.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/c/car/src/car_private.h
+++ b/projects/default/libraries/vehicle/c/car/src/car_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/c/driver/Makefile
+++ b/projects/default/libraries/vehicle/c/driver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/c/driver/src/driver.c
+++ b/projects/default/libraries/vehicle/c/driver/src/driver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/cpp/car/Makefile
+++ b/projects/default/libraries/vehicle/cpp/car/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/cpp/car/src/Car.cpp
+++ b/projects/default/libraries/vehicle/cpp/car/src/Car.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/cpp/driver/Makefile
+++ b/projects/default/libraries/vehicle/cpp/driver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/cpp/driver/src/Driver.cpp
+++ b/projects/default/libraries/vehicle/cpp/driver/src/Driver.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/java/Makefile
+++ b/projects/default/libraries/vehicle/java/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/libraries/vehicle/python/Makefile
+++ b/projects/default/libraries/vehicle/python/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/default/resources/Makefile
+++ b/projects/default/resources/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/humans/c3d/controllers/c3d_viewer/c3d_viewer.py
+++ b/projects/humans/c3d/controllers/c3d_viewer/c3d_viewer.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/humans/pedestrian/controllers/pedestrian/pedestrian.py
+++ b/projects/humans/pedestrian/controllers/pedestrian/pedestrian.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/Makefile
+++ b/projects/languages/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/cpp/controllers/Makefile
+++ b/projects/languages/cpp/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/cpp/controllers/driver/Makefile
+++ b/projects/languages/cpp/controllers/driver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/cpp/controllers/driver/driver.cpp
+++ b/projects/languages/cpp/controllers/driver/driver.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/cpp/controllers/slave/Makefile
+++ b/projects/languages/cpp/controllers/slave/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/cpp/controllers/slave/slave.cpp
+++ b/projects/languages/cpp/controllers/slave/slave.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/java/controllers/Driver/Driver.java
+++ b/projects/languages/java/controllers/Driver/Driver.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/java/controllers/Makefile
+++ b/projects/languages/java/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/java/controllers/Slave/MultiThreadedSlave.java
+++ b/projects/languages/java/controllers/Slave/MultiThreadedSlave.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/java/controllers/Slave/Slave.java
+++ b/projects/languages/java/controllers/Slave/Slave.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/matlab/controllers/Makefile
+++ b/projects/languages/matlab/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/matlab/controllers/e-puck_position_supervisor/Makefile
+++ b/projects/languages/matlab/controllers/e-puck_position_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/matlab/controllers/e-puck_position_supervisor/e-puck_position_supervisor.c
+++ b/projects/languages/matlab/controllers/e-puck_position_supervisor/e-puck_position_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/languages/python/controllers/driver/driver.py
+++ b/projects/languages/python/controllers/driver/driver.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/python/controllers/slave/slave.py
+++ b/projects/languages/python/controllers/slave/slave.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/ros/controllers/ros_python/Makefile
+++ b/projects/languages/ros/controllers/ros_python/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/ros/controllers/ros_python/ros_controller.py
+++ b/projects/languages/ros/controllers/ros_python/ros_controller.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/ros/controllers/ros_python/ros_python.py
+++ b/projects/languages/ros/controllers/ros_python/ros_python.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/catch_the_bird.cpp
+++ b/projects/languages/ros/webots_ros/src/catch_the_bird.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/complete_test.cpp
+++ b/projects/languages/ros/webots_ros/src/complete_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/e_puck_line.cpp
+++ b/projects/languages/ros/webots_ros/src/e_puck_line.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/keyboard_teleop.cpp
+++ b/projects/languages/ros/webots_ros/src/keyboard_teleop.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/panoramic_view_recorder.cpp
+++ b/projects/languages/ros/webots_ros/src/panoramic_view_recorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/pioneer3at.cpp
+++ b/projects/languages/ros/webots_ros/src/pioneer3at.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/pr2_beer.cpp
+++ b/projects/languages/ros/webots_ros/src/pr2_beer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/robot_information_parser.cpp
+++ b/projects/languages/ros/webots_ros/src/robot_information_parser.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/languages/ros/webots_ros/src/webots_launcher.py
+++ b/projects/languages/ros/webots_ros/src/webots_launcher.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/Makefile
+++ b/projects/objects/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/buildings/protos/textures/colored_textures/textures_generator.py
+++ b/projects/objects/buildings/protos/textures/colored_textures/textures_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/computers/controllers/Makefile
+++ b/projects/objects/computers/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/computers/controllers/laptop_switch_on/Makefile
+++ b/projects/objects/computers/controllers/laptop_switch_on/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/computers/controllers/laptop_switch_on/laptop_switch_on.c
+++ b/projects/objects/computers/controllers/laptop_switch_on/laptop_switch_on.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/create_wall/controllers/Makefile
+++ b/projects/objects/create_wall/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/create_wall/controllers/create_wall_emit_signal/Makefile
+++ b/projects/objects/create_wall/controllers/create_wall_emit_signal/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/create_wall/controllers/create_wall_emit_signal/create_wall_emit_signal.c
+++ b/projects/objects/create_wall/controllers/create_wall_emit_signal/create_wall_emit_signal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/factory/conveyor_belt/controllers/Makefile
+++ b/projects/objects/factory/conveyor_belt/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/factory/conveyor_belt/controllers/conveyor_belt/Makefile
+++ b/projects/objects/factory/conveyor_belt/controllers/conveyor_belt/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/factory/conveyor_belt/controllers/conveyor_belt/conveyor_belt.c
+++ b/projects/objects/factory/conveyor_belt/controllers/conveyor_belt/conveyor_belt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/factory/valves/controllers/valve_turner/valve_turner.py
+++ b/projects/objects/factory/valves/controllers/valve_turner/valve_turner.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/mirror/controllers/Makefile
+++ b/projects/objects/mirror/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/mirror/controllers/mirror/Makefile
+++ b/projects/objects/mirror/controllers/mirror/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/mirror/controllers/mirror/mirror.c
+++ b/projects/objects/mirror/controllers/mirror/mirror.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/television/controllers/Makefile
+++ b/projects/objects/television/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/television/controllers/television_switch_on/Makefile
+++ b/projects/objects/television/controllers/television_switch_on/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/television/controllers/television_switch_on/television_switch_on.c
+++ b/projects/objects/television/controllers/television_switch_on/television_switch_on.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/Makefile
+++ b/projects/objects/traffic/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/crossroads_traffic_lights/Makefile
+++ b/projects/objects/traffic/controllers/crossroads_traffic_lights/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/crossroads_traffic_lights/crossroads_traffic_lights.c
+++ b/projects/objects/traffic/controllers/crossroads_traffic_lights/crossroads_traffic_lights.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/defective_street_light/Makefile
+++ b/projects/objects/traffic/controllers/defective_street_light/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/defective_street_light/defective_street_light.c
+++ b/projects/objects/traffic/controllers/defective_street_light/defective_street_light.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/generic_traffic_light/Makefile
+++ b/projects/objects/traffic/controllers/generic_traffic_light/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/objects/traffic/controllers/generic_traffic_light/generic_traffic_light.c
+++ b/projects/objects/traffic/controllers/generic_traffic_light/generic_traffic_light.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/Makefile
+++ b/projects/robots/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/a4/portal/controllers/Makefile
+++ b/projects/robots/a4/portal/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/a4/portal/controllers/portal_pe/Makefile
+++ b/projects/robots/a4/portal/controllers/portal_pe/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/a4/portal/controllers/portal_pe/portal_pe.c
+++ b/projects/robots/a4/portal/controllers/portal_pe/portal_pe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/Makefile
+++ b/projects/robots/adept/pioneer3/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3at_obstacle_avoidance_with_lidar/Makefile
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3at_obstacle_avoidance_with_lidar/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3at_obstacle_avoidance_with_lidar/pioneer3at_obstacle_avoidance_with_lidar.c
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3at_obstacle_avoidance_with_lidar/pioneer3at_obstacle_avoidance_with_lidar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_collision_avoidance/Makefile
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_collision_avoidance/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_collision_avoidance/pioneer3dx_collision_avoidance.c
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_collision_avoidance/pioneer3dx_collision_avoidance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_gripper/Makefile
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_gripper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_gripper/pioneer3dx_gripper.c
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_gripper/pioneer3dx_gripper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_obstacle_avoidance_with_kinect/Makefile
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_obstacle_avoidance_with_kinect/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/adept/pioneer3/controllers/pioneer3dx_obstacle_avoidance_with_kinect/pioneer3dx_obstacle_avoidance_with_kinect.c
+++ b/projects/robots/adept/pioneer3/controllers/pioneer3dx_obstacle_avoidance_with_kinect/pioneer3dx_obstacle_avoidance_with_kinect.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/bluebotics/shrimp/controllers/Makefile
+++ b/projects/robots/bluebotics/shrimp/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/bluebotics/shrimp/controllers/shrimp/Makefile
+++ b/projects/robots/bluebotics/shrimp/controllers/shrimp/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp.c
+++ b/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp_protocol.c
+++ b/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp_protocol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp_protocol.h
+++ b/projects/robots/bluebotics/shrimp/controllers/shrimp/shrimp_protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/boston_dynamics/atlas/controllers/Makefile
+++ b/projects/robots/boston_dynamics/atlas/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/boston_dynamics/atlas/controllers/hello_world_demo/Makefile
+++ b/projects/robots/boston_dynamics/atlas/controllers/hello_world_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/boston_dynamics/atlas/controllers/hello_world_demo/hello_world_demo.c
+++ b/projects/robots/boston_dynamics/atlas/controllers/hello_world_demo/hello_world_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/moose/controllers/Makefile
+++ b/projects/robots/clearpath/moose/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/moose/controllers/moose_path_following/Makefile
+++ b/projects/robots/clearpath/moose/controllers/moose_path_following/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/moose/controllers/moose_path_following/moose_path_following.c
+++ b/projects/robots/clearpath/moose/controllers/moose_path_following/moose_path_following.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/pr2/controllers/Makefile
+++ b/projects/robots/clearpath/pr2/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/pr2/controllers/pr2_demo/Makefile
+++ b/projects/robots/clearpath/pr2/controllers/pr2_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/clearpath/pr2/controllers/pr2_demo/pr2_demo.c
+++ b/projects/robots/clearpath/pr2/controllers/pr2_demo/pr2_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/dji/mavic/controllers/Makefile
+++ b/projects/robots/dji/mavic/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/dji/mavic/controllers/mavic2pro/Makefile
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
+++ b/projects/robots/dji/mavic/controllers/mavic2pro/mavic2pro.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/Makefile
+++ b/projects/robots/epfl/biorob/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/ghostdog/Makefile
+++ b/projects/robots/epfl/biorob/controllers/ghostdog/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/ghostdog/ghostdog.c
+++ b/projects/robots/epfl/biorob/controllers/ghostdog/ghostdog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/salamander/Makefile
+++ b/projects/robots/epfl/biorob/controllers/salamander/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/salamander/salamander.c
+++ b/projects/robots/epfl/biorob/controllers/salamander/salamander.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/yamor/Makefile
+++ b/projects/robots/epfl/biorob/controllers/yamor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/biorob/controllers/yamor/yamor.c
+++ b/projects/robots/epfl/biorob/controllers/yamor/yamor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/lis/controllers/Makefile
+++ b/projects/robots/epfl/lis/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/lis/controllers/blimp/Makefile
+++ b/projects/robots/epfl/lis/controllers/blimp/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/lis/plugins/physics/Makefile
+++ b/projects/robots/epfl/lis/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/epfl/lis/plugins/physics/blimp_physics/Makefile
+++ b/projects/robots/epfl/lis/plugins/physics/blimp_physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/festo/robotino3/controllers/Makefile
+++ b/projects/robots/festo/robotino3/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/festo/robotino3/controllers/robotino3/Makefile
+++ b/projects/robots/festo/robotino3/controllers/robotino3/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/festo/robotino3/controllers/robotino3/base.c
+++ b/projects/robots/festo/robotino3/controllers/robotino3/base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/festo/robotino3/controllers/robotino3/base.h
+++ b/projects/robots/festo/robotino3/controllers/robotino3/base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/festo/robotino3/controllers/robotino3/robotino3.c
+++ b/projects/robots/festo/robotino3/controllers/robotino3/robotino3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/fujitsu/hoap2/controllers/Makefile
+++ b/projects/robots/fujitsu/hoap2/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/fujitsu/hoap2/controllers/hoap2/Makefile
+++ b/projects/robots/fujitsu/hoap2/controllers/hoap2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/fujitsu/hoap2/controllers/hoap2/hoap2.c
+++ b/projects/robots/fujitsu/hoap2/controllers/hoap2/hoap2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck/e-puck.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck/e-puck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck2_server/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck2_server/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck2_server/e-puck2_server.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck2_server/e-puck2_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_avoid_obstacles/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_avoid_obstacles/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_avoid_obstacles/e-puck_avoid_obstacles.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_avoid_obstacles/e-puck_avoid_obstacles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_cross-compilation/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_cross-compilation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_cross-compilation/e-puck_cross-compilation.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_cross-compilation/e-puck_cross-compilation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_line/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_line/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_line/e-puck_line.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_line/e-puck_line.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_line_demo/Makefile
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_line_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/controllers/e-puck_line_demo/e-puck_line_demo.c
+++ b/projects/robots/gctronic/e-puck/controllers/e-puck_line_demo/e-puck_line_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Camera.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Camera.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Communication.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Communication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Communication.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Communication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Device.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Device.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Device.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckInputPacket.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckInputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckInputPacket.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckInputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckOutputPacket.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckOutputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckOutputPacket.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/EPuckOutputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Led.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Led.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Motor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Packet.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Packet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Packet.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Packet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Sensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Sensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/SingleValueSensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/SingleValueSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Time.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Time.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Time.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Time.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/TripleValuesSensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/TripleValuesSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Uploader.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Uploader.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Uploader.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Uploader.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/UploaderData.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/UploaderData.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/entry_points.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/entry_points.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Camera.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Camera.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Communication.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Communication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Communication.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Communication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Device.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Device.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Device.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/EPuckCommandPacket.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/EPuckCommandPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/EPuckCommandPacket.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/EPuckCommandPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Led.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Led.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Motor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Sensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Sensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/SingleValueSensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/SingleValueSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Time.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Time.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Time.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Time.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/TripleValuesSensor.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/TripleValuesSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/entry_points.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/entry_points.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/test.c
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Automaton.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Automaton.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Automaton.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Automaton.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObject.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObject.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObject.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObject.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObjectRepresentation.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObjectRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObjectRepresentation.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonObjectRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonScene.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonScene.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonScene.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonScene.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/AutomatonWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioPaths.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioPaths.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioPaths.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioPaths.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioWindow.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioWindow.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/BotStudioWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/CommonProperties.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/CommonProperties.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/CommonProperties.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/CommonProperties.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Model.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Model.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Model.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Model.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RemoteControlWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RemoteControlWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RemoteControlWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RemoteControlWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotActuatorCommand.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotActuatorCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotConditionWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotConditionWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotConditionWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotConditionWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotFacade.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotFacade.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotObjectFactory.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotObjectFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotObjectFactory.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotObjectFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotSensorCondition.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotSensorCondition.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotStateWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotStateWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotStateWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotStateWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotViewWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotViewWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotViewWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/RobotViewWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/State.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/State.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/State.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/State.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/StateRepresentation.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/StateRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/StateRepresentation.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/StateRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/SwitchWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/SwitchWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/SwitchWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/SwitchWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Tokenizer.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Tokenizer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Tokenizer.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Tokenizer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Transition.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Transition.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Transition.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/Transition.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/TransitionRepresentation.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/TransitionRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/TransitionRepresentation.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/TransitionRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/entry_points.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/entry_points.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/core/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckActuatorCommand.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckActuatorCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckActuatorCommand.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckActuatorCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckConditionWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckConditionWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckConditionWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckConditionWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckDrawingHelper.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckDrawingHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckDrawingHelper.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckDrawingHelper.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckFacade.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckFacade.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckFacade.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckFacade.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckLedButton.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckLedButton.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckLedButton.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckLedButton.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckObjectFactory.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckObjectFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckObjectFactory.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckObjectFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSensorCondition.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSensorCondition.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSensorCondition.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSensorCondition.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSlider.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSlider.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSlider.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckSlider.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckStateWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckStateWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckStateWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckStateWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckViewWidget.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckViewWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckViewWidget.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/botstudio/e-puck/EPuckViewWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/e-puck/Makefile
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/e-puck/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/plugins/robot_windows/e-puck/e-puck.c
+++ b/projects/robots/gctronic/e-puck/plugins/robot_windows/e-puck/e-puck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/Makefile
+++ b/projects/robots/gctronic/e-puck/transfer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/firmware/Makefile
+++ b/projects/robots/gctronic/e-puck/transfer/firmware/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/firmware/firmware.c
+++ b/projects/robots/gctronic/e-puck/transfer/firmware/firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/Makefile
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/accelerometer.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/accelerometer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/camera.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/camera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/distance_sensor.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/distance_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/led.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/led.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/light_sensor.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/light_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/motor.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/motor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/position_sensor.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/position_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/printf_override.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/printf_override.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/robot.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/robot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/types.h
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/include/webots/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/libepuck/libepuck.c
+++ b/projects/robots/gctronic/e-puck/transfer/libepuck/libepuck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/e-puck/transfer/populate_xc16_directory.py
+++ b/projects/robots/gctronic/e-puck/transfer/populate_xc16_directory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/elisa/controllers/Makefile
+++ b/projects/robots/gctronic/elisa/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/elisa/controllers/elisa3/Makefile
+++ b/projects/robots/gctronic/elisa/controllers/elisa3/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/gctronic/elisa/controllers/elisa3/elisa3.c
+++ b/projects/robots/gctronic/elisa/controllers/elisa3/elisa3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/irobot/create/controllers/Makefile
+++ b/projects/robots/irobot/create/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/irobot/create/controllers/create_avoid_obstacles/Makefile
+++ b/projects/robots/irobot/create/controllers/create_avoid_obstacles/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/irobot/create/controllers/create_avoid_obstacles/create_avoid_obstacles.c
+++ b/projects/robots/irobot/create/controllers/create_avoid_obstacles/create_avoid_obstacles.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/irobot/create/controllers/ground/Makefile
+++ b/projects/robots/irobot/create/controllers/ground/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/irobot/create/controllers/ground/ground.c
+++ b/projects/robots/irobot/create/controllers/ground/ground.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/hemisson/controllers/Makefile
+++ b/projects/robots/k-team/hemisson/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/hemisson/controllers/hemisson/Makefile
+++ b/projects/robots/k-team/hemisson/controllers/hemisson/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/hemisson/controllers/hemisson/hemisson.c
+++ b/projects/robots/k-team/hemisson/controllers/hemisson/hemisson.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/hemisson/controllers/hemisson/hemisson.h
+++ b/projects/robots/k-team/hemisson/controllers/hemisson/hemisson.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_bus/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/khepera_bus/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_bus/khepera_bus.c
+++ b/projects/robots/k-team/khepera1/controllers/khepera_bus/khepera_bus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_gripper/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/khepera_gripper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_gripper/khepera_gripper.c
+++ b/projects/robots/k-team/khepera1/controllers/khepera_gripper/khepera_gripper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_k213/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/khepera_k213/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/khepera_k213/khepera_k213.c
+++ b/projects/robots/k-team/khepera1/controllers/khepera_k213/khepera_k213.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/pipe/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/pipe/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/pipe/client.c
+++ b/projects/robots/k-team/khepera1/controllers/pipe/client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/pipe/common.h
+++ b/projects/robots/k-team/khepera1/controllers/pipe/common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/pipe/pipe.c
+++ b/projects/robots/k-team/khepera1/controllers/pipe/pipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/tcpip/Makefile
+++ b/projects/robots/k-team/khepera1/controllers/tcpip/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/tcpip/client.c
+++ b/projects/robots/k-team/khepera1/controllers/tcpip/client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera1/controllers/tcpip/tcpip.c
+++ b/projects/robots/k-team/khepera1/controllers/tcpip/tcpip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera3/controllers/Makefile
+++ b/projects/robots/k-team/khepera3/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera3/controllers/khepera3_gripper/Makefile
+++ b/projects/robots/k-team/khepera3/controllers/khepera3_gripper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera3/controllers/khepera3_gripper/khepera3_gripper.c
+++ b/projects/robots/k-team/khepera3/controllers/khepera3_gripper/khepera3_gripper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera4/controllers/Makefile
+++ b/projects/robots/k-team/khepera4/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera4/controllers/khepera4/Makefile
+++ b/projects/robots/k-team/khepera4/controllers/khepera4/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/k-team/khepera4/controllers/khepera4/khepera4.c
+++ b/projects/robots/k-team/khepera4/controllers/khepera4/khepera4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/crane/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/crane/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/crane/crane.c
+++ b/projects/robots/kinematics/tinkerbots/controllers/crane/crane.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/four_wheels_vehicle/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/four_wheels_vehicle/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/four_wheels_vehicle/four_wheels_vehicle.c
+++ b/projects/robots/kinematics/tinkerbots/controllers/four_wheels_vehicle/four_wheels_vehicle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/grabber_base/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/grabber_base/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/grabber_base/grabber_base.c
+++ b/projects/robots/kinematics/tinkerbots/controllers/grabber_base/grabber_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/tinkerbots_demo/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/tinkerbots_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/tinkerbots_demo/tinkerbots_demo.c
+++ b/projects/robots/kinematics/tinkerbots/controllers/tinkerbots_demo/tinkerbots_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/two_wheels_vehicle/two_wheels_vehicle.py
+++ b/projects/robots/kinematics/tinkerbots/controllers/two_wheels_vehicle/two_wheels_vehicle.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/vehicle/Makefile
+++ b/projects/robots/kinematics/tinkerbots/controllers/vehicle/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/vehicle/vehicle.c
+++ b/projects/robots/kinematics/tinkerbots/controllers/vehicle/vehicle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kinematics/tinkerbots/controllers/vision_car/vision_car.py
+++ b/projects/robots/kinematics/tinkerbots/controllers/vision_car/vision_car.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/Makefile
+++ b/projects/robots/kondo/khr-2hv/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/KHR2_Data.h
+++ b/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/KHR2_Data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/Makefile
+++ b/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/khr2.cpp
+++ b/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/khr2.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/rcb3_simulator.cpp
+++ b/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/rcb3_simulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/rcb3_simulator.h
+++ b/projects/robots/kondo/khr-2hv/controllers/khr-2hv_demo/rcb3_simulator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/controllers/Makefile
+++ b/projects/robots/kuka/youbot/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/controllers/youbot/Makefile
+++ b/projects/robots/kuka/youbot/controllers/youbot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/controllers/youbot/youbot.c
+++ b/projects/robots/kuka/youbot/controllers/youbot/youbot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/Makefile
+++ b/projects/robots/kuka/youbot/libraries/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/Makefile
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/include/arm.h
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/include/arm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/include/base.h
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/include/base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/include/gripper.h
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/include/gripper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/include/tiny_math.h
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/include/tiny_math.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/src/arm.c
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/src/arm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/src/base.c
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/src/base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/src/gripper.c
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/src/gripper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/kuka/youbot/libraries/youbot_control/src/tiny_math.c
+++ b/projects/robots/kuka/youbot/libraries/youbot_control/src/tiny_math.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/lego/mindstorms/controllers/Makefile
+++ b/projects/robots/lego/mindstorms/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/lego/mindstorms/controllers/Rover/Makefile
+++ b/projects/robots/lego/mindstorms/controllers/Rover/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/lego/mindstorms/controllers/Rover/Rover.c
+++ b/projects/robots/lego/mindstorms/controllers/Rover/Rover.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/lego/mindstorms/controllers/Rover/Rover.java
+++ b/projects/robots/lego/mindstorms/controllers/Rover/Rover.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/micromagic/mantis/controllers/Makefile
+++ b/projects/robots/micromagic/mantis/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/micromagic/mantis/controllers/mantis/Makefile
+++ b/projects/robots/micromagic/mantis/controllers/mantis/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/micromagic/mantis/controllers/mantis/mantis.c
+++ b/projects/robots/micromagic/mantis/controllers/mantis/mantis.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/Makefile
+++ b/projects/robots/mobsya/thymio/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Makefile
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2AsebaHub.cpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2AsebaHub.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2AsebaHub.hpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2AsebaHub.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.cpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.hpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/main.cpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_definitions.c
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_definitions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_definitions.h
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_definitions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_natives.c
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_natives.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_natives.h
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/thymio2_natives.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_demo/Makefile
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/controllers/thymio2_demo/thymio2_demo.c
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_demo/thymio2_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/mobsya/thymio/libraries/Makefile
+++ b/projects/robots/mobsya/thymio/libraries/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nasa/controllers/Makefile
+++ b/projects/robots/nasa/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nasa/controllers/sojourner/Makefile
+++ b/projects/robots/nasa/controllers/sojourner/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nasa/controllers/sojourner/sojourner.c
+++ b/projects/robots/nasa/controllers/sojourner/sojourner.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/conveyor_belt/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/conveyor_belt/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/conveyor_belt/conveyor_belt.c
+++ b/projects/robots/neuronics/ipr/controllers/conveyor_belt/conveyor_belt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr1_collaboration/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/ipr1_collaboration/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr1_collaboration/ipr1_collaboration.cpp
+++ b/projects/robots/neuronics/ipr/controllers/ipr1_collaboration/ipr1_collaboration.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr2_collaboration/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/ipr2_collaboration/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr2_collaboration/ipr2_collaboration.cpp
+++ b/projects/robots/neuronics/ipr/controllers/ipr2_collaboration/ipr2_collaboration.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr_cube/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/ipr_cube/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr_cube/ipr_cube.cpp
+++ b/projects/robots/neuronics/ipr/controllers/ipr_cube/ipr_cube.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr_factory/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/ipr_factory/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/ipr_factory/ipr_factory.cpp
+++ b/projects/robots/neuronics/ipr/controllers/ipr_factory/ipr_factory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/target_coordinates/Makefile
+++ b/projects/robots/neuronics/ipr/controllers/target_coordinates/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/controllers/target_coordinates/target_coordinates.c
+++ b/projects/robots/neuronics/ipr/controllers/target_coordinates/target_coordinates.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/Makefile
+++ b/projects/robots/neuronics/ipr/libraries/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/ipr/IPR.cpp
+++ b/projects/robots/neuronics/ipr/libraries/ipr/IPR.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/ipr/IPR.hpp
+++ b/projects/robots/neuronics/ipr/libraries/ipr/IPR.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/ipr/IPRCollaboration.cpp
+++ b/projects/robots/neuronics/ipr/libraries/ipr/IPRCollaboration.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/ipr/IPRCollaboration.hpp
+++ b/projects/robots/neuronics/ipr/libraries/ipr/IPRCollaboration.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/neuronics/ipr/libraries/ipr/Makefile
+++ b/projects/robots/neuronics/ipr/libraries/ipr/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/controllers/Makefile
+++ b/projects/robots/nex/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/controllers/fire_bird_6_obstacle_avoidance/Makefile
+++ b/projects/robots/nex/controllers/fire_bird_6_obstacle_avoidance/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/controllers/fire_bird_6_obstacle_avoidance/fire_bird_6_obstacle_avoidance.c
+++ b/projects/robots/nex/controllers/fire_bird_6_obstacle_avoidance/fire_bird_6_obstacle_avoidance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/nex/controllers/fire_bird_6_sensor_acquisition/Makefile
+++ b/projects/robots/nex/controllers/fire_bird_6_sensor_acquisition/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/controllers/fire_bird_6_sensor_acquisition/fire_bird_6_sensor_acquisition.c
+++ b/projects/robots/nex/controllers/fire_bird_6_sensor_acquisition/fire_bird_6_sensor_acquisition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/Makefile
+++ b/projects/robots/nex/plugins/remote_controls/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Communication.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Communication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Communication.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Communication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Device.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Device.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Device.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6OutputPacket.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6OutputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6OutputPacket.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6OutputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Makefile
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Motor.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Packet.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Packet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Packet.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Packet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Sensor.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Sensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/SingleValueSensor.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/SingleValueSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Time.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Time.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Time.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Time.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/TripleValuesSensor.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/TripleValuesSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/entry_points.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/entry_points.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/Makefile
+++ b/projects/robots/nex/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/AccelerometerGroupBox.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/AccelerometerGroupBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/AccelerometerGroupBox.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/AccelerometerGroupBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/EncoderGroupBox.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/EncoderGroupBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/EncoderGroupBox.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/EncoderGroupBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/FireBird6Representation.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/FireBird6Representation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/FireBird6Representation.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/FireBird6Representation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Gui.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Gui.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Gui.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Gui.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/GyroGroupBox.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/GyroGroupBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/GyroGroupBox.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/GyroGroupBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MagnetometerGroupBox.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MagnetometerGroupBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MagnetometerGroupBox.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MagnetometerGroupBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MainWidget.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MainWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MainWidget.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/MainWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Makefile
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/RemoteControlWidget.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/RemoteControlWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/RemoteControlWidget.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/RemoteControlWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/entry_points.cpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/entry_points.hpp
+++ b/projects/robots/nex/plugins/robot_windows/fire_bird_6_window/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago++/controllers/tiago++/Makefile
+++ b/projects/robots/pal_robotics/tiago++/controllers/tiago++/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago++/controllers/tiago++/tiago++.c
+++ b/projects/robots/pal_robotics/tiago++/controllers/tiago++/tiago++.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_base/controllers/tiago_base/Makefile
+++ b/projects/robots/pal_robotics/tiago_base/controllers/tiago_base/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_base/controllers/tiago_base/tiago_base.c
+++ b/projects/robots/pal_robotics/tiago_base/controllers/tiago_base/tiago_base.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_iron/controllers/tiago_iron/Makefile
+++ b/projects/robots/pal_robotics/tiago_iron/controllers/tiago_iron/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_iron/controllers/tiago_iron/tiago_iron.c
+++ b/projects/robots/pal_robotics/tiago_iron/controllers/tiago_iron/tiago_iron.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_steel/controllers/tiago_steel/Makefile
+++ b/projects/robots/pal_robotics/tiago_steel/controllers/tiago_steel/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_steel/controllers/tiago_steel/tiago_steel.c
+++ b/projects/robots/pal_robotics/tiago_steel/controllers/tiago_steel/tiago_steel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_titanium/controllers/tiago_titanium/Makefile
+++ b/projects/robots/pal_robotics/tiago_titanium/controllers/tiago_titanium/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/pal_robotics/tiago_titanium/controllers/tiago_titanium/tiago_titanium.c
+++ b/projects/robots/pal_robotics/tiago_titanium/controllers/tiago_titanium/tiago_titanium.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/parallax/boebot/controllers/Makefile
+++ b/projects/robots/parallax/boebot/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/parallax/boebot/controllers/boebot/Makefile
+++ b/projects/robots/parallax/boebot/controllers/boebot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/parallax/boebot/controllers/boebot/boebot.c
+++ b/projects/robots/parallax/boebot/controllers/boebot/boebot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/picaxe/microbot/controllers/Makefile
+++ b/projects/robots/picaxe/microbot/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/picaxe/microbot/controllers/microbot_pe/Makefile
+++ b/projects/robots/picaxe/microbot/controllers/microbot_pe/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/picaxe/microbot/controllers/microbot_pe/microbot_pe.c
+++ b/projects/robots/picaxe/microbot/controllers/microbot_pe/microbot_pe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/bioloid/controllers/Makefile
+++ b/projects/robots/robotis/bioloid/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/bioloid/controllers/bioloid_dog/Makefile
+++ b/projects/robots/robotis/bioloid/controllers/bioloid_dog/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/bioloid/controllers/bioloid_dog/Robot.cpp
+++ b/projects/robots/robotis/bioloid/controllers/bioloid_dog/Robot.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/bioloid/controllers/bioloid_dog/Robot.h
+++ b/projects/robots/robotis/bioloid/controllers/bioloid_dog/Robot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/bioloid/controllers/bioloid_dog/bioloid.cpp
+++ b/projects/robots/robotis/bioloid/controllers/bioloid_dog/bioloid.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/check_start_position/main.cpp
+++ b/projects/robots/robotis/darwin-op/check_start_position/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/motion_player/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/motion_player/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/motion_player/MotionPlayer.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/motion_player/MotionPlayer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/motion_player/MotionPlayer.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/motion_player/MotionPlayer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/motion_player/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/motion_player/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Op3MotionPlayer.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Op3MotionPlayer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Op3MotionPlayer.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/op3_motion_player/Op3MotionPlayer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/op3_motion_player/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/op3_motion_player/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/soccer/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/soccer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/soccer/Soccer.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/soccer/Soccer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/soccer/Soccer.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/soccer/Soccer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/soccer/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/soccer/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/symmetry/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/symmetry/Symmetry.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry/Symmetry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/symmetry/Symmetry.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry/Symmetry.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/symmetry/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/visual_tracking/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/visual_tracking/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/visual_tracking/VisualTracking.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/visual_tracking/VisualTracking.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/visual_tracking/VisualTracking.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/visual_tracking/VisualTracking.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/visual_tracking/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/visual_tracking/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/walk/Makefile
+++ b/projects/robots/robotis/darwin-op/controllers/walk/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/walk/Walk.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/walk/Walk.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/walk/Walk.hpp
+++ b/projects/robots/robotis/darwin-op/controllers/walk/Walk.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/controllers/walk/main.cpp
+++ b/projects/robots/robotis/darwin-op/controllers/walk/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/managers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2DirectoryManager.hpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2DirectoryManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2GaitManager.hpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2GaitManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2MotionManager.hpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2MotionManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2MotionTimerManager.hpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2MotionTimerManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2VisionManager.hpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/include/RobotisOp2VisionManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2GaitManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2GaitManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2MotionManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2MotionManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2MotionTimerManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2MotionTimerManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2VisionManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2VisionManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/libraries/robotis-op2/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/robotis-op2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/Makefile
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Camera.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Camera.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Communication.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Communication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Communication.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Communication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Device.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Device.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Device.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Led.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Led.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Makefile
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Motor.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Packet.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Packet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Packet.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Packet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2InputPacket.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2InputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2InputPacket.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2InputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2OutputPacket.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2OutputPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2OutputPacket.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/RobotisOp2OutputPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Sensor.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Sensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/SingleValueSensor.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/SingleValueSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Time.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Time.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Time.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Time.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/TripleValuesSensor.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/TripleValuesSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/entry_points.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/entry_points.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/Makefile
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Makefile
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/SSH.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/SSH.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/SSH.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/SSH.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/TransferWidget.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/TransferWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/TransferWidget.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/TransferWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Viewer.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Viewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Viewer.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/Viewer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/ZIP.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/ZIP.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/ZIP.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/ZIP.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/common.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/common.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/entry_points.cpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/entry_points.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/robot_windows/robotis-op2_window/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/remote_control/main.cpp
+++ b/projects/robots/robotis/darwin-op/remote_control/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/remote_control/remote.cpp
+++ b/projects/robots/robotis/darwin-op/remote_control/remote.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/remote_control/remote.hpp
+++ b/projects/robots/robotis/darwin-op/remote_control/remote.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Accelerometer.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Accelerometer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Camera.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Device.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Device.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Gyro.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Gyro.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Keyboard.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Keyboard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/LED.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/LED.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Motor.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Motor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/PositionSensor.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/PositionSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Robot.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Robot.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/Speaker.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/Speaker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/include/webots/utils/Motion.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/include/webots/utils/Motion.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/keyboard/keyboardInterface.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/keyboard/keyboardInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/keyboard/keyboardInterface.hpp
+++ b/projects/robots/robotis/darwin-op/transfer/keyboard/keyboardInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/lib/Makefile
+++ b/projects/robots/robotis/darwin-op/transfer/lib/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Accelerometer.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Accelerometer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Camera.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Gyro.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Gyro.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Keyboard.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Keyboard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/LED.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/LED.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Motion.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Motion.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Motor.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Motor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/PositionSensor.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/PositionSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Robot.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Robot.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/darwin-op/transfer/src/Speaker.cpp
+++ b/projects/robots/robotis/darwin-op/transfer/src/Speaker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/turtlebot/controllers/Makefile
+++ b/projects/robots/robotis/turtlebot/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/turtlebot/controllers/turtlebot3_ostacle_avoidance/Makefile
+++ b/projects/robots/robotis/turtlebot/controllers/turtlebot3_ostacle_avoidance/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/robotis/turtlebot/controllers/turtlebot3_ostacle_avoidance/turtlebot3_ostacle_avoidance.c
+++ b/projects/robots/robotis/turtlebot/controllers/turtlebot3_ostacle_avoidance/turtlebot3_ostacle_avoidance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/saeon/controllers/vehicle_driver_altino/vehicle_driver_altino.py
+++ b/projects/robots/saeon/controllers/vehicle_driver_altino/vehicle_driver_altino.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/Makefile
+++ b/projects/robots/softbank/nao/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/distributor/Makefile
+++ b/projects/robots/softbank/nao/controllers/distributor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/distributor/distributor.c
+++ b/projects/robots/softbank/nao/controllers/distributor/distributor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_demo/Makefile
+++ b/projects/robots/softbank/nao/controllers/nao_demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_demo/nao_demo.c
+++ b/projects/robots/softbank/nao/controllers/nao_demo/nao_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_demo_python/nao_demo_python.py
+++ b/projects/robots/softbank/nao/controllers/nao_demo_python/nao_demo_python.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_soccer_player/Makefile
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_player/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_soccer_player/nao_soccer_player.c
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_player/nao_soccer_player.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/Makefile
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/RoboCupGameControlData.h
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/RoboCupGameControlData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/nao_soccer_supervisor.c
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/nao_soccer_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_wave_hand/Makefile
+++ b/projects/robots/softbank/nao/controllers/nao_wave_hand/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/softbank/nao/controllers/nao_wave_hand/nao_wave_hand.c
+++ b/projects/robots/softbank/nao/controllers/nao_wave_hand/nao_wave_hand.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/controllers/Makefile
+++ b/projects/robots/sony/aibo/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/controllers/ers7/Makefile
+++ b/projects/robots/sony/aibo/controllers/ers7/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/controllers/ers7/ers7.c
+++ b/projects/robots/sony/aibo/controllers/ers7/ers7.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/controllers/ers7_mimic/Makefile
+++ b/projects/robots/sony/aibo/controllers/ers7_mimic/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/controllers/ers7_mimic/ers7_mimic.c
+++ b/projects/robots/sony/aibo/controllers/ers7_mimic/ers7_mimic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/libraries/mtn/mtn.c
+++ b/projects/robots/sony/aibo/libraries/mtn/mtn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sony/aibo/libraries/mtn/mtn.h
+++ b/projects/robots/sony/aibo/libraries/mtn/mtn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sony/qrio/controllers/Makefile
+++ b/projects/robots/sony/qrio/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sony/qrio/controllers/qrio/Makefile
+++ b/projects/robots/sony/qrio/controllers/qrio/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sony/qrio/controllers/qrio/qrio.c
+++ b/projects/robots/sony/qrio/controllers/qrio/qrio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/sphero/bb8/controllers/Makefile
+++ b/projects/robots/sphero/bb8/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sphero/bb8/controllers/bb-8/Makefile
+++ b/projects/robots/sphero/bb8/controllers/bb-8/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/sphero/bb8/controllers/bb-8/bb-8.c
+++ b/projects/robots/sphero/bb8/controllers/bb-8/bb-8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/Makefile
+++ b/projects/robots/surveyor/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/Makefile
+++ b/projects/robots/surveyor/controllers/surveyor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor.c
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor_protocol.c
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor_protocol.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor_protocol.h
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor_protocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor_scan.c
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor_scan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor_scan.h
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor_scan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/surveyor/controllers/surveyor/surveyor_xbee.c
+++ b/projects/robots/surveyor/controllers/surveyor/surveyor_xbee.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/unimation/puma/controllers/Makefile
+++ b/projects/robots/unimation/puma/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/unimation/puma/controllers/puma560/Makefile
+++ b/projects/robots/unimation/puma/controllers/puma560/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/unimation/puma/controllers/puma560/puma560.c
+++ b/projects/robots/unimation/puma/controllers/puma560/puma560.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/Makefile
+++ b/projects/robots/universal_robots/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/universal_robots_ros/joint_state_publisher.py
+++ b/projects/robots/universal_robots/controllers/universal_robots_ros/joint_state_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/universal_robots_ros/trajectory_follower.py
+++ b/projects/robots/universal_robots/controllers/universal_robots_ros/trajectory_follower.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/universal_robots_ros/universal_robots_ros.py
+++ b/projects/robots/universal_robots/controllers/universal_robots_ros/universal_robots_ros.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/ure_can_grasper/Makefile
+++ b/projects/robots/universal_robots/controllers/ure_can_grasper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/robots/universal_robots/controllers/ure_can_grasper/ure_can_grasper.c
+++ b/projects/robots/universal_robots/controllers/ure_can_grasper/ure_can_grasper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/Makefile
+++ b/projects/samples/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/Makefile
+++ b/projects/samples/contests/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/Makefile
+++ b/projects/samples/contests/ratslife/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/Makefile
+++ b/projects/samples/contests/ratslife/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/R0/R0.java
+++ b/projects/samples/contests/ratslife/controllers/R0/R0.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/R1/R1.java
+++ b/projects/samples/contests/ratslife/controllers/R1/R1.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/Rat0/Rat0.java
+++ b/projects/samples/contests/ratslife/controllers/Rat0/Rat0.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/Rat1/Rat1.java
+++ b/projects/samples/contests/ratslife/controllers/Rat1/Rat1.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/Makefile
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/boolean.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/boolean.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/contest_manager.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/contest_manager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/helper.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/linked_list.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/linked_list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/linked_list.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/linked_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/maze_builder.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/maze_builder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/maze_builder.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/maze_builder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/maze_definition.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/maze_definition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/maze_generator.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/maze_generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/maze_generator.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/maze_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/parameters.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/parameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/round_manager.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/round_manager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/round_manager.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/round_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/texture_generator.c
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/texture_generator.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/ratslife/controllers/contest_manager/texture_generator.h
+++ b/projects/samples/contests/ratslife/controllers/contest_manager/texture_generator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/contests/rockin/package_generator.py
+++ b/projects/samples/contests/rockin/package_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/tower_of_hanoi/Makefile
+++ b/projects/samples/contests/tower_of_hanoi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/tower_of_hanoi/controllers/Makefile
+++ b/projects/samples/contests/tower_of_hanoi/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/tower_of_hanoi/controllers/hanoi/Makefile
+++ b/projects/samples/contests/tower_of_hanoi/controllers/hanoi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/contests/tower_of_hanoi/controllers/hanoi/hanoi.c
+++ b/projects/samples/contests/tower_of_hanoi/controllers/hanoi/hanoi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/Makefile
+++ b/projects/samples/curriculum/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm/advanced_genetic_algorithm.c
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm/advanced_genetic_algorithm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/advanced_genetic_algorithm_supervisor.c
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/advanced_genetic_algorithm_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/genotype.c
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/genotype.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/genotype.h
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/genotype.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/population.c
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/population.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/population.h
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/population.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/random.c
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/random.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/random.h
+++ b/projects/samples/curriculum/controllers/advanced_genetic_algorithm_supervisor/random.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_odometry/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_odometry/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_odometry/advanced_odometry.c
+++ b/projects/samples/curriculum/controllers/advanced_odometry/advanced_odometry.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/advanced_particle_swarm_optimization.c
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/advanced_particle_swarm_optimization.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/ann.h
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/ann.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.c
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.h
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/advanced_particle_swarm_optimization_supervisor.c
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/advanced_particle_swarm_optimization_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_path_planning_NF1/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_path_planning_NF1/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_path_planning_NF1/advanced_path_planning_NF1.c
+++ b/projects/samples/curriculum/controllers/advanced_path_planning_NF1/advanced_path_planning_NF1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_path_planning_potential_field/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_path_planning_potential_field/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_path_planning_potential_field/advanced_path_planning_potential_field.c
+++ b/projects/samples/curriculum/controllers/advanced_path_planning_potential_field/advanced_path_planning_potential_field.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_pattern_recognition/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_pattern_recognition/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_pattern_recognition/advanced_pattern_recognition.c
+++ b/projects/samples/curriculum/controllers/advanced_pattern_recognition/advanced_pattern_recognition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_pattern_recognition/ann.h
+++ b/projects/samples/curriculum/controllers/advanced_pattern_recognition/ann.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_pattern_recognition_supervisor/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_pattern_recognition_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_pattern_recognition_supervisor/advanced_pattern_recognition_supervisor.c
+++ b/projects/samples/curriculum/controllers/advanced_pattern_recognition_supervisor/advanced_pattern_recognition_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_slam_1/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_slam_1/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_slam_1/advanced_slam_1.c
+++ b/projects/samples/curriculum/controllers/advanced_slam_1/advanced_slam_1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_slam_2/Makefile
+++ b/projects/samples/curriculum/controllers/advanced_slam_2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/advanced_slam_2/advanced_slam_2.c
+++ b/projects/samples/curriculum/controllers/advanced_slam_2/advanced_slam_2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/ball/Makefile
+++ b/projects/samples/curriculum/controllers/ball/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/ball/ball.c
+++ b/projects/samples/curriculum/controllers/ball/ball.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/beginner_robot_controller/Makefile
+++ b/projects/samples/curriculum/controllers/beginner_robot_controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/beginner_robot_controller/beginner_robot_controller.c
+++ b/projects/samples/curriculum/controllers/beginner_robot_controller/beginner_robot_controller.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/Makefile
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based_corr.c
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based_corr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_finite_state_machine/Makefile
+++ b/projects/samples/curriculum/controllers/intermediate_finite_state_machine/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_finite_state_machine/intermediate_finite_state_machine.c
+++ b/projects/samples/curriculum/controllers/intermediate_finite_state_machine/intermediate_finite_state_machine.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_lawn_mower/Makefile
+++ b/projects/samples/curriculum/controllers/intermediate_lawn_mower/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_lawn_mower/intermediate_lawn_mower.c
+++ b/projects/samples/curriculum/controllers/intermediate_lawn_mower/intermediate_lawn_mower.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_lfm/Makefile
+++ b/projects/samples/curriculum/controllers/intermediate_lfm/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_lfm/intermediate_lfm.c
+++ b/projects/samples/curriculum/controllers/intermediate_lfm/intermediate_lfm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_oam/Makefile
+++ b/projects/samples/curriculum/controllers/intermediate_oam/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/intermediate_oam/intermediate_oam.c
+++ b/projects/samples/curriculum/controllers/intermediate_oam/intermediate_oam.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_accelerometer/Makefile
+++ b/projects/samples/curriculum/controllers/novice_accelerometer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_accelerometer/novice_accelerometer.c
+++ b/projects/samples/curriculum/controllers/novice_accelerometer/novice_accelerometer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_camera/Makefile
+++ b/projects/samples/curriculum/controllers/novice_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_camera/novice_camera.c
+++ b/projects/samples/curriculum/controllers/novice_camera/novice_camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_ir_sensors/Makefile
+++ b/projects/samples/curriculum/controllers/novice_ir_sensors/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_ir_sensors/novice_ir_sensors.c
+++ b/projects/samples/curriculum/controllers/novice_ir_sensors/novice_ir_sensors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_k2000/Makefile
+++ b/projects/samples/curriculum/controllers/novice_k2000/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_k2000/novice_k2000.c
+++ b/projects/samples/curriculum/controllers/novice_k2000/novice_k2000.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_linear_camera/Makefile
+++ b/projects/samples/curriculum/controllers/novice_linear_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_linear_camera/novice_linear_camera.c
+++ b/projects/samples/curriculum/controllers/novice_linear_camera/novice_linear_camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_motors/Makefile
+++ b/projects/samples/curriculum/controllers/novice_motors/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/controllers/novice_motors/novice_motors.c
+++ b/projects/samples/curriculum/controllers/novice_motors/novice_motors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/backprop.c
+++ b/projects/samples/curriculum/lib/backprop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/backprop.h
+++ b/projects/samples/curriculum/lib/backprop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/odometry.c
+++ b/projects/samples/curriculum/lib/odometry.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/odometry.h
+++ b/projects/samples/curriculum/lib/odometry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/odometry_goto.c
+++ b/projects/samples/curriculum/lib/odometry_goto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/curriculum/lib/odometry_goto.h
+++ b/projects/samples/curriculum/lib/odometry_goto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/Makefile
+++ b/projects/samples/demos/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/anaglyph/Makefile
+++ b/projects/samples/demos/controllers/anaglyph/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/anaglyph/anaglyph.c
+++ b/projects/samples/demos/controllers/anaglyph/anaglyph.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/anaglyph/sc_control.c
+++ b/projects/samples/demos/controllers/anaglyph/sc_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/anaglyph/sc_control.h
+++ b/projects/samples/demos/controllers/anaglyph/sc_control.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/gantry/Makefile
+++ b/projects/samples/demos/controllers/gantry/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/gantry/gantry.c
+++ b/projects/samples/demos/controllers/gantry/gantry.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/hexapod/Makefile
+++ b/projects/samples/demos/controllers/hexapod/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/hexapod/hexapod.c
+++ b/projects/samples/demos/controllers/hexapod/hexapod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/moon/Makefile
+++ b/projects/samples/demos/controllers/moon/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/moon/moon.c
+++ b/projects/samples/demos/controllers/moon/moon.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/soccer_player/Makefile
+++ b/projects/samples/demos/controllers/soccer_player/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/soccer_player/soccer_player.c
+++ b/projects/samples/demos/controllers/soccer_player/soccer_player.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/soccer_referee_supervisor/Makefile
+++ b/projects/samples/demos/controllers/soccer_referee_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/soccer_referee_supervisor/soccer_referee_supervisor.c
+++ b/projects/samples/demos/controllers/soccer_referee_supervisor/soccer_referee_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/stewart_platform/Makefile
+++ b/projects/samples/demos/controllers/stewart_platform/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/demos/controllers/stewart_platform/stewart_platform.c
+++ b/projects/samples/demos/controllers/stewart_platform/stewart_platform.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/EmitterReceiver/EmitterReceiver.java
+++ b/projects/samples/devices/controllers/EmitterReceiver/EmitterReceiver.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/Makefile
+++ b/projects/samples/devices/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/accelerometer/Makefile
+++ b/projects/samples/devices/controllers/accelerometer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/accelerometer/accelerometer.c
+++ b/projects/samples/devices/controllers/accelerometer/accelerometer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/axial_and_tail_rotors/Makefile
+++ b/projects/samples/devices/controllers/axial_and_tail_rotors/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/axial_and_tail_rotors/axial_and_tail_rotors.c
+++ b/projects/samples/devices/controllers/axial_and_tail_rotors/axial_and_tail_rotors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/axial_rotor/Makefile
+++ b/projects/samples/devices/controllers/axial_rotor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/axial_rotor/axial_rotor.c
+++ b/projects/samples/devices/controllers/axial_rotor/axial_rotor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/battery/Makefile
+++ b/projects/samples/devices/controllers/battery/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/battery/battery.c
+++ b/projects/samples/devices/controllers/battery/battery.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/brake/Makefile
+++ b/projects/samples/devices/controllers/brake/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/brake/brake.c
+++ b/projects/samples/devices/controllers/brake/brake.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/bumper/Makefile
+++ b/projects/samples/devices/controllers/bumper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/bumper/bumper.c
+++ b/projects/samples/devices/controllers/bumper/bumper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera/Makefile
+++ b/projects/samples/devices/controllers/camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera/camera.c
+++ b/projects/samples/devices/controllers/camera/camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera_auto_focus/Makefile
+++ b/projects/samples/devices/controllers/camera_auto_focus/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera_auto_focus/camera_auto_focus.c
+++ b/projects/samples/devices/controllers/camera_auto_focus/camera_auto_focus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera_recognition/Makefile
+++ b/projects/samples/devices/controllers/camera_recognition/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/camera_recognition/camera_recognition.c
+++ b/projects/samples/devices/controllers/camera_recognition/camera_recognition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/coaxial_rotors/Makefile
+++ b/projects/samples/devices/controllers/coaxial_rotors/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/coaxial_rotors/coaxial_rotors.c
+++ b/projects/samples/devices/controllers/coaxial_rotors/coaxial_rotors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/compass/Makefile
+++ b/projects/samples/devices/controllers/compass/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/compass/compass.c
+++ b/projects/samples/devices/controllers/compass/compass.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/connector/Makefile
+++ b/projects/samples/devices/controllers/connector/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/connector/connector.c
+++ b/projects/samples/devices/controllers/connector/connector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/display/Makefile
+++ b/projects/samples/devices/controllers/display/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/display/display.c
+++ b/projects/samples/devices/controllers/display/display.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/display_supervisor/Makefile
+++ b/projects/samples/devices/controllers/display_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/display_supervisor/display_supervisor.c
+++ b/projects/samples/devices/controllers/display_supervisor/display_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/distance_sensor/Makefile
+++ b/projects/samples/devices/controllers/distance_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/distance_sensor/distance_sensor.c
+++ b/projects/samples/devices/controllers/distance_sensor/distance_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/emitter_receiver/Makefile
+++ b/projects/samples/devices/controllers/emitter_receiver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/emitter_receiver/emitter_receiver.c
+++ b/projects/samples/devices/controllers/emitter_receiver/emitter_receiver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/encoders/Makefile
+++ b/projects/samples/devices/controllers/encoders/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/encoders/encoders.c
+++ b/projects/samples/devices/controllers/encoders/encoders.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/force3d_sensor/Makefile
+++ b/projects/samples/devices/controllers/force3d_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/force3d_sensor/force3d_sensor.c
+++ b/projects/samples/devices/controllers/force3d_sensor/force3d_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/force_sensor/Makefile
+++ b/projects/samples/devices/controllers/force_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/force_sensor/force_sensor.c
+++ b/projects/samples/devices/controllers/force_sensor/force_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps/Makefile
+++ b/projects/samples/devices/controllers/gps/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps/gps.c
+++ b/projects/samples/devices/controllers/gps/gps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps_lat_long/Makefile
+++ b/projects/samples/devices/controllers/gps_lat_long/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps_lat_long/gps_lat_long.c
+++ b/projects/samples/devices/controllers/gps_lat_long/gps_lat_long.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps_supervisor/Makefile
+++ b/projects/samples/devices/controllers/gps_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gps_supervisor/gps_supervisor.c
+++ b/projects/samples/devices/controllers/gps_supervisor/gps_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gyro/Makefile
+++ b/projects/samples/devices/controllers/gyro/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/gyro/gyro.c
+++ b/projects/samples/devices/controllers/gyro/gyro.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/hokuyo/Makefile
+++ b/projects/samples/devices/controllers/hokuyo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/hokuyo/hokuyo.c
+++ b/projects/samples/devices/controllers/hokuyo/hokuyo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/inertial_unit/Makefile
+++ b/projects/samples/devices/controllers/inertial_unit/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/inertial_unit/inertial_unit.c
+++ b/projects/samples/devices/controllers/inertial_unit/inertial_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/laser_pointer/Makefile
+++ b/projects/samples/devices/controllers/laser_pointer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/led/Makefile
+++ b/projects/samples/devices/controllers/led/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/led/led.c
+++ b/projects/samples/devices/controllers/led/led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/lidar/Makefile
+++ b/projects/samples/devices/controllers/lidar/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/lidar/lidar.c
+++ b/projects/samples/devices/controllers/lidar/lidar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/light_sensor/Makefile
+++ b/projects/samples/devices/controllers/light_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/light_sensor/light_sensor.c
+++ b/projects/samples/devices/controllers/light_sensor/light_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/linear_motor/Makefile
+++ b/projects/samples/devices/controllers/linear_motor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/linear_motor/linear_motor.c
+++ b/projects/samples/devices/controllers/linear_motor/linear_motor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor/Makefile
+++ b/projects/samples/devices/controllers/motor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor/motor.c
+++ b/projects/samples/devices/controllers/motor/motor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor2/Makefile
+++ b/projects/samples/devices/controllers/motor2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor2/motor2.c
+++ b/projects/samples/devices/controllers/motor2/motor2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor3/Makefile
+++ b/projects/samples/devices/controllers/motor3/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/motor3/motor3.c
+++ b/projects/samples/devices/controllers/motor3/motor3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/pen/Makefile
+++ b/projects/samples/devices/controllers/pen/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/pen/pen.c
+++ b/projects/samples/devices/controllers/pen/pen.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/position_sensor/Makefile
+++ b/projects/samples/devices/controllers/position_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/position_sensor/position_sensor.c
+++ b/projects/samples/devices/controllers/position_sensor/position_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/radar/Makefile
+++ b/projects/samples/devices/controllers/radar/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/radar/radar.c
+++ b/projects/samples/devices/controllers/radar/radar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/range_finder/Makefile
+++ b/projects/samples/devices/controllers/range_finder/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/range_finder/range_finder.c
+++ b/projects/samples/devices/controllers/range_finder/range_finder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/receiver_noise/Makefile
+++ b/projects/samples/devices/controllers/receiver_noise/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/receiver_noise/receiver_noise.c
+++ b/projects/samples/devices/controllers/receiver_noise/receiver_noise.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sample_supervisor/Makefile
+++ b/projects/samples/devices/controllers/sample_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sample_supervisor/sample_supervisor.c
+++ b/projects/samples/devices/controllers/sample_supervisor/sample_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sick/Makefile
+++ b/projects/samples/devices/controllers/sick/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sick/sick.c
+++ b/projects/samples/devices/controllers/sick/sick.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sick_point_cloud/Makefile
+++ b/projects/samples/devices/controllers/sick_point_cloud/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/sick_point_cloud/sick_point_cloud.c
+++ b/projects/samples/devices/controllers/sick_point_cloud/sick_point_cloud.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/speaker/Makefile
+++ b/projects/samples/devices/controllers/speaker/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/speaker/speaker.c
+++ b/projects/samples/devices/controllers/speaker/speaker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/speaker_text_to_speech/Makefile
+++ b/projects/samples/devices/controllers/speaker_text_to_speech/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/speaker_text_to_speech/speaker_text_to_speech.c
+++ b/projects/samples/devices/controllers/speaker_text_to_speech/speaker_text_to_speech.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/spherical_camera/Makefile
+++ b/projects/samples/devices/controllers/spherical_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
+++ b/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/track/Makefile
+++ b/projects/samples/devices/controllers/track/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/track/track.c
+++ b/projects/samples/devices/controllers/track/track.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/track_conveyor_belt/Makefile
+++ b/projects/samples/devices/controllers/track_conveyor_belt/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/devices/controllers/track_conveyor_belt/track_conveyor_belt.c
+++ b/projects/samples/devices/controllers/track_conveyor_belt/track_conveyor_belt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/environments/factory/controllers/led_controller/led_controller.py
+++ b/projects/samples/environments/factory/controllers/led_controller/led_controller.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/environments/factory/controllers/screw_controller/screw_controller.py
+++ b/projects/samples/environments/factory/controllers/screw_controller/screw_controller.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/geometries/controllers/Makefile
+++ b/projects/samples/geometries/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/geometries/controllers/muscle/Makefile
+++ b/projects/samples/geometries/controllers/muscle/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/geometries/controllers/muscle/muscle.c
+++ b/projects/samples/geometries/controllers/muscle/muscle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/geometries/controllers/water_flow_animation/Makefile
+++ b/projects/samples/geometries/controllers/water_flow_animation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/geometries/controllers/water_flow_animation/water_flow_animation.c
+++ b/projects/samples/geometries/controllers/water_flow_animation/water_flow_animation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/Makefile
+++ b/projects/samples/howto/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/binocular/Makefile
+++ b/projects/samples/howto/controllers/binocular/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/binocular/binocular.c
+++ b/projects/samples/howto/controllers/binocular/binocular.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/biped/Makefile
+++ b/projects/samples/howto/controllers/biped/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/biped/biped.c
+++ b/projects/samples/howto/controllers/biped/biped.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/center_of_mass/Makefile
+++ b/projects/samples/howto/controllers/center_of_mass/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/center_of_mass/center_of_mass.c
+++ b/projects/samples/howto/controllers/center_of_mass/center_of_mass.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/contact_points_supervisor/Makefile
+++ b/projects/samples/howto/controllers/contact_points_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/contact_points_supervisor/contact_points_supervisor.c
+++ b/projects/samples/howto/controllers/contact_points_supervisor/contact_points_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/force_control/Makefile
+++ b/projects/samples/howto/controllers/force_control/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/force_control/force_control.c
+++ b/projects/samples/howto/controllers/force_control/force_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/four_wheels/Makefile
+++ b/projects/samples/howto/controllers/four_wheels/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/four_wheels/four_wheels.c
+++ b/projects/samples/howto/controllers/four_wheels/four_wheels.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/inverted_pendulum/Makefile
+++ b/projects/samples/howto/controllers/inverted_pendulum/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/inverted_pendulum/inverted_pendulum.c
+++ b/projects/samples/howto/controllers/inverted_pendulum/inverted_pendulum.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/mouse_events/Makefile
+++ b/projects/samples/howto/controllers/mouse_events/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/mouse_events/mouse_events.c
+++ b/projects/samples/howto/controllers/mouse_events/mouse_events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/mouse_events_non_blocking/Makefile
+++ b/projects/samples/howto/controllers/mouse_events_non_blocking/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/mouse_events_non_blocking/mouse_events_non_blocking.c
+++ b/projects/samples/howto/controllers/mouse_events_non_blocking/mouse_events_non_blocking.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/omni_wheels/Makefile
+++ b/projects/samples/howto/controllers/omni_wheels/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/omni_wheels/omni_wheels.c
+++ b/projects/samples/howto/controllers/omni_wheels/omni_wheels.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/physics/Makefile
+++ b/projects/samples/howto/controllers/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/physics/physics.c
+++ b/projects/samples/howto/controllers/physics/physics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/rotation/Makefile
+++ b/projects/samples/howto/controllers/rotation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/rotation/rotation.c
+++ b/projects/samples/howto/controllers/rotation/rotation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/sick_terrain_scanning/Makefile
+++ b/projects/samples/howto/controllers/sick_terrain_scanning/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/sick_terrain_scanning/sick_terrain_scanning.c
+++ b/projects/samples/howto/controllers/sick_terrain_scanning/sick_terrain_scanning.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/sick_terrain_scanning_supervisor/Makefile
+++ b/projects/samples/howto/controllers/sick_terrain_scanning_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/sick_terrain_scanning_supervisor/sick_terrain_scanning_supervisor.c
+++ b/projects/samples/howto/controllers/sick_terrain_scanning_supervisor/sick_terrain_scanning_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/supervisor_draw_trail/Makefile
+++ b/projects/samples/howto/controllers/supervisor_draw_trail/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/supervisor_draw_trail/supervisor_draw_trail.c
+++ b/projects/samples/howto/controllers/supervisor_draw_trail/supervisor_draw_trail.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/texture_change/Makefile
+++ b/projects/samples/howto/controllers/texture_change/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/texture_change/texture_change.c
+++ b/projects/samples/howto/controllers/texture_change/texture_change.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/texture_robot/Makefile
+++ b/projects/samples/howto/controllers/texture_robot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/texture_robot/texture_robot.c
+++ b/projects/samples/howto/controllers/texture_robot/texture_robot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/vision/Makefile
+++ b/projects/samples/howto/controllers/vision/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/vision/vision.cpp
+++ b/projects/samples/howto/controllers/vision/vision.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/ziegler_nichols/Makefile
+++ b/projects/samples/howto/controllers/ziegler_nichols/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/controllers/ziegler_nichols/ziegler_nichols.c
+++ b/projects/samples/howto/controllers/ziegler_nichols/ziegler_nichols.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/physics/Makefile
+++ b/projects/samples/howto/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/physics/flying_mybot/Makefile
+++ b/projects/samples/howto/plugins/physics/flying_mybot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/physics/flying_mybot/flying_mybot.c
+++ b/projects/samples/howto/plugins/physics/flying_mybot/flying_mybot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/robot_windows/Makefile
+++ b/projects/samples/howto/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/robot_windows/custom_html_robot_window/Makefile
+++ b/projects/samples/howto/plugins/robot_windows/custom_html_robot_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/howto/plugins/robot_windows/custom_html_robot_window/custom_html_robot_window.c
+++ b/projects/samples/howto/plugins/robot_windows/custom_html_robot_window/custom_html_robot_window.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/mybot/controllers/Makefile
+++ b/projects/samples/mybot/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/mybot/controllers/mybot_camera/Makefile
+++ b/projects/samples/mybot/controllers/mybot_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/mybot/controllers/mybot_camera/mybot_camera.c
+++ b/projects/samples/mybot/controllers/mybot_camera/mybot_camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/mybot/controllers/mybot_simple/Makefile
+++ b/projects/samples/mybot/controllers/mybot_simple/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/mybot/controllers/mybot_simple/mybot_simple.c
+++ b/projects/samples/mybot/controllers/mybot_simple/mybot_simple.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/rendering/controllers/Makefile
+++ b/projects/samples/rendering/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/rendering/controllers/salamander/Makefile
+++ b/projects/samples/rendering/controllers/salamander/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/rendering/controllers/salamander/salamander.c
+++ b/projects/samples/rendering/controllers/salamander/salamander.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/Makefile
+++ b/projects/samples/robotbenchmark/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/Makefile
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon_supervisor/Makefile
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon_supervisor/marathon_supervisor.c
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon_supervisor/marathon_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/Makefile
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/Makefile
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
+++ b/projects/samples/robotbenchmark/humanoid_sprint/controllers/race_stopwatch/race_stopwatch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/include/robotbenchmark.h
+++ b/projects/samples/robotbenchmark/include/robotbenchmark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/inverted_pendulum/plugins/Makefile
+++ b/projects/samples/robotbenchmark/inverted_pendulum/plugins/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/inverted_pendulum/plugins/physics/inverted_pendulum_perturbation/Makefile
+++ b/projects/samples/robotbenchmark/inverted_pendulum/plugins/physics/inverted_pendulum_perturbation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/inverted_pendulum/plugins/physics/inverted_pendulum_perturbation/inverted_pendulum_perturbation.c
+++ b/projects/samples/robotbenchmark/inverted_pendulum/plugins/physics/inverted_pendulum_perturbation/inverted_pendulum_perturbation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/pit_escape/controllers/pit_escape_supervisor/Makefile
+++ b/projects/samples/robotbenchmark/pit_escape/controllers/pit_escape_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/pit_escape/controllers/pit_escape_supervisor/pit_escape_supervisor.c
+++ b/projects/samples/robotbenchmark/pit_escape/controllers/pit_escape_supervisor/pit_escape_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/square_path/Makefile
+++ b/projects/samples/robotbenchmark/square_path/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/square_path/real_robot/Makefile
+++ b/projects/samples/robotbenchmark/square_path/real_robot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/Makefile
+++ b/projects/samples/robotbenchmark/wall_following/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/Makefile
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/path.c
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/path.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/path.h
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/path.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/vector.h
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/vector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_metric.c
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_metric.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_metric.h
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_metric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_supervisor.c
+++ b/projects/samples/robotbenchmark/wall_following/controllers/wall_following_supervisor/wall_following_supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/4_wheels_collision_avoidance/4_wheels_collision_avoidance.c
+++ b/projects/samples/tutorials/controllers/4_wheels_collision_avoidance/4_wheels_collision_avoidance.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/4_wheels_collision_avoidance/Makefile
+++ b/projects/samples/tutorials/controllers/4_wheels_collision_avoidance/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/Makefile
+++ b/projects/samples/tutorials/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/e-puck_avoid_collision/Makefile
+++ b/projects/samples/tutorials/controllers/e-puck_avoid_collision/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/e-puck_avoid_collision/e-puck_avoid_collision.c
+++ b/projects/samples/tutorials/controllers/e-puck_avoid_collision/e-puck_avoid_collision.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/e-puck_go_forward/Makefile
+++ b/projects/samples/tutorials/controllers/e-puck_go_forward/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/samples/tutorials/controllers/e-puck_go_forward/e-puck_go_forward.c
+++ b/projects/samples/tutorials/controllers/e-puck_go_forward/e-puck_go_forward.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/vehicles/Makefile
+++ b/projects/vehicles/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/Makefile
+++ b/projects/vehicles/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/VehicleDriver/Makefile
+++ b/projects/vehicles/controllers/VehicleDriver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/VehicleDriver/VehicleDriver.java
+++ b/projects/vehicles/controllers/VehicleDriver/VehicleDriver.java
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/autonomous_vehicle/Makefile
+++ b/projects/vehicles/controllers/autonomous_vehicle/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/autonomous_vehicle/autonomous_vehicle.c
+++ b/projects/vehicles/controllers/autonomous_vehicle/autonomous_vehicle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/boomer/Makefile
+++ b/projects/vehicles/controllers/boomer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/boomer/boomer.c
+++ b/projects/vehicles/controllers/boomer/boomer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/enable_all_lidars/enable_all_lidars.py
+++ b/projects/vehicles/controllers/enable_all_lidars/enable_all_lidars.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/highway_overtake/highway_overtake.py
+++ b/projects/vehicles/controllers/highway_overtake/highway_overtake.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/racing_wheel/JoystickInterface.cpp
+++ b/projects/vehicles/controllers/racing_wheel/JoystickInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/racing_wheel/JoystickInterface.hpp
+++ b/projects/vehicles/controllers/racing_wheel/JoystickInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/racing_wheel/Makefile
+++ b/projects/vehicles/controllers/racing_wheel/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/racing_wheel/main.cpp
+++ b/projects/vehicles/controllers/racing_wheel/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/radar_target_tracker/Makefile
+++ b/projects/vehicles/controllers/radar_target_tracker/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/radar_target_tracker/radar_target_tracker.c
+++ b/projects/vehicles/controllers/radar_target_tracker/radar_target_tracker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/ros_automobile/Makefile
+++ b/projects/vehicles/controllers/ros_automobile/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/ros_automobile/RosAutomobile.cpp
+++ b/projects/vehicles/controllers/ros_automobile/RosAutomobile.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/ros_automobile/RosAutomobile.hpp
+++ b/projects/vehicles/controllers/ros_automobile/RosAutomobile.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/ros_automobile/main.cpp
+++ b/projects/vehicles/controllers/ros_automobile/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/controllers/vehicle_driver/vehicle_driver.py
+++ b/projects/vehicles/controllers/vehicle_driver/vehicle_driver.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/Makefile
+++ b/projects/vehicles/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/AbstractWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/AbstractWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/AbstractWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/AbstractWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/BrakeWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/BrakeWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/BrakeWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/BrakeWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/EncodersWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/EncodersWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/EncodersWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/EncodersWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/GeneralInformationWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/GeneralInformationWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/GeneralInformationWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/GeneralInformationWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/Makefile
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/RPMWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/RPMWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/RPMWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/RPMWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/SpeedWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/SpeedWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/SpeedWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/SpeedWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/SteeringWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/SteeringWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/SteeringWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/SteeringWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/ThrottleWidget.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/ThrottleWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/ThrottleWidget.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/ThrottleWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/entry_points.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/entry_points.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/plugins/robot_windows/automobile_window/entry_points.hpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/entry_points.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/vehicles/worlds/highway_overtake_net/generate_route.py
+++ b/projects/vehicles/worlds/highway_overtake_net/generate_route.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/worlds/sumo_interface_example_net/generate_route_file.py
+++ b/projects/vehicles/worlds/sumo_interface_example_net/generate_route_file.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vehicles/worlds/sumo_interface_example_net/plugin.py
+++ b/projects/vehicles/worlds/sumo_interface_example_net/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/Makefile.java.include
+++ b/resources/Makefile.java.include
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/Makefile.os.include
+++ b/resources/Makefile.os.include
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/languages/Makefile
+++ b/resources/languages/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Accelerometer.cpp
+++ b/resources/languages/cpp/Accelerometer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Brake.cpp
+++ b/resources/languages/cpp/Brake.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Camera.cpp
+++ b/resources/languages/cpp/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Compass.cpp
+++ b/resources/languages/cpp/Compass.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Connector.cpp
+++ b/resources/languages/cpp/Connector.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Device.cpp
+++ b/resources/languages/cpp/Device.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/DifferentialWheels.cpp
+++ b/resources/languages/cpp/DifferentialWheels.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Display.cpp
+++ b/resources/languages/cpp/Display.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/DistanceSensor.cpp
+++ b/resources/languages/cpp/DistanceSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Emitter.cpp
+++ b/resources/languages/cpp/Emitter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Field.cpp
+++ b/resources/languages/cpp/Field.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/GPS.cpp
+++ b/resources/languages/cpp/GPS.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Gyro.cpp
+++ b/resources/languages/cpp/Gyro.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/InertialUnit.cpp
+++ b/resources/languages/cpp/InertialUnit.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Joystick.cpp
+++ b/resources/languages/cpp/Joystick.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Keyboard.cpp
+++ b/resources/languages/cpp/Keyboard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/LED.cpp
+++ b/resources/languages/cpp/LED.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Lidar.cpp
+++ b/resources/languages/cpp/Lidar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/LightSensor.cpp
+++ b/resources/languages/cpp/LightSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Makefile
+++ b/resources/languages/cpp/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Motion.cpp
+++ b/resources/languages/cpp/Motion.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Motor.cpp
+++ b/resources/languages/cpp/Motor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Mouse.cpp
+++ b/resources/languages/cpp/Mouse.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Node.cpp
+++ b/resources/languages/cpp/Node.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Pen.cpp
+++ b/resources/languages/cpp/Pen.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/PositionSensor.cpp
+++ b/resources/languages/cpp/PositionSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Radar.cpp
+++ b/resources/languages/cpp/Radar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/RangeFinder.cpp
+++ b/resources/languages/cpp/RangeFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Receiver.cpp
+++ b/resources/languages/cpp/Receiver.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Robot.cpp
+++ b/resources/languages/cpp/Robot.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Skin.cpp
+++ b/resources/languages/cpp/Skin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Speaker.cpp
+++ b/resources/languages/cpp/Speaker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/Supervisor.cpp
+++ b/resources/languages/cpp/Supervisor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/cpp/TouchSensor.cpp
+++ b/resources/languages/cpp/TouchSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/java/Makefile
+++ b/resources/languages/java/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/languages/java/controller.i
+++ b/resources/languages/java/controller.i
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/languages/python/Makefile
+++ b/resources/languages/python/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/languages/python/controller.i
+++ b/resources/languages/python/controller.i
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resources/osm_importer/elevation.py
+++ b/resources/osm_importer/elevation.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/importer.py
+++ b/resources/osm_importer/importer.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/osm_objects.py
+++ b/resources/osm_importer/osm_objects.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/parser_objects.py
+++ b/resources/osm_importer/parser_objects.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/projection.py
+++ b/resources/osm_importer/projection.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/settings.py
+++ b/resources/osm_importer/settings.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/utils/misc_utils.py
+++ b/resources/osm_importer/utils/misc_utils.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/utils/shapely_utils.py
+++ b/resources/osm_importer/utils/shapely_utils.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/utils/vector.py
+++ b/resources/osm_importer/utils/vector.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/area.py
+++ b/resources/osm_importer/webots_objects/area.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/barrier.py
+++ b/resources/osm_importer/webots_objects/barrier.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/building.py
+++ b/resources/osm_importer/webots_objects/building.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/parking_lines.py
+++ b/resources/osm_importer/webots_objects/parking_lines.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/river.py
+++ b/resources/osm_importer/webots_objects/river.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/road.py
+++ b/resources/osm_importer/webots_objects/road.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/speed_limit.py
+++ b/resources/osm_importer/webots_objects/speed_limit.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/tree.py
+++ b/resources/osm_importer/webots_objects/tree.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/osm_importer/webots_objects/webots_object.py
+++ b/resources/osm_importer/webots_objects/webots_object.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/Makefile
+++ b/resources/projects/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/controllers/void/Makefile
+++ b/resources/projects/controllers/void/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/libraries/qt_utils/Makefile
+++ b/resources/projects/libraries/qt_utils/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/plugins/physics/Makefile
+++ b/resources/projects/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/plugins/robot_windows/generic/Makefile
+++ b/resources/projects/plugins/robot_windows/generic/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/projects/plugins/robot_windows/generic_window/Makefile
+++ b/resources/projects/plugins/robot_windows/generic_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/templates/controllers/Makefile
+++ b/resources/templates/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/templates/plugins/physics/Makefile
+++ b/resources/templates/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/translations/Makefile
+++ b/resources/translations/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/web/server/session_server.py
+++ b/resources/web/server/session_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/icon_studio/controllers/icon_creator/icon_creator.py
+++ b/scripts/icon_studio/controllers/icon_creator/icon_creator.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/icon_studio/controllers/leds/leds.py
+++ b/scripts/icon_studio/controllers/leds/leds.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/clamp_hdr.py
+++ b/scripts/image_tools/clamp_hdr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/convert_hdr_format.py
+++ b/scripts/image_tools/convert_hdr_format.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/downscale_hdr.py
+++ b/scripts/image_tools/downscale_hdr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/equirectangular_to_cubemap.py
+++ b/scripts/image_tools/equirectangular_to_cubemap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/images/__init__.py
+++ b/scripts/image_tools/images/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/images/hdr.py
+++ b/scripts/image_tools/images/hdr.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/images/regular_image.py
+++ b/scripts/image_tools/images/regular_image.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/utils/__init__.py
+++ b/scripts/image_tools/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/image_tools/utils/range.py
+++ b/scripts/image_tools/utils/range.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/preferences_cleaner/preferences_cleaner.py
+++ b/scripts/preferences_cleaner/preferences_cleaner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/web_component_studio/controllers/web_component_studio_supervisor/web_component_studio_supervisor.py
+++ b/scripts/web_component_studio/controllers/web_component_studio_supervisor/web_component_studio_supervisor.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/web_component_studio/web_component_studio.py
+++ b/scripts/web_component_studio/web_component_studio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/glad/Makefile
+++ b/src/glad/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/lib/Controller/Makefile
+++ b/src/lib/Controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/abstract_camera.c
+++ b/src/lib/Controller/api/abstract_camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/abstract_camera.h
+++ b/src/lib/Controller/api/abstract_camera.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/accelerometer.c
+++ b/src/lib/Controller/api/accelerometer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/brake.c
+++ b/src/lib/Controller/api/brake.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/camera.c
+++ b/src/lib/Controller/api/camera.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/compass.c
+++ b/src/lib/Controller/api/compass.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/connector.c
+++ b/src/lib/Controller/api/connector.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/console.c
+++ b/src/lib/Controller/api/console.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/default_robot_window.c
+++ b/src/lib/Controller/api/default_robot_window.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/default_robot_window_private.h
+++ b/src/lib/Controller/api/default_robot_window_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/device.c
+++ b/src/lib/Controller/api/device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/device_private.h
+++ b/src/lib/Controller/api/device_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/differential_wheels.c
+++ b/src/lib/Controller/api/differential_wheels.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/differential_wheels_private.h
+++ b/src/lib/Controller/api/differential_wheels_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/display.c
+++ b/src/lib/Controller/api/display.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/display_private.h
+++ b/src/lib/Controller/api/display_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/distance_sensor.c
+++ b/src/lib/Controller/api/distance_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/dynamic_library.c
+++ b/src/lib/Controller/api/dynamic_library.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/dynamic_library.h
+++ b/src/lib/Controller/api/dynamic_library.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/emitter.c
+++ b/src/lib/Controller/api/emitter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/file.c
+++ b/src/lib/Controller/api/file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/file.h
+++ b/src/lib/Controller/api/file.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/gps.c
+++ b/src/lib/Controller/api/gps.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/gyro.c
+++ b/src/lib/Controller/api/gyro.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/html_robot_window.c
+++ b/src/lib/Controller/api/html_robot_window.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/html_robot_window_private.h
+++ b/src/lib/Controller/api/html_robot_window_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/inertial_unit.c
+++ b/src/lib/Controller/api/inertial_unit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/joystick.c
+++ b/src/lib/Controller/api/joystick.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/joystick_private.h
+++ b/src/lib/Controller/api/joystick_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/keyboard.c
+++ b/src/lib/Controller/api/keyboard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/keyboard_private.h
+++ b/src/lib/Controller/api/keyboard_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/led.c
+++ b/src/lib/Controller/api/led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/lidar.c
+++ b/src/lib/Controller/api/lidar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/light_sensor.c
+++ b/src/lib/Controller/api/light_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/messages.h
+++ b/src/lib/Controller/api/messages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/microphone.c
+++ b/src/lib/Controller/api/microphone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/motion.c
+++ b/src/lib/Controller/api/motion.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/motion_private.h
+++ b/src/lib/Controller/api/motion_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/motor.c
+++ b/src/lib/Controller/api/motor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/mouse.c
+++ b/src/lib/Controller/api/mouse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/mouse_private.h
+++ b/src/lib/Controller/api/mouse_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/node.c
+++ b/src/lib/Controller/api/node.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/pen.c
+++ b/src/lib/Controller/api/pen.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/position_sensor.c
+++ b/src/lib/Controller/api/position_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/radar.c
+++ b/src/lib/Controller/api/radar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/radio.c
+++ b/src/lib/Controller/api/radio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/range_finder.c
+++ b/src/lib/Controller/api/range_finder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/receiver.c
+++ b/src/lib/Controller/api/receiver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/remote_control.c
+++ b/src/lib/Controller/api/remote_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/remote_control_private.h
+++ b/src/lib/Controller/api/remote_control_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/request.c
+++ b/src/lib/Controller/api/request.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/request.h
+++ b/src/lib/Controller/api/request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/robot.c
+++ b/src/lib/Controller/api/robot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/robot_private.h
+++ b/src/lib/Controller/api/robot_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/robot_window.c
+++ b/src/lib/Controller/api/robot_window.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/robot_window_private.h
+++ b/src/lib/Controller/api/robot_window_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/scheduler.c
+++ b/src/lib/Controller/api/scheduler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/scheduler.h
+++ b/src/lib/Controller/api/scheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/skin.c
+++ b/src/lib/Controller/api/skin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/speaker.c
+++ b/src/lib/Controller/api/speaker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/supervisor_private.h
+++ b/src/lib/Controller/api/supervisor_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/api/touch_sensor.c
+++ b/src/lib/Controller/api/touch_sensor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/base64.c
+++ b/src/lib/Controller/util/base64.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/base64.h
+++ b/src/lib/Controller/util/base64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/g_image.c
+++ b/src/lib/Controller/util/g_image.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/g_image.h
+++ b/src/lib/Controller/util/g_image.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/g_pipe.c
+++ b/src/lib/Controller/util/g_pipe.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib/Controller/util/g_pipe.h
+++ b/src/lib/Controller/util/g_pipe.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 1996-2019 Cyberbotics Ltd.
+ * Copyright 1996-2020 Cyberbotics Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ode/Makefile
+++ b/src/ode/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/Makefile
+++ b/src/packaging/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/check_rpath.py
+++ b/src/packaging/check_rpath.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/copy_msys64_files.py
+++ b/src/packaging/copy_msys64_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/generate_projects_files.py
+++ b/src/packaging/generate_projects_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/publish_release.py
+++ b/src/packaging/publish_release.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/set_commit_and_date_in_version.py
+++ b/src/packaging/set_commit_and_date_in_version.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/packaging/update_all_worlds.py
+++ b/src/packaging/update_all_worlds.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbApplication.hpp
+++ b/src/webots/app/WbApplication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbContactPointsRepresentation.cpp
+++ b/src/webots/app/WbContactPointsRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbContactPointsRepresentation.hpp
+++ b/src/webots/app/WbContactPointsRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbPerspective.cpp
+++ b/src/webots/app/WbPerspective.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbPerspective.hpp
+++ b/src/webots/app/WbPerspective.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbPhysicsVectorRepresentation.cpp
+++ b/src/webots/app/WbPhysicsVectorRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbPhysicsVectorRepresentation.hpp
+++ b/src/webots/app/WbPhysicsVectorRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbProtoCachedInfo.cpp
+++ b/src/webots/app/WbProtoCachedInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbProtoCachedInfo.hpp
+++ b/src/webots/app/WbProtoCachedInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbSelection.cpp
+++ b/src/webots/app/WbSelection.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/app/WbSelection.hpp
+++ b/src/webots/app/WbSelection.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbController.hpp
+++ b/src/webots/control/WbController.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbApplicationInfo.cpp
+++ b/src/webots/core/WbApplicationInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbApplicationInfo.hpp
+++ b/src/webots/core/WbApplicationInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbBinaryIncubator.cpp
+++ b/src/webots/core/WbBinaryIncubator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbBinaryIncubator.hpp
+++ b/src/webots/core/WbBinaryIncubator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbControllerPlugin.cpp
+++ b/src/webots/core/WbControllerPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbControllerPlugin.hpp
+++ b/src/webots/core/WbControllerPlugin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbDesktopServices.cpp
+++ b/src/webots/core/WbDesktopServices.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbDesktopServices.hpp
+++ b/src/webots/core/WbDesktopServices.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbFileUtil.cpp
+++ b/src/webots/core/WbFileUtil.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbFileUtil.hpp
+++ b/src/webots/core/WbFileUtil.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbGuiRefreshOracle.cpp
+++ b/src/webots/core/WbGuiRefreshOracle.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbGuiRefreshOracle.hpp
+++ b/src/webots/core/WbGuiRefreshOracle.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbHttpReply.cpp
+++ b/src/webots/core/WbHttpReply.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbHttpReply.hpp
+++ b/src/webots/core/WbHttpReply.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbIniParser.cpp
+++ b/src/webots/core/WbIniParser.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbIniParser.hpp
+++ b/src/webots/core/WbIniParser.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbLanguage.cpp
+++ b/src/webots/core/WbLanguage.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbLanguage.hpp
+++ b/src/webots/core/WbLanguage.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbLog.cpp
+++ b/src/webots/core/WbLog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbLog.hpp
+++ b/src/webots/core/WbLog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbMacAddress.cpp
+++ b/src/webots/core/WbMacAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbMacAddress.hpp
+++ b/src/webots/core/WbMacAddress.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbPosixSharedMemory.cpp
+++ b/src/webots/core/WbPosixSharedMemory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbPosixSharedMemory.hpp
+++ b/src/webots/core/WbPosixSharedMemory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbPreferences.hpp
+++ b/src/webots/core/WbPreferences.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbProject.hpp
+++ b/src/webots/core/WbProject.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbQtObjectSpy.cpp
+++ b/src/webots/core/WbQtObjectSpy.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbQtObjectSpy.hpp
+++ b/src/webots/core/WbQtObjectSpy.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbSimulationState.cpp
+++ b/src/webots/core/WbSimulationState.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbSimulationState.hpp
+++ b/src/webots/core/WbSimulationState.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbStandardPaths.hpp
+++ b/src/webots/core/WbStandardPaths.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbSysInfo.hpp
+++ b/src/webots/core/WbSysInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTelemetry.cpp
+++ b/src/webots/core/WbTelemetry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTelemetry.hpp
+++ b/src/webots/core/WbTelemetry.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTemplateEngine.hpp
+++ b/src/webots/core/WbTemplateEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTranslator.cpp
+++ b/src/webots/core/WbTranslator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbTranslator.hpp
+++ b/src/webots/core/WbTranslator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbVersion.cpp
+++ b/src/webots/core/WbVersion.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbVersion.hpp
+++ b/src/webots/core/WbVersion.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbWebotsUpdateManager.cpp
+++ b/src/webots/core/WbWebotsUpdateManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbWebotsUpdateManager.hpp
+++ b/src/webots/core/WbWebotsUpdateManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbWindowsRegistry.cpp
+++ b/src/webots/core/WbWindowsRegistry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/core/WbWindowsRegistry.hpp
+++ b/src/webots/core/WbWindowsRegistry.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbBuildEditor.hpp
+++ b/src/webots/editor/WbBuildEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbFindReplaceDialog.cpp
+++ b/src/webots/editor/WbFindReplaceDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbFindReplaceDialog.hpp
+++ b/src/webots/editor/WbFindReplaceDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbProjectRelocationDialog.hpp
+++ b/src/webots/editor/WbProjectRelocationDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbSyntaxHighlighter.cpp
+++ b/src/webots/editor/WbSyntaxHighlighter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbSyntaxHighlighter.hpp
+++ b/src/webots/editor/WbSyntaxHighlighter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextBuffer.cpp
+++ b/src/webots/editor/WbTextBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextBuffer.hpp
+++ b/src/webots/editor/WbTextBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextEditor.cpp
+++ b/src/webots/editor/WbTextEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextEditor.hpp
+++ b/src/webots/editor/WbTextEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextFind.cpp
+++ b/src/webots/editor/WbTextFind.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/editor/WbTextFind.hpp
+++ b/src/webots/editor/WbTextFind.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbAnimationRecorder.hpp
+++ b/src/webots/engine/WbAnimationRecorder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbMultimediaStreamer.cpp
+++ b/src/webots/engine/WbMultimediaStreamer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbMultimediaStreamer.hpp
+++ b/src/webots/engine/WbMultimediaStreamer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/engine/WbSimulationWorld.hpp
+++ b/src/webots/engine/WbSimulationWorld.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbAboutBox.cpp
+++ b/src/webots/gui/WbAboutBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbAboutBox.hpp
+++ b/src/webots/gui/WbAboutBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbAbstractDragEvent.cpp
+++ b/src/webots/gui/WbAbstractDragEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbAbstractDragEvent.hpp
+++ b/src/webots/gui/WbAbstractDragEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbConsole.cpp
+++ b/src/webots/gui/WbConsole.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbConsole.hpp
+++ b/src/webots/gui/WbConsole.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDocumentation.cpp
+++ b/src/webots/gui/WbDocumentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDocumentation.hpp
+++ b/src/webots/gui/WbDocumentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragOverlayEvent.cpp
+++ b/src/webots/gui/WbDragOverlayEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragOverlayEvent.hpp
+++ b/src/webots/gui/WbDragOverlayEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragResizeEvent.cpp
+++ b/src/webots/gui/WbDragResizeEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragResizeEvent.hpp
+++ b/src/webots/gui/WbDragResizeEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragScaleEvent.cpp
+++ b/src/webots/gui/WbDragScaleEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragScaleEvent.hpp
+++ b/src/webots/gui/WbDragScaleEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragSolidEvent.cpp
+++ b/src/webots/gui/WbDragSolidEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragSolidEvent.hpp
+++ b/src/webots/gui/WbDragSolidEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragTransformEvent.hpp
+++ b/src/webots/gui/WbDragTransformEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragViewpointEvent.cpp
+++ b/src/webots/gui/WbDragViewpointEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbDragViewpointEvent.hpp
+++ b/src/webots/gui/WbDragViewpointEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbGuiApplication.hpp
+++ b/src/webots/gui/WbGuiApplication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbGuidedTour.cpp
+++ b/src/webots/gui/WbGuidedTour.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbGuidedTour.hpp
+++ b/src/webots/gui/WbGuidedTour.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbHtmlExportDialog.cpp
+++ b/src/webots/gui/WbHtmlExportDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbHtmlExportDialog.hpp
+++ b/src/webots/gui/WbHtmlExportDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbMainWindow.hpp
+++ b/src/webots/gui/WbMainWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewControllerWizard.cpp
+++ b/src/webots/gui/WbNewControllerWizard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewControllerWizard.hpp
+++ b/src/webots/gui/WbNewControllerWizard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewPhysicsPluginWizard.cpp
+++ b/src/webots/gui/WbNewPhysicsPluginWizard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewPhysicsPluginWizard.hpp
+++ b/src/webots/gui/WbNewPhysicsPluginWizard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewProjectWizard.cpp
+++ b/src/webots/gui/WbNewProjectWizard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewProjectWizard.hpp
+++ b/src/webots/gui/WbNewProjectWizard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewVersionDialog.cpp
+++ b/src/webots/gui/WbNewVersionDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbNewVersionDialog.hpp
+++ b/src/webots/gui/WbNewVersionDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbOpenSampleWorldDialog.cpp
+++ b/src/webots/gui/WbOpenSampleWorldDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbOpenSampleWorldDialog.hpp
+++ b/src/webots/gui/WbOpenSampleWorldDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRecentFilesList.cpp
+++ b/src/webots/gui/WbRecentFilesList.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRecentFilesList.hpp
+++ b/src/webots/gui/WbRecentFilesList.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRenderingDeviceWindow.hpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRenderingDeviceWindowFactory.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindowFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRenderingDeviceWindowFactory.hpp
+++ b/src/webots/gui/WbRenderingDeviceWindowFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRobotWindow.hpp
+++ b/src/webots/gui/WbRobotWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRobotWindowTransportLayer.cpp
+++ b/src/webots/gui/WbRobotWindowTransportLayer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbRobotWindowTransportLayer.hpp
+++ b/src/webots/gui/WbRobotWindowTransportLayer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSaveWarningDialog.cpp
+++ b/src/webots/gui/WbSaveWarningDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSaveWarningDialog.hpp
+++ b/src/webots/gui/WbSaveWarningDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSimulationStateIndicator.cpp
+++ b/src/webots/gui/WbSimulationStateIndicator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSimulationStateIndicator.hpp
+++ b/src/webots/gui/WbSimulationStateIndicator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSimulationView.hpp
+++ b/src/webots/gui/WbSimulationView.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSingleTaskApplication.hpp
+++ b/src/webots/gui/WbSingleTaskApplication.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSplashScreen.cpp
+++ b/src/webots/gui/WbSplashScreen.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbSplashScreen.hpp
+++ b/src/webots/gui/WbSplashScreen.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbStreamingTcpServer.cpp
+++ b/src/webots/gui/WbStreamingTcpServer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbStreamingTcpServer.hpp
+++ b/src/webots/gui/WbStreamingTcpServer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbVideoRecorder.hpp
+++ b/src/webots/gui/WbVideoRecorder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbVideoRecorderDialog.cpp
+++ b/src/webots/gui/WbVideoRecorderDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbVideoRecorderDialog.hpp
+++ b/src/webots/gui/WbVideoRecorderDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbView3D.hpp
+++ b/src/webots/gui/WbView3D.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWebPage.cpp
+++ b/src/webots/gui/WbWebPage.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWebPage.hpp
+++ b/src/webots/gui/WbWebPage.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWebotsUpdateDialog.cpp
+++ b/src/webots/gui/WbWebotsUpdateDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWebotsUpdateDialog.hpp
+++ b/src/webots/gui/WbWebotsUpdateDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWheelEvent.cpp
+++ b/src/webots/gui/WbWheelEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWheelEvent.hpp
+++ b/src/webots/gui/WbWheelEvent.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/WbWrenWindow.hpp
+++ b/src/webots/gui/WbWrenWindow.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbAffinePlane.cpp
+++ b/src/webots/maths/WbAffinePlane.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbAffinePlane.hpp
+++ b/src/webots/maths/WbAffinePlane.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbImage.cpp
+++ b/src/webots/maths/WbImage.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbImage.hpp
+++ b/src/webots/maths/WbImage.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMathsUtilities.cpp
+++ b/src/webots/maths/WbMathsUtilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMathsUtilities.hpp
+++ b/src/webots/maths/WbMathsUtilities.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMatrix3.cpp
+++ b/src/webots/maths/WbMatrix3.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMatrix3.hpp
+++ b/src/webots/maths/WbMatrix3.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMatrix4.cpp
+++ b/src/webots/maths/WbMatrix4.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbMatrix4.hpp
+++ b/src/webots/maths/WbMatrix4.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbPolygon.cpp
+++ b/src/webots/maths/WbPolygon.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbPolygon.hpp
+++ b/src/webots/maths/WbPolygon.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbPrecision.cpp
+++ b/src/webots/maths/WbPrecision.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbPrecision.hpp
+++ b/src/webots/maths/WbPrecision.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbQuaternion.hpp
+++ b/src/webots/maths/WbQuaternion.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRandom.cpp
+++ b/src/webots/maths/WbRandom.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRandom.hpp
+++ b/src/webots/maths/WbRandom.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRay.cpp
+++ b/src/webots/maths/WbRay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRay.hpp
+++ b/src/webots/maths/WbRay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRotation.cpp
+++ b/src/webots/maths/WbRotation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbRotation.hpp
+++ b/src/webots/maths/WbRotation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbVector2.hpp
+++ b/src/webots/maths/WbVector2.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbVector3.hpp
+++ b/src/webots/maths/WbVector3.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbVector4.cpp
+++ b/src/webots/maths/WbVector4.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/maths/WbVector4.hpp
+++ b/src/webots/maths/WbVector4.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractAppearance.cpp
+++ b/src/webots/nodes/WbAbstractAppearance.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractAppearance.hpp
+++ b/src/webots/nodes/WbAbstractAppearance.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractTransform.cpp
+++ b/src/webots/nodes/WbAbstractTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAbstractTransform.hpp
+++ b/src/webots/nodes/WbAbstractTransform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAccelerometer.cpp
+++ b/src/webots/nodes/WbAccelerometer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAccelerometer.hpp
+++ b/src/webots/nodes/WbAccelerometer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAnchorParameter.cpp
+++ b/src/webots/nodes/WbAnchorParameter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAnchorParameter.hpp
+++ b/src/webots/nodes/WbAnchorParameter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAppearance.cpp
+++ b/src/webots/nodes/WbAppearance.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbAppearance.hpp
+++ b/src/webots/nodes/WbAppearance.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBackground.hpp
+++ b/src/webots/nodes/WbBackground.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBallJoint.hpp
+++ b/src/webots/nodes/WbBallJoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBallJointParameters.cpp
+++ b/src/webots/nodes/WbBallJointParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBallJointParameters.hpp
+++ b/src/webots/nodes/WbBallJointParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBaseNode.cpp
+++ b/src/webots/nodes/WbBaseNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBaseNode.hpp
+++ b/src/webots/nodes/WbBaseNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBasicJoint.hpp
+++ b/src/webots/nodes/WbBasicJoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBox.hpp
+++ b/src/webots/nodes/WbBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBrake.cpp
+++ b/src/webots/nodes/WbBrake.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbBrake.hpp
+++ b/src/webots/nodes/WbBrake.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCapsule.hpp
+++ b/src/webots/nodes/WbCapsule.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCharger.hpp
+++ b/src/webots/nodes/WbCharger.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbColor.cpp
+++ b/src/webots/nodes/WbColor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbColor.hpp
+++ b/src/webots/nodes/WbColor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCompass.cpp
+++ b/src/webots/nodes/WbCompass.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCompass.hpp
+++ b/src/webots/nodes/WbCompass.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCone.cpp
+++ b/src/webots/nodes/WbCone.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCone.hpp
+++ b/src/webots/nodes/WbCone.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbConnector.hpp
+++ b/src/webots/nodes/WbConnector.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbContactProperties.hpp
+++ b/src/webots/nodes/WbContactProperties.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCoordinate.cpp
+++ b/src/webots/nodes/WbCoordinate.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCoordinate.hpp
+++ b/src/webots/nodes/WbCoordinate.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbCylinder.hpp
+++ b/src/webots/nodes/WbCylinder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDamping.cpp
+++ b/src/webots/nodes/WbDamping.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDamping.hpp
+++ b/src/webots/nodes/WbDamping.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDevice.cpp
+++ b/src/webots/nodes/WbDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDevice.hpp
+++ b/src/webots/nodes/WbDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDifferentialWheels.cpp
+++ b/src/webots/nodes/WbDifferentialWheels.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDifferentialWheels.hpp
+++ b/src/webots/nodes/WbDifferentialWheels.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDirectionalLight.cpp
+++ b/src/webots/nodes/WbDirectionalLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDirectionalLight.hpp
+++ b/src/webots/nodes/WbDirectionalLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDisplay.hpp
+++ b/src/webots/nodes/WbDisplay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbDistanceSensor.hpp
+++ b/src/webots/nodes/WbDistanceSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbElevationGrid.cpp
+++ b/src/webots/nodes/WbElevationGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbElevationGrid.hpp
+++ b/src/webots/nodes/WbElevationGrid.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbEmitter.cpp
+++ b/src/webots/nodes/WbEmitter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbEmitter.hpp
+++ b/src/webots/nodes/WbEmitter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFluid.cpp
+++ b/src/webots/nodes/WbFluid.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFluid.hpp
+++ b/src/webots/nodes/WbFluid.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFocus.cpp
+++ b/src/webots/nodes/WbFocus.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFocus.hpp
+++ b/src/webots/nodes/WbFocus.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFog.cpp
+++ b/src/webots/nodes/WbFog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbFog.hpp
+++ b/src/webots/nodes/WbFog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGps.cpp
+++ b/src/webots/nodes/WbGps.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGps.hpp
+++ b/src/webots/nodes/WbGps.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGroup.hpp
+++ b/src/webots/nodes/WbGroup.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGyro.cpp
+++ b/src/webots/nodes/WbGyro.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbGyro.hpp
+++ b/src/webots/nodes/WbGyro.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHinge2Joint.hpp
+++ b/src/webots/nodes/WbHinge2Joint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHingeJoint.cpp
+++ b/src/webots/nodes/WbHingeJoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHingeJoint.hpp
+++ b/src/webots/nodes/WbHingeJoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHingeJointParameters.cpp
+++ b/src/webots/nodes/WbHingeJointParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbHingeJointParameters.hpp
+++ b/src/webots/nodes/WbHingeJointParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbImageTexture.hpp
+++ b/src/webots/nodes/WbImageTexture.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbImmersionProperties.cpp
+++ b/src/webots/nodes/WbImmersionProperties.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbImmersionProperties.hpp
+++ b/src/webots/nodes/WbImmersionProperties.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbIndexedFaceSet.cpp
+++ b/src/webots/nodes/WbIndexedFaceSet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbIndexedFaceSet.hpp
+++ b/src/webots/nodes/WbIndexedFaceSet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbIndexedLineSet.cpp
+++ b/src/webots/nodes/WbIndexedLineSet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbIndexedLineSet.hpp
+++ b/src/webots/nodes/WbIndexedLineSet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbInertialUnit.cpp
+++ b/src/webots/nodes/WbInertialUnit.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbInertialUnit.hpp
+++ b/src/webots/nodes/WbInertialUnit.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJoint.cpp
+++ b/src/webots/nodes/WbJoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJoint.hpp
+++ b/src/webots/nodes/WbJoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJointDevice.cpp
+++ b/src/webots/nodes/WbJointDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJointDevice.hpp
+++ b/src/webots/nodes/WbJointDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJointParameters.cpp
+++ b/src/webots/nodes/WbJointParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbJointParameters.hpp
+++ b/src/webots/nodes/WbJointParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLed.hpp
+++ b/src/webots/nodes/WbLed.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLens.cpp
+++ b/src/webots/nodes/WbLens.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLens.hpp
+++ b/src/webots/nodes/WbLens.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLensFlare.cpp
+++ b/src/webots/nodes/WbLensFlare.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLensFlare.hpp
+++ b/src/webots/nodes/WbLensFlare.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLidar.hpp
+++ b/src/webots/nodes/WbLidar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLight.cpp
+++ b/src/webots/nodes/WbLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLight.hpp
+++ b/src/webots/nodes/WbLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLightSensor.cpp
+++ b/src/webots/nodes/WbLightSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLightSensor.hpp
+++ b/src/webots/nodes/WbLightSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLinearMotor.cpp
+++ b/src/webots/nodes/WbLinearMotor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLinearMotor.hpp
+++ b/src/webots/nodes/WbLinearMotor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLogicalDevice.cpp
+++ b/src/webots/nodes/WbLogicalDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLogicalDevice.hpp
+++ b/src/webots/nodes/WbLogicalDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLookupTable.cpp
+++ b/src/webots/nodes/WbLookupTable.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbLookupTable.hpp
+++ b/src/webots/nodes/WbLookupTable.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMaterial.cpp
+++ b/src/webots/nodes/WbMaterial.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMaterial.hpp
+++ b/src/webots/nodes/WbMaterial.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMatter.cpp
+++ b/src/webots/nodes/WbMatter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMatter.hpp
+++ b/src/webots/nodes/WbMatter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMicrophone.cpp
+++ b/src/webots/nodes/WbMicrophone.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMicrophone.hpp
+++ b/src/webots/nodes/WbMicrophone.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMotor.hpp
+++ b/src/webots/nodes/WbMotor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMuscle.cpp
+++ b/src/webots/nodes/WbMuscle.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbMuscle.hpp
+++ b/src/webots/nodes/WbMuscle.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbNormal.cpp
+++ b/src/webots/nodes/WbNormal.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbNormal.hpp
+++ b/src/webots/nodes/WbNormal.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPbrAppearance.cpp
+++ b/src/webots/nodes/WbPbrAppearance.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPbrAppearance.hpp
+++ b/src/webots/nodes/WbPbrAppearance.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPen.cpp
+++ b/src/webots/nodes/WbPen.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPen.hpp
+++ b/src/webots/nodes/WbPen.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPhysics.cpp
+++ b/src/webots/nodes/WbPhysics.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPhysics.hpp
+++ b/src/webots/nodes/WbPhysics.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPlane.hpp
+++ b/src/webots/nodes/WbPlane.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPointLight.cpp
+++ b/src/webots/nodes/WbPointLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPointLight.hpp
+++ b/src/webots/nodes/WbPointLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPointSet.cpp
+++ b/src/webots/nodes/WbPointSet.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPointSet.hpp
+++ b/src/webots/nodes/WbPointSet.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPositionSensor.cpp
+++ b/src/webots/nodes/WbPositionSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPositionSensor.hpp
+++ b/src/webots/nodes/WbPositionSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPropeller.cpp
+++ b/src/webots/nodes/WbPropeller.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbPropeller.hpp
+++ b/src/webots/nodes/WbPropeller.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRadar.cpp
+++ b/src/webots/nodes/WbRadar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRadar.hpp
+++ b/src/webots/nodes/WbRadar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRadio.cpp
+++ b/src/webots/nodes/WbRadio.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRadio.hpp
+++ b/src/webots/nodes/WbRadio.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRangeFinder.cpp
+++ b/src/webots/nodes/WbRangeFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRangeFinder.hpp
+++ b/src/webots/nodes/WbRangeFinder.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbReceiver.hpp
+++ b/src/webots/nodes/WbReceiver.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRecognition.cpp
+++ b/src/webots/nodes/WbRecognition.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRecognition.hpp
+++ b/src/webots/nodes/WbRecognition.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRenderingDevice.cpp
+++ b/src/webots/nodes/WbRenderingDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRenderingDevice.hpp
+++ b/src/webots/nodes/WbRenderingDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRotationalMotor.cpp
+++ b/src/webots/nodes/WbRotationalMotor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbRotationalMotor.hpp
+++ b/src/webots/nodes/WbRotationalMotor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSensor.cpp
+++ b/src/webots/nodes/WbSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSensor.hpp
+++ b/src/webots/nodes/WbSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbShape.hpp
+++ b/src/webots/nodes/WbShape.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSkin.hpp
+++ b/src/webots/nodes/WbSkin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSliderJoint.hpp
+++ b/src/webots/nodes/WbSliderJoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSlot.cpp
+++ b/src/webots/nodes/WbSlot.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSlot.hpp
+++ b/src/webots/nodes/WbSlot.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolidDevice.cpp
+++ b/src/webots/nodes/WbSolidDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolidDevice.hpp
+++ b/src/webots/nodes/WbSolidDevice.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSolidReference.hpp
+++ b/src/webots/nodes/WbSolidReference.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSpeaker.cpp
+++ b/src/webots/nodes/WbSpeaker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSpeaker.hpp
+++ b/src/webots/nodes/WbSpeaker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSphere.hpp
+++ b/src/webots/nodes/WbSphere.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSpotLight.cpp
+++ b/src/webots/nodes/WbSpotLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbSpotLight.hpp
+++ b/src/webots/nodes/WbSpotLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTextureCoordinate.cpp
+++ b/src/webots/nodes/WbTextureCoordinate.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTextureCoordinate.hpp
+++ b/src/webots/nodes/WbTextureCoordinate.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTextureTransform.cpp
+++ b/src/webots/nodes/WbTextureTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTextureTransform.hpp
+++ b/src/webots/nodes/WbTextureTransform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTouchSensor.cpp
+++ b/src/webots/nodes/WbTouchSensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTouchSensor.hpp
+++ b/src/webots/nodes/WbTouchSensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTrack.hpp
+++ b/src/webots/nodes/WbTrack.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTrackWheel.cpp
+++ b/src/webots/nodes/WbTrackWheel.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTrackWheel.hpp
+++ b/src/webots/nodes/WbTrackWheel.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbTransform.hpp
+++ b/src/webots/nodes/WbTransform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbViewpoint.hpp
+++ b/src/webots/nodes/WbViewpoint.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbWorldInfo.hpp
+++ b/src/webots/nodes/WbWorldInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbZoom.cpp
+++ b/src/webots/nodes/WbZoom.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/WbZoom.hpp
+++ b/src/webots/nodes/WbZoom.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbBoundingSphere.hpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.hpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDataPacket.cpp
+++ b/src/webots/nodes/utils/WbDataPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDataPacket.hpp
+++ b/src/webots/nodes/utils/WbDataPacket.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDictionary.hpp
+++ b/src/webots/nodes/utils/WbDictionary.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDisplayFont.cpp
+++ b/src/webots/nodes/utils/WbDisplayFont.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbDisplayFont.hpp
+++ b/src/webots/nodes/utils/WbDisplayFont.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbFieldChecker.cpp
+++ b/src/webots/nodes/utils/WbFieldChecker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbFieldChecker.hpp
+++ b/src/webots/nodes/utils/WbFieldChecker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbHiddenKinematicParameters.cpp
+++ b/src/webots/nodes/utils/WbHiddenKinematicParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbHiddenKinematicParameters.hpp
+++ b/src/webots/nodes/utils/WbHiddenKinematicParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbJoystickInterface.cpp
+++ b/src/webots/nodes/utils/WbJoystickInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbJoystickInterface.hpp
+++ b/src/webots/nodes/utils/WbJoystickInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbJoystickListener.cpp
+++ b/src/webots/nodes/utils/WbJoystickListener.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbJoystickListener.hpp
+++ b/src/webots/nodes/utils/WbJoystickListener.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbKinematicDifferentialWheels.cpp
+++ b/src/webots/nodes/utils/WbKinematicDifferentialWheels.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbKinematicDifferentialWheels.hpp
+++ b/src/webots/nodes/utils/WbKinematicDifferentialWheels.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbMassChecker.cpp
+++ b/src/webots/nodes/utils/WbMassChecker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbMassChecker.hpp
+++ b/src/webots/nodes/utils/WbMassChecker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbMouse.cpp
+++ b/src/webots/nodes/utils/WbMouse.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbMouse.hpp
+++ b/src/webots/nodes/utils/WbMouse.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbNodeUtilities.hpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbObjectDetection.hpp
+++ b/src/webots/nodes/utils/WbObjectDetection.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbPaintTexture.cpp
+++ b/src/webots/nodes/utils/WbPaintTexture.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbPaintTexture.hpp
+++ b/src/webots/nodes/utils/WbPaintTexture.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSolidMerger.cpp
+++ b/src/webots/nodes/utils/WbSolidMerger.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSolidMerger.hpp
+++ b/src/webots/nodes/utils/WbSolidMerger.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSolidUtilities.cpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSolidUtilities.hpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbSupervisorUtilities.hpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTemplateManager.hpp
+++ b/src/webots/nodes/utils/WbTemplateManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTriangleMesh.cpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTriangleMesh.hpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTriangleMeshCache.cpp
+++ b/src/webots/nodes/utils/WbTriangleMeshCache.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbTriangleMeshCache.hpp
+++ b/src/webots/nodes/utils/WbTriangleMeshCache.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbUrl.hpp
+++ b/src/webots/nodes/utils/WbUrl.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbVirtualRealityHeadset.cpp
+++ b/src/webots/nodes/utils/WbVirtualRealityHeadset.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbVirtualRealityHeadset.hpp
+++ b/src/webots/nodes/utils/WbVirtualRealityHeadset.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbVisualBoundingSphere.hpp
+++ b/src/webots/nodes/utils/WbVisualBoundingSphere.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWorld.hpp
+++ b/src/webots/nodes/utils/WbWorld.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWrenMeshBuffers.cpp
+++ b/src/webots/nodes/utils/WbWrenMeshBuffers.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWrenMeshBuffers.hpp
+++ b/src/webots/nodes/utils/WbWrenMeshBuffers.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.cpp
+++ b/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.hpp
+++ b/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeContact.hpp
+++ b/src/webots/ode/WbOdeContact.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeContext.cpp
+++ b/src/webots/ode/WbOdeContext.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeContext.hpp
+++ b/src/webots/ode/WbOdeContext.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeDebugger.cpp
+++ b/src/webots/ode/WbOdeDebugger.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeDebugger.hpp
+++ b/src/webots/ode/WbOdeDebugger.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeGeomData.hpp
+++ b/src/webots/ode/WbOdeGeomData.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeTypes.hpp
+++ b/src/webots/ode/WbOdeTypes.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeUtilities.cpp
+++ b/src/webots/ode/WbOdeUtilities.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/ode/WbOdeUtilities.hpp
+++ b/src/webots/ode/WbOdeUtilities.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbPhysicsPlugin.cpp
+++ b/src/webots/plugins/WbPhysicsPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbPhysicsPlugin.hpp
+++ b/src/webots/plugins/WbPhysicsPlugin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbPlugin.cpp
+++ b/src/webots/plugins/WbPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbPlugin.hpp
+++ b/src/webots/plugins/WbPlugin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbRadioPlugin.cpp
+++ b/src/webots/plugins/WbRadioPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/plugins/WbRadioPlugin.hpp
+++ b/src/webots/plugins/WbRadioPlugin.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbAddInertiaMatrixDialog.cpp
+++ b/src/webots/scene_tree/WbAddInertiaMatrixDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbAddInertiaMatrixDialog.hpp
+++ b/src/webots/scene_tree/WbAddInertiaMatrixDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbAddNodeDialog.hpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbBoolEditor.cpp
+++ b/src/webots/scene_tree/WbBoolEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbBoolEditor.hpp
+++ b/src/webots/scene_tree/WbBoolEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbColorEditor.cpp
+++ b/src/webots/scene_tree/WbColorEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbColorEditor.hpp
+++ b/src/webots/scene_tree/WbColorEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbDoubleEditor.cpp
+++ b/src/webots/scene_tree/WbDoubleEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbDoubleEditor.hpp
+++ b/src/webots/scene_tree/WbDoubleEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbExtendedStringEditor.hpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldDoubleSpinBox.cpp
+++ b/src/webots/scene_tree/WbFieldDoubleSpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldDoubleSpinBox.hpp
+++ b/src/webots/scene_tree/WbFieldDoubleSpinBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldEditor.cpp
+++ b/src/webots/scene_tree/WbFieldEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldEditor.hpp
+++ b/src/webots/scene_tree/WbFieldEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldIntSpinBox.cpp
+++ b/src/webots/scene_tree/WbFieldIntSpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldIntSpinBox.hpp
+++ b/src/webots/scene_tree/WbFieldIntSpinBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldLineEdit.cpp
+++ b/src/webots/scene_tree/WbFieldLineEdit.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbFieldLineEdit.hpp
+++ b/src/webots/scene_tree/WbFieldLineEdit.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbIntEditor.cpp
+++ b/src/webots/scene_tree/WbIntEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbIntEditor.hpp
+++ b/src/webots/scene_tree/WbIntEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbNodeEditor.cpp
+++ b/src/webots/scene_tree/WbNodeEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbNodeEditor.hpp
+++ b/src/webots/scene_tree/WbNodeEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbNodePane.cpp
+++ b/src/webots/scene_tree/WbNodePane.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbNodePane.hpp
+++ b/src/webots/scene_tree/WbNodePane.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbPhysicsViewer.cpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbPhysicsViewer.hpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbPositionViewer.cpp
+++ b/src/webots/scene_tree/WbPositionViewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbPositionViewer.hpp
+++ b/src/webots/scene_tree/WbPositionViewer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbRotationEditor.cpp
+++ b/src/webots/scene_tree/WbRotationEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbRotationEditor.hpp
+++ b/src/webots/scene_tree/WbRotationEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbSceneTree.hpp
+++ b/src/webots/scene_tree/WbSceneTree.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbSceneTreeModel.cpp
+++ b/src/webots/scene_tree/WbSceneTreeModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbSceneTreeModel.hpp
+++ b/src/webots/scene_tree/WbSceneTreeModel.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbStringEditor.cpp
+++ b/src/webots/scene_tree/WbStringEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbStringEditor.hpp
+++ b/src/webots/scene_tree/WbStringEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbTreeItem.hpp
+++ b/src/webots/scene_tree/WbTreeItem.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbTreeView.cpp
+++ b/src/webots/scene_tree/WbTreeView.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbTreeView.hpp
+++ b/src/webots/scene_tree/WbTreeView.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbValueEditor.cpp
+++ b/src/webots/scene_tree/WbValueEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbValueEditor.hpp
+++ b/src/webots/scene_tree/WbValueEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVector2Editor.cpp
+++ b/src/webots/scene_tree/WbVector2Editor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVector2Editor.hpp
+++ b/src/webots/scene_tree/WbVector2Editor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVector3Editor.cpp
+++ b/src/webots/scene_tree/WbVector3Editor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVector3Editor.hpp
+++ b/src/webots/scene_tree/WbVector3Editor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVelocityViewer.cpp
+++ b/src/webots/scene_tree/WbVelocityViewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/scene_tree/WbVelocityViewer.hpp
+++ b/src/webots/scene_tree/WbVelocityViewer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbContactSound.cpp
+++ b/src/webots/sound/WbContactSound.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbContactSound.hpp
+++ b/src/webots/sound/WbContactSound.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbContactSoundManager.cpp
+++ b/src/webots/sound/WbContactSoundManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbContactSoundManager.hpp
+++ b/src/webots/sound/WbContactSoundManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbMicrosoftTextToSpeech.cpp
+++ b/src/webots/sound/WbMicrosoftTextToSpeech.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbMicrosoftTextToSpeech.hpp
+++ b/src/webots/sound/WbMicrosoftTextToSpeech.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbMotorSoundManager.cpp
+++ b/src/webots/sound/WbMotorSoundManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbMotorSoundManager.hpp
+++ b/src/webots/sound/WbMotorSoundManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbPicoTextToSpeech.cpp
+++ b/src/webots/sound/WbPicoTextToSpeech.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbPicoTextToSpeech.hpp
+++ b/src/webots/sound/WbPicoTextToSpeech.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundClip.cpp
+++ b/src/webots/sound/WbSoundClip.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundClip.hpp
+++ b/src/webots/sound/WbSoundClip.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundEngine.cpp
+++ b/src/webots/sound/WbSoundEngine.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundEngine.hpp
+++ b/src/webots/sound/WbSoundEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundSource.cpp
+++ b/src/webots/sound/WbSoundSource.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbSoundSource.hpp
+++ b/src/webots/sound/WbSoundSource.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbTextToSpeech.hpp
+++ b/src/webots/sound/WbTextToSpeech.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbWaveFile.cpp
+++ b/src/webots/sound/WbWaveFile.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/sound/WbWaveFile.hpp
+++ b/src/webots/sound/WbWaveFile.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbActionManager.cpp
+++ b/src/webots/user_commands/WbActionManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbActionManager.hpp
+++ b/src/webots/user_commands/WbActionManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbAddItemCommand.cpp
+++ b/src/webots/user_commands/WbAddItemCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbAddItemCommand.hpp
+++ b/src/webots/user_commands/WbAddItemCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbClipboard.cpp
+++ b/src/webots/user_commands/WbClipboard.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbClipboard.hpp
+++ b/src/webots/user_commands/WbClipboard.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbContextMenuGenerator.cpp
+++ b/src/webots/user_commands/WbContextMenuGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbContextMenuGenerator.hpp
+++ b/src/webots/user_commands/WbContextMenuGenerator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbEditCommand.cpp
+++ b/src/webots/user_commands/WbEditCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbEditCommand.hpp
+++ b/src/webots/user_commands/WbEditCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbRemoveItemCommand.hpp
+++ b/src/webots/user_commands/WbRemoveItemCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResetCommand.cpp
+++ b/src/webots/user_commands/WbResetCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResetCommand.hpp
+++ b/src/webots/user_commands/WbResetCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResizeAndTranslateCommand.cpp
+++ b/src/webots/user_commands/WbResizeAndTranslateCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResizeAndTranslateCommand.hpp
+++ b/src/webots/user_commands/WbResizeAndTranslateCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResizeCommand.cpp
+++ b/src/webots/user_commands/WbResizeCommand.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbResizeCommand.hpp
+++ b/src/webots/user_commands/WbResizeCommand.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbUndoStack.cpp
+++ b/src/webots/user_commands/WbUndoStack.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/user_commands/WbUndoStack.hpp
+++ b/src/webots/user_commands/WbUndoStack.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/util/WbPerformanceLog.cpp
+++ b/src/webots/util/WbPerformanceLog.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbField.hpp
+++ b/src/webots/vrml/WbField.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbFieldModel.cpp
+++ b/src/webots/vrml/WbFieldModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbFieldModel.hpp
+++ b/src/webots/vrml/WbFieldModel.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFBool.cpp
+++ b/src/webots/vrml/WbMFBool.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFBool.hpp
+++ b/src/webots/vrml/WbMFBool.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFColor.cpp
+++ b/src/webots/vrml/WbMFColor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFColor.hpp
+++ b/src/webots/vrml/WbMFColor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFDouble.cpp
+++ b/src/webots/vrml/WbMFDouble.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFDouble.hpp
+++ b/src/webots/vrml/WbMFDouble.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFInt.cpp
+++ b/src/webots/vrml/WbMFInt.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFInt.hpp
+++ b/src/webots/vrml/WbMFInt.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFNode.cpp
+++ b/src/webots/vrml/WbMFNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFNode.hpp
+++ b/src/webots/vrml/WbMFNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFRotation.cpp
+++ b/src/webots/vrml/WbMFRotation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFRotation.hpp
+++ b/src/webots/vrml/WbMFRotation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFString.cpp
+++ b/src/webots/vrml/WbMFString.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFString.hpp
+++ b/src/webots/vrml/WbMFString.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFVector2.cpp
+++ b/src/webots/vrml/WbMFVector2.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFVector2.hpp
+++ b/src/webots/vrml/WbMFVector2.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFVector3.cpp
+++ b/src/webots/vrml/WbMFVector3.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMFVector3.hpp
+++ b/src/webots/vrml/WbMFVector3.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMultipleValue.cpp
+++ b/src/webots/vrml/WbMultipleValue.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbMultipleValue.hpp
+++ b/src/webots/vrml/WbMultipleValue.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeFactory.cpp
+++ b/src/webots/vrml/WbNodeFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeFactory.hpp
+++ b/src/webots/vrml/WbNodeFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeModel.cpp
+++ b/src/webots/vrml/WbNodeModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeModel.hpp
+++ b/src/webots/vrml/WbNodeModel.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeReader.cpp
+++ b/src/webots/vrml/WbNodeReader.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbNodeReader.hpp
+++ b/src/webots/vrml/WbNodeReader.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbParser.cpp
+++ b/src/webots/vrml/WbParser.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbParser.hpp
+++ b/src/webots/vrml/WbParser.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoList.cpp
+++ b/src/webots/vrml/WbProtoList.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoList.hpp
+++ b/src/webots/vrml/WbProtoList.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoModel.hpp
+++ b/src/webots/vrml/WbProtoModel.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbProtoTemplateEngine.hpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbRgb.hpp
+++ b/src/webots/vrml/WbRgb.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFBool.cpp
+++ b/src/webots/vrml/WbSFBool.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFBool.hpp
+++ b/src/webots/vrml/WbSFBool.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFColor.cpp
+++ b/src/webots/vrml/WbSFColor.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFColor.hpp
+++ b/src/webots/vrml/WbSFColor.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFDouble.cpp
+++ b/src/webots/vrml/WbSFDouble.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFDouble.hpp
+++ b/src/webots/vrml/WbSFDouble.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFInt.cpp
+++ b/src/webots/vrml/WbSFInt.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFInt.hpp
+++ b/src/webots/vrml/WbSFInt.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFNode.cpp
+++ b/src/webots/vrml/WbSFNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFNode.hpp
+++ b/src/webots/vrml/WbSFNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFRotation.cpp
+++ b/src/webots/vrml/WbSFRotation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFRotation.hpp
+++ b/src/webots/vrml/WbSFRotation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFString.cpp
+++ b/src/webots/vrml/WbSFString.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFString.hpp
+++ b/src/webots/vrml/WbSFString.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFVector2.cpp
+++ b/src/webots/vrml/WbSFVector2.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFVector2.hpp
+++ b/src/webots/vrml/WbSFVector2.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFVector3.cpp
+++ b/src/webots/vrml/WbSFVector3.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSFVector3.hpp
+++ b/src/webots/vrml/WbSFVector3.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSingleValue.cpp
+++ b/src/webots/vrml/WbSingleValue.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbSingleValue.hpp
+++ b/src/webots/vrml/WbSingleValue.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbToken.cpp
+++ b/src/webots/vrml/WbToken.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbToken.hpp
+++ b/src/webots/vrml/WbToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbTokenizer.cpp
+++ b/src/webots/vrml/WbTokenizer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbTokenizer.hpp
+++ b/src/webots/vrml/WbTokenizer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbValue.cpp
+++ b/src/webots/vrml/WbValue.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbValue.hpp
+++ b/src/webots/vrml/WbValue.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbVariant.cpp
+++ b/src/webots/vrml/WbVariant.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbVariant.hpp
+++ b/src/webots/vrml/WbVariant.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbVrmlWriter.cpp
+++ b/src/webots/vrml/WbVrmlWriter.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/vrml/WbVrmlWriter.hpp
+++ b/src/webots/vrml/WbVrmlWriter.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDockTitleBar.cpp
+++ b/src/webots/widgets/WbDockTitleBar.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDockTitleBar.hpp
+++ b/src/webots/widgets/WbDockTitleBar.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDockWidget.cpp
+++ b/src/webots/widgets/WbDockWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDockWidget.hpp
+++ b/src/webots/widgets/WbDockWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDoubleSpinBox.cpp
+++ b/src/webots/widgets/WbDoubleSpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbDoubleSpinBox.hpp
+++ b/src/webots/widgets/WbDoubleSpinBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbIntSpinBox.cpp
+++ b/src/webots/widgets/WbIntSpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbIntSpinBox.hpp
+++ b/src/webots/widgets/WbIntSpinBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbLineEdit.cpp
+++ b/src/webots/widgets/WbLineEdit.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbLineEdit.hpp
+++ b/src/webots/widgets/WbLineEdit.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbMessageBox.cpp
+++ b/src/webots/widgets/WbMessageBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/widgets/WbMessageBox.hpp
+++ b/src/webots/widgets/WbMessageBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbCoordinateSystem.cpp
+++ b/src/webots/wren/WbCoordinateSystem.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbCoordinateSystem.hpp
+++ b/src/webots/wren/WbCoordinateSystem.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbLightRepresentation.cpp
+++ b/src/webots/wren/WbLightRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbLightRepresentation.hpp
+++ b/src/webots/wren/WbLightRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbResizeManipulator.cpp
+++ b/src/webots/wren/WbResizeManipulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbResizeManipulator.hpp
+++ b/src/webots/wren/WbResizeManipulator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbSpotLightRepresentation.cpp
+++ b/src/webots/wren/WbSpotLightRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbSpotLightRepresentation.hpp
+++ b/src/webots/wren/WbSpotLightRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbSupportPolygonRepresentation.cpp
+++ b/src/webots/wren/WbSupportPolygonRepresentation.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbSupportPolygonRepresentation.hpp
+++ b/src/webots/wren/WbSupportPolygonRepresentation.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbTesselator.cpp
+++ b/src/webots/wren/WbTesselator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbTesselator.hpp
+++ b/src/webots/wren/WbTesselator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbTranslateRotateManipulator.cpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbTranslateRotateManipulator.hpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractManipulator.cpp
+++ b/src/webots/wren/WbWrenAbstractManipulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractManipulator.hpp
+++ b/src/webots/wren/WbWrenAbstractManipulator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractPostProcessingEffect.cpp
+++ b/src/webots/wren/WbWrenAbstractPostProcessingEffect.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractPostProcessingEffect.hpp
+++ b/src/webots/wren/WbWrenAbstractPostProcessingEffect.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractResizeManipulator.cpp
+++ b/src/webots/wren/WbWrenAbstractResizeManipulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenAbstractResizeManipulator.hpp
+++ b/src/webots/wren/WbWrenAbstractResizeManipulator.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenBloom.cpp
+++ b/src/webots/wren/WbWrenBloom.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenBloom.hpp
+++ b/src/webots/wren/WbWrenBloom.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenCamera.hpp
+++ b/src/webots/wren/WbWrenCamera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenColorNoise.cpp
+++ b/src/webots/wren/WbWrenColorNoise.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenColorNoise.hpp
+++ b/src/webots/wren/WbWrenColorNoise.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenDepthOfField.cpp
+++ b/src/webots/wren/WbWrenDepthOfField.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenDepthOfField.hpp
+++ b/src/webots/wren/WbWrenDepthOfField.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenFullScreenOverlay.cpp
+++ b/src/webots/wren/WbWrenFullScreenOverlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenFullScreenOverlay.hpp
+++ b/src/webots/wren/WbWrenFullScreenOverlay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenGtao.cpp
+++ b/src/webots/wren/WbWrenGtao.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenGtao.hpp
+++ b/src/webots/wren/WbWrenGtao.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenHdr.cpp
+++ b/src/webots/wren/WbWrenHdr.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenHdr.hpp
+++ b/src/webots/wren/WbWrenHdr.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLabelOverlay.cpp
+++ b/src/webots/wren/WbWrenLabelOverlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLabelOverlay.hpp
+++ b/src/webots/wren/WbWrenLabelOverlay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLensDistortion.cpp
+++ b/src/webots/wren/WbWrenLensDistortion.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLensDistortion.hpp
+++ b/src/webots/wren/WbWrenLensDistortion.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLensFlare.cpp
+++ b/src/webots/wren/WbWrenLensFlare.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenLensFlare.hpp
+++ b/src/webots/wren/WbWrenLensFlare.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenMotionBlur.cpp
+++ b/src/webots/wren/WbWrenMotionBlur.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenMotionBlur.hpp
+++ b/src/webots/wren/WbWrenMotionBlur.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenNoiseMask.cpp
+++ b/src/webots/wren/WbWrenNoiseMask.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenNoiseMask.hpp
+++ b/src/webots/wren/WbWrenNoiseMask.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenOpenGlContext.cpp
+++ b/src/webots/wren/WbWrenOpenGlContext.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenOpenGlContext.hpp
+++ b/src/webots/wren/WbWrenOpenGlContext.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenPicker.cpp
+++ b/src/webots/wren/WbWrenPicker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenPicker.hpp
+++ b/src/webots/wren/WbWrenPicker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenPostProcessingEffects.cpp
+++ b/src/webots/wren/WbWrenPostProcessingEffects.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenPostProcessingEffects.hpp
+++ b/src/webots/wren/WbWrenPostProcessingEffects.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRangeNoise.cpp
+++ b/src/webots/wren/WbWrenRangeNoise.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRangeNoise.hpp
+++ b/src/webots/wren/WbWrenRangeNoise.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRangeQuantization.cpp
+++ b/src/webots/wren/WbWrenRangeQuantization.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRangeQuantization.hpp
+++ b/src/webots/wren/WbWrenRangeQuantization.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRenderingContext.cpp
+++ b/src/webots/wren/WbWrenRenderingContext.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenRenderingContext.hpp
+++ b/src/webots/wren/WbWrenRenderingContext.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenShaders.cpp
+++ b/src/webots/wren/WbWrenShaders.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenShaders.hpp
+++ b/src/webots/wren/WbWrenShaders.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenSmaa.cpp
+++ b/src/webots/wren/WbWrenSmaa.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenSmaa.hpp
+++ b/src/webots/wren/WbWrenSmaa.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/webots/wren/WbWrenTextureOverlay.hpp
+++ b/src/webots/wren/WbWrenTextureOverlay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Cache.cpp
+++ b/src/wren/Cache.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Cache.hpp
+++ b/src/wren/Cache.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Camera.cpp
+++ b/src/wren/Camera.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Camera.hpp
+++ b/src/wren/Camera.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ColorUtils.cpp
+++ b/src/wren/ColorUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ColorUtils.hpp
+++ b/src/wren/ColorUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Config.cpp
+++ b/src/wren/Config.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Config.hpp
+++ b/src/wren/Config.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Constants.cpp
+++ b/src/wren/Constants.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Constants.hpp
+++ b/src/wren/Constants.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ContainerUtils.hpp
+++ b/src/wren/ContainerUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/CpuTimeLogger.cpp
+++ b/src/wren/CpuTimeLogger.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/CpuTimeLogger.hpp
+++ b/src/wren/CpuTimeLogger.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/CustomUniform.cpp
+++ b/src/wren/CustomUniform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/CustomUniform.hpp
+++ b/src/wren/CustomUniform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Debug.hpp
+++ b/src/wren/Debug.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DirectionalLight.cpp
+++ b/src/wren/DirectionalLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DirectionalLight.hpp
+++ b/src/wren/DirectionalLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DrawableTexture.cpp
+++ b/src/wren/DrawableTexture.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DrawableTexture.hpp
+++ b/src/wren/DrawableTexture.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DynamicMesh.cpp
+++ b/src/wren/DynamicMesh.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/DynamicMesh.hpp
+++ b/src/wren/DynamicMesh.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/FileImport.cpp
+++ b/src/wren/FileImport.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/FileImport.hpp
+++ b/src/wren/FileImport.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Font.hpp
+++ b/src/wren/Font.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/FrameBuffer.hpp
+++ b/src/wren/FrameBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Frustum.cpp
+++ b/src/wren/Frustum.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Frustum.hpp
+++ b/src/wren/Frustum.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlState.hpp
+++ b/src/wren/GlState.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlUser.cpp
+++ b/src/wren/GlUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlUser.hpp
+++ b/src/wren/GlUser.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlslLayout.cpp
+++ b/src/wren/GlslLayout.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/GlslLayout.hpp
+++ b/src/wren/GlslLayout.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Id.cpp
+++ b/src/wren/Id.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Id.hpp
+++ b/src/wren/Id.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/LightNode.cpp
+++ b/src/wren/LightNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/LightNode.hpp
+++ b/src/wren/LightNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Makefile
+++ b/src/wren/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/wren/Material.cpp
+++ b/src/wren/Material.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Material.hpp
+++ b/src/wren/Material.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Mesh.cpp
+++ b/src/wren/Mesh.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Mesh.hpp
+++ b/src/wren/Mesh.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Node.cpp
+++ b/src/wren/Node.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Node.hpp
+++ b/src/wren/Node.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Overlay.cpp
+++ b/src/wren/Overlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Overlay.hpp
+++ b/src/wren/Overlay.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PbrMaterial.cpp
+++ b/src/wren/PbrMaterial.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PbrMaterial.hpp
+++ b/src/wren/PbrMaterial.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PhongMaterial.cpp
+++ b/src/wren/PhongMaterial.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PhongMaterial.hpp
+++ b/src/wren/PhongMaterial.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PointLight.cpp
+++ b/src/wren/PointLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PointLight.hpp
+++ b/src/wren/PointLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PositionalLight.cpp
+++ b/src/wren/PositionalLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PositionalLight.hpp
+++ b/src/wren/PositionalLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PostProcessingEffect.cpp
+++ b/src/wren/PostProcessingEffect.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/PostProcessingEffect.hpp
+++ b/src/wren/PostProcessingEffect.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Primitive.cpp
+++ b/src/wren/Primitive.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Primitive.hpp
+++ b/src/wren/Primitive.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Renderable.cpp
+++ b/src/wren/Renderable.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Renderable.hpp
+++ b/src/wren/Renderable.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Scene.hpp
+++ b/src/wren/Scene.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ShaderProgram.hpp
+++ b/src/wren/ShaderProgram.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ShadowVolumeCaster.cpp
+++ b/src/wren/ShadowVolumeCaster.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/ShadowVolumeCaster.hpp
+++ b/src/wren/ShadowVolumeCaster.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Skeleton.cpp
+++ b/src/wren/Skeleton.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Skeleton.hpp
+++ b/src/wren/Skeleton.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/SkeletonBone.cpp
+++ b/src/wren/SkeletonBone.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/SkeletonBone.hpp
+++ b/src/wren/SkeletonBone.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/SpotLight.cpp
+++ b/src/wren/SpotLight.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/SpotLight.hpp
+++ b/src/wren/SpotLight.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/StaticMesh.hpp
+++ b/src/wren/StaticMesh.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Texture.cpp
+++ b/src/wren/Texture.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Texture.hpp
+++ b/src/wren/Texture.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Texture2d.cpp
+++ b/src/wren/Texture2d.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Texture2d.hpp
+++ b/src/wren/Texture2d.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureCubeMap.cpp
+++ b/src/wren/TextureCubeMap.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureCubeMap.hpp
+++ b/src/wren/TextureCubeMap.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureCubeMapBaker.cpp
+++ b/src/wren/TextureCubeMapBaker.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureCubeMapBaker.hpp
+++ b/src/wren/TextureCubeMapBaker.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureRtt.cpp
+++ b/src/wren/TextureRtt.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureRtt.hpp
+++ b/src/wren/TextureRtt.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureTransform.cpp
+++ b/src/wren/TextureTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TextureTransform.hpp
+++ b/src/wren/TextureTransform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Transform.cpp
+++ b/src/wren/Transform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Transform.hpp
+++ b/src/wren/Transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TransformNode.cpp
+++ b/src/wren/TransformNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/TransformNode.hpp
+++ b/src/wren/TransformNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/UniformBuffer.cpp
+++ b/src/wren/UniformBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/UniformBuffer.hpp
+++ b/src/wren/UniformBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Viewport.cpp
+++ b/src/wren/Viewport.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/Viewport.hpp
+++ b/src/wren/Viewport.hpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/demo/Makefile
+++ b/src/wren/demo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/wren/demo/default.cpp
+++ b/src/wren/demo/default.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/wren/demo/phong.cpp
+++ b/src/wren/demo/phong.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2019 Cyberbotics Ltd.
+// Copyright 1996-2020 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/Makefile
+++ b/tests/api/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/Makefile
+++ b/tests/api/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/accelerometer/Makefile
+++ b/tests/api/controllers/accelerometer/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/asymmetric_friction/Makefile
+++ b/tests/api/controllers/asymmetric_friction/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/battery/Makefile
+++ b/tests/api/controllers/battery/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/brake/Makefile
+++ b/tests/api/controllers/brake/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/camera_checker/Makefile
+++ b/tests/api/controllers/camera_checker/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/camera_image_update/Makefile
+++ b/tests/api/controllers/camera_image_update/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/camera_noise_mask/Makefile
+++ b/tests/api/controllers/camera_noise_mask/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/camera_recognition/Makefile
+++ b/tests/api/controllers/camera_recognition/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/camera_revert/Makefile
+++ b/tests/api/controllers/camera_revert/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/center_of_mass_and_contact_points/Makefile
+++ b/tests/api/controllers/center_of_mass_and_contact_points/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/compass/Makefile
+++ b/tests/api/controllers/compass/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/device/Makefile
+++ b/tests/api/controllers/device/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/display/Makefile
+++ b/tests/api/controllers/display/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/display_attach_camera/Makefile
+++ b/tests/api/controllers/display_attach_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/display_infrared/Makefile
+++ b/tests/api/controllers/display_infrared/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/display_test/Makefile
+++ b/tests/api/controllers/display_test/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_enable_disable/Makefile
+++ b/tests/api/controllers/distance_sensor_enable_disable/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_infra-red/Makefile
+++ b/tests/api/controllers/distance_sensor_infra-red/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_infra-red_vs_transformed_planes/Makefile
+++ b/tests/api/controllers/distance_sensor_infra-red_vs_transformed_planes/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_laser/Makefile
+++ b/tests/api/controllers/distance_sensor_laser/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_resolution/Makefile
+++ b/tests/api/controllers/distance_sensor_resolution/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/distance_sensor_sonar/Makefile
+++ b/tests/api/controllers/distance_sensor_sonar/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_determinism/Makefile
+++ b/tests/api/controllers/emitter_receiver_determinism/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_determinism_supervisor/Makefile
+++ b/tests/api/controllers/emitter_receiver_determinism_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_enable_disable/Makefile
+++ b/tests/api/controllers/emitter_receiver_enable_disable/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_infra-red/Makefile
+++ b/tests/api/controllers/emitter_receiver_infra-red/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_infra-red_aperture/Makefile
+++ b/tests/api/controllers/emitter_receiver_infra-red_aperture/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_invalid_function_call/Makefile
+++ b/tests/api/controllers/emitter_receiver_invalid_function_call/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_physics_plugin/Makefile
+++ b/tests/api/controllers/emitter_receiver_physics_plugin/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_radio/Makefile
+++ b/tests/api/controllers/emitter_receiver_radio/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_radio_aperture/Makefile
+++ b/tests/api/controllers/emitter_receiver_radio_aperture/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_serial/Makefile
+++ b/tests/api/controllers/emitter_receiver_serial/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_receiver_serial_aperture/Makefile
+++ b/tests/api/controllers/emitter_receiver_serial_aperture/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/emitter_set_channel/Makefile
+++ b/tests/api/controllers/emitter_set_channel/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/extern/Makefile
+++ b/tests/api/controllers/extern/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/gps/Makefile
+++ b/tests/api/controllers/gps/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/gps_coordinates/Makefile
+++ b/tests/api/controllers/gps_coordinates/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/gps_coordinates_north_direction/Makefile
+++ b/tests/api/controllers/gps_coordinates_north_direction/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/gps_speed/Makefile
+++ b/tests/api/controllers/gps_speed/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/gyro/Makefile
+++ b/tests/api/controllers/gyro/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/inertial_unit/Makefile
+++ b/tests/api/controllers/inertial_unit/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/joint_end_point_collision/Makefile
+++ b/tests/api/controllers/joint_end_point_collision/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/led/Makefile
+++ b/tests/api/controllers/led/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/lidar_point_cloud/Makefile
+++ b/tests/api/controllers/lidar_point_cloud/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/lidar_rotating/Makefile
+++ b/tests/api/controllers/lidar_rotating/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/lidar_vs_range_finder/Makefile
+++ b/tests/api/controllers/lidar_vs_range_finder/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/light_sensor_point_spot_light_no_occlusion/Makefile
+++ b/tests/api/controllers/light_sensor_point_spot_light_no_occlusion/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/motion/Makefile
+++ b/tests/api/controllers/motion/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/motor/Makefile
+++ b/tests/api/controllers/motor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/motor2/Makefile
+++ b/tests/api/controllers/motor2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/motor_spinner/Makefile
+++ b/tests/api/controllers/motor_spinner/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/my_bot_controller/Makefile
+++ b/tests/api/controllers/my_bot_controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/my_bot_straight_controller/Makefile
+++ b/tests/api/controllers/my_bot_straight_controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen/Makefile
+++ b/tests/api/controllers/pen/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_box/Makefile
+++ b/tests/api/controllers/pen_box/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_box_scaled/Makefile
+++ b/tests/api/controllers/pen_box_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_capsule/Makefile
+++ b/tests/api/controllers/pen_capsule/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_capsule_scaled/Makefile
+++ b/tests/api/controllers/pen_capsule_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_cone/Makefile
+++ b/tests/api/controllers/pen_cone/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_cone_scaled/Makefile
+++ b/tests/api/controllers/pen_cone_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_cylinder/Makefile
+++ b/tests/api/controllers/pen_cylinder/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_cylinder_scaled/Makefile
+++ b/tests/api/controllers/pen_cylinder_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_elevation_grid/Makefile
+++ b/tests/api/controllers/pen_elevation_grid/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_elevation_grid_scaled/Makefile
+++ b/tests/api/controllers/pen_elevation_grid_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_indexed_face_set/Makefile
+++ b/tests/api/controllers/pen_indexed_face_set/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_indexed_face_set_scaled/Makefile
+++ b/tests/api/controllers/pen_indexed_face_set_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_plane/Makefile
+++ b/tests/api/controllers/pen_plane/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_sphere/Makefile
+++ b/tests/api/controllers/pen_sphere/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/pen_sphere_scaled/Makefile
+++ b/tests/api/controllers/pen_sphere_scaled/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/position_sensor/Makefile
+++ b/tests/api/controllers/position_sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/radar_frustum/Makefile
+++ b/tests/api/controllers/radar_frustum/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/radar_occlusion/Makefile
+++ b/tests/api/controllers/radar_occlusion/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/radar_relative_speed/Makefile
+++ b/tests/api/controllers/radar_relative_speed/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/radar_target_merging/Makefile
+++ b/tests/api/controllers/radar_target_merging/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/range_finder_checker/Makefile
+++ b/tests/api/controllers/range_finder_checker/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/range_finder_horizontal_spherical_projection/Makefile
+++ b/tests/api/controllers/range_finder_horizontal_spherical_projection/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/range_finder_spherical_horizontal_vertical/Makefile
+++ b/tests/api/controllers/range_finder_spherical_horizontal_vertical/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/remote_control/Makefile
+++ b/tests/api/controllers/remote_control/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_data/Makefile
+++ b/tests/api/controllers/robot_data/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_data_supervisor/Makefile
+++ b/tests/api/controllers/robot_data_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_multiple_step/Makefile
+++ b/tests/api/controllers/robot_multiple_step/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_multiple_step_supervisor/Makefile
+++ b/tests/api/controllers/robot_multiple_step_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_nested/Makefile
+++ b/tests/api/controllers/robot_nested/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_nested_child/Makefile
+++ b/tests/api/controllers/robot_nested_child/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_synchronous_time/Makefile
+++ b/tests/api/controllers/robot_synchronous_time/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_time_consecutive_packets/Makefile
+++ b/tests/api/controllers/robot_time_consecutive_packets/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_wait_for_user_input_event/Makefile
+++ b/tests/api/controllers/robot_wait_for_user_input_event/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_window/Makefile
+++ b/tests/api/controllers/robot_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/robot_window_html/Makefile
+++ b/tests/api/controllers/robot_window_html/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/runtime_config_file/Makefile
+++ b/tests/api/controllers/runtime_config_file/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/speaker/Makefile
+++ b/tests/api/controllers/speaker/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_animation/Makefile
+++ b/tests/api/controllers/supervisor_animation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_export_image/Makefile
+++ b/tests/api/controllers/supervisor_export_image/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_field/Makefile
+++ b/tests/api/controllers/supervisor_field/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_field_determinism/Makefile
+++ b/tests/api/controllers/supervisor_field_determinism/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_field_import_mf_node/Makefile
+++ b/tests/api/controllers/supervisor_field_import_mf_node/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_force_torque/Makefile
+++ b/tests/api/controllers/supervisor_force_torque/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_get_def/Makefile
+++ b/tests/api/controllers/supervisor_get_def/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_get_from_def/Makefile
+++ b/tests/api/controllers/supervisor_get_from_def/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_get_position_orientation/Makefile
+++ b/tests/api/controllers/supervisor_get_position_orientation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_get_velocity_with_joints/Makefile
+++ b/tests/api/controllers/supervisor_get_velocity_with_joints/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_import_remove/Makefile
+++ b/tests/api/controllers/supervisor_import_remove/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_import_remove_mf/Makefile
+++ b/tests/api/controllers/supervisor_import_remove_mf/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_import_robot_node/Makefile
+++ b/tests/api/controllers/supervisor_import_robot_node/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_inertia/Makefile
+++ b/tests/api/controllers/supervisor_inertia/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_internal_field/Makefile
+++ b/tests/api/controllers/supervisor_internal_field/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_node/Makefile
+++ b/tests/api/controllers/supervisor_node/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_node_set_visibility/Makefile
+++ b/tests/api/controllers/supervisor_node_set_visibility/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_reset_physics/Makefile
+++ b/tests/api/controllers/supervisor_reset_physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_reset_physics_hinge/Makefile
+++ b/tests/api/controllers/supervisor_reset_physics_hinge/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_reset_simulation/Makefile
+++ b/tests/api/controllers/supervisor_reset_simulation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_restart_controller/Makefile
+++ b/tests/api/controllers/supervisor_restart_controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_restart_controller_display/Makefile
+++ b/tests/api/controllers/supervisor_restart_controller_display/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_save_world/Makefile
+++ b/tests/api/controllers/supervisor_save_world/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_self_restart/Makefile
+++ b/tests/api/controllers/supervisor_self_restart/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_set_hinge_position/Makefile
+++ b/tests/api/controllers/supervisor_set_hinge_position/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_set_position_loop/Makefile
+++ b/tests/api/controllers/supervisor_set_position_loop/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_set_position_of_dynamic_object/Makefile
+++ b/tests/api/controllers/supervisor_set_position_of_dynamic_object/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_set_position_orientation/Makefile
+++ b/tests/api/controllers/supervisor_set_position_orientation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_simulation_mode/Makefile
+++ b/tests/api/controllers/supervisor_simulation_mode/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_start_stop_movie/Makefile
+++ b/tests/api/controllers/supervisor_start_stop_movie/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/supervisor_velocity/Makefile
+++ b/tests/api/controllers/supervisor_velocity/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/touch_sensor_bumper/Makefile
+++ b/tests/api/controllers/touch_sensor_bumper/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/touch_sensor_force/Makefile
+++ b/tests/api/controllers/touch_sensor_force/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/touch_sensor_force3d/Makefile
+++ b/tests/api/controllers/touch_sensor_force3d/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/touch_sensor_kinematic/Makefile
+++ b/tests/api/controllers/touch_sensor_kinematic/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/controllers/track/Makefile
+++ b/tests/api/controllers/track/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/physics/Makefile
+++ b/tests/api/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/physics/emitter_receiver_physics/Makefile
+++ b/tests/api/plugins/physics/emitter_receiver_physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/remote_controls/Makefile
+++ b/tests/api/plugins/remote_controls/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/remote_controls/remote_control/Makefile
+++ b/tests/api/plugins/remote_controls/remote_control/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/robot_windows/Makefile
+++ b/tests/api/plugins/robot_windows/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/api/plugins/robot_windows/robot_window/Makefile
+++ b/tests/api/plugins/robot_windows/robot_window/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/command.py
+++ b/tests/command.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/command_test.py
+++ b/tests/command_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
+++ b/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/manual_tests/controllers/procedural_proto_regenerator/procedural_proto_regenerator.py
+++ b/tests/manual_tests/controllers/procedural_proto_regenerator/procedural_proto_regenerator.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/manual_tests/test_worlds_warnings.py
+++ b/tests/manual_tests/test_worlds_warnings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/parser/Makefile
+++ b/tests/parser/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/parser/controllers/Makefile
+++ b/tests/parser/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/parser/controllers/hidden_parameter_single/Makefile
+++ b/tests/parser/controllers/hidden_parameter_single/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/Makefile
+++ b/tests/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/Makefile
+++ b/tests/physics/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/ball_joint_vs_hinge_joints/Makefile
+++ b/tests/physics/controllers/ball_joint_vs_hinge_joints/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/check_joint_hard_limits_after_move/Makefile
+++ b/tests/physics/controllers/check_joint_hard_limits_after_move/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/check_saved_hidden_parameters/Makefile
+++ b/tests/physics/controllers/check_saved_hidden_parameters/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/connector_detach/Makefile
+++ b/tests/physics/controllers/connector_detach/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/connector_static_autolock/Makefile
+++ b/tests/physics/controllers/connector_static_autolock/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/damping/Makefile
+++ b/tests/physics/controllers/damping/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/determinism/Makefile
+++ b/tests/physics/controllers/determinism/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/distance_sensor_rays/Makefile
+++ b/tests/physics/controllers/distance_sensor_rays/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/elevation_grid_rotation/Makefile
+++ b/tests/physics/controllers/elevation_grid_rotation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/emitter_rays/Makefile
+++ b/tests/physics/controllers/emitter_rays/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/floating_point_precision/Makefile
+++ b/tests/physics/controllers/floating_point_precision/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/hinge_2_joint_damping/Makefile
+++ b/tests/physics/controllers/hinge_2_joint_damping/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/hinge_2_joint_damping_supervisor/Makefile
+++ b/tests/physics/controllers/hinge_2_joint_damping_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/hinge_joint_damping/Makefile
+++ b/tests/physics/controllers/hinge_joint_damping/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/hinge_joint_slot/Makefile
+++ b/tests/physics/controllers/hinge_joint_slot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/joint_controller/Makefile
+++ b/tests/physics/controllers/joint_controller/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/kinematic_geometry_update/Makefile
+++ b/tests/physics/controllers/kinematic_geometry_update/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/light_sensor_rays/Makefile
+++ b/tests/physics/controllers/light_sensor_rays/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/move_car/Makefile
+++ b/tests/physics/controllers/move_car/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/move_hinge_2_joint_with_suspension/Makefile
+++ b/tests/physics/controllers/move_hinge_2_joint_with_suspension/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/move_hinge_2_joint_with_suspension_robot/Makefile
+++ b/tests/physics/controllers/move_hinge_2_joint_with_suspension_robot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/move_vehicle_with_hinge_2_joint/Makefile
+++ b/tests/physics/controllers/move_vehicle_with_hinge_2_joint/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/passive_hinge_joint/Makefile
+++ b/tests/physics/controllers/passive_hinge_joint/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/radar_rays/Makefile
+++ b/tests/physics/controllers/radar_rays/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/receiver_rays/Makefile
+++ b/tests/physics/controllers/receiver_rays/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/runtime_geom_update/Makefile
+++ b/tests/physics/controllers/runtime_geom_update/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/spring_damping_force/Makefile
+++ b/tests/physics/controllers/spring_damping_force/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/world_dont_crash/Makefile
+++ b/tests/physics/controllers/world_dont_crash/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/controllers/youbot_move_arm/Makefile
+++ b/tests/physics/controllers/youbot_move_arm/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/plugins/physics/Makefile
+++ b/tests/physics/plugins/physics/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/plugins/physics/connector_apply_force/Makefile
+++ b/tests/physics/plugins/physics/connector_apply_force/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/plugins/physics/ode_dif_exporter/Makefile
+++ b/tests/physics/plugins/physics/ode_dif_exporter/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/physics/plugins/physics/spring_damping_force_plugin/Makefile
+++ b/tests/physics/plugins/physics/spring_damping_force_plugin/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/Makefile
+++ b/tests/protos/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/Makefile
+++ b/tests/protos/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/copy_args_in_custom_data/Makefile
+++ b/tests/protos/controllers/copy_args_in_custom_data/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/derived_proto_automatic_IS_redirection/Makefile
+++ b/tests/protos/controllers/derived_proto_automatic_IS_redirection/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/derived_proto_parameter/Makefile
+++ b/tests/protos/controllers/derived_proto_parameter/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/dummy/Makefile
+++ b/tests/protos/controllers/dummy/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/follow_solid_in_slot/Makefile
+++ b/tests/protos/controllers/follow_solid_in_slot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/internal_template_proto_update/Makefile
+++ b/tests/protos/controllers/internal_template_proto_update/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/mixed_template_derived_proto/Makefile
+++ b/tests/protos/controllers/mixed_template_derived_proto/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/nested/Makefile
+++ b/tests/protos/controllers/nested/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/nested_mixed_template_proto/Makefile
+++ b/tests/protos/controllers/nested_mixed_template_proto/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/proto_nested_internal/Makefile
+++ b/tests/protos/controllers/proto_nested_internal/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/proto_nested_internal_import/Makefile
+++ b/tests/protos/controllers/proto_nested_internal_import/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/proto_nested_parameter/Makefile
+++ b/tests/protos/controllers/proto_nested_parameter/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/proto_nested_parameter_2/Makefile
+++ b/tests/protos/controllers/proto_nested_parameter_2/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/proto_regeneration_multiple_instances/Makefile
+++ b/tests/protos/controllers/proto_regeneration_multiple_instances/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/save_joint_proto_parameter/Makefile
+++ b/tests/protos/controllers/save_joint_proto_parameter/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/single_distance_sensor_detection/Makefile
+++ b/tests/protos/controllers/single_distance_sensor_detection/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/slot_node/Makefile
+++ b/tests/protos/controllers/slot_node/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/slot_node_derived/Makefile
+++ b/tests/protos/controllers/slot_node_derived/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/slots/Makefile
+++ b/tests/protos/controllers/slots/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/slots_node_proto_parameter/Makefile
+++ b/tests/protos/controllers/slots_node_proto_parameter/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/super_parameter_instances/Makefile
+++ b/tests/protos/controllers/super_parameter_instances/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_exhaustive_parameter_type/Makefile
+++ b/tests/protos/controllers/template_exhaustive_parameter_type/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_internal_proto_regeneration/Makefile
+++ b/tests/protos/controllers/template_internal_proto_regeneration/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_nested_slot_container/Makefile
+++ b/tests/protos/controllers/template_nested_slot_container/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_node_id/Makefile
+++ b/tests/protos/controllers/template_node_id/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_parameter_toggle_from_supervisor/Makefile
+++ b/tests/protos/controllers/template_parameter_toggle_from_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_proto_follow_solid/Makefile
+++ b/tests/protos/controllers/template_proto_follow_solid/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_robot_regenerated/Makefile
+++ b/tests/protos/controllers/template_robot_regenerated/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_static/Makefile
+++ b/tests/protos/controllers/template_static/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_texture/Makefile
+++ b/tests/protos/controllers/template_texture/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/template_viewpoint_proto/Makefile
+++ b/tests/protos/controllers/template_viewpoint_proto/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/protos/controllers/test_cylinder_size_and_resizing/Makefile
+++ b/tests/protos/controllers/test_cylinder_size_and_resizing/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/Makefile
+++ b/tests/rendering/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/controllers/Makefile
+++ b/tests/rendering/controllers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/controllers/mirror_supervisor/Makefile
+++ b/tests/rendering/controllers/mirror_supervisor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/controllers/normals/Makefile
+++ b/tests/rendering/controllers/normals/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/controllers/point_set/Makefile
+++ b/tests/rendering/controllers/point_set/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/rendering/controllers/smooth_shading_camera/Makefile
+++ b/tests/rendering/controllers/smooth_shading_camera/Makefile
@@ -1,4 +1,4 @@
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/generate_diff.py
+++ b/tests/sources/generate_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_clang_format.py
+++ b/tests/sources/test_clang_format.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_cppcheck.py
+++ b/tests/sources/test_cppcheck.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_header_version.py
+++ b/tests/sources/test_header_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_icons.py
+++ b/tests/sources/test_icons.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_license.py
+++ b/tests/sources/test_license.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_matlab_functions.py
+++ b/tests/sources/test_matlab_functions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_pep8.py
+++ b/tests/sources/test_pep8.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_project_structure.py
+++ b/tests/sources/test_project_structure.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_proto_names.py
+++ b/tests/sources/test_proto_names.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/test_textures.py
+++ b/tests/sources/test_textures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2019 Cyberbotics Ltd.
+# Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update the date to 2020 in the copyrights.
This was the cause of the nightly test failures.