### PR TITLE
Fix wb_supervisor_add_force_with_offset()

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,6 +7,7 @@ Released on XXX YYYrd, 2020.
     - Improved the SUMO interface to use the version of SUMO already installed (if any).
     - Improved the SUMO interface to be compatible with the latest version (1.4).
   - Bug fixes
+    - Fix the [wb_supervisor_node_add_force_with_offset()](supervisor.md#wb_supervisor_node_add_force_with_offset) function.
     - Fix default controller of the [ABB IRB 4600/40](../guide/irb4600-40.md) robot.
   - Cleanup
     - OpenCV is not distributed within Webots anymore.

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,7 +7,7 @@ Released on XXX YYYrd, 2020.
     - Improved the SUMO interface to use the version of SUMO already installed (if any).
     - Improved the SUMO interface to be compatible with the latest version (1.4).
   - Bug fixes
-    - Fix the [wb_supervisor_node_add_force_with_offset()](supervisor.md#wb_supervisor_node_add_force_with_offset) function.
+    - Fix the [`wb_supervisor_node_add_force_with_offset()`](supervisor.md#wb_supervisor_node_add_force_with_offset) function.
     - Fix default controller of the [ABB IRB 4600/40](../guide/irb4600-40.md) robot.
   - Cleanup
     - OpenCV is not distributed within Webots anymore.

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,7 +7,7 @@ Released on XXX YYYrd, 2020.
     - Improved the SUMO interface to use the version of SUMO already installed (if any).
     - Improved the SUMO interface to be compatible with the latest version (1.4).
   - Bug fixes
-    - Fix the [`wb_supervisor_node_add_force_with_offset()`](supervisor.md#wb_supervisor_node_add_force_with_offset) function.
+    - Fixed the direction of the force applied with the [`wb_supervisor_node_add_force_with_offset()`](supervisor.md#wb_supervisor_node_add_force_with_offset) function.
     - Fix default controller of the [ABB IRB 4600/40](../guide/irb4600-40.md) robot.
   - Cleanup
     - OpenCV is not distributed within Webots anymore.

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -796,7 +796,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       if (solid) {
         const WbMatrix4 &solidMatrix = solid->matrix();
 
-        WbVector3 offset = solidMatrix * WbVector3(ox, oy, oz);
+        const WbVector3 offset = solidMatrix * WbVector3(ox, oy, oz);
 
         WbVector3 force(fx, fy, fz);
         if (relative == 1)

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -794,13 +794,17 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       WbNode *const node = getProtoParameterNodeInstance(WbNode::findNode(id));
       WbSolid *const solid = dynamic_cast<WbSolid *>(node);
       if (solid) {
-        WbVector3 force(fx, fy, fz), offset(ox, oy, oz);
+        const WbMatrix4 &solidMatrix = solid->matrix();
+
+        WbVector3 offset = solidMatrix * WbVector3(ox, oy, oz);
+
+        WbVector3 force(fx, fy, fz);
         if (relative == 1)
-          force = solid->matrix().extracted3x3Matrix() * force;
-        offset = solid->matrix().extracted3x3Matrix() * offset;
+          force = solidMatrix.extracted3x3Matrix() * force;
+
         dBodyID body = solid->bodyMerger();
         if (body)
-          dBodyAddForceAtRelPos(body, force.x(), force.y(), force.z(), offset.x(), offset.y(), offset.z());
+          dBodyAddForceAtPos(body, force.x(), force.y(), force.z(), offset.x(), offset.y(), offset.z());
         else
           mRobot->warn(tr("wb_supervisor_node_add_force_with_offset() can't be used with a kinematic Solid"));
       } else


### PR DESCRIPTION
The offset is wrongly computed, probably because of the ODE rotation which is not correctly taken into account. Using `dBodyAddForceAtPos()` instead of `dBodyAddForceAtRelPos()` simplifies and fixes this issue.