### PR TITLE
Fix Travis on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,8 +234,10 @@ jobs:
             - cmake
             - swig
             - wget
+            - node
       before_install:
         - export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+        - export PATH=/usr/local/bin/:$PATH  # Prefer Brew binaries over Travis ones.
         - npm install -g appdmg
         - pip install PyGithub  # used to upload packages to Github releases
         - sudo mkdir -p /Library/Frameworks/Python.framework/Versions/3.7  # we can't use python3.7 from homebrew for the compilation because it is not compatible with the normal one

--- a/.travis.yml
+++ b/.travis.yml
@@ -234,7 +234,6 @@ jobs:
             - cmake
             - swig
             - wget
-            - node
       before_install:
         - export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
         - npm install -g appdmg

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -113,7 +113,8 @@ $(LOCAL_THREEJS_EXAMPLE_SOURCES):
 
 $(INSTALL_TOKEN): package.json
 	@echo "# installing npm dependencies"
-	@npm --silent install 1> /dev/null
+	npm install
+	# @npm --silent install 1> /dev/null
 	@touch $(INSTALL_TOKEN)
 
 cleanse: clean

--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -113,8 +113,7 @@ $(LOCAL_THREEJS_EXAMPLE_SOURCES):
 
 $(INSTALL_TOKEN): package.json
 	@echo "# installing npm dependencies"
-	npm install
-	# @npm --silent install 1> /dev/null
+	@npm --silent install 1> /dev/null
 	@touch $(INSTALL_TOKEN)
 
 cleanse: clean


### PR DESCRIPTION
Fix this error on the Travis build:

```
# compressing webots.min.js
454Error: Package exports for '/Users/travis/build/cyberbotics/webots/resources/web/wwi/node_modules/@babel/helper-compilation-targets' do not define a '.' subpath
455    at resolveExports (internal/modules/cjs/loader.js:419:17)
456    at Function.Module._findPath (internal/modules/cjs/loader.js:492:20)
457    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:787:27)
458    at Function.Module._load (internal/modules/cjs/loader.js:693:27)
459    at Module.require (internal/modules/cjs/loader.js:864:19)
460    at require (internal/modules/cjs/helpers.js:74:18)
461    at Object.<anonymous> (/Users/travis/build/cyberbotics/webots/resources/web/wwi/node_modules/@babel/preset-env/lib/debug.js:8:33)
462    at Module._compile (internal/modules/cjs/loader.js:971:30)
463    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1011:10)
464    at Module.load (internal/modules/cjs/loader.js:822:32) {
465  code: 'MODULE_NOT_FOUND'
```