### PR TITLE
Fix Camera Image Save to JPEG

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -5,6 +5,8 @@ Released on XXX.
 
   - Enhancements
     - Improved the environment colors of the sojourner simulation (Mars is a red planet).
+  - Bug fixes
+    - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
 
 ## Webots R2020a Revision 1
 Released on January 14th, 2020.

--- a/src/lib/Controller/util/g_image.c
+++ b/src/lib/Controller/util/g_image.c
@@ -148,7 +148,7 @@ static int g_image_png_save(GImage *img, const char *filename) {
       image[4 * i + 2] = img->data[4 * i];
       image[4 * i + 3] = img->data[4 * i + 3];
     }
-    int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb_alpha, image, img->width * STBI_rgb_alpha);
+    const int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb_alpha, image, img->width * STBI_rgb_alpha);
     free(image);
     if (ret != 1)
       return -1;
@@ -180,7 +180,7 @@ static int g_image_jpeg_save(GImage *img, char quality, const char *filename) {
       image[3 * i + 1] = img->data[4 * i + 1];
       image[3 * i + 2] = img->data[4 * i];
     }
-    int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
+    const int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
     free(image);
     if (ret != 1)
       return -1;

--- a/src/lib/Controller/util/g_image.c
+++ b/src/lib/Controller/util/g_image.c
@@ -180,7 +180,7 @@ static int g_image_jpeg_save(GImage *img, char quality, const char *filename) {
       image[3 * i + 1] = img->data[4 * i + 1];
       image[3 * i + 2] = img->data[4 * i];
     }
-    const int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
+    const int ret = stbi_write_jpg(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
     free(image);
     if (ret != 1)
       return -1;

--- a/src/lib/Controller/util/g_image.c
+++ b/src/lib/Controller/util/g_image.c
@@ -180,7 +180,7 @@ static int g_image_jpeg_save(GImage *img, char quality, const char *filename) {
       image[3 * i + 1] = img->data[4 * i + 1];
       image[3 * i + 2] = img->data[4 * i];
     }
-    const int ret = stbi_write_jpg(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
+    const int ret = stbi_write_jpg(filename, img->width, img->height, STBI_rgb, image, quality);
     free(image);
     if (ret != 1)
       return -1;

--- a/src/lib/Controller/util/g_image.c
+++ b/src/lib/Controller/util/g_image.c
@@ -172,6 +172,21 @@ static int g_image_jpeg_save(GImage *img, char quality, const char *filename) {
   }
   fclose(fd);
 
+  if (img->data_format == G_IMAGE_DATA_FORMAT_BGRA) {
+    unsigned char *image = (unsigned char *)malloc(3 * img->width * img->height);
+    int i;
+    for (i = 0; i < img->width * img->height; ++i) {
+      image[3 * i] = img->data[4 * i + 2];
+      image[3 * i + 1] = img->data[4 * i + 1];
+      image[3 * i + 2] = img->data[4 * i];
+    }
+    int ret = stbi_write_png(filename, img->width, img->height, STBI_rgb, image, img->width * STBI_rgb);
+    free(image);
+    if (ret != 1)
+      return -1;
+    return 0;
+  }
+
   if (stbi_write_jpg(filename, img->width, img->height, STBI_rgb, img->data, quality) != 1)
     return -1;
   return 0;


### PR DESCRIPTION
When saving a BGRA image to jpeg the resulting image was wrong, this is visible in the robot-window of the e-puck2.wbt world.