### PR TITLE
Fixed TurtleBot3 Burger max Velocity.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,6 +7,7 @@ Released on XXX.
     - Improved the environment colors of the sojourner simulation (Mars is a red planet).
   - Bug fixes
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
+    - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
 
 ## Webots R2020a Revision 1
 Released on January 14th, 2020.

--- a/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto
+++ b/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto
@@ -39,7 +39,7 @@ PROTO TurtleBot3Burger [
           RotationalMotor {
             name "right wheel motor"
             consumptionFactor -0.001
-            maxVelocity 2.84
+            maxVelocity 6.67
           }
           PositionSensor {
             name "right wheel sensor"
@@ -162,7 +162,7 @@ PROTO TurtleBot3Burger [
           RotationalMotor {
             name "left wheel motor"
             consumptionFactor -0.001
-            maxVelocity 2.84
+            maxVelocity 6.67
           }
           PositionSensor {
             name "left wheel sensor"


### PR DESCRIPTION
**Description**
the 'Maximum rotational velocity' was used to compute the maximum wheel speed instead of the 'Maximum translational velocity': http://emanual.robotis.com/docs/en/platform/turtlebot3/specifications/

**Additional context**
Reported by a user.
