### PR TITLE
Fixed the Center of Mass of the TurtleBot3.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -8,6 +8,7 @@ Released on XXX.
   - Bug fixes
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
+    - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
 
 ## Webots R2020a Revision 1
 Released on January 14th, 2020.

--- a/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto
+++ b/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto
@@ -521,7 +521,7 @@ PROTO TurtleBot3Burger [
       density -1
       mass 0.825735
       centerOfMass [
-        0 0 0
+        0 0.03 0.035
       ]
     }
   }


### PR DESCRIPTION
The center of mass is now in the middle of the battery at the center of the robot.

![1](https://user-images.githubusercontent.com/2461619/73157332-f249db80-40e0-11ea-9b5f-09802ebf5705.png)