### PR TITLE
webots.min.js: fix texture transform not applied at load

### DIFF
--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -302,6 +302,10 @@ webots.View = class View {
 
       if (this.runOnLoad && this.toolBar)
         this.toolBar.realTime();
+
+      // force a rendering after 1 second
+      // this should make sure that all the texture transforms are applied (for example in the Highway Driving benchmark)
+      setTimeout(() => this.x3dScene.render(), 1000); 
     };
 
     if (mode === 'video') {

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -303,8 +303,8 @@ webots.View = class View {
       if (this.runOnLoad && this.toolBar)
         this.toolBar.realTime();
 
-      // force a rendering after 1 second
-      // this should make sure that all the texture transforms are applied (for example in the Highway Driving benchmark)
+      // Force a rendering after 1 second.
+      // This should make sure that all the texture transforms are applied (for example in the Highway Driving benchmark).
       setTimeout(() => this.x3dScene.render(), 1000); 
     };
 

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -13,7 +13,7 @@ class X3dScene { // eslint-disable-line no-unused-vars
     this.useNodeCache = {};
     this.objectsIdCache = {};
 
-    // The Mozilla WebGL implementation does not support automatic mimaps generation on float32 cube textures.
+    // The Mozilla WebGL implementation does not support automatic mipmaps generation on float32 cube textures.
     // - Warning (JS console): "Texture at base level is not unsized internal format or is not color-renderable or texture-filterable."
     // - The related OpenGL specification is known as cryptic about this topic:
     //   - https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glGenerateMipmap.xhtml


### PR DESCRIPTION
**Description**
Sometimes when an web animation (in pause mode) or web simulation is loaded some texture transforms are not loaded correctly.
This happens in particular if the browser cache is empty.
But as soon as a new rendering is called (by starting the animation/simulation, moving the viewpoint, etc.) the texture appearance is correct.

I can reproduce this on my PC loading the Highway Driving benchmark page: the grass texture is sometimes not correctly scaled.

**Related Issues**
This pull-request fixes issue  #1287.

**Tasks**
Force an additional rendering 1s after the scene has been finalized.
Note that textures loading is asynchronous and could still not be completed (in particular if the browser cache is empty).
