### PR TITLE
Fix Robot X3D export.

### DIFF
--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1355,10 +1355,14 @@ bool WbRobot::refreshJoyStickSensorIfNeeded() {
 void WbRobot::exportNodeFields(WbVrmlWriter &writer) const {
   WbSolid::exportNodeFields(writer);
   if (writer.isX3d()) {
-    if (findField("controller") && !controllerName().isEmpty())
-      writer << " controller='" << controllerName() << "'";
-    if (findField("window") && !window().isEmpty())
-      writer << " window='" << window() << "'";
+    if (findField("controller") && !controllerName().isEmpty()) {
+      writer << " controller=";
+      writer.writeLiteralString(controllerName());
+    }
+    if (findField("window") && !window().isEmpty()) {
+      writer << " window=";
+      writer.writeLiteralString(window());
+    }
   }
 }
 


### PR DESCRIPTION
**Description**
A user reported that his model was not working in the web interface once exported as x3d file. It appears that the cause of the issue was that its controller was set to `<extern>`, this was breaking the xml syntax.
The regular S/MFString are already escaped but not the controller field.