### PR TITLE
Improve Convert to Base Nodes

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -5,6 +5,7 @@ Released on XXX.
 
   - New Features
     - macOS: Added support for Python 3.8.
+    - Added a 'Convert Root to Base Node(s)' option in the context menu to convert a PROTO node in base node(s) without converting the nested PROTO nodes.
   - Enhancements
     - Improved the environment colors of the sojourner simulation (Mars is a red planet).
   - Bug fixes

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -5,7 +5,7 @@ Released on XXX.
 
   - New Features
     - macOS and Windows: Added support for Python 3.8.
-    - Added a 'Convert Root to Base Node(s)' option in the context menu to convert a PROTO node in base node(s) without converting the nested PROTO nodes.
+    - Added a 'Convert Root to Base Node(s)' option in the context menu to convert a PROTO node to base node(s) without converting the nested PROTO nodes.
   - Enhancements
     - Improved the environment colors of the sojourner simulation (Mars is a red planet).
   - Bug fixes

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -382,6 +382,20 @@ QString WbImageTexture::path() {
   return WbUrl::computePath(this, "url", mUrl, 0);
 }
 
+void WbImageTexture::write(WbVrmlWriter &writer) const {
+  if (!isUseNode() && writer.isProto()) {
+    for (int i = 0; i < mUrl->size(); ++i) {
+      QString texturePath(WbUrl::computePath(this, "url", mUrl, i));
+      const QString &url(mUrl->item(i));
+      if (cQualityChangedTexturesList.contains(texturePath))
+        texturePath = WbStandardPaths::webotsTmpPath() + QFileInfo(url).fileName();
+      writer.addTextureToList(url, texturePath);
+    }
+  }
+
+  WbBaseNode::write(writer);
+}
+
 bool WbImageTexture::exportNodeHeader(WbVrmlWriter &writer) const {
   if (!writer.isX3d() || !isUseNode() || mRole.isEmpty())
     return WbBaseNode::exportNodeHeader(writer);

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -417,8 +417,7 @@ void WbImageTexture::exportNodeFields(WbVrmlWriter &writer) const {
     if (writer.isWritingToFile()) {
       QString newUrl = WbUrl::exportTexture(this, mUrl, i, writer);
       dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, newUrl);
-    } else if (writer.isProto())
-      dynamic_cast<WbMFString *>(urlFieldCopy.value())->setItem(i, texturePath);
+    }
 
     const QString &url(mUrl->item(i));
     if (cQualityChangedTexturesList.contains(texturePath))

--- a/src/webots/nodes/WbImageTexture.hpp
+++ b/src/webots/nodes/WbImageTexture.hpp
@@ -65,6 +65,8 @@ public:
 
   void setRole(const QString &role) { mRole = role; }
 
+  void write(WbVrmlWriter &writer) const override;
+
 signals:
   void changed();
 

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -718,7 +718,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     while (it.hasNext()) {
       it.next();
       const QString destination(WbProject::current()->worldsPath() + it.key());
-      QFileInfo fileInfo(destination);
+      const QFileInfo fileInfo(destination);
       if (!QDir(fileInfo.absolutePath()).exists())
         QDir().mkpath(fileInfo.absolutePath());
       QFile::copy(it.value(), destination);

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -696,6 +696,7 @@ void WbSceneTree::convertProtoToBaseNode() {
     WbNode *parentNode = currentNode->parent();
     QString nodeString;
     WbVrmlWriter writer(&nodeString, currentNode->modelName() + ".proto");
+    writer.setRootNode(currentNode);
     currentNode->write(writer);
     WbNodeOperations::instance()->deleteNode(currentNode);
     if (WbNodeOperations::instance()->importNode(parentNode, parentField, index, "", nodeString) == WbNodeOperations::SUCCESS) {

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -698,7 +698,19 @@ void WbSceneTree::convertProtoToBaseNode() {
     WbVrmlWriter writer(&nodeString, currentNode->modelName() + ".proto");
     writer.setRootNode(currentNode);
     currentNode->write(writer);
+    // remove previous node
     WbNodeOperations::instance()->deleteNode(currentNode);
+    // copy textures
+    QHashIterator<QString, QString> it(writer.texturesList());
+    while (it.hasNext()) {
+      it.next();
+      const QString destination(WbProject::current()->worldsPath() + it.key());
+      QFileInfo fileInfo(destination);
+      if (!QDir(fileInfo.absolutePath()).exists())
+        QDir().mkpath(fileInfo.absolutePath());
+      QFile::copy(it.value(), destination);
+    }
+    // import new node
     if (WbNodeOperations::instance()->importNode(parentNode, parentField, index, "", nodeString) == WbNodeOperations::SUCCESS) {
       WbNode *node = NULL;
       if (parentField->type() == WB_SF_NODE)

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -120,7 +120,9 @@ WbSceneTree::WbSceneTree(QWidget *parent) :
           &WbSceneTree::moveViewpointToObject);
   connect(mActionManager->action(WbActionManager::RESET_VALUE), &QAction::triggered, this, &WbSceneTree::reset);
   connect(mActionManager->action(WbActionManager::CONVERT_TO_BASE_NODES), &QAction::triggered, this,
-          &WbSceneTree::convertProtoToBaseNode);
+          &WbSceneTree::convertToBaseNode);
+  connect(mActionManager->action(WbActionManager::CONVERT_ROOT_TO_BASE_NODES), &QAction::triggered, this,
+          &WbSceneTree::convertRootToBaseNode);
   connect(mActionManager->action(WbActionManager::OPEN_HELP), &QAction::triggered, this, &WbSceneTree::help);
   connect(mActionManager->action(WbActionManager::SHOW_PROTO_SOURCE), &QAction::triggered, this,
           &WbSceneTree::openProtoInTextEditor);
@@ -685,7 +687,15 @@ void WbSceneTree::transform(const QString &modelName) {
   WbUndoStack::instance()->clear();  // clear undo stack if no available UNDO/REDO implementation of transform action
 }
 
-void WbSceneTree::convertProtoToBaseNode() {
+void WbSceneTree::convertToBaseNode() {
+  convertProtoToBaseNode(false);
+}
+
+void WbSceneTree::convertRootToBaseNode() {
+  convertProtoToBaseNode(true);
+}
+
+void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
   WbNode *const currentNode = mSelectedItem->node();
   if (currentNode->isProtoInstance()) {
     const WbSolid *const solid = dynamic_cast<WbSolid *>(currentNode);
@@ -696,7 +706,10 @@ void WbSceneTree::convertProtoToBaseNode() {
     WbNode *parentNode = currentNode->parent();
     QString nodeString;
     WbVrmlWriter writer(&nodeString, currentNode->modelName() + ".proto");
-    writer.setRootNode(currentNode);
+    if (rootOnly)
+      writer.setRootNode(currentNode);
+    else
+      writer.setRootNode(NULL);
     currentNode->write(writer);
     // remove previous node
     WbNodeOperations::instance()->deleteNode(currentNode);

--- a/src/webots/scene_tree/WbSceneTree.hpp
+++ b/src/webots/scene_tree/WbSceneTree.hpp
@@ -82,7 +82,8 @@ private slots:
   void handleUserCommand(WbActionManager::WbActionKind actionKind);
   void reset();
   void transform(const QString &modelName);
-  void convertProtoToBaseNode();
+  void convertToBaseNode();
+  void convertRootToBaseNode();
   void moveViewpointToObject();
   void addNew();
   void startWatching(const QModelIndex &index);
@@ -133,7 +134,7 @@ private:
   void pasteInMFValue();
   void clearSelection();
   bool isIndexAncestorOfCurrentIndex(const QModelIndex &index, int start, int end);
-
+  void convertProtoToBaseNode(bool rootOnly);
   bool insertInertiaMatrix(const WbField *selectedField);
   void cut();
   void copy();

--- a/src/webots/user_commands/WbActionManager.cpp
+++ b/src/webots/user_commands/WbActionManager.cpp
@@ -983,9 +983,15 @@ void WbActionManager::populateActions() {
 
   action = new QAction(this);
   action->setText(tr("&Convert to Base Node(s)"));
-  action->setStatusTip(tr("Convert this PROTO node into the equivalent base node(s)."));
+  action->setStatusTip(tr("Convert this PROTO node (and nested PROTO nodes) into the equivalent base node(s)."));
   action->setToolTip(action->statusTip());
   mActions[CONVERT_TO_BASE_NODES] = action;
+
+  action = new QAction(this);
+  action->setText(tr("Convert &Root to Base Node(s)"));
+  action->setStatusTip(tr("Convert this PROTO node into the equivalent base node(s)."));
+  action->setToolTip(action->statusTip());
+  mActions[CONVERT_ROOT_TO_BASE_NODES] = action;
 
   assert(NACTIONS == mActions.size());
 }

--- a/src/webots/user_commands/WbActionManager.hpp
+++ b/src/webots/user_commands/WbActionManager.hpp
@@ -138,6 +138,7 @@ public:
     SHOW_PROTO_SOURCE,
     SHOW_PROTO_RESULT,
     CONVERT_TO_BASE_NODES,
+    CONVERT_ROOT_TO_BASE_NODES,
     // keep track of numher of actions
     NACTIONS
   };

--- a/src/webots/user_commands/WbContextMenuGenerator.cpp
+++ b/src/webots/user_commands/WbContextMenuGenerator.cpp
@@ -154,6 +154,7 @@ namespace WbContextMenuGenerator {
           contextMenu.addAction(WbActionManager::instance()->action(WbActionManager::SHOW_PROTO_RESULT));
 
         contextMenu.addAction(WbActionManager::instance()->action(WbActionManager::CONVERT_TO_BASE_NODES));
+        contextMenu.addAction(WbActionManager::instance()->action(WbActionManager::CONVERT_ROOT_TO_BASE_NODES));
       }
       contextMenu.addSeparator();
     }

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -955,7 +955,7 @@ void WbNode::write(WbVrmlWriter &writer) const {
       return;
     }
   }
-  if (writer.isX3d() || writer.isVrml() || (writer.isProto() && this == writer.getRootNode())) {
+  if (writer.isX3d() || writer.isVrml() || (writer.isProto() && (!writer.getRootNode() || this == writer.getRootNode()))) {
     writeExport(writer);
     return;
   }

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1060,18 +1060,15 @@ bool WbNode::exportNodeHeader(WbVrmlWriter &writer) const {
 
 void WbNode::exportNodeFields(WbVrmlWriter &writer) const {
   foreach (WbField *field, fields())
-    if (!field->isDeprecated() &&
-        ((field->isVrml() || (writer.isProto() && this == writer.getRootNode())) && field->singleType() != WB_SF_NODE))
+    if (!field->isDeprecated() && ((field->isVrml() || writer.isProto()) && field->singleType() != WB_SF_NODE))
       field->write(writer);
 }
 
 void WbNode::exportNodeSubNodes(WbVrmlWriter &writer) const {
   foreach (WbField *field, fields())
-    if (!field->isDeprecated() &&
-        ((field->isVrml() || (writer.isProto() && this == writer.getRootNode())) && field->singleType() == WB_SF_NODE)) {
+    if (!field->isDeprecated() && ((field->isVrml() || writer.isProto()) && field->singleType() == WB_SF_NODE)) {
       const WbSFNode *const node = dynamic_cast<WbSFNode *>(field->value());
-      if (node == NULL || node->value() == NULL || node->value()->shallExport() ||
-          (writer.isProto() && this == writer.getRootNode())) {
+      if (node == NULL || node->value() == NULL || node->value()->shallExport() || writer.isProto()) {
         if (writer.isX3d())
           field->value()->write(writer);
         else

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -955,7 +955,7 @@ void WbNode::write(WbVrmlWriter &writer) const {
       return;
     }
   }
-  if (writer.isX3d() || writer.isVrml() || (writer.isProto() && (!writer.getRootNode() || this == writer.getRootNode()))) {
+  if (writer.isX3d() || writer.isVrml() || (writer.isProto() && (!writer.rootNode() || this == writer.rootNode()))) {
     writeExport(writer);
     return;
   }

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -955,7 +955,7 @@ void WbNode::write(WbVrmlWriter &writer) const {
       return;
     }
   }
-  if (writer.isX3d() || writer.isVrml() || writer.isProto()) {
+  if (writer.isX3d() || writer.isVrml() || (writer.isProto() && this == writer.getRootNode())) {
     writeExport(writer);
     return;
   }
@@ -1060,15 +1060,18 @@ bool WbNode::exportNodeHeader(WbVrmlWriter &writer) const {
 
 void WbNode::exportNodeFields(WbVrmlWriter &writer) const {
   foreach (WbField *field, fields())
-    if (!field->isDeprecated() && ((field->isVrml() || writer.isProto()) && field->singleType() != WB_SF_NODE))
+    if (!field->isDeprecated() &&
+        ((field->isVrml() || (writer.isProto() && this == writer.getRootNode())) && field->singleType() != WB_SF_NODE))
       field->write(writer);
 }
 
 void WbNode::exportNodeSubNodes(WbVrmlWriter &writer) const {
   foreach (WbField *field, fields())
-    if (!field->isDeprecated() && ((field->isVrml() || writer.isProto()) && field->singleType() == WB_SF_NODE)) {
+    if (!field->isDeprecated() &&
+        ((field->isVrml() || (writer.isProto() && this == writer.getRootNode())) && field->singleType() == WB_SF_NODE)) {
       const WbSFNode *const node = dynamic_cast<WbSFNode *>(field->value());
-      if (node == NULL || node->value() == NULL || node->value()->shallExport() || writer.isProto()) {
+      if (node == NULL || node->value() == NULL || node->value()->shallExport() ||
+          (writer.isProto() && this == writer.getRootNode())) {
         if (writer.isX3d())
           field->value()->write(writer);
         else

--- a/src/webots/vrml/WbVrmlWriter.cpp
+++ b/src/webots/vrml/WbVrmlWriter.cpp
@@ -24,6 +24,7 @@ WbVrmlWriter::WbVrmlWriter(QIODevice *device, const QString &fileName) :
   QTextStream(device),
   mFileName(fileName),
   mIndent(0),
+  mRootNode(NULL),
   mIsWritingToFile(true) {
   setVrmlType();
 }
@@ -32,6 +33,7 @@ WbVrmlWriter::WbVrmlWriter(QString *target, const QString &fileName) :
   QTextStream(target, QIODevice::ReadWrite),
   mFileName(fileName),
   mIndent(0),
+  mRootNode(NULL),
   mIsWritingToFile(false) {
   setVrmlType();
 }

--- a/src/webots/vrml/WbVrmlWriter.hpp
+++ b/src/webots/vrml/WbVrmlWriter.hpp
@@ -59,7 +59,7 @@ public:
   void writeFooter(const QStringList *info = NULL);
 
   void setRootNode(WbNode *node) { mRootNode = node; }
-  WbNode *getRootNode() const { return mRootNode; }
+  WbNode *rootNode() const { return mRootNode; }
 
   void setX3DFrustumCullingValue(const QString &value) { mFrustumCullingValue = value; }
   QMap<uint64_t, QString> &indexedFaceSetDefMap() { return mIndexedFaceSetDefMap; }

--- a/src/webots/vrml/WbVrmlWriter.hpp
+++ b/src/webots/vrml/WbVrmlWriter.hpp
@@ -22,6 +22,7 @@
 #include <QtCore/QTextStream>
 
 class QIODevice;
+class WbNode;
 
 class WbVrmlWriter : public QTextStream {
 public:
@@ -57,6 +58,9 @@ public:
   void writeHeader(const QString &title);
   void writeFooter(const QStringList *info = NULL);
 
+  void setRootNode(WbNode *node) { mRootNode = node; }
+  WbNode *getRootNode() const { return mRootNode; }
+
   void setX3DFrustumCullingValue(const QString &value) { mFrustumCullingValue = value; }
   QMap<uint64_t, QString> &indexedFaceSetDefMap() { return mIndexedFaceSetDefMap; }
 
@@ -70,6 +74,7 @@ private:
   QString mFrustumCullingValue;
   QMap<uint64_t, QString> mIndexedFaceSetDefMap;
   QHash<QString, QString> mTexturesList;  // this hash represents the list of textures used and their associated filepath
+  WbNode *mRootNode;
   bool mIsWritingToFile;
 };
 


### PR DESCRIPTION
**Description**
Currently, when converting a PROTO node to base nodes all the nodes are converted.
Ideally, only the root node should be converted, the nested PROTO node should remain PROTO nodes (e.g. we don't want to unprototize all the appearance PROTO nodes of a robot PROTO when converting it).

**Related Issues**
Fix issue #1297

**Tasks**
  - [x] Fix conversion.
  - [x] Device whether a 'convertAll' utility would be usefull.
  - [x] Changelog.

