### PR TITLE
Simulation server script: connect to check port availability

### DIFF
--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -176,7 +176,7 @@ These are the configuration parameters for the simulation server:
 - `keyDir`: directory where the website host keys needed for validation are stored. This folder should include a file named as the host (for example "robotbenchmark.net") containing a key identifying it.
 - `logDir`: directory where the log files are written. Default value is "WEBOTS\_HOME/resources/web/server/log/simulation".
 - `monitorLogEnabled`: specify if the monitor data have to be stored in a file.
-- `maxConnections`: specifiy the maximum number of Webots instances running on the server. Default value is 100.
+- `maxConnections`: specify the maximum number of Webots instances running on the server. Default value is 100.
 
 
 HTTP request handlers:

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -176,6 +176,7 @@ These are the configuration parameters for the simulation server:
 - `keyDir`: directory where the website host keys needed for validation are stored. This folder should include a file named as the host (for example "robotbenchmark.net") containing a key identifying it.
 - `logDir`: directory where the log files are written. Default value is "WEBOTS\_HOME/resources/web/server/log/simulation".
 - `monitorLogEnabled`: specify if the monitor data have to be stored in a file.
+- `maxConnections`: specifiy the maximum number of Webots instances running on the server. Default value is 100.
 
 
 HTTP request handlers:

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -176,7 +176,7 @@ These are the configuration parameters for the simulation server:
 - `keyDir`: directory where the website host keys needed for validation are stored. This folder should include a file named as the host (for example "robotbenchmark.net") containing a key identifying it.
 - `logDir`: directory where the log files are written. Default value is "WEBOTS\_HOME/resources/web/server/log/simulation".
 - `monitorLogEnabled`: specify if the monitor data have to be stored in a file.
-- `maxConnections`: specify the maximum number of Webots instances running on the server. Default value is 100.
+- `maxConnections`: maximum number of simultaneous Webots instances. Default value is 100.
 
 
 HTTP request handlers:

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -287,7 +287,7 @@ class ClientWebSocketHandler(tornado.websocket.WebSocketHandler):
                 testSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 result = testSocket.connect_ex(('localhost', port)) == 0
                 testSocket.close()
-                if result == 0:
+                if result:
                     return port
             port += 1
             if port > config['port'] + config['maxConnections']:

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -621,7 +621,7 @@ def main():
     if 'port' not in config:
         config['port'] = 2000
     if 'maxConnections' not in config:
-        config['maxConnections'] = 200
+        config['maxConnections'] = 100
     os.environ['WEBOTS_FIREJAIL_CONTROLLERS'] = '1'
     config['instancesPath'] = tempfile.gettempdir().replace('\\', '/') + '/webots/instances/'
     # create the instances path

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -590,7 +590,7 @@ def main():
     # keyDir:            directory where the host keys needed for validation are stored.
     # logDir:            directory where the log files are written.
     # monitorLogEnabled: specify if the monitor data have to be stored in a file.
-    # maxConnections:   maximum number of simultaneous Webots instances.
+    # maxConnections:    maximum number of simultaneous Webots instances.
     #
     global config
     global snapshots

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -282,9 +282,16 @@ class ClientWebSocketHandler(tornado.websocket.WebSocketHandler):
                 if port == client.streaming_server_port:
                     found = True
                     break
-            if found:
-                port += 1
-            else:
+            if not found:
+                # try to connect to make sure that port is available
+                testSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                result = testSocket.connect_ex(('localhost', port)) == 0
+                testSocket.close()
+                if result == 0:
+                    return port
+            port += 1
+            if port > config['port'] + config['maxConnections']:
+                logging.error("Too many open connections (>" + config['maxConnections']) + ")")
                 return port
 
     def open(self):
@@ -583,6 +590,7 @@ def main():
     # keyDir:            directory where the host keys needed for validation are stored.
     # logDir:            directory where the log files are written.
     # monitorLogEnabled: specify if the monitor data have to be stored in a file.
+    # maxConnections:   maximum number of simultaneous Webots instances.
     #
     global config
     global snapshots
@@ -612,6 +620,8 @@ def main():
         config['keyDir'] = expand_path(config['keyDir'])
     if 'port' not in config:
         config['port'] = 2000
+    if 'maxConnections' not in config:
+        config['maxConnections'] = 200
     os.environ['WEBOTS_FIREJAIL_CONTROLLERS'] = '1'
     config['instancesPath'] = tempfile.gettempdir().replace('\\', '/') + '/webots/instances/'
     # create the instances path


### PR DESCRIPTION
Using the internal list of ports in use is to pick an available port is not sufficiently robust.
The only effective and robust way to check the status of a port is to try to connect to it.