### PR TITLE
Improve ABB PROTO

### DIFF
--- a/docs/guide/irb4600-40.md
+++ b/docs/guide/irb4600-40.md
@@ -25,6 +25,7 @@ PROTO Irb4600-40 [
   SFBool     synchronization TRUE
   SFColor    color           1 0.45 0
   MFNode     handSlot        []
+  SFBool     staticBase      FALSE
 ]
 ```
 
@@ -33,6 +34,8 @@ PROTO Irb4600-40 [
 #### Irb4600-40 Field Summary
 
 - `handSlot`: Extends the arm hand with new nodes.
+
+- `staticBase`: Defines if the robot base should be pinned to the static environment.
 
 ### "ikpy"
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -10,6 +10,7 @@ Released on XXX.
   - Enhancements
     - Improved the environment colors of the sojourner simulation (Mars is a red planet).
     - Added missing `supervisor` field in `UR3e`, `UR5e` and `UR10e` robots.
+    - Added a `staticBase` field to the `Irb4600-40` PROTO node.
   - Bug fixes
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -80,7 +80,7 @@ for motorName in ['A motor', 'B motor', 'C motor', 'D motor', 'E motor', 'F moto
 
 # Get the arm and target nodes.
 target = supervisor.getFromDef('TARGET')
-arm = supervisor.getFromDef('ARM')
+arm = supervisor.getSelf()
 
 # Loop 1: Draw a circle on the paper sheet.
 print('Draw a circle on the paper sheet...')

--- a/projects/robots/abb/irb/protos/Irb4600-40.proto
+++ b/projects/robots/abb/irb/protos/Irb4600-40.proto
@@ -2,6 +2,7 @@
 # license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 # license url: https://cyberbotics.com/webots_assets_license
 # documentation url: https://www.cyberbotics.com/doc/guide/irb4600-40
+# tags: static
 # The "IRB 4600/40" is a 6 DOF arm developed by ABB: https://new.abb.com/products/robotics/industrial-robots/irb-4600
 # It has a payload of 40kg.
 
@@ -16,6 +17,7 @@ PROTO Irb4600-40 [
   field SFBool     synchronization TRUE                  # Is `Robot.synchronization`.
   field SFColor    color           1 0.45 0              # Is `PBRAppearance.baseColor`.
   field MFNode     handSlot        []                    # Extends the arm with new nodes in the hand slot.
+  field SFBool     staticBase      FALSE                 # Defines if the robot base should be pinned to the static environment.
 ]
 {
   Robot {
@@ -392,9 +394,11 @@ PROTO Irb4600-40 [
         }
       ]
     }
+    %{ if fields.staticBase.value == false then }%
     physics Physics {
       density 1500
     }
+    %{ end }%
     controller IS controller
     controllerArgs IS controllerArgs
     customData IS customData

--- a/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
+++ b/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
@@ -31,68 +31,64 @@ Floor {
   appearance ThreadMetalPlate {
   }
 }
-Robot {
-  translation -1 0 4.84
-  children [
-    Table {
-      size 3 0.74 3
-      feetPadding 0.05
-      frameThickness 0.1
-      trayAppearance OldSteel {
-        textureTransform TextureTransform {
-          scale 2 2
-        }
-      }
-      legAppearance GalvanizedMetal {
-      }
-    }
-    DEF ARM Irb4600-40 {
-      translation 1 0.74 0
-      rotation 1 0 0 4.712388966
-      supervisor TRUE
-      handSlot [
-        Pen {
-          translation 0 0 0.02
-          rotation 1 0 0 -1.5708
+Irb4600-40 {
+  translation 0 0.74 4.84
+  rotation 1 0 0 4.712388966
+  supervisor TRUE
+  handSlot [
+    Pen {
+      translation 0 0 0.02
+      rotation 1 0 0 -1.5708
+      children [
+        Transform {
+          translation 0 0.05 0
           children [
-            Transform {
-              translation 0 0.05 0
-              children [
-                Shape {
-                  appearance BrushedAluminium {
-                    colorOverride 0 0.4131074998092622 0.9919279774166476
-                  }
-                  geometry Cylinder {
-                    height 0.05
-                    radius 0.04
-                    subdivision 24
-                  }
-                }
-              ]
-            }
-            Transform {
-              translation 0 0.04 0
-              children [
-                Shape {
-                  appearance BrushedAluminium {
-                    colorOverride 0 0 0
-                  }
-                  geometry Cylinder {
-                    height 0.07
-                    radius 0.01
-                    subdivision 12
-                  }
-                }
-              ]
+            Shape {
+              appearance BrushedAluminium {
+                colorOverride 0 0.4131074998092622 0.9919279774166476
+              }
+              geometry Cylinder {
+                height 0.05
+                radius 0.04
+                subdivision 24
+              }
             }
           ]
-          leadSize 0.01
-          maxDistance 0.05
+        }
+        Transform {
+          translation 0 0.04 0
+          children [
+            Shape {
+              appearance BrushedAluminium {
+                colorOverride 0 0 0
+              }
+              geometry Cylinder {
+                height 0.07
+                radius 0.01
+                subdivision 12
+              }
+            }
+          ]
         }
       ]
+      leadSize 0.01
+      maxDistance 0.05
     }
   ]
-  controller ""
+  staticBase TRUE
+}
+Table {
+  translation -1 0 4.84
+  size 3 0.74 3
+  feetPadding 0.05
+  frameThickness 0.1
+  trayAppearance OldSteel {
+    textureTransform TextureTransform {
+      scale 2 2
+    }
+  }
+  legAppearance GalvanizedMetal {
+  }
 }
 DEF TABLE_WITH_PAPER_SHEET Transform {
   translation 1.1 0 5.8

--- a/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
+++ b/projects/robots/abb/irb/worlds/inverse_kinematics.wbt
@@ -113,6 +113,7 @@ DEF TABLE_WITH_PAPER_SHEET Transform {
       ]
     }
     Table {
+      name "table with paper"
       size 1 0.74 1
       feetPadding 0.05
       frameThickness 0.1


### PR DESCRIPTION
Adding a `staticBase` field remove the need of a useless Robot node to pin the arm to the static environment.
