### PR TITLE
Fix universal robot ros python version

### DIFF
--- a/projects/robots/universal_robots/controllers/universal_robots_ros/universal_robots_ros.py
+++ b/projects/robots/universal_robots/controllers/universal_robots_ros/universal_robots_ros.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 # Copyright 1996-2020 Cyberbotics Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/sources/test_license.py
+++ b/tests/sources/test_license.py
@@ -170,7 +170,7 @@ class TestLicense(unittest.TestCase):
                     )
                 elif source.endswith('.py') or source.endswith('Makefile'):
                     for pythonHeader in PYTHON_OPTIONAL_HEADERS:
-                        if content.startswith(pythonHeader):
+                        if content.startswith(pythonHeader + '\n'):
                             content = content[len(pythonHeader):].lstrip('\n')
                     self.assertTrue(
                         content.startswith(APACHE2_LICENSE_PYTHON),

--- a/tests/sources/test_license.py
+++ b/tests/sources/test_license.py
@@ -67,12 +67,11 @@ APACHE2_LICENSE_PYTHON = """# Copyright 1996-20XX Cyberbotics Ltd.
 # See the License for the specific language governing permissions and
 # limitations under the License.""".replace('20XX', str(datetime.datetime.now().year))
 
-PYTHON_OPTIONAL_HEADER = """#!/usr/bin/env python
-
-"""
-PYTHON3_OPTIONAL_HEADER = """#!/usr/bin/env python3
-
-"""
+PYTHON_OPTIONAL_HEADERS = [
+    '#!/usr/bin/env python2',
+    '#!/usr/bin/env python3',
+    '#!/usr/bin/env python',
+]
 
 
 class TestLicense(unittest.TestCase):
@@ -170,10 +169,12 @@ class TestLicense(unittest.TestCase):
                             (source, APACHE2_LICENSE_CPP)
                     )
                 elif source.endswith('.py') or source.endswith('Makefile'):
+                    for pythonHeader in PYTHON_OPTIONAL_HEADERS:
+                        if content.startswith(pythonHeader):
+                            content = content[len(pythonHeader):]
+                            content = content.lstrip('\n')
                     self.assertTrue(
-                        content.startswith(APACHE2_LICENSE_PYTHON) or
-                        content.startswith(PYTHON_OPTIONAL_HEADER + APACHE2_LICENSE_PYTHON) or
-                        content.startswith(PYTHON3_OPTIONAL_HEADER + APACHE2_LICENSE_PYTHON),
+                        content.startswith(APACHE2_LICENSE_PYTHON),
                         msg='Source file "%s" doesn\'t contain the correct Apache 2.0 License:\n%s' %
                             (source, APACHE2_LICENSE_PYTHON)
                     )

--- a/tests/sources/test_license.py
+++ b/tests/sources/test_license.py
@@ -171,8 +171,7 @@ class TestLicense(unittest.TestCase):
                 elif source.endswith('.py') or source.endswith('Makefile'):
                     for pythonHeader in PYTHON_OPTIONAL_HEADERS:
                         if content.startswith(pythonHeader):
-                            content = content[len(pythonHeader):]
-                            content = content.lstrip('\n')
+                            content = content[len(pythonHeader):].lstrip('\n')
                     self.assertTrue(
                         content.startswith(APACHE2_LICENSE_PYTHON),
                         msg='Source file "%s" doesn\'t contain the correct Apache 2.0 License:\n%s' %


### PR DESCRIPTION
**Description**
This controller should use python 2.7 as ROS1 supports only python 2.7 for now.