### PR TITLE
Add argument check for ROS supervisor functions.

### DIFF
--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -729,7 +729,7 @@ bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functio
 
 bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res) {
   assert(this);
-  if (!req.node)
+  if (!req.field)
     return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.type = field->getType();

--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -451,6 +451,8 @@ bool RosSupervisor::virtualRealityHeadsetIsUsedCallback(webots_ros::get_bool::Re
 
 bool RosSupervisor::nodeGetIdCallback(webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.id = node->getId();
   return true;
@@ -458,6 +460,8 @@ bool RosSupervisor::nodeGetIdCallback(webots_ros::node_get_id::Request &req, web
 
 bool RosSupervisor::nodeGetTypeCallback(webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.type = node->getType();
   return true;
@@ -465,6 +469,8 @@ bool RosSupervisor::nodeGetTypeCallback(webots_ros::node_get_type::Request &req,
 
 bool RosSupervisor::nodeGetTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.name = node->getTypeName();
   return true;
@@ -472,6 +478,8 @@ bool RosSupervisor::nodeGetTypeNameCallback(webots_ros::node_get_name::Request &
 
 bool RosSupervisor::nodeGetDefCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.name = node->getDef();
   return true;
@@ -480,6 +488,8 @@ bool RosSupervisor::nodeGetDefCallback(webots_ros::node_get_name::Request &req, 
 bool RosSupervisor::nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Request &req,
                                                 webots_ros::node_get_name::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.name = node->getBaseTypeName();
   return true;
@@ -488,6 +498,8 @@ bool RosSupervisor::nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Reque
 bool RosSupervisor::nodeGetParentNodeCallback(webots_ros::node_get_parent_node::Request &req,
                                               webots_ros::node_get_parent_node::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.node = reinterpret_cast<uint64_t>(node->getParentNode());
   return true;
@@ -496,6 +508,8 @@ bool RosSupervisor::nodeGetParentNodeCallback(webots_ros::node_get_parent_node::
 bool RosSupervisor::nodeGetPositionCallback(webots_ros::node_get_position::Request &req,
                                             webots_ros::node_get_position::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   const double *position;
   position = node->getPosition();
@@ -508,6 +522,8 @@ bool RosSupervisor::nodeGetPositionCallback(webots_ros::node_get_position::Reque
 bool RosSupervisor::nodeGetOrientationCallback(webots_ros::node_get_orientation::Request &req,
                                                webots_ros::node_get_orientation::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   const double *matrix;
   matrix = node->getOrientation();
@@ -518,6 +534,8 @@ bool RosSupervisor::nodeGetOrientationCallback(webots_ros::node_get_orientation:
 bool RosSupervisor::nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_mass::Request &req,
                                                 webots_ros::node_get_center_of_mass::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   const double *centerOfMass;
   centerOfMass = node->getCenterOfMass();
@@ -530,6 +548,8 @@ bool RosSupervisor::nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_m
 bool RosSupervisor::nodeGetNumberOfContactPointsCallback(webots_ros::node_get_number_of_contact_points::Request &req,
                                                          webots_ros::node_get_number_of_contact_points::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.numberOfContactPoints = node->getNumberOfContactPoints();
   return true;
@@ -538,6 +558,8 @@ bool RosSupervisor::nodeGetNumberOfContactPointsCallback(webots_ros::node_get_nu
 bool RosSupervisor::nodeGetContactPointCallback(webots_ros::node_get_contact_point::Request &req,
                                                 webots_ros::node_get_contact_point::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   const double *point;
   point = node->getContactPoint(req.index);
@@ -550,6 +572,8 @@ bool RosSupervisor::nodeGetContactPointCallback(webots_ros::node_get_contact_poi
 bool RosSupervisor::nodeGetStaticBalanceCallback(webots_ros::node_get_static_balance::Request &req,
                                                  webots_ros::node_get_static_balance::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.balance = node->getStaticBalance();
   return true;
@@ -558,6 +582,8 @@ bool RosSupervisor::nodeGetStaticBalanceCallback(webots_ros::node_get_static_bal
 bool RosSupervisor::nodeGetVelocityCallback(webots_ros::node_get_velocity::Request &req,
                                             webots_ros::node_get_velocity::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   const double *velocity;
   velocity = node->getVelocity();
@@ -573,6 +599,8 @@ bool RosSupervisor::nodeGetVelocityCallback(webots_ros::node_get_velocity::Reque
 bool RosSupervisor::nodeSetVelocityCallback(webots_ros::node_set_velocity::Request &req,
                                             webots_ros::node_set_velocity::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   double velocity[6];
   velocity[0] = req.velocity.linear.x;
@@ -589,6 +617,8 @@ bool RosSupervisor::nodeSetVelocityCallback(webots_ros::node_set_velocity::Reque
 bool RosSupervisor::nodeAddForceCallback(webots_ros::node_add_force_or_torque::Request &req,
                                          webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   double force[3];
   force[0] = req.force.x;
@@ -602,6 +632,8 @@ bool RosSupervisor::nodeAddForceCallback(webots_ros::node_add_force_or_torque::R
 bool RosSupervisor::nodeAddForceWithOffsetCallback(webots_ros::node_add_force_with_offset::Request &req,
                                                    webots_ros::node_add_force_with_offset::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   double force[3];
   force[0] = req.force.x;
@@ -619,6 +651,8 @@ bool RosSupervisor::nodeAddForceWithOffsetCallback(webots_ros::node_add_force_wi
 bool RosSupervisor::nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::Request &req,
                                           webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   double torque[3];
   torque[0] = req.force.x;
@@ -631,6 +665,8 @@ bool RosSupervisor::nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::
 
 bool RosSupervisor::nodeGetFieldCallback(webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   res.field = reinterpret_cast<uint64_t>(node->getField(req.fieldName));
   return true;
@@ -639,6 +675,8 @@ bool RosSupervisor::nodeGetFieldCallback(webots_ros::node_get_field::Request &re
 bool RosSupervisor::nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::Request &req,
                                               webots_ros::node_move_viewpoint::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   node->moveViewpoint();
   res.success = 1;
@@ -648,6 +686,8 @@ bool RosSupervisor::nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::R
 bool RosSupervisor::nodeSetVisibilityCallback(webots_ros::node_set_visibility::Request &req,
                                               webots_ros::node_set_visibility::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   Node *from = reinterpret_cast<Node *>(req.from);
   node->setVisibility(from, req.visible);
@@ -657,6 +697,8 @@ bool RosSupervisor::nodeSetVisibilityCallback(webots_ros::node_set_visibility::R
 
 bool RosSupervisor::nodeRemoveCallback(webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   node->remove();
   res.success = 1;
@@ -666,6 +708,8 @@ bool RosSupervisor::nodeRemoveCallback(webots_ros::node_remove::Request &req, we
 bool RosSupervisor::nodeResetPhysicsCallback(webots_ros::node_reset_functions::Request &req,
                                              webots_ros::node_reset_functions::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   node->resetPhysics();
   res.success = 1;
@@ -675,6 +719,8 @@ bool RosSupervisor::nodeResetPhysicsCallback(webots_ros::node_reset_functions::R
 bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functions::Request &req,
                                                   webots_ros::node_reset_functions::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Node *node = reinterpret_cast<Node *>(req.node);
   node->restartController();
   res.success = 1;
@@ -683,6 +729,8 @@ bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functio
 
 bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res) {
   assert(this);
+  if (!req.node)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.type = field->getType();
   return true;
@@ -691,6 +739,8 @@ bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &re
 bool RosSupervisor::fieldGetTypeNameCallback(webots_ros::field_get_type_name::Request &req,
                                              webots_ros::field_get_type_name::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.name = field->getTypeName();
   return true;
@@ -699,6 +749,8 @@ bool RosSupervisor::fieldGetTypeNameCallback(webots_ros::field_get_type_name::Re
 bool RosSupervisor::fieldGetCountCallback(webots_ros::field_get_count::Request &req,
                                           webots_ros::field_get_count::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.count = field->getCount();
   return true;
@@ -706,6 +758,8 @@ bool RosSupervisor::fieldGetCountCallback(webots_ros::field_get_count::Request &
 
 bool RosSupervisor::fieldGetBoolCallback(webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     res.value = field->getSFBool();
@@ -717,6 +771,8 @@ bool RosSupervisor::fieldGetBoolCallback(webots_ros::field_get_bool::Request &re
 bool RosSupervisor::fieldGetInt32Callback(webots_ros::field_get_int32::Request &req,
                                           webots_ros::field_get_int32::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     res.value = field->getSFInt32();
@@ -728,6 +784,8 @@ bool RosSupervisor::fieldGetInt32Callback(webots_ros::field_get_int32::Request &
 bool RosSupervisor::fieldGetFloatCallback(webots_ros::field_get_float::Request &req,
                                           webots_ros::field_get_float::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     res.value = field->getSFFloat();
@@ -739,6 +797,8 @@ bool RosSupervisor::fieldGetFloatCallback(webots_ros::field_get_float::Request &
 bool RosSupervisor::fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &req,
                                           webots_ros::field_get_vec2f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   const double *value;
   if (field->getType() <= 0x09)
@@ -753,6 +813,8 @@ bool RosSupervisor::fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &
 bool RosSupervisor::fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &req,
                                           webots_ros::field_get_vec3f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   const double *value;
   if (field->getType() <= 0x09)
@@ -768,6 +830,8 @@ bool RosSupervisor::fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &
 bool RosSupervisor::fieldGetRotationCallback(webots_ros::field_get_rotation::Request &req,
                                              webots_ros::field_get_rotation::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   const double *axisAngleValues;
   if (field->getType() <= 0x09)
@@ -781,6 +845,8 @@ bool RosSupervisor::fieldGetRotationCallback(webots_ros::field_get_rotation::Req
 bool RosSupervisor::fieldGetColorCallback(webots_ros::field_get_color::Request &req,
                                           webots_ros::field_get_color::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   const double *value;
   if (field->getType() <= 0x09)
@@ -797,6 +863,8 @@ bool RosSupervisor::fieldGetColorCallback(webots_ros::field_get_color::Request &
 bool RosSupervisor::fieldGetStringCallback(webots_ros::field_get_string::Request &req,
                                            webots_ros::field_get_string::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     res.value = field->getSFString();
@@ -807,6 +875,8 @@ bool RosSupervisor::fieldGetStringCallback(webots_ros::field_get_string::Request
 
 bool RosSupervisor::fieldGetNodeCallback(webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     res.node = reinterpret_cast<uint64_t>(field->getSFNode());
@@ -817,6 +887,8 @@ bool RosSupervisor::fieldGetNodeCallback(webots_ros::field_get_node::Request &re
 
 bool RosSupervisor::fieldSetBoolCallback(webots_ros::field_set_bool::Request &req, webots_ros::field_set_bool::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     field->setSFBool(req.value);
@@ -829,6 +901,8 @@ bool RosSupervisor::fieldSetBoolCallback(webots_ros::field_set_bool::Request &re
 bool RosSupervisor::fieldSetInt32Callback(webots_ros::field_set_int32::Request &req,
                                           webots_ros::field_set_int32::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     field->setSFInt32(req.value);
@@ -841,6 +915,8 @@ bool RosSupervisor::fieldSetInt32Callback(webots_ros::field_set_int32::Request &
 bool RosSupervisor::fieldSetFloatCallback(webots_ros::field_set_float::Request &req,
                                           webots_ros::field_set_float::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     field->setSFFloat(req.value);
@@ -853,6 +929,8 @@ bool RosSupervisor::fieldSetFloatCallback(webots_ros::field_set_float::Request &
 bool RosSupervisor::fieldSetVec2fCallback(webots_ros::field_set_vec2f::Request &req,
                                           webots_ros::field_set_vec2f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   double values[2];
   values[0] = req.value.x;
@@ -868,6 +946,8 @@ bool RosSupervisor::fieldSetVec2fCallback(webots_ros::field_set_vec2f::Request &
 bool RosSupervisor::fieldSetVec3fCallback(webots_ros::field_set_vec3f::Request &req,
                                           webots_ros::field_set_vec3f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   double values[3];
   values[0] = req.value.x;
@@ -884,6 +964,8 @@ bool RosSupervisor::fieldSetVec3fCallback(webots_ros::field_set_vec3f::Request &
 bool RosSupervisor::fieldSetRotationCallback(webots_ros::field_set_rotation::Request &req,
                                              webots_ros::field_set_rotation::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   double axisAngleValues[4];
   RosMathUtils::quaternionToAxisAngle(req.value, axisAngleValues);
@@ -898,6 +980,8 @@ bool RosSupervisor::fieldSetRotationCallback(webots_ros::field_set_rotation::Req
 bool RosSupervisor::fieldSetColorCallback(webots_ros::field_set_color::Request &req,
                                           webots_ros::field_set_color::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   double values[3];
   values[0] = req.value.r;
@@ -914,6 +998,8 @@ bool RosSupervisor::fieldSetColorCallback(webots_ros::field_set_color::Request &
 bool RosSupervisor::fieldSetStringCallback(webots_ros::field_set_string::Request &req,
                                            webots_ros::field_set_string::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   if (field->getType() <= 0x09)
     field->setSFString(req.value);
@@ -926,6 +1012,8 @@ bool RosSupervisor::fieldSetStringCallback(webots_ros::field_set_string::Request
 bool RosSupervisor::fieldInsertBoolCallback(webots_ros::field_set_bool::Request &req,
                                             webots_ros::field_set_bool::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() <= 0x09)
@@ -938,6 +1026,8 @@ bool RosSupervisor::fieldInsertBoolCallback(webots_ros::field_set_bool::Request 
 bool RosSupervisor::fieldInsertInt32Callback(webots_ros::field_set_int32::Request &req,
                                              webots_ros::field_set_int32::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() <= 0x09)
@@ -950,6 +1040,8 @@ bool RosSupervisor::fieldInsertInt32Callback(webots_ros::field_set_int32::Reques
 bool RosSupervisor::fieldInsertFloatCallback(webots_ros::field_set_float::Request &req,
                                              webots_ros::field_set_float::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() <= 0x09)
@@ -962,6 +1054,8 @@ bool RosSupervisor::fieldInsertFloatCallback(webots_ros::field_set_float::Reques
 bool RosSupervisor::fieldInsertVec2fCallback(webots_ros::field_set_vec2f::Request &req,
                                              webots_ros::field_set_vec2f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   double values[2];
@@ -977,6 +1071,8 @@ bool RosSupervisor::fieldInsertVec2fCallback(webots_ros::field_set_vec2f::Reques
 bool RosSupervisor::fieldInsertVec3fCallback(webots_ros::field_set_vec3f::Request &req,
                                              webots_ros::field_set_vec3f::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   double values[3];
@@ -993,6 +1089,8 @@ bool RosSupervisor::fieldInsertVec3fCallback(webots_ros::field_set_vec3f::Reques
 bool RosSupervisor::fieldInsertRotationCallback(webots_ros::field_set_rotation::Request &req,
                                                 webots_ros::field_set_rotation::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   double axisAngleValues[4];
@@ -1007,6 +1105,8 @@ bool RosSupervisor::fieldInsertRotationCallback(webots_ros::field_set_rotation::
 bool RosSupervisor::fieldInsertColorCallback(webots_ros::field_set_color::Request &req,
                                              webots_ros::field_set_color::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   double values[3];
@@ -1023,6 +1123,8 @@ bool RosSupervisor::fieldInsertColorCallback(webots_ros::field_set_color::Reques
 bool RosSupervisor::fieldInsertStringCallback(webots_ros::field_set_string::Request &req,
                                               webots_ros::field_set_string::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() <= 0x09)
@@ -1034,6 +1136,8 @@ bool RosSupervisor::fieldInsertStringCallback(webots_ros::field_set_string::Requ
 
 bool RosSupervisor::fieldRemoveCallback(webots_ros::field_remove::Request &req, webots_ros::field_remove::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() == Field::SF_NODE)
@@ -1048,6 +1152,8 @@ bool RosSupervisor::fieldRemoveCallback(webots_ros::field_remove::Request &req, 
 bool RosSupervisor::fieldImportNodeCallback(webots_ros::field_import_node::Request &req,
                                             webots_ros::field_import_node::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() == Field::SF_NODE)
@@ -1062,6 +1168,8 @@ bool RosSupervisor::fieldImportNodeCallback(webots_ros::field_import_node::Reque
 bool RosSupervisor::fieldImportNodeFromStringCallback(webots_ros::field_import_node_from_string::Request &req,
                                                       webots_ros::field_import_node_from_string::Response &res) {
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   res.success = 1;
   if (field->getType() == Field::SF_NODE)
@@ -1078,6 +1186,8 @@ bool RosSupervisor::fieldRemoveNodeCallback(webots_ros::field_remove_node::Reque
                                             webots_ros::field_remove_node::Response &res) {
   ROS_WARN("Deprecated '/supervisor/field/remove_node' service, use '/supervisor/field/remove' service instead.");
   assert(this);
+  if (!req.field)
+    return false;
   Field *field = reinterpret_cast<Field *>(req.field);
   field->removeMF(req.position);
   res.success = 1;


### PR DESCRIPTION
**Description**
Currently, if the argument of the supervisor services in ROS1 is not valid, the controller will crash.