### PR TITLE
Fixed a mistake in the table for IDs

### DIFF
--- a/docs/guide/gripper-actuators.md
+++ b/docs/guide/gripper-actuators.md
@@ -12,7 +12,7 @@ The `ROBOTIQ 3F Gripper` is a 3-fingers adaptive robot gripper.
 | Motor Name                | Position Sensor Name               |
 | ------------------------- | -------------------------------    |
 | palm\_finger\_1\_joint    |  palm\_finger\_1\_joint\_sensor    |
-| finger\_1\_joint\_1       |  palm\_finger\_1\_joint\_sensor    |
+| finger\_1\_joint\_1       |  finger\_1\_joint\_1_sensor        |
 | finger\_1\_joint\_2       |  finger\_1\_joint\_2\_sensor       |
 | finger\_1\_joint\_3       |  finger\_1\_joint\_3\_sensor       |
 | palm\_finger\_2\_joint    |  palm\_finger\_2\_joint\_sensor    |


### PR DESCRIPTION
**Description**
Changed palm_finger_1_joint_sensor to finger_1_joint_1_sensor in the third row of the second column, because palm_finger_1_joint_sensor was mentioned in two places.