### PR TITLE
Updated to the latest version of MSYS2

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -10,10 +10,8 @@ LUA_PACKAGE = lua-5.2.3.tar.gz
 OIS_PACKAGE = libOIS.zip
 PICO_PACKAGE = libpico.zip
 LUA_GD_PACKAGE = lua-gd-windows.zip
-ICU_PACKAGE = icu64.zip
-ICU_VERSION = $(subst .zip,,$(subst icu,,$(ICU_PACKAGE)))
 
-PACKAGES = open-vr lua ois pico lua-gd icu
+PACKAGES = open-vr lua ois pico lua-gd
 PACKAGES_CLEAN = $(addsuffix -clean, $(PACKAGES))
 null :=
 space := $(null) $(null)
@@ -178,21 +176,3 @@ $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE):
 	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $(LUA_GD_PACKAGE)"; exit 1; fi
 	@rm $(LUA_GD_PACKAGE).md5
 	@touch "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE)"
-
-icu-clean:
-	@rm -rf $(ICU_PACKAGE) /mingw64/bin/libicu??$(ICU_VERSION).dll
-
-$(ICU_PACKAGE):
-	@echo "# downloading $@"
-	@wget -qq "$(DEPENDENCIES_URL)/$@"
-	@echo "e43df508b5bf8d3ba40ddd6bb4f88e4f *$@" > $@.md5
-	@md5sum -c --status $@.md5
-	if [ $$? -ne 0 ]; then echo "MD5 checksum failed for $@"; exit 1; fi
-	@rm $@.md5
-
-/mingw64/bin/libicudt$(ICU_VERSION).dll: $(ICU_PACKAGE)
-	@echo "# uncompressing $(ICU_PACKAGE)"
-	@unzip -q -u -d /mingw64/bin $(ICU_PACKAGE)
-	@touch $@
-
-icu: /mingw64/bin/libicudt$(ICU_VERSION).dll

--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -9,6 +9,7 @@
 /mingw64/bin/Qt5PrintSupport.dll
 /mingw64/bin/Qt5Quick.dll
 /mingw64/bin/Qt5Qml.dll
+/mingw64/bin/Qt5QmlModels.dll
 /mingw64/bin/Qt5Sensors.dll
 /mingw64/bin/Qt5WebChannel.dll
 /mingw64/bin/Qt5WebKit.dll
@@ -16,9 +17,8 @@
 /mingw64/bin/Qt5WebSockets.dll
 /mingw64/bin/Qt5Widgets.dll
 /mingw64/bin/Qt5Xml.dll
-/mingw64/bin/libicuuc64.dll
-/mingw64/bin/libicuin64.dll
-/mingw64/bin/libicudt64.dll
+/mingw64/bin/libbrotlicommon.dll
+/mingw64/bin/libbrotlidec.dll
 /mingw64/bin/libicuuc65.dll
 /mingw64/bin/libicuin65.dll
 /mingw64/bin/libicudt65.dll
@@ -41,6 +41,8 @@
 /mingw64/bin/libpcre2-16-0.dll
 /mingw64/bin/libwebp-7.dll
 /mingw64/bin/libwebpdecoder-3.dll
+/mingw64/bin/libwoff2common.dll
+/mingw64/bin/libwoff2dec.dll
 /mingw64/bin/libxml2-2.dll
 /mingw64/bin/libzzip-0-13.dll
 /mingw64/bin/libopenal-1.dll


### PR DESCRIPTION
MSYS2 released a new version of QtWebKit which doesn't require any more libicu64, but has new dependencies. See details here: https://github.com/msys2/MINGW-packages/issues/5934. This pull-request fixes issue #1369.