### PR TITLE
Fixed bounding object collision color update

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -17,6 +17,7 @@ Released on XXX.
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
     - Fixed addition of PROTO nodes including a [Connector](connector.md) node from the Add Node dialog (thanks to Acwok).
     - Fixed the [`wb_display_image_load`](display.md#wb_display_image_load) function when used with a PNG image with transparency.
+    - Fixed color of the bounding objects remaining in the collision state if the collision was lasting only one step (thanks to Acwok).
 
 ## Webots R2020a Revision 1
 Released on January 14th, 2020.

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -235,6 +235,7 @@ void WbGeometry::updateCollisionMaterial(bool triggerChange, bool onSelection) {
   if (onSelection && !isColliding)
     isColliding = mCollisionTime == WbSimulationState::instance()->time() - WbWorld::instance()->basicTimeStep();
   const bool wasColliding =
+    mCollisionTime == WbSimulationState::instance()->time() - WbWorld::instance()->basicTimeStep() ||
     mPreviousCollisionTime >= WbSimulationState::instance()->time() - 2 * WbWorld::instance()->basicTimeStep();
   const bool changeBoundingObjectMaterial = isColliding != wasColliding || triggerChange;
 


### PR DESCRIPTION
**Description**
If the collision was lasting only one time-step the bounding object color was not updated correctly.

**Related Issues**
This pull-request fixes issue #1368
