### PR TITLE
Fix Receiver Reset

### DIFF
--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -363,6 +363,7 @@ void WbReceiver::reset() {
   qDeleteAll(mWaitingQueue);
   mWaitingQueue.clear();
   mLastWaitingPacketIndex = 0;
+  mSensor->reset();
 }
 
 // return true is a transmission respects the emitter's and receiver's aperture

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -179,7 +179,7 @@ void WbReceiver::updateTransmissionSetup() {
 
 void WbReceiver::writeConfigure(QDataStream &stream) {
   // TODO disable in remote or not ?
-  // mSensor->connectToRobotSignal(robot());
+  mSensor->connectToRobotSignal(robot(), false);
 
   stream << tag();
   stream << (unsigned char)C_CONFIGURE;
@@ -363,7 +363,6 @@ void WbReceiver::reset() {
   qDeleteAll(mWaitingQueue);
   mWaitingQueue.clear();
   mLastWaitingPacketIndex = 0;
-  mSensor->reset();
 }
 
 // return true is a transmission respects the emitter's and receiver's aperture

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -217,6 +217,7 @@ void WbRobot::reset() {
     mBattery->setItem(CURRENT_ENERGY, mBatteryInitialValue);
   if (mSupervisorUtilities)
     mSupervisorUtilities->reset();
+  emit robotResetted();
 }
 
 void WbRobot::save() {

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -217,7 +217,7 @@ void WbRobot::reset() {
     mBattery->setItem(CURRENT_ENERGY, mBatteryInitialValue);
   if (mSupervisorUtilities)
     mSupervisorUtilities->reset();
-  emit robotResetted();
+  emit wasReset();
 }
 
 void WbRobot::save() {

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -141,6 +141,7 @@ signals:
   void controllerChanged();
   void controllerRestarted();
   void controllerExited();
+  void robotResetted();
   void toggleRemoteMode(bool enable);
   void sendToJavascript(const QByteArray &);
   void appendMessageToConsole(const QString &message, bool useStdout);

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -141,7 +141,7 @@ signals:
   void controllerChanged();
   void controllerRestarted();
   void controllerExited();
-  void robotResetted();
+  void wasReset();
   void toggleRemoteMode(bool enable);
   void sendToJavascript(const QByteArray &);
   void appendMessageToConsole(const QString &message, bool useStdout);

--- a/src/webots/nodes/WbSensor.cpp
+++ b/src/webots/nodes/WbSensor.cpp
@@ -21,7 +21,7 @@
 
 WbSensor::WbSensor() :
   mRefreshRate(0),  // disabled
-  mLastUpdate(-9999),
+  mLastUpdate(-std::numeric_limits<double>::infinity()),
   mIsRemoteMode(false),
   mIsFirstValueReady(false),
   mHasPendingValue(false) {
@@ -73,7 +73,7 @@ void WbSensor::connectToRobotSignal(const WbRobot *robot, bool connectRemoteMode
 }
 
 void WbSensor::reset() {
-  mLastUpdate = -9999;
+  mLastUpdate = -std::numeric_limits<double>::infinity();
   mIsFirstValueReady = false;
   mHasPendingValue = false;
 }

--- a/src/webots/nodes/WbSensor.cpp
+++ b/src/webots/nodes/WbSensor.cpp
@@ -68,3 +68,9 @@ void WbSensor::toggleRemoteMode(bool enabled) {
 void WbSensor::connectToRobotSignal(const WbRobot *robot) {
   connect(robot, &WbRobot::toggleRemoteMode, this, &WbSensor::toggleRemoteMode, Qt::UniqueConnection);
 }
+
+void WbSensor::reset() {
+  mLastUpdate = -9999;
+  mIsFirstValueReady = false;
+  mHasPendingValue = false;
+}

--- a/src/webots/nodes/WbSensor.cpp
+++ b/src/webots/nodes/WbSensor.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "WbSensor.hpp"
+
 #include "WbRobot.hpp"
 #include "WbSimulationState.hpp"
 
@@ -65,8 +66,10 @@ void WbSensor::toggleRemoteMode(bool enabled) {
   mIsRemoteMode = enabled;
 }
 
-void WbSensor::connectToRobotSignal(const WbRobot *robot) {
-  connect(robot, &WbRobot::toggleRemoteMode, this, &WbSensor::toggleRemoteMode, Qt::UniqueConnection);
+void WbSensor::connectToRobotSignal(const WbRobot *robot, bool connectRemoteMode) {
+  if (connectRemoteMode)
+    connect(robot, &WbRobot::toggleRemoteMode, this, &WbSensor::toggleRemoteMode, Qt::UniqueConnection);
+  connect(robot, &WbRobot::robotResetted, this, &WbSensor::reset);
 }
 
 void WbSensor::reset() {

--- a/src/webots/nodes/WbSensor.cpp
+++ b/src/webots/nodes/WbSensor.cpp
@@ -69,7 +69,7 @@ void WbSensor::toggleRemoteMode(bool enabled) {
 void WbSensor::connectToRobotSignal(const WbRobot *robot, bool connectRemoteMode) {
   if (connectRemoteMode)
     connect(robot, &WbRobot::toggleRemoteMode, this, &WbSensor::toggleRemoteMode, Qt::UniqueConnection);
-  connect(robot, &WbRobot::robotResetted, this, &WbSensor::reset);
+  connect(robot, &WbRobot::wasReset, this, &WbSensor::reset);
 }
 
 void WbSensor::reset() {

--- a/src/webots/nodes/WbSensor.hpp
+++ b/src/webots/nodes/WbSensor.hpp
@@ -55,7 +55,7 @@ public:
 
   // remote control
   bool isRemoteModeEnabled() const { return mIsRemoteMode; }
-  void connectToRobotSignal(const WbRobot *robot);
+  void connectToRobotSignal(const WbRobot *robot, bool connectRemoteMode = true);
 
   void reset();
 

--- a/src/webots/nodes/WbSensor.hpp
+++ b/src/webots/nodes/WbSensor.hpp
@@ -57,6 +57,8 @@ public:
   bool isRemoteModeEnabled() const { return mIsRemoteMode; }
   void connectToRobotSignal(const WbRobot *robot);
 
+  void reset();
+
 signals:
   void stateChanged();
 

--- a/src/webots/nodes/utils/WbMouse.cpp
+++ b/src/webots/nodes/utils/WbMouse.cpp
@@ -64,9 +64,6 @@ void WbMouse::reset() {
   mX = NAN;
   mY = NAN;
   mZ = NAN;
-
-  if (mSensor)
-    mSensor->resetPendingValue();
 }
 
 bool WbMouse::refreshSensorIfNeeded() {


### PR DESCRIPTION
**Description**
Since the time is reset to 0 but the controller is not restarted, we should reset the sensor to make sure the `needToRefresh` returns true after the next step even if the sensor is not re-enabled (which is not the case since the controller is not restarted).

**Related Issues**
This pull-request fixes issue #1384

