### PR TITLE
Update compiling-controllers-in-a-terminal.md

### DIFF
--- a/docs/guide/compiling-controllers-in-a-terminal.md
+++ b/docs/guide/compiling-controllers-in-a-terminal.md
@@ -18,7 +18,7 @@ Or add this line to your "~/.bash\_profile" file.
 On macOS, type this:
 
 ```sh
-$ export WEBOTS_HOME=/Applications/Webots
+$ export WEBOTS_HOME=/Applications/Webots.app
 ```
 
 Or add this line to your "~/.profile" file.


### PR DESCRIPTION
added ".app" to the macOS export.

**Description**
The WEBOTS_HOME export was missing the .app extension

**Documentation**
https://cyberbotics.com/doc/guide/compiling-controllers-in-a-terminal
