### PR TITLE
Fix macOS Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ jobs:
       language: generic     # Travis doesn't support python on macos yet
       addons:
         homebrew:
+          update: true
           packages:
             - clang-format
             - cppcheck
@@ -229,6 +230,7 @@ jobs:
       language: generic     # Travis doesn't support python on macos yet
       addons: &mac_addons
         homebrew:
+          update: true
           packages:
             - python
             - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
       language: generic     # Travis doesn't support python on macos yet
       addons:
         homebrew:
-          update: true
+          update: true  # TODO: this should be removed once this bug is fixed: https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296
           packages:
             - clang-format
             - cppcheck
@@ -230,7 +230,7 @@ jobs:
       language: generic     # Travis doesn't support python on macos yet
       addons: &mac_addons
         homebrew:
-          update: true
+          update: true  # TODO: this should be removed once this bug is fixed: https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296
           packages:
             - python
             - cmake


### PR DESCRIPTION
**Description**
Travis tests are currently broken because of some bug in Homebrew.
The bug was introduced in https://github.com/Homebrew/homebrew-bundle/pull/643
This is already reported on the Homebrew repository: https://github.com/Homebrew/homebrew-bundle/issues/646
And here is a thread about this in the Travis forum: https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296

The workaround, for now, seems to ask for a homebrew update before using it, however, this slows down quite a lot the test (~7 minutes longer, we should, therefore, remove this as soon as the Travis Image is fixed).