### PR TITLE
Force stdout/stderr flush when a controller is restarted.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -21,6 +21,7 @@ Released on XXX.
     - Fixed the [`wb_display_image_load`](display.md#wb_display_image_load) function when used with a PNG image with transparency.
     - Fixed color of the bounding objects remaining in the collision state if the collision was lasting only one step (thanks to Acwok).
     - Fixed Matlab API.
+    - Fixed missing stdout/stderr flush when a controller is changed or restarted while simulation is running (thanks to tsampazk).
 
 ## Webots R2020a Revision 1
 Released on January 14th, 2020.

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -387,6 +387,7 @@ void WbControlledWorld::updateRobotController(WbRobot *robot) {
   for (int i = 0; i < size; ++i) {
     WbController *controller = mControllers[i];
     if (controller->robotId() == robotID) {
+      controller->flushBuffers();
       disconnect(controller, &WbController::hasTerminatedByItself, this,
                  &WbControlledWorld::deleteController);  // avoids double delete
       mNewControllers.removeOne(controller);


### PR DESCRIPTION
**Description**
When a controller is restarted or changed at runtime, the stdout/stderr of the last step is lost because the process is deleted before any flush.

**Related Issues**
This is reported here: https://github.com/cyberbotics/webots/issues/1384#issuecomment-589219808
