### PR TITLE
Awake connectors after detach

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -15,7 +15,7 @@ Released on XXX.
   - Dependency Updates
     - Upgraded to Qt 5.14.1 on Windows.
   - Bug fixes
-    - Fixed the physics behavior of Connector nodes sometimes remaining idle after being detached from each other (thanks to Giorgio).
+    - Fixed the physics behavior of [Connector](connector.md) nodes sometimes remaining idle after being detached from each other (thanks to Giorgio).
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -15,6 +15,7 @@ Released on XXX.
   - Dependency Updates
     - Upgraded to Qt 5.14.1 on Windows.
   - Bug fixes
+    - Fixed the physics behavior of Connector nodes sometimes remaining idle after being detached from each other (thanks to Giorgio).
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -493,6 +493,12 @@ void WbConnector::detachFromPeer() {
   else
     mPeer->destroyFixedJoint();
 
+  // detaching connectors may cause some motion that wasn't possible when they were attached to each other
+  // therefore we need to explicitely awake both of them in case they were idle
+  // so that the physics engine can generate their motion accordingly
+  awake();
+  mPeer->awake();
+
   // divorce
   mPeer->mPeer = NULL;
   mPeer = NULL;

--- a/tests/api/controllers/connector/.gitignore
+++ b/tests/api/controllers/connector/.gitignore
@@ -1,0 +1,1 @@
+/connector

--- a/tests/api/controllers/connector/Makefile
+++ b/tests/api/controllers/connector/Makefile
@@ -1,0 +1,25 @@
+# Copyright 1996-2020 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Webots Makefile system 
+#
+# You may add some variable definitions hereafter to customize the build process
+# See documentation in $(WEBOTS_HOME_PATH)/resources/Makefile.include
+
+
+# Do not modify the following: this includes Webots global Makefile.include
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -20,19 +20,15 @@ int main(int argc, char **argv) {
   while (wb_robot_step(TIME_STEP) != -1) {
     if (t == 34 * TIME_STEP) {  // fail with 34
       ts_assert_int_equal(wb_connector_get_presence(rear_connector), 1, "connector presence should be 1");
-      printf("%d\n", wb_connector_get_presence(rear_connector));  // should be 1
       wb_connector_unlock(front_connector);
       wb_connector_unlock(rear_connector);
     }
     if (t == 38 * TIME_STEP) {
       ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0");
-      printf("%d\n", wb_connector_get_presence(rear_connector));  // should be 0
       break;
     }
     t += TIME_STEP;
   }
-  printf("Done\n");
   ts_send_success();
-  printf("Done 2\n");
   return EXIT_SUCCESS;
 }

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <webots/connector.h>
+#include <webots/robot.h>
+
+#include "../../../lib/ts_assertion.h"
+#include "../../../lib/ts_utils.h"
+
+#define TIME_STEP 32
+
+static double t = 0.0; /* time elapsed since simulation start [s] */
+
+int main(int argc, char **argv) {
+  ts_setup(argv[0]);
+
+  WbDeviceTag rear_connector = wb_robot_get_device("rear_connector");
+  WbDeviceTag front_connector = wb_robot_get_device("front_connector");
+  wb_connector_enable_presence(rear_connector, TIME_STEP);
+  wb_connector_enable_presence(front_connector, TIME_STEP);
+
+  while (wb_robot_step(TIME_STEP) != -1) {
+    if (t == 34 * TIME_STEP) {  // fail with 34
+      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 1, "connector presence should be 1");
+      printf("%d\n", wb_connector_get_presence(rear_connector));  // should be 1
+      wb_connector_unlock(front_connector);
+      wb_connector_unlock(rear_connector);
+    }
+    if (t == 38 * TIME_STEP) {
+      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0");
+      printf("%d\n", wb_connector_get_presence(rear_connector));  // should be 0
+      break;
+    }
+    t += TIME_STEP;
+  }
+  printf("Done\n");
+  ts_send_success();
+  printf("Done 2\n");
+  return EXIT_SUCCESS;
+}

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -7,7 +7,7 @@
 
 #define TIME_STEP 32
 
-static double t = 0.0; /* time elapsed since simulation start [s] */
+static int t = 0; /* time elapsed since simulation start [ms] */
 
 int main(int argc, char **argv) {
   ts_setup(argv[0]);

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -23,7 +23,8 @@ int main(int argc, char **argv) {
       wb_connector_unlock(front_connector);
       wb_connector_unlock(rear_connector);
     } else if (t == 38 * TIME_STEP) {
-      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0, as the other module should have fallen.");
+      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0,
+                          "connector presence should be 0, as the other module should have fallen.");
       break;
     }
     t += TIME_STEP;

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
       wb_connector_unlock(front_connector);
       wb_connector_unlock(rear_connector);
     } else if (t == 38 * TIME_STEP) {
-      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0");
+      ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0, as the other module should have fallen.");
       break;
     }
     t += TIME_STEP;

--- a/tests/api/controllers/connector/connector.c
+++ b/tests/api/controllers/connector/connector.c
@@ -22,8 +22,7 @@ int main(int argc, char **argv) {
       ts_assert_int_equal(wb_connector_get_presence(rear_connector), 1, "connector presence should be 1");
       wb_connector_unlock(front_connector);
       wb_connector_unlock(rear_connector);
-    }
-    if (t == 38 * TIME_STEP) {
+    } else if (t == 38 * TIME_STEP) {
       ts_assert_int_equal(wb_connector_get_presence(rear_connector), 0, "connector presence should be 0");
       break;
     }

--- a/tests/api/worlds/connector.wbt
+++ b/tests/api/worlds/connector.wbt
@@ -1,0 +1,46 @@
+#VRML_SIM R2020a utf8
+WorldInfo {
+  title "Modular Robot"
+  basicTimeStep 8
+}
+Viewpoint {
+  orientation 0 1 0 4.6416
+  position -0.65 0.239 -0.007
+}
+Background {
+  skyColor [
+    0.15 0.45 1
+  ]
+}
+Floor {
+  size 2 2
+}
+Yamor {
+  translation -3.67321e-08 0.23 -0.02
+  rotation 0 0 1 1.5708
+  name "module_1"
+  controller "connector"
+  extensionSlot TestSuiteEmitter {
+  }
+}
+Yamor {
+  translation -7.3464e-07 0.23 0.077
+  rotation 0 0 1 1.5708
+  name "module_2"
+  controller ""
+}
+Solid {
+  translation 0 0.1 0
+  children [
+    DEF BOX Shape {
+      geometry Box {
+        size 0.1 0.2 0.1
+      }
+    }
+  ]
+  boundingObject USE BOX
+  physics Physics {
+  }
+}
+TestSuiteSupervisor {
+}


### PR DESCRIPTION
As reported by some user, the Connector nodes were sometimes not actually moving away from each other after being detached. Setting `WorldInfo.physicsDisableTime` to `0` was fixing the problem.

Awaking both Connector nodes when detaching them from each other was indeed missing.

This PR fixes that bug.