### PR TITLE
Fix textureAnimation field and hide them.

### DIFF
--- a/docs/guide/object-factory.md
+++ b/docs/guide/object-factory.md
@@ -125,7 +125,6 @@ ConveyorBelt {
   SFFloat    speed            0.5
   SFFloat    acceleration     -1
   SFFloat    timer            0.0
-  SFFloat    textureAnimation 0.008
 }
 ```
 
@@ -147,8 +146,6 @@ ConveyorBelt {
 - `acceleration`: Defines the acceleration of the conveyor belt.
 
 - `timer`: Defines for how long the conveyor belt should move (it will move forever if set to 0).
-
-- `textureAnimation`: defines the speed of the texture animation.
 
 ### ConveyorPlatform
 
@@ -174,7 +171,6 @@ ConveyorPlatform {
    SFFloat     speed            0.3
    SFFloat     acceleration     -1
    SFFloat     timer            0.0
-   SFFloat     textureAnimation 0.004
 }
 ```
 
@@ -190,8 +186,6 @@ ConveyorPlatform {
 - `acceleration`: Defines the acceleration of the conveyor belt.
 
 - `timer`: Defines for how long the conveyor belt should move (it will move forever if set to 0).
-
-- `textureAnimation`: defines the speed of the texture animation.
 
 ## Fire Extinguisher
 

--- a/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
+++ b/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
@@ -15,7 +15,6 @@ PROTO ConveyorBelt [
   field SFFloat    speed            0.5                                                                  # Defines the rubber band speed in meters per second.
   field SFFloat    acceleration     -1                                                                   # Defines the acceleration of the conveyor belt.
   field SFFloat    timer            0.0                                                                  # Defines for how long the conveyor belt should move (it will move forever if set to 0).
-  field SFFloat    textureAnimation 0.008                                                                # defines the speed of the texture animation.
 ]
 {
   %{
@@ -93,7 +92,7 @@ PROTO ConveyorBelt [
             sound ""
           }
         ]
-        textureAnimation %{=-fields.textureAnimation.value / size.x}% 0
+        textureAnimation %{=-0.0325 / size.x}% 0
       }
       Shape {
         appearance IS appearance

--- a/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto
+++ b/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto
@@ -15,7 +15,6 @@ PROTO ConveyorPlatform [
   field  SFFloat     speed            0.3                  # Defines the rubber band speed in meters per second.
   field  SFFloat     acceleration     -1                   # Defines the acceleration of the conveyor belt.
   field  SFFloat     timer            0.0                  # Defines for how long the conveyor belt should move (it will move forever if set to 0).
-  field  SFFloat     textureAnimation 0.004                # defines the speed of the texture animation.
 ]
 {
   Robot {
@@ -91,7 +90,7 @@ PROTO ConveyorPlatform [
             sound ""
           }
         ]
-        textureAnimation %{=-fields.textureAnimation.value}% 0
+        textureAnimation -0.0175 0
       }
       DEF emergency_button_1 Shape {
         appearance MattePaint {


### PR DESCRIPTION
**Description**
In factory's objects (`ConveyorBlet` and `ConveyorPlatform` PROTOs), I fixed the texture animation by correcting the speed and hide this field in the PROTO since the user don't need to have acces to it.

**Documentation**
File : [docs/guide/object-factory.md](https://cyberbotics.com/doc/guide/object-factory?version=michou214:fix-converoyPlatform)
