### PR TITLE
Improve tutorial documentation - adding icons - typos

### DIFF
--- a/docs/guide/the-scene-tree.md
+++ b/docs/guide/the-scene-tree.md
@@ -1,6 +1,6 @@
 ## The Scene Tree
 
-As seen in the previous section, to access to the Scene Tree Window you can either choose `Scene Tree` in the `Tools` menu, or press the `Show Scene Tree` button in the main toolbar.
+As seen in the previous section, to access the Scene Tree Window you can either choose `Scene Tree` in the `Tools` menu, or press the `Show Scene Tree` button in the main toolbar.
 The scene tree contains the information that describes a simulated world, including robots and environment, and its graphical representation.
 The scene tree of Webots is structured like a VRML97 file.
 It is composed of a list of nodes, each containing fields.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -325,7 +325,7 @@ The controller directory name should match with the binary name.
 
 ### Extend the Controller to Speed Control
 
-The robots wheels are often controlled using velocity, and not in position like we did in the previous example.
+The robots wheels are often controlled using velocity, and not position like we did in the previous example.
 In order to control the motors of the wheels in speed you need to set the target position to the infinity and to set the desired speed:
 
 %tab-component "language"

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -29,7 +29,7 @@ A world is stored in a file having the `.wbt` extension.
 The file format is derived from the **VRML97** language, and is human readable.
 The world files must be stored directly in a directory called `worlds`.
 
-> **Hands-on #2**: Pause the current simulation by clicking on the `Pause` ![](images/pause-button.png =26x26) button of the 3D view (see the [user interface description](the-user-interface.md#simulation-menu) to find out the buttons).
+> **Hands-on #2**: Pause the current simulation by clicking on the `Pause` button ![](images/pause-button.png =26x26) of the 3D view (see the [user interface description](the-user-interface.md#simulation-menu) to find out the buttons).
 The simulation is paused if the virtual time counter on the main toolbar is stopped.
 Create a new project from the `Wizards` menu by selecting the `New Project Directory...` menu item and follow the instructions:
 1. Name the project directory `my_first_simulation` instead of the proposed `my_project`.
@@ -131,7 +131,7 @@ It is not possible to apply a force to a `WoodenBox` node, because by default, t
 To enable physics on the `WoodenBox` nodes, you should set their `mass` field to a certain value (for example 0.2 kg).
 Once this is done, should be able to apply a force on them as well.
 
-The simulation may be paused (pause button), run step-by-step (step button), in real time (right arrow button), in run (double right arrow button) or in fast (triple right arrow button) modes.
+The simulation may be paused ![](images/pause-button.png =26x26), run step-by-step ![](images/step-button.png =26x26), in real time ![](images/realtime-button.png =26x26), in run ![](images/run-button.png =26x26) or in fast ![](images/fast-button.png =26x26) modes.
 
 Now we are going to modify the world and decrease the step of the physics simulation: this will increase the accuracy and stability of the simulation (but reduce the maximum simulation speed).
 
@@ -486,7 +486,7 @@ In order to control the motors of the wheels in speed you need to set the target
 %end
 
 The robot will now move (the wheels will rotate at a speed of 1 radian per second) and never stop.
-If nothing happens, don't forget to compile your code by selecting the `Build / Build` menu item or click on the gear icon above the code area.
+If nothing happens, don't forget to compile your code by selecting the `Build / Build` menu item or clicking on the gear icon ![](images/build-button.png =26x26) above the code area.
 Compilation errors are displayed in red in the console.
 If there are any, fix them and retry to compile.
 Then, reload the world.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -96,7 +96,7 @@ We will learn how to use other capabilities in the next tutorials.
 
 Now, we are going to add an e-puck model to the world.
 Make sure that the simulation is paused and that the virtual time elapsed is 0.
-If this is not the case, reset the simulation with the `Reset` button ![](images/reset-simulation-button.png =26x26) ([rewind](the-user-interface.md)).
+If this is not the case, reset the simulation with the `Reset` button ![](images/reset-simulation-button.png =26x26).
 
 When a Webots world is modified with the intention of being saved, it is fundamental that the simulation is first paused and reloaded to its initial state, i.e. the virtual time counter on the main toolbar should show 0:00:00:000.
 Otherwise at each save, the position of each 3D object can accumulate errors.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -29,7 +29,7 @@ A world is stored in a file having the `.wbt` extension.
 The file format is derived from the **VRML97** language, and is human readable.
 The world files must be stored directly in a directory called `worlds`.
 
-> **Hands-on #2**: Pause the current simulation by clicking on the `Pause` button of the 3D view (see the [user interface description](the-user-interface.md#simulation-menu) to find out the buttons).
+> **Hands-on #2**: Pause the current simulation by clicking on the `Pause` ![](images/pause-button.png =26x26) button of the 3D view (see the [user interface description](the-user-interface.md#simulation-menu) to find out the buttons).
 The simulation is paused if the virtual time counter on the main toolbar is stopped.
 Create a new project from the `Wizards` menu by selecting the `New Project Directory...` menu item and follow the instructions:
 1. Name the project directory `my_first_simulation` instead of the proposed `my_project`.
@@ -69,7 +69,7 @@ In the [scene tree view](the-scene-tree.md), the fields are displayed in a diffe
 Now, we would like to add some objects:
 
 > **Hands-on #4**: Double-click on the `RectangleArena` in the scene tree to close it and select it.
-Click on the `Add` button (plus sign) at the top of the scene tree.
+Click on the `Add` button ![](images/add-button.png =26x26) at the top of the scene tree.
 In the open dialog box, choose `PROTO nodes (Webots Projects) / objects / factory / containers / WoodenBox (Solid)`.
 A big box should appear in the middle of the arena.
 Double-click on it in the scene tree to open its fields.
@@ -96,7 +96,7 @@ We will learn how to use other capabilities in the next tutorials.
 
 Now, we are going to add an e-puck model to the world.
 Make sure that the simulation is paused and that the virtual time elapsed is 0.
-If this is not the case, reset the simulation with the `Reset` button ([rewind](the-user-interface.md)).
+If this is not the case, reset the simulation with the `Reset` button ![](images/reset-simulation-button.png =26x26) ([rewind](the-user-interface.md)).
 
 When a Webots world is modified with the intention of being saved, it is fundamental that the simulation is first paused and reloaded to its initial state, i.e. the virtual time counter on the main toolbar should show 0:00:00:000.
 Otherwise at each save, the position of each 3D object can accumulate errors.
@@ -106,11 +106,11 @@ We don't need to create the e-puck robot from scratch, we will just have to impo
 This node is actually a [PROTO](../reference/proto.md) node, like the `RectangleArena` or the `WoodenBox` we introduced before. Prototyping allows you to create custom objects and to reuse them.
 
 > **Hands-on #5**: Select the last node `WoodenBox` of the scene tree view.
-Click on the `Add` button (plus sign) at the top of the scene tree view.
+Click on the `Add` button ![](images/add-button.png =26x26) at the top of the scene tree view.
 In the dialog box, choose `PROTO nodes (Webots Projects) / robots / gctronic / e-puck / E-puck (Robot)`.
 An e-puck robot should appear in the middle of the arena.
 Move and rotate this robot, the same way you did it with the boxes.
-Save the simulation and press the `Run real-time` button (right arrow).
+Save the simulation and press the `Run real-time` button ![](images/realtime-button.png =26x26).
 
 The robot should move, blink LEDs and avoid obstacles.
 That's because it has a default controller with that behavior.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -325,7 +325,7 @@ The controller directory name should match with the binary name.
 
 ### Extend the Controller to Speed Control
 
-The wheels of differential wheels robots are often controlled in velocity and not in position like we did in the previous example.
+The robots wheels are often controlled using velocity, and not in position like we did in the previous example.
 In order to control the motors of the wheels in speed you need to set the target position to the infinity and to set the desired speed:
 
 %tab-component "language"

--- a/docs/guide/tutorial-2-modification-of-the-environment.md
+++ b/docs/guide/tutorial-2-modification-of-the-environment.md
@@ -134,7 +134,7 @@ The [field editor](the-scene-tree.md#field-editor) of the scene tree view allows
 
 Now, changing the `radius` field of the first [Sphere](../reference/sphere.md) node also modifies its `boundingObject`.
 
-For convenience, the `boundingObject` field accepts also the [Shape](../reference/shape.md) node (rather than the [Sphere](../reference/sphere.md) node directly).
+For convenience, the `boundingObject` field also accepts the [Shape](../reference/shape.md) node (rather than the [Sphere](../reference/sphere.md) node directly).
 It would be also possible to use the same DEF-USE mechanism at the [Shape](../reference/shape.md) level as shown in [this figure](#def-use-mechanism-applied-on-the-shape-node-of-a-solid).
 For now the greatest benefit is being able to also use this [Shape](../reference/shape.md) directly for graphical purposes.
 Later this mechanism will turn out to be very useful for some sensors.


### PR DESCRIPTION
Does it make more sense this way ?
Also should we add application icons (Play - Rewind - Forward) to the documentation instead of describing how the buttons look like ?

https://cyberbotics.com/doc/guide/tutorial-1-your-first-simulation-in-webots?version=remi-cyberbotics-patch-1#extend-the-controller-to-speed-control