### PR TITLE
Fix runtime.ini path section header name

### DIFF
--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -486,7 +486,8 @@ The Webots "runtime.ini" supports 7 sections:
     absolute paths. Paths must be separated using the colon symbol ':' and directory components
     must be separated using the slash symbol '/'. Variables declared in this section will be
     added on every platform. On Windows, colons will be replaced by semicolon and
-    slash will be replaced by backslash according to the Windows syntax.<br>
+    slash will be replaced by backslash according to the Windows syntax.
+
     **NOTE**: The legacy form of this section was ```[environment variables with relative path]```.
     You are encouraged to follow the new notation, though the backward compability is kept.
 

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -483,8 +483,8 @@ The Webots "runtime.ini" supports 7 sections:
 - `[environment variables with paths]`
 
     This section should only contain environment variables with either relative or
-    absolute paths. Paths must be separated using the colon symbol ':' and the separator for
-    directories to use is the slash symbol '/'. Variables declared in this section will be
+    absolute paths. Paths must be separated using the colon symbol ':' and directory components
+    must be separated using the slash symbol '/'. Variables declared in this section will be
     added on every platform. On Windows, colons will be replaced by semicolon and
     slash will be replaced by backslash according to the Windows syntax.<br>
     **NOTE**: The legacy form of this section was ```[environment variables with relative path]```.

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -487,8 +487,8 @@ The Webots "runtime.ini" supports 7 sections:
     directories to use is the slash symbol '/'. Variables declared in this section will be
     added on every platform. On Windows, colons will be replaced by semicolon and
     slash will be replaced by backslash according to the Windows syntax.<br>
-    NOTE: The legacy form of this section was ```[environment variables with relative path]```,
-    though it is encouraged to follow this new notation, the backward compability is kept.
+    **NOTE**: The legacy form of this section was ```[environment variables with relative path]```.
+    You are encouraged to follow the new notation, though the backward compability is kept.
 
 - `[environment variables]`
 

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -488,9 +488,6 @@ The Webots "runtime.ini" supports 7 sections:
     added on every platform. On Windows, colons will be replaced by semicolon and
     slash will be replaced by backslash according to the Windows syntax.
 
-    **NOTE**: The legacy form of this section was ```[environment variables with relative path]```.
-    You are encouraged to follow the new notation, though the backward compability is kept.
-
 - `[environment variables]`
 
     Environment variables defined in this section will also be added to the

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -480,13 +480,15 @@ Environment variables in this file can contain references to other environment v
 They will be automatically replaced by the actual value already existing in the environment.
 The Webots "runtime.ini" supports 7 sections:
 
-- `[environment variables with relative paths]`
+- `[environment variables with paths]`
 
-    This section should contain only environment variables with relative paths.
-    Paths must be separated by the colon symbol ':' and the separator between
-    directories is the slash symbol '/'. Variables declared in this section will be
+    This section should only contain environment variables with either relative or
+    absolute paths. Paths must be separated using the colon symbol ':' and the separator for
+    directories to use is the slash symbol '/'. Variables declared in this section will be
     added on every platform. On Windows, colons will be replaced by semicolon and
-    slash will be replaced by backslash according to the Windows syntax.
+    slash will be replaced by backslash according to the Windows syntax.<br>
+    NOTE: The legacy form of this section was ```[environment variables with relative path]```,
+    though it is encouraged to follow this new notation, the backward compability is kept.
 
 - `[environment variables]`
 
@@ -523,7 +525,7 @@ Here is an example of a typical runtime.ini file.
 ```ini
 ; typical runtime.ini
 
-[environment variables with relative paths]
+[environment variables with paths]
 WEBOTS_LIBRARY_PATH = lib:$(WEBOTS_LIBRARY_PATH):../../library
 
 [environment variables]
@@ -559,7 +561,7 @@ In the example above, the resulting command issued by Webots will be: `/opt/loca
 ```ini
 ; runtime.ini for a Java controller on Windows
 
-[environment variables with relative paths]
+[environment variables with paths]
 CLASSPATH = ../lib/MyLibrary.jar
 JAVA_LIBRARY_PATH = ../lib
 

--- a/projects/languages/ros/controllers/ros_python/runtime.ini
+++ b/projects/languages/ros/controllers/ros_python/runtime.ini
@@ -1,4 +1,4 @@
-[environment variables with relative paths]
+[environment variables with paths]
 PYTHONPATH=python/site-packages:kinetic/dist-packages
 
 [environment variables]

--- a/projects/robots/saeon/controllers/vehicle_driver_altino/runtime.ini
+++ b/projects/robots/saeon/controllers/vehicle_driver_altino/runtime.ini
@@ -1,3 +1,3 @@
-[environment variables with relative paths]
+[environment variables with paths]
 
 WEBOTS_LIBRARY_PATH=$(WEBOTS_HOME)/projects/automobile/libraries/car:$(WEBOTS_HOME)/projects/automobile/libraries/driver:$(WEBOTS_HOME)/projects/automobile/libraries/CppCar:$(WEBOTS_HOME)/projects/automobile/libraries/CppDriver:$(WEBOTS_HOME)/projects/automobile/libraries/python:$(WEBOTS_LIBRARY_PATH)

--- a/projects/robots/universal_robots/controllers/universal_robots_ros/runtime.ini
+++ b/projects/robots/universal_robots/controllers/universal_robots_ros/runtime.ini
@@ -1,4 +1,4 @@
-[environment variables with relative paths]
+[environment variables with paths]
 PYTHONPATH=$(WEBOTS_HOME)/projects/languages/ros/controllers/ros_python/python/site-packages:$(WEBOTS_HOME)/projects/languages/ros/controllers/ros_python/kinetic/dist-packages
 
 [environment variables]

--- a/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving/runtime.ini
+++ b/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving/runtime.ini
@@ -1,4 +1,4 @@
-[environment variables with relative paths]
+[environment variables with paths]
 
 AUTOMOBILE_LIBRARIES_PATH=$(WEBOTS_HOME)/projects/vehicles/libraries
 WEBOTS_LIBRARY_PATH=$(AUTOMOBILE_LIBRARIES_PATH)/python:$(AUTOMOBILE_LIBRARIES_PATH)/CppCar:$(AUTOMOBILE_LIBRARIES_PATH)/CppDriver:$(AUTOMOBILE_LIBRARIES_PATH)/driver:$(AUTOMOBILE_LIBRARIES_PATH)/car:$(WEBOTS_LIBRARY_PATH)

--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/runtime.ini
@@ -1,4 +1,4 @@
-[environment variables with relative paths]
+[environment variables with paths]
 
 ROBOTIS_PATH=$(WEBOTS_HOME)/projects/robots/robotis/darwin-op
 WEBOTS_LIBRARY_PATH=$(ROBOTIS_PATH)/libraries/python:$(ROBOTIS_PATH)/libraries/python27:$(ROBOTIS_PATH)/libraries/python35:$(ROBOTIS_PATH)/libraries/python36:$(ROBOTIS_PATH)/libraries/python37:$(ROBOTIS_PATH)/libraries/robotis-op2:$(ROBOTIS_PATH)/libraries/managers:$(WEBOTS_LIBRARY_PATH)

--- a/projects/samples/robotbenchmark/inverted_pendulum/controllers/inverted_pendulum/runtime.ini
+++ b/projects/samples/robotbenchmark/inverted_pendulum/controllers/inverted_pendulum/runtime.ini
@@ -1,3 +1,3 @@
-[environment variables with relative paths]
+[environment variables with paths]
 
 FIREJAIL_PATH=$(WEBOTS_HOME)/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/libe-puck_bluetooth.so

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -252,7 +252,8 @@ void WbController::start() {
       else {
         for (int i = 0; i < iniParser.size(); ++i) {
           if (iniParser.sectionAt(i) == "environment variables with relative paths")
-            warn("[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
+            warn(
+              "[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
           if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
               iniParser.sectionAt(i) == "environment variables with paths" ||
               iniParser.sectionAt(i) == "environment variables for linux" ||
@@ -372,7 +373,8 @@ void WbController::setProcessEnvironment() {
         const QString &value = iniParser.resolvedValueAt(i, env);
         iniParser.setValue(i, value);
         if (iniParser.sectionAt(i) == "environment variables with relative paths")
-            warn("[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
+          warn(
+            "[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
         if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
             iniParser.sectionAt(i) == "environment variables with paths")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -254,10 +254,10 @@ void WbController::start() {
           if (iniParser.sectionAt(i) == "environment variables with relative paths")
             warn(
               "[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
-          if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
-              iniParser.sectionAt(i) == "environment variables with paths" ||
-              iniParser.sectionAt(i) == "environment variables for linux" ||
-              iniParser.sectionAt(i) == "environment variables for linux 64")
+          if (iniParser.sectionAt(i) != "environment variables with relative paths" &&
+              iniParser.sectionAt(i) != "environment variables with paths" &&
+              iniParser.sectionAt(i) != "environment variables for linux" &&
+              iniParser.sectionAt(i) != "environment variables for linux 64")
             continue;
 
           if (iniParser.keyAt(i) == ("WEBOTS_LIBRARY_PATH") || iniParser.keyAt(i) == ("FIREJAIL_PATH")) {

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -251,10 +251,10 @@ void WbController::start() {
         warn(tr("Environment variables from runtime.ini could not be loaded: the file contains illegal definitions."));
       else {
         for (int i = 0; i < iniParser.size(); ++i) {
-          if ((iniParser.sectionAt(i).compare("environment variables with relative paths") ||
-               iniParser.sectionAt(i).compare("environment variables with paths")) &&
-              iniParser.sectionAt(i).compare("environment variables for Linux") &&
-              iniParser.sectionAt(i).compare("environment variables for Linux 64"))
+          if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
+              iniParser.sectionAt(i) == "environment variables with paths" ||
+              iniParser.sectionAt(i) == "environment variables for linux" ||
+              iniParser.sectionAt(i) == "environment variables for linux 64")
             continue;
 
           if (iniParser.keyAt(i) == ("WEBOTS_LIBRARY_PATH") || iniParser.keyAt(i) == ("FIREJAIL_PATH")) {
@@ -369,12 +369,12 @@ void WbController::setProcessEnvironment() {
       for (int i = 0; i < iniParser.size(); ++i) {
         const QString &value = iniParser.resolvedValueAt(i, env);
         iniParser.setValue(i, value);
-        if (!iniParser.sectionAt(i).compare("environment variables with relative paths", Qt::CaseInsensitive) ||
-            !iniParser.sectionAt(i).compare("environment variables with paths", Qt::CaseInsensitive))
+        if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
+            iniParser.sectionAt(i) == "environment variables with paths")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
-        if (!iniParser.sectionAt(i).compare("environment variables", Qt::CaseInsensitive))
+        if (iniParser.sectionAt(i) == "environment variables")
           addEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i));
-        if (!iniParser.sectionAt(i).compare("java", Qt::CaseInsensitive)) {
+        if (iniParser.sectionAt(i) == "java") {
           if (iniParser.keyAt(i) == "COMMAND")
             mJavaCommand = iniParser.valueAt(i);
           else if (iniParser.keyAt(i) == "OPTIONS")
@@ -382,7 +382,7 @@ void WbController::setProcessEnvironment() {
           else
             WbLog::warning(tr("Unknown key: %1 in java section").arg(iniParser.keyAt(i)));
         }
-        if (!iniParser.sectionAt(i).compare("python", Qt::CaseInsensitive)) {
+        if (iniParser.sectionAt(i) == "python") {
           if (iniParser.keyAt(i) == "COMMAND")
             mPythonCommand = WbLanguageTools::pythonCommand(mPythonShortVersion, iniParser.valueAt(i));
           else if (iniParser.keyAt(i) == "OPTIONS")
@@ -390,7 +390,7 @@ void WbController::setProcessEnvironment() {
           else
             WbLog::warning(tr("Unknown key: %1 in python section").arg(iniParser.keyAt(i)));
         }
-        if (!iniParser.sectionAt(i).compare("matlab", Qt::CaseInsensitive)) {
+        if (iniParser.sectionAt(i) == "matlab") {
           if (iniParser.keyAt(i) == "COMMAND")
             mMatlabCommand = iniParser.valueAt(i);
           else if (iniParser.keyAt(i) == "OPTIONS")
@@ -399,20 +399,20 @@ void WbController::setProcessEnvironment() {
             WbLog::warning(tr("Unknown key: %1 in matlab section").arg(iniParser.keyAt(i)));
         }
 #ifdef _WIN32
-        if (!iniParser.sectionAt(i).compare("environment variables for Windows", Qt::CaseInsensitive))
+        if (iniParser.sectionAt(i) == "environment variables for windows")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
 #elif defined(__APPLE__)
-        if (!iniParser.sectionAt(i).compare("environment variables for Mac OS X", Qt::CaseInsensitive) ||
-            !iniParser.sectionAt(i).compare("environment variables for macOS", Qt::CaseInsensitive))
+        if (iniParser.sectionAt(i) == "environment variables for mac os x" ||
+            iniParser.sectionAt(i) == "environment variables for macos")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
 #else
-        if (!iniParser.sectionAt(i).compare("environment variables for Linux", Qt::CaseInsensitive))
+        if (iniParser.sectionAt(i) == "environment variables for linux")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
         if (!WbSysInfo::isPointerSize64bits()) {
-          if (!iniParser.sectionAt(i).compare("environment variables for Linux 32", Qt::CaseInsensitive))
+          if (iniParser.sectionAt(i) == "environment variables for linux 32")
             addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
         } else {
-          if (!iniParser.sectionAt(i).compare("environment variables for Linux 64", Qt::CaseInsensitive))
+          if (iniParser.sectionAt(i) == "environment variables for linux 64")
             addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
         }
 #endif

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -251,6 +251,8 @@ void WbController::start() {
         warn(tr("Environment variables from runtime.ini could not be loaded: the file contains illegal definitions."));
       else {
         for (int i = 0; i < iniParser.size(); ++i) {
+          if (iniParser.sectionAt(i) == "environment variables with relative paths")
+            warn("[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
           if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
               iniParser.sectionAt(i) == "environment variables with paths" ||
               iniParser.sectionAt(i) == "environment variables for linux" ||
@@ -369,6 +371,8 @@ void WbController::setProcessEnvironment() {
       for (int i = 0; i < iniParser.size(); ++i) {
         const QString &value = iniParser.resolvedValueAt(i, env);
         iniParser.setValue(i, value);
+        if (iniParser.sectionAt(i) == "environment variables with relative paths")
+            warn("[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
         if (iniParser.sectionAt(i) == "environment variables with relative paths" ||
             iniParser.sectionAt(i) == "environment variables with paths")
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -251,9 +251,6 @@ void WbController::start() {
         warn(tr("Environment variables from runtime.ini could not be loaded: the file contains illegal definitions."));
       else {
         for (int i = 0; i < iniParser.size(); ++i) {
-          if (iniParser.sectionAt(i) == "environment variables with relative paths")
-            warn(
-              "[environment variables with relative path] is deprecated, please use [environment variables with path] instead");
           if (iniParser.sectionAt(i) != "environment variables with relative paths" &&
               iniParser.sectionAt(i) != "environment variables with paths" &&
               iniParser.sectionAt(i) != "environment variables for linux" &&

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -251,9 +251,10 @@ void WbController::start() {
         warn(tr("Environment variables from runtime.ini could not be loaded: the file contains illegal definitions."));
       else {
         for (int i = 0; i < iniParser.size(); ++i) {
-          if (iniParser.sectionAt(i).compare("environment variables with relative paths") != 0 &&
-              iniParser.sectionAt(i).compare("environment variables for Linux") != 0 &&
-              iniParser.sectionAt(i).compare("environment variables for Linux 64") != 0)
+          if ((iniParser.sectionAt(i).compare("environment variables with relative paths") ||
+               iniParser.sectionAt(i).compare("environment variables with paths")) &&
+              iniParser.sectionAt(i).compare("environment variables for Linux") &&
+              iniParser.sectionAt(i).compare("environment variables for Linux 64"))
             continue;
 
           if (iniParser.keyAt(i) == ("WEBOTS_LIBRARY_PATH") || iniParser.keyAt(i) == ("FIREJAIL_PATH")) {
@@ -368,7 +369,8 @@ void WbController::setProcessEnvironment() {
       for (int i = 0; i < iniParser.size(); ++i) {
         const QString &value = iniParser.resolvedValueAt(i, env);
         iniParser.setValue(i, value);
-        if (!iniParser.sectionAt(i).compare("environment variables with relative paths", Qt::CaseInsensitive))
+        if (!iniParser.sectionAt(i).compare("environment variables with relative paths", Qt::CaseInsensitive) ||
+            !iniParser.sectionAt(i).compare("environment variables with paths", Qt::CaseInsensitive))
           addPathEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i), true);
         if (!iniParser.sectionAt(i).compare("environment variables", Qt::CaseInsensitive))
           addEnvironmentVariable(env, iniParser.keyAt(i), iniParser.valueAt(i));

--- a/src/webots/core/WbIniParser.cpp
+++ b/src/webots/core/WbIniParser.cpp
@@ -39,7 +39,7 @@ WbIniParser::WbIniParser(const QString &filename) {
           mValid = false;
           break;
         }
-        mSections.append(section);
+        mSections.append(section.toLower());
         int equalPosition = line.indexOf("=");
         mKeys.append(line.mid(0, equalPosition).trimmed());
         QString value = line.mid(equalPosition + 1).trimmed();
@@ -68,8 +68,8 @@ void WbIniParser::setValue(int index, QString newValue) {
 
 QString WbIniParser::resolvedValueAt(int index, const QStringList &environment) const {
   QString value = valueAt(index);
-  if (!sectionAt(index).compare("environment variables with relative paths", Qt::CaseInsensitive) ||
-      !sectionAt(index).compare("environment variables with paths", Qt::CaseInsensitive)) {
+  if (sectionAt(index) == "environment variables with relative paths" ||
+      sectionAt(index) == "environment variables with paths") {
 #ifdef _WIN32
     QString newWindowsValue = value;
     newWindowsValue.replace(':', ';');
@@ -95,7 +95,8 @@ QString WbIniParser::resolvedValueAt(int index, const QStringList &environment) 
       environmentValue = "";
     QString newValue = value;
     newValue.replace("$(" + environmentKey + ")", environmentValue);
-    if (!sectionAt(index).compare("environment variables with relative paths", Qt::CaseInsensitive)) {
+    if (sectionAt(index) == "environment variables with relative paths" ||
+        sectionAt(index) == "environment variables with paths") {
 #ifndef _WIN32
       newValue.replace("::", ":");
       if (newValue.startsWith(':'))

--- a/src/webots/core/WbIniParser.cpp
+++ b/src/webots/core/WbIniParser.cpp
@@ -68,7 +68,8 @@ void WbIniParser::setValue(int index, QString newValue) {
 
 QString WbIniParser::resolvedValueAt(int index, const QStringList &environment) const {
   QString value = valueAt(index);
-  if (!sectionAt(index).compare("environment variables with relative paths", Qt::CaseInsensitive)) {
+  if (!sectionAt(index).compare("environment variables with relative paths", Qt::CaseInsensitive) ||
+      !sectionAt(index).compare("environment variables with paths", Qt::CaseInsensitive)) {
 #ifdef _WIN32
     QString newWindowsValue = value;
     newWindowsValue.replace(':', ';');

--- a/tests/api/controllers/runtime_config_file/runtime.ini
+++ b/tests/api/controllers/runtime_config_file/runtime.ini
@@ -1,4 +1,4 @@
-[environment variables with relative paths]
+[environment variables with paths]
 TEST_RELATIVE_PATHS=test1/test2:test3
 
 [environment variables]


### PR DESCRIPTION
This pull-request fixes issue #1430

https://cyberbotics.com/doc/guide/controller-programming?version=fix-runtime-ini-path-section-header-name#environment-variables
