### PR TITLE
Fixed MATLAB instructions for extern controllers and launcher test

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -95,13 +95,15 @@ Add the `-Djava.library.path=${WEBOTS_HOME}/lib/controller/java` option to the `
 | WEBOTS\_CONTROLLER\_NAME | `my_robot_controller`                             |
 | WEBOTS\_VERSION          | `R2020a revision 1`                               |
 
+
 Here is an example of what you should enter in the MATLAB console:
 
 ```matlab
 >> setenv('WEBOTS_PROJECT','C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')
 >> setenv('WEBOTS_VERSION', 'R2020a revision 1')
->> cd('C:\Program Files\Webots\lib\controller\matlab')
+>> cd(getenv('WEBOTS_HOME'))
+>> cd('lib/controller/matlab')
 >> launcher
 ```
 

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -95,6 +95,8 @@ Add the `-Djava.library.path=${WEBOTS_HOME}/lib/controller/java` option to the `
 | WEBOTS\_CONTROLLER\_NAME | `my_robot_controller`                             |
 | WEBOTS\_VERSION          | `R2020a revision 1`                               |
 
+Here is an example of what you should enter in the MATLAB console:
+
 ```matlab
 >> setenv('WEBOTS_PROJECT','C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -93,11 +93,12 @@ Add the `-Djava.library.path=${WEBOTS_HOME}/lib/controller/java` option to the `
 |--------------------------|---------------------------------------------------|
 | WEBOTS\_PROJECT          | `C:\Users\MyUsername\my_folder\my_webots_project` |
 | WEBOTS\_CONTROLLER\_NAME | `my_robot_controller`                             |
-| WEBOTS\_VERSION          | `R2019a revision 1`                               |
+| WEBOTS\_VERSION          | `R2020a revision 1`                               |
 
 ```matlab
 >> setenv('WEBOTS_PROJECT','C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')
+>> setenv('WEBOTS_VERSION', 'R2020a revision 1')
 >> cd('C:\Program Files\Webots\lib\controller\matlab')
 >> launcher
 ```

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -89,11 +89,18 @@ Add the `-Djava.library.path=${WEBOTS_HOME}/lib/controller/java` option to the `
 
 %tab "MATLAB"
 
-| Environment Variable     | Typical Value                                    |
-|--------------------------|--------------------------------------------------|
-| WEBOTS\_PROJECT          | `/my_folder/my_webots_project`                   |
-| WEBOTS\_CONTROLLER\_NAME | `my_robot_controller.m`                          |
-| WEBOTS\_VERSION          | `R2019a-rev1`                                    |
+| Environment Variable     | Typical Value                                     |
+|--------------------------|---------------------------------------------------|
+| WEBOTS\_PROJECT          | `C:\Users\MyUsername\my_folder\my_webots_project` |
+| WEBOTS\_CONTROLLER\_NAME | `my_robot_controller`                             |
+| WEBOTS\_VERSION          | `R2019a revision 1`                               |
+
+```matlab
+>> setenv('WEBOTS_PROJECT','C:\Users\MyUsername\my_folder\my_webots_project')
+>> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')
+>> cd('C:\Program Files\Webots\lib\controller\matlab')
+>> launcher
+```
 
 %tab-end
 

--- a/lib/controller/matlab/launcher.m
+++ b/lib/controller/matlab/launcher.m
@@ -8,12 +8,20 @@ WEBOTS_VERSION = getenv('WEBOTS_VERSION');
 if isempty(WEBOTS_CONTROLLER_NAME)
   disp('Entering test mode (normally launcher.m should be called by Webots, not from the MATLAB command line)');
   disp(['Using MATLAB R' version('-release')]);
-  cd('../../..');
-  WEBOTS_HOME = pwd;
+  if isempty(WEBOTS_HOME)
+    cd('../../..');
+    WEBOTS_HOME = pwd;
+  else
+    cd(WEBOTS_HOME)
+  end
   [status, cmdout] = system('msys64/mingw64/bin/webots.exe --version');
-  WEBOTS_VERSION = strrep(cmdout(17:end-1),'.','_');
-  cd('lib/controller/matlab');
-  disp(['Using Webots ' strrep(WEBOTS_VERSION,'_','.') ' from ' pwd ])
+  k = strfind(cmdout, ' Nightly Build ');
+  if isempty(k)
+    WEBOTS_VERSION = strrep(cmdout(17:end-1),'.','_');
+  else
+    WEBOTS_VERSION = strrep(cmdout(17:k(1)-1),'.','_');
+  end
+  disp(['Using Webots ' strrep(WEBOTS_VERSION,'_','.') ' from ' pwd ]);
   test_mode = true;
 else
   test_mode = false;


### PR DESCRIPTION
The instructions for launching an extern controller in MATLAB were not correct.
Also, the test in the MATLAB launcher was broken when run with nightly builds.

Link to [documentation](https://cyberbotics.com/doc/guide/running-extern-robot-controllers?tab-language=matlab&version=fix-matlab-launcher#environment-variables).