### PR TITLE
Fixed supervisor crash

### DIFF
--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -45,6 +45,7 @@ It can be read from the robot controller using the `wb_robot_get_custom_data` fu
 It may also be used as a convenience for communicating between a robot and a supervisor without implementing a Receiver / Emitter system: The supervisor can read and write in this field using the generic supervisor functions for accessing fields.
 
 - `supervisor`: if the value is `TRUE` the robot will have [supervisor capabilities](supervisor.md).
+You will have to save and reload the simulation if you change this field from the scene tree, so that the new value is actually taken into account.
 
 - `synchronization`: if the value is `TRUE` (default value), the simulator is synchronized with the controller; if the value is `FALSE`, the simulator runs as fast as possible, without waiting for the controller.
 The `wb_robot_get_synchronization` function can be used to read the value of this field from a controller program.

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -176,8 +176,7 @@ WbRobot::~WbRobot() {
   delete mKinematicDifferentialWheels;
   if (mMouse)
     WbMouse::destroy(mMouse);
-  if (mSupervisorUtilities)
-    delete mSupervisorUtilities;
+  delete mSupervisorUtilities;
   mPressedKeys.clear();
   WbWorld::instance()->removeRobotIfPresent(this);
 }
@@ -682,7 +681,7 @@ void WbRobot::writeConfigure(QDataStream &stream) {
   mBatterySensor->connectToRobotSignal(this);
   stream << (short unsigned int)0;
   stream << (unsigned char)C_CONFIGURE;
-  stream << (unsigned char)(supervisor() ? 1 : 0);
+  stream << (unsigned char)(mSupervisorUtilities ? 1 : 0);
   stream << (unsigned char)(synchronization() ? 1 : 0);
   stream << (short int)(1 + deviceCount());
   stream << (short int)nodeType();


### PR DESCRIPTION
Fixes #1441.

This patch will prevent Webots from crashing following the procedure described in #1441.
However, the supervisor will not be working until the world is saved and reloaded.