### PR TITLE
Fix Simulation Reset Timming

### DIFF
--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -269,6 +269,14 @@ void WbControlledWorld::processWaitingStep() {
   }
 }
 
+void WbControlledWorld::reset(bool restartControllers) {
+  WbSimulationWorld::reset(restartControllers);
+  if (!restartControllers) {
+    foreach (WbController *controller, mControllers)
+      controller->resetRequestTime();
+  }
+}
+
 void WbControlledWorld::step() {
   if (mFirstStep && !mRetryEnabled) {
     startControllers();

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -41,6 +41,8 @@ public:
   void writePendingImmediateAnswer();
   bool isExecutingStep() const { return mIsExecutingStep; }
 
+  void reset(bool restartControllers) override;
+
   void step() override;
 
 public slots:

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -175,6 +175,10 @@ void WbController::updateName(const QString &name) {
   mPrefix = QString("[%1] ").arg(mName);
 }
 
+void WbController::resetRequestTime() {
+  mRequestTime = WbSimulationState::instance()->time();
+}
+
 bool WbController::isRunning() const {
   return mRobot->isControllerStarted() && !mHasBeenTerminatedByItself;
 }

--- a/src/webots/control/WbController.hpp
+++ b/src/webots/control/WbController.hpp
@@ -55,6 +55,7 @@ public:
   const QString &args() const;
   bool synchronization() const { return mRobot->synchronization(); }
   double requestTime() const { return mRequestTime; }
+  void resetRequestTime();
   bool isIncompleteRequest() const { return mIncompleteRequest; }
   unsigned int deltaTimeRequested() const { return mDeltaTimeRequested; }
   bool isRequestPending() const { return mRequestPending; }

--- a/tests/api/worlds/supervisor_reset_simulation.wbt
+++ b/tests/api/worlds/supervisor_reset_simulation.wbt
@@ -3,6 +3,7 @@ WorldInfo {
   info [
     "Test world resetting the simulation"
   ]
+  basicTimeStep 8
 }
 Viewpoint {
   orientation 0.3011392881427894 -0.8944857953945254 -0.3304698034227591 4.845225060401701


### PR DESCRIPTION
**Description**
When the supervisor controller resetting the simulation was using a bigger step value than the world, its step was then very long because the controller 'request time' was stuck at the time before the reset.

**Related Issues**
This pull-request fixes issue #1439
