### PR TITLE
Fix motorized ball joint revert

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -22,6 +22,7 @@ Released on XXX.
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
+    - Fixed crash when resetting worlds with motorized [BallJoint](balljoint.md) nodes (thanks to lordNil).
     - Fixed addition of PROTO nodes including a [Connector](connector.md) node from the Add Node dialog (thanks to Acwok).
     - Fixed the [`wb_display_image_load`](display.md#wb_display_image_load) function when used with a PNG image with transparency.
     - Fixed color of the bounding objects remaining in the collision state if the collision was lasting only one step (thanks to Acwok).

--- a/src/webots/nodes/WbBallJoint.hpp
+++ b/src/webots/nodes/WbBallJoint.hpp
@@ -41,6 +41,7 @@ public:
   void resetPhysics() override;
   void save() override;
   QVector<WbLogicalDevice *> devices() const override;
+  dJointID jointID() const override { return mControlMotor; }
   bool resetJointPositions() override;
   void setPosition(double position, int index = 1) override;
   double position(int index = 1) const override;

--- a/src/webots/nodes/WbBasicJoint.hpp
+++ b/src/webots/nodes/WbBasicJoint.hpp
@@ -60,7 +60,7 @@ public:
   WbSolid *solidEndPoint() const;
   WbSolidReference *solidReference() const;
   WbSolid *solidParent() const;
-  dJointID jointID() const { return mJoint; }
+  virtual dJointID jointID() const { return mJoint; }
   // endPoint Solid translation and rotation if joint position is 0
   const WbVector3 &zeroEndPointTranslation() const { return mEndPointZeroTranslation; }
   const WbRotation &zeroEndPointRotation() const { return mEndPointZeroRotation; }


### PR DESCRIPTION
**Description**
Fixed crash when resetting worlds with motorized BallJoint nodes.
The BallJoint is a special case, because the motor control is not applied to the main joint but on an auxiliary joint.

**Related Issues**
This pull-request fixes issue #1454
