### PR TITLE
Fix Supervisor set Orientation Normalization

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -30,7 +30,7 @@ Released on XXX.
     - Fixed Matlab API.
     - Fixed missing stdout/stderr flush when a controller is changed or restarted while simulation is running (thanks to tsampazk).
     - Fixed the ROS controller of the Universal Robots UR3e, UR5e and UR10e to send the success state when a trajectory succeeded (thanks to Tim-Stoll).
-    - Fxed the [`wb_supervisor_field_set_sf_rotation`](supervisor.md#wb_supervisor_field_set_sf_rotation) and [`wb_supervisor_field_set_mf_rotation`](supervisor.md#wb_supervisor_field_set_mf_rotation) functions to handle non-normalized rotations.
+    - Fixed the [`wb_supervisor_field_set_sf_rotation`](supervisor.md#wb_supervisor_field_set_sf_rotation) and [`wb_supervisor_field_set_mf_rotation`](supervisor.md#wb_supervisor_field_set_mf_rotation) functions to handle non-normalized rotations.
     - Fixed a crash when trying to add an [IndexedLineSet](indexedlineset.md) node to a geometry's [Shape](shape.md) node with no coordinates.
 
 ## Webots R2020a Revision 1

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -30,6 +30,7 @@ Released on XXX.
     - Fixed Matlab API.
     - Fixed missing stdout/stderr flush when a controller is changed or restarted while simulation is running (thanks to tsampazk).
     - Fixed the ROS controller of the Universal Robots UR3e, UR5e and UR10e to send the success state when a trajectory succeeded (thanks to Tim-Stoll).
+    - Fxed the [`wb_supervisor_field_set_sf_rotation`](supervisor.md#wb_supervisor_field_set_sf_rotation) and [`wb_supervisor_field_set_mf_rotation`](supervisor.md#wb_supervisor_field_set_mf_rotation) functions to handle non-normalized rotations.
     - Fixed a crash when trying to add an [IndexedLineSet](indexedlineset.md) node to a geometry's [Shape](shape.md) node with no coordinates.
 
 ## Webots R2020a Revision 1

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -194,6 +194,7 @@ public:
     mValue(x, y, z, a) {
     assert((f->type() == WB_SF_ROTATION && dynamic_cast<WbSFRotation *>(f->value()) && index == -1) ||
            (f->type() == WB_MF_ROTATION && dynamic_cast<WbMFRotation *>(f->value()) && index >= 0));
+    mValue.normalize();
   }
   void apply() const override {
     if (mIndex == -1)


### PR DESCRIPTION
**Description**
As reported by a user (https://stackoverflow.com/questions/60586220/problem-while-setting-a-specific-rotation-to-a-humanoid-robot-in-webots) if the rotation vector given to the `wb_supervisor_field_set_rotation` function is not normalized, the node was 'broken'.

Example controller:
```Python
from controller import Supervisor


supervisor = Supervisor()

timestep = int(supervisor.getBasicTimeStep())

rotation = supervisor.getFromDef('ROBOT').getField('rotation')
rotation.setSFRotation([1, 1, 0, 1.5708])

while supervisor.step(timestep) != -1:
    pass
```

master:
![master](https://user-images.githubusercontent.com/2461619/76732800-cef5f100-675f-11ea-84d1-79f9deb95210.png)

this branch:
![patch](https://user-images.githubusercontent.com/2461619/76732813-d3220e80-675f-11ea-94c2-ba28ba430252.png)

