### PR TITLE
Fixed Test Suite Crash.

### DIFF
--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -517,7 +517,10 @@ bool WbGeometry::isAValidBoundingObject(bool checkOde, bool warning) const {
 }
 
 int WbGeometry::triangleCount() const {
-  return wr_static_mesh_get_triangle_count(this->wrenMesh());
+  if (areWrenObjectsInitialized())
+    return wr_static_mesh_get_triangle_count(this->wrenMesh());
+  else
+    return 0;
 }
 
 ////////////////////////////////


### PR DESCRIPTION
**Description**
This crash was caused by a rare case when a supervisor changes a procedural field, the node was regenerated and the selection was temporarily set to a node whose mesh was not yet initialized.
