### PR TITLE
Apply patch to debug

### DIFF
--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -614,7 +614,8 @@ void WbTrack::prePhysicsStep(double ms) {
 
   // texture animation
   if (mTextureTransform) {
-    mTextureTransform->translate(mSurfaceVelocity * mTextureAnimationField->value());
+    // TODO: Set mTextureAnimationField tp 1.00/0.00
+    mTextureTransform->translate(0.001 * ms * mSurfaceVelocity * mTextureAnimationField->value());
     mTextureTransform->modifyWrenMaterial(mShape->wrenMaterial());
   }
 


### PR DESCRIPTION
This PR will rewire the textureAnimation mechanism so it will be related to the WorldInfo.basicTimeStep, as such the Track.textureAnimation will be deprecated