### PR TITLE
Fix Test Failure rosdep Missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,7 @@ jobs:
             - fakeroot
             - pbzip2
             - libxkbcommon-x11-dev
+            - python-rosdep
     - &distribution_staging
       stage: Distribution
       if: type = cron OR commit_message IN (travis_distrib, travis_distrib_only) OR (NOT tag =~ ^nightly_ AND tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,6 +186,10 @@ jobs:
             - fakeroot
             - pbzip2
             - libxkbcommon-x11-dev
+      script:  # TODO: remove this part once ROS melodic is fixed to restore the ROS test.
+        - make release -j2
+        - make release -j2 -C tests
+        - python tests/test_suite.py --no-ansi-escape --nomake
     - &distribution_staging
       stage: Distribution
       if: type = cron OR commit_message IN (travis_distrib, travis_distrib_only) OR (NOT tag =~ ^nightly_ AND tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,7 @@ jobs:
         - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
         - sudo apt update -qq
         - sudo apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf
+        - sudo apt-get install -y python-rosdep
         - sudo rosdep init
         - rosdep update
         - pip install rospkg catkin_pkg empy defusedxml netifaces  # by default ros only comes with python2.7 libraries
@@ -185,7 +186,6 @@ jobs:
             - fakeroot
             - pbzip2
             - libxkbcommon-x11-dev
-            - python-rosdep
     - &distribution_staging
       stage: Distribution
       if: type = cron OR commit_message IN (travis_distrib, travis_distrib_only) OR (NOT tag =~ ^nightly_ AND tag IS present)


### PR DESCRIPTION
**Description**
An update of ROS melodic did break the test suite because the `rosdep` command is not available anymore.