### PR TITLE
fix python2.7 should be optional to compile webots

### DIFF
--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -28,7 +28,7 @@ endif
 .PHONY: release debug profile clean
 
 release debug profile: $(TARGETS)
-	cp python27/*managers.* python  # kept for backward compatibility with < R2019b
+	cp python27/*managers.* python || true # kept for backward compatibility with < R2019b
 
 clean: $(TARGETS)
 	# Remove python/*managers.* except python/managers.i


### PR DESCRIPTION
Closes #1470 

This fix will not block the make process when compiling webots with no python2.7 installed.