### PR TITLE
Update Travis OSX Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
       if: type = cron OR commit_message IN (travis_sources, travis_unit, travis_release, travis_distrib) OR (NOT tag =~ ^nightly_ AND tag IS present)
       name: OSX / Python 2.7
       os: osx
-      osx_image: xcode10.2  # Xcode: 10.2.1  |  macOS: 10.14
+      osx_image: xcode11.3  # Xcode: 11.3.1  |  macOS: 10.14
       language: generic     # Travis doesn't support python on macos yet
       addons:
         homebrew:
@@ -231,7 +231,7 @@ jobs:
     - <<: *distribution_staging
       name: OSX / Python 2.7
       os: osx
-      osx_image: xcode10.2  # Xcode: 10.2.1  |  macOS: 10.14
+      osx_image: xcode11.3  # Xcode: 11.3.1  |  macOS: 10.14
       language: generic     # Travis doesn't support python on macos yet
       addons: &mac_addons
         homebrew:
@@ -282,7 +282,7 @@ jobs:
       if: commit_message IN (travis_release, travis_release_only)
       name: OSX / Python 2.7
       os: osx
-      osx_image: xcode10.2  # Xcode: 10.2.1  |  macOS: 10.14
+      osx_image: xcode11.3  # Xcode: 11.3.1  |  macOS: 10.14
       language: generic     # Travis doesn't support python on macos yet
       addons: *mac_addons
       before_install: *mac_before_install


### PR DESCRIPTION
**Description**
This PR updates Travis to use the latest version of Xcode.

This new version is available on Travis since two month ago: https://changelog.travis-ci.com/xcode-11-3-1-is-now-available-136765