### PR TITLE
using Ros::fixedNameString() for fixing String in RosDistanceSensor.cpp

### DIFF
--- a/projects/default/controllers/ros/RosDistanceSensor.cpp
+++ b/projects/default/controllers/ros/RosDistanceSensor.cpp
@@ -18,11 +18,7 @@
 RosDistanceSensor::RosDistanceSensor(DistanceSensor *distanceSensor, Ros *ros) :
   RosSensor(distanceSensor->getName(), distanceSensor, ros) {
   mDistanceSensor = distanceSensor;
-  std::string deviceNameFixed = mDistanceSensor->getName();
-  for (size_t i = 0; i < deviceNameFixed.size(); i++) {
-    if (deviceNameFixed[i] == '-' || deviceNameFixed[i] == ' ')
-      deviceNameFixed[i] = '_';
-  }
+  std::string deviceNameFixed = Ros::fixedNameString(mDistanceSensor->getName());
   mMinValueServer = RosDevice::rosAdvertiseService((ros->name()) + '/' + deviceNameFixed + '/' + "get_min_value",
                                                    &RosDistanceSensor::getMinValueCallback);
   mMaxValueServer = RosDevice::rosAdvertiseService((ros->name()) + '/' + deviceNameFixed + '/' + "get_max_value",


### PR DESCRIPTION
**Description**
using Ros::fixedNameString() in `RosDistanceSensor.cpp` for fixing String instead of own, faulty implementation (`.` not handled).

**Screenshots**
fixes `ros::InvalidNameException` when using `Thymio_II` with ROS: http://prntscr.com/rpzfmc