### PR TITLE
Fix OpenGL error with contact point optionnal rendering

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -39,6 +39,7 @@ Released on XXX.
     - Fixed MATLAB API.
     - Fixed missing stdout/stderr flush when a controller is changed or restarted while simulation is running (thanks to tsampazk).
     - Fixed the ROS controller of the Universal Robots UR3e, UR5e and UR10e to send the success state when a trajectory succeeded (thanks to Tim-Stoll).
+    - Fixed the `Show Contact Points` optional rendering which was causing an OpenGL error.
     - Fixed the [`wb_supervisor_field_set_sf_rotation`](supervisor.md#wb_supervisor_field_set_sf_rotation) and [`wb_supervisor_field_set_mf_rotation`](supervisor.md#wb_supervisor_field_set_mf_rotation) functions to handle non-normalized rotations.
     - Fixed a crash when trying to add an [IndexedLineSet](indexedlineset.md) node to a geometry's [Shape](shape.md) node with no coordinates.
     - Fixed a crash related to [InertialUnit](inertialunit.md) node when gravity was null.

--- a/src/wren/DynamicMesh.cpp
+++ b/src/wren/DynamicMesh.cpp
@@ -123,23 +123,27 @@ namespace wren {
 
   void DynamicMesh::clear(bool vertices, bool normals, bool textureCoordinates, bool colors) {
     if (vertices) {
-      mCoords.clear();
-      mShadowCoords.clear();
-      mCoordsDirty = true;
-      mSupportShadows = true;
+      if (mCoords.size() > 0) {
+        mCoords.clear();
+        mCoordsDirty = true;
+      }
+      if (mShadowCoords.size() > 0) {
+        mShadowCoords.clear();
+        mSupportShadows = true;
+      }
     }
 
-    if (normals) {
+    if (normals && mNormals.size() > 0) {
       mNormals.clear();
       mNormalsDirty = true;
     }
 
-    if (textureCoordinates) {
+    if (textureCoordinates && mTexCoords.size() > 0) {
       mTexCoords.clear();
       mTexCoordsDirty = true;
     }
 
-    if (colors) {
+    if (colors && mColors.size() > 0) {
       mColors.clear();
       mColorsDirty = true;
     }

--- a/src/wren/DynamicMesh.hpp
+++ b/src/wren/DynamicMesh.hpp
@@ -51,8 +51,8 @@ namespace wren {
     void release() override;
     void render(unsigned int drawingMode) override;
     void clear() override {
-      Mesh::clear();
       clear(true, mHasNormals, mHasTextureCoordinates, mHasColorPerVertex);
+      Mesh::clear();
     }
     void clear(bool vertices, bool normals, bool textureCoordinates, bool colors);
 


### PR DESCRIPTION
**Description**
When the contact point optional rendering is enabled an OpenGL error was displayed in the console.
This was because an empty mesh was cleared and therefore the `mCoordsDirty` flag was set to true while it should not because the mesh was not changed.

This PR might also slightly improve performance (but it is difficult to measure it) since the dirty flags are not triggering useless updates anymore.

**Related Issues**
This pull-request fixes issue #1434