### PR TITLE
Fix Add Node Dialog Crash

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -33,6 +33,7 @@ Released on XXX.
     - Fixed the C/C++ Makefiles to handle spaces in the Webots installation directory.
     - Fixed crash when resetting worlds with motorized [BallJoint](balljoint.md) nodes (thanks to lordNil).
     - Fixed addition of PROTO nodes including a [Connector](connector.md) node from the Add Node dialog (thanks to Acwok).
+    - Fixed crash when using the search bar of the Add Node dialog.
     - Fixed the [`wb_display_image_load`](display.md#wb_display_image_load) function when used with a PNG image with transparency.
     - Fixed color of the bounding objects remaining in the collision state if the collision was lasting only one step (thanks to Acwok).
     - Fixed rare issue with the [`wb_supervisor_simulation_reset`](supervisor.md#wb_supervisor_simulation_reset) function when the controller step is not equal to the simulation step.

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -445,7 +445,6 @@ void WbAddNodeDialog::buildTree() {
       QTreeWidgetItem *const child = new QTreeWidgetItem(mUsesItem, strl);
 
       child->setIcon(0, QIcon("enabledIcons:node.png"));
-      item->addChild(child);
     }
   }
 


### PR DESCRIPTION
**Description**
This was causing a crash when using the search bar of the add node dialog if the result was not giving any result in the base node but a result in the USE node.
I am seeing sporadically this bug since a very long time ago but I am happy that I finally managed to reproduce it in a 100% reproducible way.