### PR TITLE
Fix typo and add link

### DIFF
--- a/docs/reference/jointparameters.md
+++ b/docs/reference/jointparameters.md
@@ -30,7 +30,7 @@ When changing the `position` field from the Webots scene tree, Webots also chang
 Similarly, when changing the `position` field of a [JointParameters](#jointparameters) node in a text editor, you should take care of also changing the corresponding `rotation` or `translation` field accordingly.
 
 - The `minStop` and `maxStop` fields specify the position of physical (or mechanical) stops.
-These fields are described in more detail in the "Joint Limits" section, see below.
+These fields are described in more detail in the [Joint Limits section](https://www.cyberbotics.com/doc/reference/jointparameters#joint-limits), see below.
 
 - The `springConstant` and `dampingConstant` fields allow the addition of spring and/or damping behavior to the joint.
 These fields are described in more detail in the "Springs and Dampers" section, see below.
@@ -82,7 +82,7 @@ When used for a rotational motion the value of `minStop` must be in the range [-
 When both `minStop` and `maxStop` are zero (the default), the hard limits are deactivated.
 The joint hard limits use ODE joint stops (for more information see the ODE documentation on `dParamLoStop` and `dParamHiStop`).
 
-Finally, note that when both soft (`minPosition` and `maxPosition`, see the [Motor](motor.md)'s "Motor Limits" section) and hard limits (`minStop` and `maxStop`) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minValue` and `maxStop>= maxValue`.
+Finally, note that when both soft (`minPosition` and `maxPosition`, see the [Motor](motor.md)'s "Motor Limits" section) and hard limits (`minStop` and `maxStop`) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
 
 ### Springs and Dampers
 

--- a/docs/reference/jointparameters.md
+++ b/docs/reference/jointparameters.md
@@ -82,7 +82,7 @@ When used for a rotational motion the value of `minStop` must be in the range [-
 When both `minStop` and `maxStop` are zero (the default), the hard limits are deactivated.
 The joint hard limits use ODE joint stops (for more information see the ODE documentation on `dParamLoStop` and `dParamHiStop`).
 
-Finally, note that when both soft (`minPosition` and `maxPosition`, see the [Motor](motor.md)'s "Motor Limits" section) and hard limits (`minStop` and `maxStop`) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
+Finally, note that when both soft (`minPosition` and `maxPosition`, see the [Motor](motor.md)'s "Motor Limits" section) and hard limits (`minStop` and `maxStop`) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxStop >= maxPosition`.
 
 ### Springs and Dampers
 

--- a/docs/reference/jointparameters.md
+++ b/docs/reference/jointparameters.md
@@ -30,7 +30,7 @@ When changing the `position` field from the Webots scene tree, Webots also chang
 Similarly, when changing the `position` field of a [JointParameters](#jointparameters) node in a text editor, you should take care of also changing the corresponding `rotation` or `translation` field accordingly.
 
 - The `minStop` and `maxStop` fields specify the position of physical (or mechanical) stops.
-These fields are described in more detail in the [Joint Limits section](https://www.cyberbotics.com/doc/reference/jointparameters#joint-limits), see below.
+These fields are described in more detail in the [Joint Limits section](#joint-limits), see below.
 
 - The `springConstant` and `dampingConstant` fields allow the addition of spring and/or damping behavior to the joint.
 These fields are described in more detail in the "Springs and Dampers" section, see below.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -199,7 +199,7 @@ When both `minPosition` and `maxPosition` are zero (the default), the soft limit
 Note that the soft limits can be overstepped when an external force which exceeds the motor force is applied to the motor.
 For example, it is possible that the weight of a robot exceeds the motor force that is required to hold it up.
 
-Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md#joint-limits)) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
+Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md#joint-limits)) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxStop >= maxPosition`.
 Moreover a simulation instability can appear if `position` is exactly equal to one of the bounds defined by the `minStop` and `maxStop` fields at the simulation startup.
 Warnings are displayed if theses rules are not respected.
 

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -199,7 +199,7 @@ When both `minPosition` and `maxPosition` are zero (the default), the soft limit
 Note that the soft limits can be overstepped when an external force which exceeds the motor force is applied to the motor.
 For example, it is possible that the weight of a robot exceeds the motor force that is required to hold it up.
 
-Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md)) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minValue` and `maxStop>= maxValue`.
+Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md)'s "Joint Limits" section) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
 Moreover a simulation instability can appear if `position` is exactly equal to one of the bounds defined by the `minStop` and `maxStop` fields at the simulation startup.
 Warnings are displayed if theses rules are not respected.
 

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -199,7 +199,7 @@ When both `minPosition` and `maxPosition` are zero (the default), the soft limit
 Note that the soft limits can be overstepped when an external force which exceeds the motor force is applied to the motor.
 For example, it is possible that the weight of a robot exceeds the motor force that is required to hold it up.
 
-Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md)'s "Joint Limits" section) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
+Finally, note that when both soft (`minPosition` and `maxPosition`) and hard limits (`minStop` and `maxStop`, see [JointParameters](jointparameters.md#joint-limits)) are activated, the range of the soft limits must be included in the range of the hard limits, such that `minStop <= minPosition` and `maxPosition <= maxStop`.
 Moreover a simulation instability can appear if `position` is exactly equal to one of the bounds defined by the `minStop` and `maxStop` fields at the simulation startup.
 Warnings are displayed if theses rules are not respected.
 


### PR DESCRIPTION
**Description**
- `JointParameters.md`
A space was missing in a formula and I added a link to reproduce the same structure as in the [motor](https://cyberbotics.com/doc/reference/motor) page.

- `Motor.md`
Adapt content to be the same as in [JointParameters](https://cyberbotics.com/doc/reference/jointParameters) page.

**Documentation**
[JointParameters](https://www.cyberbotics.com/doc/reference/jointparameters?version=michou214-patch-1)
[Motor](https://www.cyberbotics.com/doc/reference/motor?version=michou214-patch-1)

