### PR TITLE
Set SoccerBall recognition colors

### DIFF
--- a/projects/objects/balls/protos/SoccerBall.proto
+++ b/projects/objects/balls/protos/SoccerBall.proto
@@ -44,5 +44,8 @@ PROTO SoccerBall [
       mass IS mass
       density -1
     }
+    recognitionColors [
+      1 1 1, 0 0 0
+    ]
   }
 }


### PR DESCRIPTION
**Description**
Set the SoccerBall recognition colours so that it can be seen by camera recognition.