### PR TITLE
Replace Car 'maxWheelVelocity' field by a 'maxVelocity' field.

### DIFF
--- a/docs/automobile/car.md
+++ b/docs/automobile/car.md
@@ -13,6 +13,7 @@ Car {
   SFFloat    engineSoundRpmReference        1000
   SFFloat    brakeCoefficient               500
   SFFloat    time0To100                     10
+  SFFloat    maxVelocity                    50
   SFFloat    engineMaxTorque                250
   SFFloat    engineMaxPower                 50000
   SFFloat    engineMinRPM                   1000
@@ -33,7 +34,8 @@ See section [Engine models](driver-library.md#engine-models) for more informatio
 - `engineSoundRpmReference`: Defines the reference rotation per minutes of the engine sound.
 See the [Engine sound](#engine-sound) paragraph for more information about the engine sound simulation.
 - `brakeCoefficient`: Defines the maximum `dampingConstant` applied by the [Brake](../reference/brake.md) on the wheels joint.
-- `time0To100`: Defines the time to accelerate from 0 to 100 km/h in seconds, this value is used to compute the wheels acceleration when controlling the car in cruising speed thanks to the [driver](driver-library.md)
+- `time0To100`: Defines the time to accelerate from 0 to 100 km/h in seconds, this value is used to compute the wheels acceleration when controlling the car in cruising speed thanks to the [driver](driver-library.md).
+- `maxVelocity`: Defines the maximum velocity of the car in meters per second.
 - `engineMaxTorque`: Defines the maximum torque of the motor in `Nm` used to compute the electric engine torque.
 - `engineMaxPower`: Defines the maximum power of the motor in `W` used to compute the electric engine torque.
 - `engineMinRPM and engineMaxRPM`: Defines the working range of the engine (`engineMinRPM` not used in case of `electric` `engineType`).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -9,6 +9,7 @@ Released on XXX.
     - Added two new functions to get internal PROTO node fields: [`wb_supervisor_node_get_from_proto_def`](supervisor.md#wb_supervisor_node_get_from_proto_def) and [`wb_supervisor_node_get_proto_field`](supervisor.md#wb_supervisor_node_get_proto_field) ([#1331](https://github.com/cyberbotics/webots/pull/1331)).
   - Enhancements
     - **Improved [Track](track.md) `textureAnimation` field so that it automatically takes the world basic time step into consideration and removed it from `ConveyorBelt` PROTO object.** ([#1477](https://github.com/cyberbotics/webots/pull/1477)).
+    - **Replaced the [Car](../automobile/car.md) `maxWheelVelocity` field by a `maxVelocity` field representing the actual maximum velocity of the car itself.** ([#1552](https://github.com/cyberbotics/webots/pull/1552)).
     - Added the possibility to edit the `S/MFRotation` fields using quaternions ([#1491](https://github.com/cyberbotics/webots/pull/1491)).
     - Improved edition of `S/MFRotation` fields using the field editor spin-boxes, only the last decimal is now incremented ([#1491](https://github.com/cyberbotics/webots/pull/1491)).
     - Improved the Webots console by supporting more [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) escape codes and removed the controller name prefix ([#1508](https://github.com/cyberbotics/webots/pull/1508)).

--- a/projects/robots/saeon/protos/Altino.proto
+++ b/projects/robots/saeon/protos/Altino.proto
@@ -272,6 +272,6 @@ PROTO Altino [
     engineMinRPM            1
     engineMaxRPM            250
     gearRatio               [-30 30]
-    maxWheelVelocity         29.8
+    maxVelocity             0.596
   }
 }

--- a/projects/vehicles/protos/abstract/Car.proto
+++ b/projects/vehicles/protos/abstract/Car.proto
@@ -201,7 +201,7 @@ PROTO Car [
     -- compute the max velocity of the rotational motors from 'time0To100'
     local frontMaxVelocity = 0
     local rearMaxVelocity = 0
-    if fields.maxWheelVelocity.value != fields.maxWheelVelocity.defaultValue and fields.maxVelocity.value == fields.maxVelocity.defaultValue then
+    if fields.maxWheelVelocity.value ~= fields.maxWheelVelocity.defaultValue and fields.maxVelocity.value == fields.maxVelocity.defaultValue then
       io.stderr:write("Deprecated 'maxWheelVelocity' field, use the 'maxVelocity' field instead.\n")
       frontMaxVelocity = fields.maxWheelVelocity.value
       rearMaxVelocity = fields.maxWheelVelocity.value

--- a/projects/vehicles/protos/abstract/Car.proto
+++ b/projects/vehicles/protos/abstract/Car.proto
@@ -44,7 +44,8 @@ PROTO Car [
   field SFString   engineSound                    "sounds/engine.wav"
   field SFFloat    engineSoundRpmReference        1000
   field SFFloat    brakeCoefficient               700
-  field SFFloat    time0To100                     10.0
+  field SFFloat    time0To100                     10.0                       # Defines the acceleration of the car.
+  field SFFloat    maxVelocity                    50                         # Defines the maximum velocity [m/s] of the car.
   field SFFloat    engineMaxTorque                250                        # Defines the maximum torque of the motor [Nm] used to compute the electric engine torque.
   field SFFloat    engineMaxPower                 50000                      # Defines the maximum power of the motor [W] used to compute the electric engine torque.
   field SFFloat    engineMinRPM                   1000                       # Defines the minimum RPM of the motor (only used in the case of combustion engine).
@@ -53,7 +54,9 @@ PROTO Car [
   field MFFloat    gearRatio                      [-12 10 6.5 4.5 3.5 2.75]
   field SFFloat    hybridPowerSplitRatio          0.25                       # Defines power split ratio (only used in the case of 'power-split hybrid' engineType).
   field SFFloat    hybridPowerSplitRPM            3000                       # Defines the power split RPM (only used in the case of 'power-split hybrid' engineType).
-  field SFFloat    maxWheelVelocity               200
+
+  # Deprecated in R2020b
+  hiddenField SFFloat maxWheelVelocity -1.0
 ]
 {
   %{
@@ -181,7 +184,7 @@ PROTO Car [
       end
     end
 
-    -- compute the acelerations of the rotational motors from 'time0To100'
+    -- compute the accelerations of the rotational motors from 'time0To100'
     local frontAcceleration = 0
     local rearAcceleration = 0
     if frontTireRadius == -1 then -- use 0.4 if radius not found
@@ -194,6 +197,25 @@ PROTO Car [
       rearAcceleration = 1000 / 36 / time0To100 / 0.4
     else
       rearAcceleration = 1000 / 36 / time0To100 / rearTireRadius
+    end
+    -- compute the max velocity of the rotational motors from 'time0To100'
+    local frontMaxVelocity = 0
+    local rearMaxVelocity = 0
+    if fields.maxWheelVelocity.value != fields.maxWheelVelocity.defaultValue and fields.maxVelocity.value == fields.maxVelocity.defaultValue then
+      io.stderr:write("Deprecated 'maxWheelVelocity' field, use the 'maxVelocity' field instead.\n")
+      frontMaxVelocity = fields.maxWheelVelocity.value
+      rearMaxVelocity = fields.maxWheelVelocity.value
+    else
+      if frontTireRadius == -1 then
+        frontMaxVelocity = fields.maxVelocity.value / 0.4
+      else
+        frontMaxVelocity = fields.maxVelocity.value /  frontTireRadius
+      end
+      if rearTireRadius == -1 then
+        rearMaxVelocity = fields.maxVelocity.value / 0.4
+      else
+        rearMaxVelocity = fields.maxVelocity.value /  rearTireRadius
+      end
     end
 
     -- compute the 'customData' string which is used to communicate configuration of the vehicle to the library
@@ -277,7 +299,7 @@ PROTO Car [
       RotationalMotor {
         name "right_front_wheel"
         acceleration %{= frontAcceleration }%
-        maxVelocity IS maxWheelVelocity
+        maxVelocity %{= frontMaxVelocity }%
         maxTorque 100000000
         sound ""
       }
@@ -294,7 +316,7 @@ PROTO Car [
       RotationalMotor {
         name "left_front_wheel"
         acceleration %{= frontAcceleration }%
-        maxVelocity IS maxWheelVelocity
+        maxVelocity %{= frontMaxVelocity }%
         maxTorque 100000000
         sound ""
       }
@@ -311,7 +333,7 @@ PROTO Car [
       RotationalMotor {
         name "right_rear_wheel"
         acceleration %{= rearAcceleration }%
-        maxVelocity IS maxWheelVelocity
+        maxVelocity %{= rearMaxVelocity }%
         maxTorque 100000000
         sound ""
       }
@@ -328,7 +350,7 @@ PROTO Car [
       RotationalMotor {
         name "left_rear_wheel"
         acceleration %{= rearAcceleration }%
-        maxVelocity IS maxWheelVelocity
+        maxVelocity %{= rearMaxVelocity }%
         maxTorque 100000000
         sound ""
       }


### PR DESCRIPTION
**Description**
It is not intuitive at all to define the wheels maximum rotation speed for a car.

**Related Issues**
This pull-request fixes issue #1541.