### PR TITLE
Fix Unwanted Warning with Passive Connectors

### DIFF
--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -145,9 +145,12 @@ void WbConnector::updateType() {
 }
 
 void WbConnector::updateIsLocked() {
-  if (mFaceType == PASSIVE && mIsLocked->isTrue()) {
-    warn(tr("Passive connectors cannot be locked."));
-    mIsLocked->setFalse();
+  if (mFaceType == PASSIVE) {
+    if (mIsLocked->isTrue()) {
+      warn(tr("Passive connectors cannot be locked."));
+      mIsLocked->setFalse();
+    }
+    return;
   }
 
   if (mIsLocked->isTrue())


### PR DESCRIPTION
**Description**
The calls to the lock/unlock introduced in #1518 should not occurs in the passive case otherwise they raise a warning.