### PR TITLE
Add libpjeg to tarball package

### DIFF
--- a/src/packaging/webots_distro.c
+++ b/src/packaging/webots_distro.c
@@ -1160,6 +1160,7 @@ static void create_file(const char *name, int m) {
 #endif
       // libraries common to Ubuntu 16.04 and 18.04
       fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/libfreeimage.so.3 debian/usr/local/webots/lib/webots\n");
+      fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/libjpeg.so.8 debian/usr/local/webots/lib/webots\n");
       fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/libjxrglue.so.0 debian/usr/local/webots/lib/webots\n");
       fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/libopenjp2.so.7 debian/usr/local/webots/lib/webots\n");
       fprintf(fd, "cp /usr/lib/x86_64-linux-gnu/libjpegxr.so.0 debian/usr/local/webots/lib/webots\n");


### PR DESCRIPTION
**Description**
Follow-up of https://github.com/cyberbotics/webots/issues/1520#issuecomment-615372716

Since this library is very small (300ko) and not easy to install on all the distributions of linux, I think we can afford to add it to the tarball package.