### PR TITLE
Use safe temporary directory on Linux

### DIFF
--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -139,11 +139,13 @@ const char *wbu_system_webots_tmp_path() {
   const size_t l = strlen(tmp);
   const char *WEBOTS_PID = getenv("WEBOTS_PID");
   int webots_pid = 0;
+  char random_part[16];
+  random_part[0] = '\0';
   if (WEBOTS_PID && strlen(WEBOTS_PID) > 0)
     sscanf(WEBOTS_PID, "%d", &webots_pid);
-  const size_t path_buffer_size = l + 32;  // enough room to hold tmp + "/webots-XXXX...XXX" (pid_t maximum string length)
+  const size_t path_buffer_size = l + 64;
   char *path_buffer = malloc(path_buffer_size);
-  if (webots_pid == 0) {  // get the webots pid from the most recent "webots-XXX" folder
+  if (webots_pid == 0) {  // get the webots pid from the most recent "webots-<PID>-XXXXXX" folder
     DIR *dir;
     dir = opendir(tmp);
     if (dir) {
@@ -159,8 +161,29 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (s.st_mtime < most_recent)
             continue;
-          sscanf(entry->d_name, "webots-%d", &webots_pid);
+          sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
           most_recent = s.st_mtime;
+        }
+      }
+      closedir(dir);
+    }
+  } else {  // get the random part
+    DIR *dir;
+    dir = opendir(tmp);
+    if (dir) {
+      struct dirent *entry;
+      char folder_start[32];
+      sprintf(folder_start, "webots-%d", webots_pid);
+      while ((entry = readdir(dir))) {
+        if (strncmp(entry->d_name, folder_start, strlen(folder_start)) == 0) {
+          struct stat s;
+          snprintf(path_buffer, path_buffer_size, "%s/%s", tmp, entry->d_name);
+          if (stat(path_buffer, &s) < 0)
+            continue;
+          if (!S_ISDIR(s.st_mode))
+            continue;
+          sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
+          break;
         }
       }
       closedir(dir);
@@ -170,7 +193,7 @@ const char *wbu_system_webots_tmp_path() {
     free(path_buffer);
     path_buffer = NULL;
   } else
-    snprintf(path_buffer, path_buffer_size, "%s/webots-%d", tmp, webots_pid);
+    snprintf(path_buffer, path_buffer_size, "%s/webots-%d%s", tmp, webots_pid, random_part);
   WEBOTS_TMP_PATH = path_buffer;
   return WEBOTS_TMP_PATH;
 }

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -139,7 +139,7 @@ const char *wbu_system_webots_tmp_path() {
   const size_t l = strlen(tmp);
   const char *WEBOTS_PID = getenv("WEBOTS_PID");
   int webots_pid = 0;
-  char random_part[16];
+  char random_part[64];
   random_part[0] = '\0';
   if (WEBOTS_PID && strlen(WEBOTS_PID) > 0)
     sscanf(WEBOTS_PID, "%d", &webots_pid);
@@ -161,6 +161,9 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (s.st_mtime < most_recent)
             continue;
+          if (strlen(entry->d_name) > 64)
+            continue;
+          // cppcheck-suppress invalidscanf
           sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
           most_recent = s.st_mtime;
         }
@@ -182,6 +185,9 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (!S_ISDIR(s.st_mode))
             continue;
+          if (strlen(entry->d_name) > 64)
+            continue;
+          // cppcheck-suppress invalidscanf
           sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
           break;
         }

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -186,8 +186,7 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (strlen(entry->d_name) > 64)
             continue;
-          // cppcheck-suppress invalidscanf
-          sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
+          sscanf(entry->d_name, "webots-%d%64s", &webots_pid, random_part);
           break;
         }
       }

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -163,8 +163,7 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (strlen(entry->d_name) > 64)
             continue;
-          // cppcheck-suppress invalidscanf
-          sscanf(entry->d_name, "webots-%d%63s", &webots_pid, random_part);
+          sscanf(entry->d_name, "webots-%d%64s", &webots_pid, random_part);
           most_recent = s.st_mtime;
         }
       }

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -143,7 +143,7 @@ const char *wbu_system_webots_tmp_path() {
   random_part[0] = '\0';
   if (WEBOTS_PID && strlen(WEBOTS_PID) > 0)
     sscanf(WEBOTS_PID, "%d", &webots_pid);
-  const size_t path_buffer_size = l + 64;
+  const size_t path_buffer_size = l + 8 + 9 + sizeof(random_part) + 1; // add 8 for "/webots-", 9 for the PID and 1 for the final '\0'
   char *path_buffer = malloc(path_buffer_size);
   if (webots_pid == 0) {  // get the webots pid from the most recent "webots-<PID>-XXXXXX" folder
     DIR *dir;

--- a/src/lib/Controller/api/system.c
+++ b/src/lib/Controller/api/system.c
@@ -164,7 +164,7 @@ const char *wbu_system_webots_tmp_path() {
           if (strlen(entry->d_name) > 64)
             continue;
           // cppcheck-suppress invalidscanf
-          sscanf(entry->d_name, "webots-%d%s", &webots_pid, random_part);
+          sscanf(entry->d_name, "webots-%d%63s", &webots_pid, random_part);
           most_recent = s.st_mtime;
         }
       }

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -61,12 +61,15 @@ fi
 
 export TMPDIR=$WEBOTS_TMPDIR
 
+# safely create a temporary directory.
+# Note that the following two lines cannot be merged into one because `export` would "hide" the return status of `mktemp`.
+WEBOTS_TMP_PATH="$(mktemp -d $TMPDIR/webots-XXXXXX)/" || exit 1
+export WEBOTS_TMP_PATH
+
+
 # create temporary lib directory
-TMP_LIB_DIR="$TMPDIR/webots-$$/lib"
-if [ ! -d $TMP_LIB_DIR ]; then
-  mkdir -p $TMP_LIB_DIR
-fi
-export WEBOTS_TMP_PATH="$TMPDIR/webots-$$/"
+TMP_LIB_DIR="$WEBOTS_TMP_PATH/lib"
+mkdir -p $TMP_LIB_DIR
 
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
 export LD_LIBRARY_PATH="$webots_home/lib/webots/":$TMP_LIB_DIR:$LD_LIBRARY_PATH

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -66,7 +66,6 @@ export TMPDIR=$WEBOTS_TMPDIR
 WEBOTS_TMP_PATH="$(mktemp -d $TMPDIR/webots-XXXXXX)/" || exit 1
 export WEBOTS_TMP_PATH
 
-
 # create temporary lib directory
 TMP_LIB_DIR="$WEBOTS_TMP_PATH/lib"
 mkdir -p $TMP_LIB_DIR

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -63,7 +63,7 @@ export TMPDIR=$WEBOTS_TMPDIR
 
 # safely create a temporary directory.
 # Note that the following two lines cannot be merged into one because `export` would "hide" the return status of `mktemp`.
-WEBOTS_TMP_PATH="$(mktemp -d $TMPDIR/webots-XXXXXX)/" || exit 1
+WEBOTS_TMP_PATH="$(mktemp -d $TMPDIR/webots-$$-XXXXXX)/" || exit 1
 export WEBOTS_TMP_PATH
 
 # create temporary lib directory


### PR DESCRIPTION
**Description**
The Linux launcher created a predictable temporary directory in an unsafe fashion.

**Related Issues**
This pull-request solves the most critical part of #1566

**Tasks**
Check all non-standard use-cases on Linux
  - [x] snap package
  - [x] external controllers
  - [x] anything else that uses TMPDIR, WEBOTS_TEMP_PATH etc.