### PR TITLE
Fixed startup from a CMD console

### DIFF
--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -121,7 +121,11 @@ int main(int argc, char *argv[]) {
   const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../..").canonicalPath();
 #else
   // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
-  const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../../..").canonicalPath();
+  const int BUFFER_SIZE = 4096;
+  char *modulePath = new char[BUFFER_SIZE];
+  GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
+  const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
+  delete modulePath;
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -121,6 +121,7 @@ int main(int argc, char *argv[]) {
   const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../..").canonicalPath();
 #else
   // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
+  // we need to use GetModuleFileName as argv[0] doesn't always provide an absolute path
   const int BUFFER_SIZE = 4096;
   char *modulePath = new char[BUFFER_SIZE];
   GetModuleFileName(NULL, modulePath, BUFFER_SIZE);

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
   char *modulePath = new char[BUFFER_SIZE];
   GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
   const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
-  delete modulePath;
+  delete[] modulePath;
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");


### PR DESCRIPTION
Following-up some bug report by a user attempting to launch Webots from a DOS console, I found that the reference to the `qt_warning_filters.conf` was wrong because it was computed from `argv[0]` which doesn't always contain a full path on Windows, but sometimes a local path. This PR relies on `GetModuleFileName` which always returns a full path and guarantees that `qt_warning_filters.conf` is computed from an absolute path and hence is correct.