### PR TITLE
fix icon path

### DIFF
--- a/src/packaging/webots.desktop
+++ b/src/packaging/webots.desktop
@@ -2,7 +2,7 @@
 Name=Webots
 Comment=Webots mobile robot simulator
 Exec=webots
-Icon=usr/share/webots/resources/icons/core/webots.png
+Icon=/usr/local/webots/resources/icons/core/webots.png
 Terminal=false
 Type=Application
 X-AppInstall-Package=webots


### PR DESCRIPTION
Currently the `WEBOTS_HOME` on Ubuntu1804 is `/usr/local/webots`, so the icon is at `/usr/local/webots/resources/icons/core/webots.png`.