### PR TITLE
fix dir to create tar and update qt download link

### DIFF
--- a/src/install_scripts/qt_linux_installer.sh
+++ b/src/install_scripts/qt_linux_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# install the latest Qt from https://download.qt.io/official_releases/qt/
+# follow the instructions from https://github.com/cyberbotics/webots/wiki/Qt-compilation#linux to download and compile Qt before executing this script.
 
 QT_VERSION=5.13.1
 ICU_VERSION=56

--- a/src/install_scripts/qt_linux_installer.sh
+++ b/src/install_scripts/qt_linux_installer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# install the latest Qt from qt.org
+# install the latest Qt from https://download.qt.io/official_releases/qt/
 
 QT_VERSION=5.13.1
 ICU_VERSION=56
@@ -166,7 +166,7 @@ ln -sf libicuuc.so.$ICU_VERSION.1             libicuuc.so.$ICU_VERSION
 # we need to clear the execstack from this library to enable the creation of the snap package.
 execstack -c libQt5WebEngineCore.so.$QT_VERSION
 
-cd ..
+cd ../..
 
 ARCHIVE=webots-qt-$QT_VERSION-linux64-release.tar.bz2
 echo Compressing $ARCHIVE \(please wait\)


### PR DESCRIPTION
- It seems that we could not download qt from qt.org anymore, I suggest change it to https://download.qt.io/official_releases/qt/
- since change dir to `$WEBOTS_HOME/lib/webots` at [line 115](https://github.com/cyberbotics/webots/blob/08af20daa37028f1d076ba123b1d2b5fa6822d6a/src/install_scripts/qt_linux_installer.sh#L115), we should use `cd ../..` to change to `$WEBOTS_HOME`, or we could not find the target files when creating a tar.