### PR TITLE
Fixed resolution of Velodyne HDL-32E and HDL-64E.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -38,6 +38,7 @@ Released on XXX.
     - Fixed the physics behavior of [Connector](connector.md) nodes sometimes remaining idle after being detached from each other (thanks to Giorgio).
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
     - Fixed the motor torque and force feedback of the ros controller.
+    - Fixed horizontal resolution of Velodyne HDL-32E and HDL-64E [Lidars](lidar.md) (thanks to jrcblue).
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
     - Fixed warnings about duplicated `name` fields in the `TruckTank` PROTO node.

--- a/docs/reference/lidar.md
+++ b/docs/reference/lidar.md
@@ -195,7 +195,6 @@ This rotation starts as soon as the lidar is enabled.
 The internal depth camera is attached to this node and is therefore also rotating along the Y axis.
 
 > **Note**: The internal depth camera is using a horizontal field of view defined in the `fieldOfView` field, but since it is rotating, the actual field of view is 2 * &pi;.
-The same comment applies to the horizontal resolution, the internal depth camera is using a horizontal resolution defined in the `horizontalResolution` field, but the actual returned resolution of the lidar is equal to: horizontalResolution * 2 * pi / fieldOfView.
 
 > **Note**: If the resulting point cloud of a rotating lidar looks distorted, it probably means that you have to reduce the simulation time step.
 

--- a/projects/devices/velodyne/protos/VelodyneHDL-32E.proto
+++ b/projects/devices/velodyne/protos/VelodyneHDL-32E.proto
@@ -99,7 +99,7 @@ Lidar {
   }
   %{ end }%
   tiltAngle -0.349
-  horizontalResolution 1125   # 360 / 0.08 / 4
+  horizontalResolution 4500  # 360 / 0.08
   fieldOfView 1.570795 # 6.28318 / 4
   verticalFieldOfView 0.7215 # 41.34deg
   numberOfLayers 32

--- a/projects/devices/velodyne/protos/VelodyneHDL-32E.proto
+++ b/projects/devices/velodyne/protos/VelodyneHDL-32E.proto
@@ -100,7 +100,7 @@ Lidar {
   %{ end }%
   tiltAngle -0.349
   horizontalResolution 4500  # 360 / 0.08
-  fieldOfView 1.570795 # 6.28318 / 4
+  fieldOfView 1.570795       # 6.28318 / 4
   verticalFieldOfView 0.7215 # 41.34deg
   numberOfLayers 32
   near 0.1

--- a/projects/devices/velodyne/protos/VelodyneHDL-64E.proto
+++ b/projects/devices/velodyne/protos/VelodyneHDL-64E.proto
@@ -688,7 +688,7 @@ Lidar {
   %{ end }%
   tiltAngle -0.19896287
   horizontalResolution 4500  # 360 / 0.08
-  fieldOfView 1.570795  # 6.28318 / 4
+  fieldOfView 1.570795       # 6.28318 / 4
   verticalFieldOfView 0.468
   numberOfLayers 64
   minRange 0.8

--- a/projects/devices/velodyne/protos/VelodyneHDL-64E.proto
+++ b/projects/devices/velodyne/protos/VelodyneHDL-64E.proto
@@ -687,8 +687,8 @@ Lidar {
   }
   %{ end }%
   tiltAngle -0.19896287
-  horizontalResolution 1125   # 360 / 0.08 / 4
-  fieldOfView 1.570795 # 6.28318 / 4
+  horizontalResolution 4500  # 360 / 0.08
+  fieldOfView 1.570795  # 6.28318 / 4
   verticalFieldOfView 0.468
   numberOfLayers 64
   minRange 0.8


### PR DESCRIPTION
**Description**
The resolution of these two lidars were not correct, only the field of view of rotating lidars should be divided but not the resolution.

**Related Issues**
This pull-request fixes issue #1628
