### PR TITLE
Fixed missing dependencies

### DIFF
--- a/resources/web/wwi/Makefile
+++ b/resources/web/wwi/Makefile
@@ -107,7 +107,7 @@ webots.debug.js: $(JS_SOURCES) $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(THREEJS_SOURCE
 
 # JS module intended to be included in another module.
 # webots.lib.js is not processed with babel or minify and does not include three.js.
-webots.lib.js:
+webots.lib.js: $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) $(INSTALL_TOKEN)
 	@echo "# compressing webots.lib.js"
 	@cat $(LOCAL_THREEJS_EXAMPLE_SOURCES) $(JS_SOURCES) > $@
 


### PR DESCRIPTION
This was causing the creation of `webots.lib.js` to fail randomly because its dependencies were not yet downloaded.