### PR TITLE
Fixed Webots crash

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -32,6 +32,7 @@ Released on XXX.
   - Cleanup
     - Deprecated the following appearances: `ChequeredParquetry`, `DarkParquetry`, `SlatePavement`, `SquarePavement` and `StonePavement`.
   - Bug fixes
+    - Fixed crash occuring when setting a 3D coordinate to a huge value (greater than 1e+151).
     - Fixed crash occuring when Webots was streaming a 3D scene and some object was inserted into a PROTO node.
     - Fixed the restoration of the 3D view which was sometimes not re-appearing after being hidden.
     - Windows: Fixed JPEG texture errors when typing `webots` from a DOS console (`cmd.exe`) by renaming `webots.exe` to `webots-bin.exe` and creating two launchers named `webotsw.exe` and `webots.exe`.

--- a/projects/languages/cpp/controllers/driver/driver.cpp
+++ b/projects/languages/cpp/controllers/driver/driver.cpp
@@ -53,6 +53,7 @@ Driver::Driver() {
   x = 0.1f;
   z = 0.3f;
   translation[0] = x;
+  translation[1] = 0;
   translation[2] = z;
   emitter = getEmitter("emitter");
   Node *robot = getFromDef("ROBOT1");

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -999,7 +999,7 @@ static bool check_float(const char *function, double value) {
     return false;
   }
   if (value > FLT_MAX) {
-    fprintf(stderr, "Error: %s() called with a value greater FLX_MAX: %g > %g.\n", function, value, FLT_MAX);
+    fprintf(stderr, "Error: %s() called with a value greater than FLX_MAX: %g > %g.\n", function, value, FLT_MAX);
     return false;
   }
   if (value < -FLT_MAX) {

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -1039,9 +1039,25 @@ void wb_supervisor_set_label(int id, const char *text, double x, double y, doubl
   unsigned int color_and_transparency = (unsigned int)color;
   color_and_transparency += (unsigned int)(transparency * 0xff) << 24;
 
-  if (!check_float(__FUNCTION__, x) || !check_float(__FUNCTION__, y) || !check_float(__FUNCTION__, size) ||
-      !check_float(__FUNCTION__, transparency))
+  if (x < 0 || x > 1) {
+    fprintf(stderr, "Error: %s() called with x parameter outside of [0,1] range.\n", __FUNCTION__);
     return;
+  }
+
+  if (y < 0 || y > 1) {
+    fprintf(stderr, "Error: %s() called with y parameter outside of [0,1] range.\n", __FUNCTION__);
+    return;
+  }
+
+  if (size < 0 || size > 1) {
+    fprintf(stderr, "Error: %s() called with size parameter outside of [0,1] range.\n", __FUNCTION__);
+    return;
+  }
+
+  if (transparency < 0 || transparency > 1) {
+    fprintf(stderr, "Error: %s() called with transparency parameter outside of [0,1] range.\n", __FUNCTION__);
+    return;
+  }
 
   if (!robot_check_supervisor(__FUNCTION__))
     return;

--- a/src/webots/maths/WbVector2.hpp
+++ b/src/webots/maths/WbVector2.hpp
@@ -25,6 +25,7 @@
 #include <QtCore/QTextStream>
 
 #include <cassert>
+#include <cfloat>
 #include <cmath>
 
 class WbVector2 {

--- a/src/webots/maths/WbVector2.hpp
+++ b/src/webots/maths/WbVector2.hpp
@@ -129,6 +129,18 @@ public:
   // returns a unit vector with the same direction: / length
   void normalize() { *this /= length(); }
   WbVector2 normalized() const { return *this / length(); }
+
+  void clamp() {  // clamp to FLT_MAX
+    if (mX > FLT_MAX)
+      mX = FLT_MAX;
+    else if (mX < -FLT_MAX)
+      mX = -FLT_MAX;
+    if (mY > FLT_MAX)
+      mY = FLT_MAX;
+    else if (mY < -FLT_MAX)
+      mY = -FLT_MAX;
+  }
+
   // vector comparison
   bool operator==(const WbVector2 &v) const { return mX == v.mX && mY == v.mY; }
   bool operator!=(const WbVector2 &v) const { return mX != v.mX || mY != v.mY; }

--- a/src/webots/maths/WbVector2.hpp
+++ b/src/webots/maths/WbVector2.hpp
@@ -131,15 +131,15 @@ public:
   void normalize() { *this /= length(); }
   WbVector2 normalized() const { return *this / length(); }
 
-  void clamp() {  // clamp to FLT_MAX
-    if (mX > FLT_MAX)
-      mX = FLT_MAX;
-    else if (mX < -FLT_MAX)
-      mX = -FLT_MAX;
-    if (mY > FLT_MAX)
-      mY = FLT_MAX;
-    else if (mY < -FLT_MAX)
-      mY = -FLT_MAX;
+  void clamp(double min = -FLT_MAX, double max = FLT_MAX) {
+    if (mX > max)
+      mX = max;
+    else if (mX < min)
+      mX = min;
+    if (mY > max)
+      mY = max;
+    else if (mY < min)
+      mY = min;
   }
 
   // vector comparison

--- a/src/webots/maths/WbVector3.hpp
+++ b/src/webots/maths/WbVector3.hpp
@@ -25,6 +25,7 @@
 #include <QtCore/QTextStream>
 
 #include <cassert>
+#include <cfloat>
 #include <cmath>
 
 class WbVector3 {
@@ -149,6 +150,21 @@ public:
   // normalization: |length| = 1.0
   void normalize() { *this /= length(); }
   WbVector3 normalized() const { return *this / length(); }
+
+  void clamp() {  // clamp to FLT_MAX
+    if (mX > FLT_MAX)
+      mX = FLT_MAX;
+    else if (mX < -FLT_MAX)
+      mX = -FLT_MAX;
+    if (mY > FLT_MAX)
+      mY = FLT_MAX;
+    else if (mY < -FLT_MAX)
+      mY = -FLT_MAX;
+    if (mZ > FLT_MAX)
+      mZ = FLT_MAX;
+    else if (mZ < -FLT_MAX)
+      mZ = -FLT_MAX;
+  }
 
   WbVector3 rounded(WbPrecision::Level level) const {
     return WbVector3(WbPrecision::roundValue(mX, level), WbPrecision::roundValue(mY, level),

--- a/src/webots/maths/WbVector3.hpp
+++ b/src/webots/maths/WbVector3.hpp
@@ -151,19 +151,19 @@ public:
   void normalize() { *this /= length(); }
   WbVector3 normalized() const { return *this / length(); }
 
-  void clamp() {  // clamp to FLT_MAX
-    if (mX > FLT_MAX)
-      mX = FLT_MAX;
-    else if (mX < -FLT_MAX)
-      mX = -FLT_MAX;
-    if (mY > FLT_MAX)
-      mY = FLT_MAX;
-    else if (mY < -FLT_MAX)
-      mY = -FLT_MAX;
-    if (mZ > FLT_MAX)
-      mZ = FLT_MAX;
-    else if (mZ < -FLT_MAX)
-      mZ = -FLT_MAX;
+  void clamp(double min = -FLT_MAX, double max = FLT_MAX) {
+    if (mX > max)
+      mX = max;
+    else if (mX < min)
+      mX = min;
+    if (mY > max)
+      mY = max;
+    else if (mY < min)
+      mY = min;
+    if (mZ > max)
+      mZ = max;
+    else if (mZ < min)
+      mZ = min;
   }
 
   WbVector3 rounded(WbPrecision::Level level) const {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -137,6 +137,7 @@ private:
 class WbVector2FieldSetRequest : public WbFieldSetRequest {
 public:
   WbVector2FieldSetRequest(WbField *f, int index, double x, double y) : WbFieldSetRequest(f, index), mValue(x, y) {
+    mValue.clamp();
     assert((f->type() == WB_SF_VEC2F && dynamic_cast<WbSFVector2 *>(f->value()) && index == -1) ||
            (f->type() == WB_MF_VEC2F && dynamic_cast<WbMFVector2 *>(f->value()) && index >= 0));
   }
@@ -154,6 +155,7 @@ private:
 class WbVector3FieldSetRequest : public WbFieldSetRequest {
 public:
   WbVector3FieldSetRequest(WbField *f, int index, double x, double y, double z) : WbFieldSetRequest(f, index), mValue(x, y, z) {
+    mValue.clamp();
     assert((f->type() == WB_SF_VEC3F && dynamic_cast<WbSFVector3 *>(f->value()) && index == -1) ||
            (f->type() == WB_MF_VEC3F && dynamic_cast<WbMFVector3 *>(f->value()) && index >= 0));
   }

--- a/src/webots/scene_tree/WbVector2Editor.cpp
+++ b/src/webots/scene_tree/WbVector2Editor.cpp
@@ -98,7 +98,7 @@ void WbVector2Editor::apply() {
   else
     mVector2.setXy(WbPrecision::roundValue(mSpinBoxes[0]->value(), WbPrecision::GUI_MEDIUM),
                    WbPrecision::roundValue(mSpinBoxes[1]->value(), WbPrecision::GUI_MEDIUM));
-
+  mVector2.clamp();
   if (singleValue()) {
     WbSFVector2 *const sfVector2 = static_cast<WbSFVector2 *>(singleValue());
     if (sfVector2->value() == mVector2)

--- a/src/webots/scene_tree/WbVector3Editor.cpp
+++ b/src/webots/scene_tree/WbVector3Editor.cpp
@@ -109,7 +109,7 @@ void WbVector3Editor::apply() {
     mVector3.setXyz(WbPrecision::roundValue(mSpinBoxes[0]->value(), WbPrecision::GUI_MEDIUM),
                     WbPrecision::roundValue(mSpinBoxes[1]->value(), WbPrecision::GUI_MEDIUM),
                     WbPrecision::roundValue(mSpinBoxes[2]->value(), WbPrecision::GUI_MEDIUM));
-
+  mVector3.clamp();
   if (singleValue()) {
     WbSFVector3 *const sfVector3 = static_cast<WbSFVector3 *>(singleValue());
     if (sfVector3->value() == mVector3)

--- a/src/webots/vrml/WbSFVector2.cpp
+++ b/src/webots/vrml/WbSFVector2.cpp
@@ -21,6 +21,7 @@ void WbSFVector2::readSFVector2(WbTokenizer *tokenizer, const QString &worldPath
     double x = tokenizer->nextToken()->toDouble();
     double y = tokenizer->nextToken()->toDouble();
     mValue.setXy(x, y);
+    mValue.clamp();
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());
     tokenizer->ungetToken();  // unexpected token: keep the tokenizer coherent

--- a/src/webots/vrml/WbSFVector3.cpp
+++ b/src/webots/vrml/WbSFVector3.cpp
@@ -22,6 +22,7 @@ void WbSFVector3::readSFVector3(WbTokenizer *tokenizer, const QString &worldPath
     double y = tokenizer->nextToken()->toDouble();
     double z = tokenizer->nextToken()->toDouble();
     mValue.setXyz(x, y, z);
+    mValue.clamp();
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());
     tokenizer->ungetToken();  // unexpected token: keep the tokenizer coherent


### PR DESCRIPTION
Because this value was not initialized, Webots was receiving random values here, causing random crashes of Webots (observed on Windows).
However, we should also fix Webots as it should not crash when the controller is sending bad values.