### PR TITLE
Fix macOS cleanse target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ cleanse: clean
 ifeq ($(OSTYPE),windows)
 	@rm -rf msys64
 endif
+ifeq ($(OSTYPE),darwin)
+	@rm -rf Contents/Frameworks Contents/MacOS 
+endif
 	@+echo "#"; echo "# * tests *"; echo "#"
 	@find tests -name .*.cache | xargs rm -f
 	@+make --silent -C tests clean

--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -84,7 +84,7 @@ $(WEBOTS_DEPENDENCY_PATH)/freetype-2.9/objs/.libs/libfreetype.a:
 
 
 ffmpeg-clean:
-	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE) $(WEBOTS_HOME)/util/ffmpeg
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(FFMPEG_PACKAGE) $(WEBOTS_HOME)/util
 
 ffmpeg: $(WEBOTS_HOME)/util/ffmpeg
 
@@ -119,7 +119,7 @@ $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
 
 
 lua-gd-clean:
-	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME_LIB)/libgd.3.dylib $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(LUA_GD_PACKAGE) $(WEBOTS_HOME_LIB)/libgd.3.dylib $(WEBOTS_HOME)/resources/lua/modules/gd
 
 lua-gd: $(WEBOTS_HOME)/resources/lua/modules/gd/gd.dylib
 
@@ -151,7 +151,7 @@ $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0/libminiglu.a:
 
 
 ois-clean:
-	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/glu-9.0.0
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_HOME_LIB)/*OIS.dylib $(WEBOTS_HOME)/include/libOIS
 
 ois: $(WEBOTS_HOME_LIB)/libOIS.dylib
 

--- a/projects/robots/robotis/darwin-op/libraries/Makefile.mac
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile.mac
@@ -12,11 +12,10 @@ PACKAGES_CLEAN = $(addsuffix -clean, $(PACKAGES))
 
 WGET=LANG=en_US.UTF-8  wget
 
-.PHONY: release debug distrib profile clean cleanse $(PACKAGES) $(PACKAGES_CLEAN)
+.PHONY: release debug distrib profile clean $(PACKAGES) $(PACKAGES_CLEAN)
 
 release debug distrib profile: $(PACKAGES)
-clean:
-cleanse: $(PACKAGES_CLEAN)
+clean: $(PACKAGES_CLEAN)
 
 ssh-clean:
 	rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(SSH_PACKAGE) $(DARWIN_OP_LIB_PATH)/libssh


### PR DESCRIPTION
**Description**
The `cleanse` target was not fully functional on macOS as it was leaving many non-committed files.