### PR TITLE
Minor spelling mistake in compass.md

### DIFF
--- a/docs/reference/compass.md
+++ b/docs/reference/compass.md
@@ -184,4 +184,4 @@ If these values are needed for a longer period they must be copied.
 
 <!-- -->
 
-> **Note** [Python]: Ths `getValues` function returns the vector as a list containing three floats.
+> **Note** [Python]: The `getValues` function returns the vector as a list containing three floats.


### PR DESCRIPTION
Fix minor spelling mistake in compass.md
[https://cyberbotics.com/doc/reference/compass?version=master](https://cyberbotics.com/doc/reference/compass?version=master)
