### PR TITLE
Fixed Windows packaging

### DIFF
--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -19,9 +19,9 @@
 /mingw64/bin/Qt5Xml.dll
 /mingw64/bin/libbrotlicommon.dll
 /mingw64/bin/libbrotlidec.dll
-/mingw64/bin/libicuuc65.dll
-/mingw64/bin/libicuin65.dll
-/mingw64/bin/libicudt65.dll
+/mingw64/bin/libicuuc??.dll
+/mingw64/bin/libicuin??.dll
+/mingw64/bin/libicudt??.dll
 /mingw64/bin/libminizip-1.dll
 /mingw64/bin/libbz2-1.dll
 /mingw64/bin/libsqlite3-0.dll

--- a/src/packaging/files_msys64.txt
+++ b/src/packaging/files_msys64.txt
@@ -61,7 +61,6 @@
 # needed to execute the lua-gd module
 /mingw64/bin/libXpm-noX4.dll
 /mingw64/bin/libgd.dll
-/mingw64/bin/libzstd.dll
 /mingw64/bin/libtiff-5.dll
 
 # needed run the darwin-op remote control library


### PR DESCRIPTION
Fix #1650.
I am setting a generic version name for this *libicu* library whose version is changing quite often, so that this bug shouldn't strike back anytime soon.