### PR TITLE
Fix cppcheck 2.0 errors

### DIFF
--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -449,7 +449,7 @@ bool RosSupervisor::virtualRealityHeadsetIsUsedCallback(webots_ros::get_bool::Re
   return true;
 }
 
-bool RosSupervisor::nodeGetIdCallback(webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res) {
+bool RosSupervisor::nodeGetIdCallback(const webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -458,7 +458,8 @@ bool RosSupervisor::nodeGetIdCallback(webots_ros::node_get_id::Request &req, web
   return true;
 }
 
-bool RosSupervisor::nodeGetTypeCallback(webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res) {
+bool RosSupervisor::nodeGetTypeCallback(const webots_ros::node_get_type::Request &req,
+                                        webots_ros::node_get_type::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -467,7 +468,8 @@ bool RosSupervisor::nodeGetTypeCallback(webots_ros::node_get_type::Request &req,
   return true;
 }
 
-bool RosSupervisor::nodeGetTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
+bool RosSupervisor::nodeGetTypeNameCallback(const webots_ros::node_get_name::Request &req,
+                                            webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -476,7 +478,8 @@ bool RosSupervisor::nodeGetTypeNameCallback(webots_ros::node_get_name::Request &
   return true;
 }
 
-bool RosSupervisor::nodeGetDefCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
+bool RosSupervisor::nodeGetDefCallback(const webots_ros::node_get_name::Request &req,
+                                       webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -485,7 +488,7 @@ bool RosSupervisor::nodeGetDefCallback(webots_ros::node_get_name::Request &req, 
   return true;
 }
 
-bool RosSupervisor::nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Request &req,
+bool RosSupervisor::nodeGetBaseTypeNameCallback(const webots_ros::node_get_name::Request &req,
                                                 webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
@@ -495,7 +498,7 @@ bool RosSupervisor::nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Reque
   return true;
 }
 
-bool RosSupervisor::nodeGetParentNodeCallback(webots_ros::node_get_parent_node::Request &req,
+bool RosSupervisor::nodeGetParentNodeCallback(const webots_ros::node_get_parent_node::Request &req,
                                               webots_ros::node_get_parent_node::Response &res) {
   assert(this);
   if (!req.node)
@@ -505,7 +508,7 @@ bool RosSupervisor::nodeGetParentNodeCallback(webots_ros::node_get_parent_node::
   return true;
 }
 
-bool RosSupervisor::nodeGetPositionCallback(webots_ros::node_get_position::Request &req,
+bool RosSupervisor::nodeGetPositionCallback(const webots_ros::node_get_position::Request &req,
                                             webots_ros::node_get_position::Response &res) {
   assert(this);
   if (!req.node)
@@ -519,7 +522,7 @@ bool RosSupervisor::nodeGetPositionCallback(webots_ros::node_get_position::Reque
   return true;
 }
 
-bool RosSupervisor::nodeGetOrientationCallback(webots_ros::node_get_orientation::Request &req,
+bool RosSupervisor::nodeGetOrientationCallback(const webots_ros::node_get_orientation::Request &req,
                                                webots_ros::node_get_orientation::Response &res) {
   assert(this);
   if (!req.node)
@@ -531,7 +534,7 @@ bool RosSupervisor::nodeGetOrientationCallback(webots_ros::node_get_orientation:
   return true;
 }
 
-bool RosSupervisor::nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_mass::Request &req,
+bool RosSupervisor::nodeGetCenterOfMassCallback(const webots_ros::node_get_center_of_mass::Request &req,
                                                 webots_ros::node_get_center_of_mass::Response &res) {
   assert(this);
   if (!req.node)
@@ -545,7 +548,7 @@ bool RosSupervisor::nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_m
   return true;
 }
 
-bool RosSupervisor::nodeGetNumberOfContactPointsCallback(webots_ros::node_get_number_of_contact_points::Request &req,
+bool RosSupervisor::nodeGetNumberOfContactPointsCallback(const webots_ros::node_get_number_of_contact_points::Request &req,
                                                          webots_ros::node_get_number_of_contact_points::Response &res) {
   assert(this);
   if (!req.node)
@@ -555,7 +558,7 @@ bool RosSupervisor::nodeGetNumberOfContactPointsCallback(webots_ros::node_get_nu
   return true;
 }
 
-bool RosSupervisor::nodeGetContactPointCallback(webots_ros::node_get_contact_point::Request &req,
+bool RosSupervisor::nodeGetContactPointCallback(const webots_ros::node_get_contact_point::Request &req,
                                                 webots_ros::node_get_contact_point::Response &res) {
   assert(this);
   if (!req.node)
@@ -569,7 +572,7 @@ bool RosSupervisor::nodeGetContactPointCallback(webots_ros::node_get_contact_poi
   return true;
 }
 
-bool RosSupervisor::nodeGetStaticBalanceCallback(webots_ros::node_get_static_balance::Request &req,
+bool RosSupervisor::nodeGetStaticBalanceCallback(const webots_ros::node_get_static_balance::Request &req,
                                                  webots_ros::node_get_static_balance::Response &res) {
   assert(this);
   if (!req.node)
@@ -579,7 +582,7 @@ bool RosSupervisor::nodeGetStaticBalanceCallback(webots_ros::node_get_static_bal
   return true;
 }
 
-bool RosSupervisor::nodeGetVelocityCallback(webots_ros::node_get_velocity::Request &req,
+bool RosSupervisor::nodeGetVelocityCallback(const webots_ros::node_get_velocity::Request &req,
                                             webots_ros::node_get_velocity::Response &res) {
   assert(this);
   if (!req.node)
@@ -596,7 +599,7 @@ bool RosSupervisor::nodeGetVelocityCallback(webots_ros::node_get_velocity::Reque
   return true;
 }
 
-bool RosSupervisor::nodeSetVelocityCallback(webots_ros::node_set_velocity::Request &req,
+bool RosSupervisor::nodeSetVelocityCallback(const webots_ros::node_set_velocity::Request &req,
                                             webots_ros::node_set_velocity::Response &res) {
   assert(this);
   if (!req.node)
@@ -614,7 +617,7 @@ bool RosSupervisor::nodeSetVelocityCallback(webots_ros::node_set_velocity::Reque
   return true;
 }
 
-bool RosSupervisor::nodeAddForceCallback(webots_ros::node_add_force_or_torque::Request &req,
+bool RosSupervisor::nodeAddForceCallback(const webots_ros::node_add_force_or_torque::Request &req,
                                          webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
   if (!req.node)
@@ -629,7 +632,7 @@ bool RosSupervisor::nodeAddForceCallback(webots_ros::node_add_force_or_torque::R
   return true;
 }
 
-bool RosSupervisor::nodeAddForceWithOffsetCallback(webots_ros::node_add_force_with_offset::Request &req,
+bool RosSupervisor::nodeAddForceWithOffsetCallback(const webots_ros::node_add_force_with_offset::Request &req,
                                                    webots_ros::node_add_force_with_offset::Response &res) {
   assert(this);
   if (!req.node)
@@ -648,7 +651,7 @@ bool RosSupervisor::nodeAddForceWithOffsetCallback(webots_ros::node_add_force_wi
   return true;
 }
 
-bool RosSupervisor::nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::Request &req,
+bool RosSupervisor::nodeAddTorqueCallback(const webots_ros::node_add_force_or_torque::Request &req,
                                           webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
   if (!req.node)
@@ -663,7 +666,8 @@ bool RosSupervisor::nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::
   return true;
 }
 
-bool RosSupervisor::nodeGetFieldCallback(webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res) {
+bool RosSupervisor::nodeGetFieldCallback(const webots_ros::node_get_field::Request &req,
+                                         webots_ros::node_get_field::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -672,7 +676,7 @@ bool RosSupervisor::nodeGetFieldCallback(webots_ros::node_get_field::Request &re
   return true;
 }
 
-bool RosSupervisor::nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::Request &req,
+bool RosSupervisor::nodeMoveViewpointCallback(const webots_ros::node_move_viewpoint::Request &req,
                                               webots_ros::node_move_viewpoint::Response &res) {
   assert(this);
   if (!req.node)
@@ -683,7 +687,7 @@ bool RosSupervisor::nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::R
   return true;
 }
 
-bool RosSupervisor::nodeSetVisibilityCallback(webots_ros::node_set_visibility::Request &req,
+bool RosSupervisor::nodeSetVisibilityCallback(const webots_ros::node_set_visibility::Request &req,
                                               webots_ros::node_set_visibility::Response &res) {
   assert(this);
   if (!req.node)
@@ -695,7 +699,7 @@ bool RosSupervisor::nodeSetVisibilityCallback(webots_ros::node_set_visibility::R
   return true;
 }
 
-bool RosSupervisor::nodeRemoveCallback(webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res) {
+bool RosSupervisor::nodeRemoveCallback(const webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -705,7 +709,7 @@ bool RosSupervisor::nodeRemoveCallback(webots_ros::node_remove::Request &req, we
   return true;
 }
 
-bool RosSupervisor::nodeResetPhysicsCallback(webots_ros::node_reset_functions::Request &req,
+bool RosSupervisor::nodeResetPhysicsCallback(const webots_ros::node_reset_functions::Request &req,
                                              webots_ros::node_reset_functions::Response &res) {
   assert(this);
   if (!req.node)
@@ -716,7 +720,7 @@ bool RosSupervisor::nodeResetPhysicsCallback(webots_ros::node_reset_functions::R
   return true;
 }
 
-bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functions::Request &req,
+bool RosSupervisor::nodeRestartControllerCallback(const webots_ros::node_reset_functions::Request &req,
                                                   webots_ros::node_reset_functions::Response &res) {
   assert(this);
   if (!req.node)
@@ -727,7 +731,8 @@ bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functio
   return true;
 }
 
-bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res) {
+bool RosSupervisor::fieldGetTypeCallback(const webots_ros::field_get_type::Request &req,
+                                         webots_ros::field_get_type::Response &res) {
   assert(this);
   if (!req.field)
     return false;
@@ -736,7 +741,7 @@ bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &re
   return true;
 }
 
-bool RosSupervisor::fieldGetTypeNameCallback(webots_ros::field_get_type_name::Request &req,
+bool RosSupervisor::fieldGetTypeNameCallback(const webots_ros::field_get_type_name::Request &req,
                                              webots_ros::field_get_type_name::Response &res) {
   assert(this);
   if (!req.field)
@@ -746,7 +751,7 @@ bool RosSupervisor::fieldGetTypeNameCallback(webots_ros::field_get_type_name::Re
   return true;
 }
 
-bool RosSupervisor::fieldGetCountCallback(webots_ros::field_get_count::Request &req,
+bool RosSupervisor::fieldGetCountCallback(const webots_ros::field_get_count::Request &req,
                                           webots_ros::field_get_count::Response &res) {
   assert(this);
   if (!req.field)
@@ -756,7 +761,8 @@ bool RosSupervisor::fieldGetCountCallback(webots_ros::field_get_count::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetBoolCallback(webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res) {
+bool RosSupervisor::fieldGetBoolCallback(const webots_ros::field_get_bool::Request &req,
+                                         webots_ros::field_get_bool::Response &res) {
   assert(this);
   if (!req.field)
     return false;
@@ -768,7 +774,7 @@ bool RosSupervisor::fieldGetBoolCallback(webots_ros::field_get_bool::Request &re
   return true;
 }
 
-bool RosSupervisor::fieldGetInt32Callback(webots_ros::field_get_int32::Request &req,
+bool RosSupervisor::fieldGetInt32Callback(const webots_ros::field_get_int32::Request &req,
                                           webots_ros::field_get_int32::Response &res) {
   assert(this);
   if (!req.field)
@@ -781,7 +787,7 @@ bool RosSupervisor::fieldGetInt32Callback(webots_ros::field_get_int32::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetFloatCallback(webots_ros::field_get_float::Request &req,
+bool RosSupervisor::fieldGetFloatCallback(const webots_ros::field_get_float::Request &req,
                                           webots_ros::field_get_float::Response &res) {
   assert(this);
   if (!req.field)
@@ -794,7 +800,7 @@ bool RosSupervisor::fieldGetFloatCallback(webots_ros::field_get_float::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &req,
+bool RosSupervisor::fieldGetVec2fCallback(const webots_ros::field_get_vec2f::Request &req,
                                           webots_ros::field_get_vec2f::Response &res) {
   assert(this);
   if (!req.field)
@@ -810,7 +816,7 @@ bool RosSupervisor::fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &req,
+bool RosSupervisor::fieldGetVec3fCallback(const webots_ros::field_get_vec3f::Request &req,
                                           webots_ros::field_get_vec3f::Response &res) {
   assert(this);
   if (!req.field)
@@ -827,7 +833,7 @@ bool RosSupervisor::fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetRotationCallback(webots_ros::field_get_rotation::Request &req,
+bool RosSupervisor::fieldGetRotationCallback(const webots_ros::field_get_rotation::Request &req,
                                              webots_ros::field_get_rotation::Response &res) {
   assert(this);
   if (!req.field)
@@ -842,7 +848,7 @@ bool RosSupervisor::fieldGetRotationCallback(webots_ros::field_get_rotation::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetColorCallback(webots_ros::field_get_color::Request &req,
+bool RosSupervisor::fieldGetColorCallback(const webots_ros::field_get_color::Request &req,
                                           webots_ros::field_get_color::Response &res) {
   assert(this);
   if (!req.field)
@@ -860,7 +866,7 @@ bool RosSupervisor::fieldGetColorCallback(webots_ros::field_get_color::Request &
   return true;
 }
 
-bool RosSupervisor::fieldGetStringCallback(webots_ros::field_get_string::Request &req,
+bool RosSupervisor::fieldGetStringCallback(const webots_ros::field_get_string::Request &req,
                                            webots_ros::field_get_string::Response &res) {
   assert(this);
   if (!req.field)
@@ -873,7 +879,8 @@ bool RosSupervisor::fieldGetStringCallback(webots_ros::field_get_string::Request
   return true;
 }
 
-bool RosSupervisor::fieldGetNodeCallback(webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res) {
+bool RosSupervisor::fieldGetNodeCallback(const webots_ros::field_get_node::Request &req,
+                                         webots_ros::field_get_node::Response &res) {
   assert(this);
   if (!req.field)
     return false;

--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -449,7 +449,8 @@ bool RosSupervisor::virtualRealityHeadsetIsUsedCallback(webots_ros::get_bool::Re
   return true;
 }
 
-bool RosSupervisor::nodeGetIdCallback(const webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetIdCallback(webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -458,8 +459,8 @@ bool RosSupervisor::nodeGetIdCallback(const webots_ros::node_get_id::Request &re
   return true;
 }
 
-bool RosSupervisor::nodeGetTypeCallback(const webots_ros::node_get_type::Request &req,
-                                        webots_ros::node_get_type::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetTypeCallback(webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -468,8 +469,8 @@ bool RosSupervisor::nodeGetTypeCallback(const webots_ros::node_get_type::Request
   return true;
 }
 
-bool RosSupervisor::nodeGetTypeNameCallback(const webots_ros::node_get_name::Request &req,
-                                            webots_ros::node_get_name::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -478,8 +479,8 @@ bool RosSupervisor::nodeGetTypeNameCallback(const webots_ros::node_get_name::Req
   return true;
 }
 
-bool RosSupervisor::nodeGetDefCallback(const webots_ros::node_get_name::Request &req,
-                                       webots_ros::node_get_name::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetDefCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -488,7 +489,8 @@ bool RosSupervisor::nodeGetDefCallback(const webots_ros::node_get_name::Request 
   return true;
 }
 
-bool RosSupervisor::nodeGetBaseTypeNameCallback(const webots_ros::node_get_name::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Request &req,
                                                 webots_ros::node_get_name::Response &res) {
   assert(this);
   if (!req.node)
@@ -498,7 +500,8 @@ bool RosSupervisor::nodeGetBaseTypeNameCallback(const webots_ros::node_get_name:
   return true;
 }
 
-bool RosSupervisor::nodeGetParentNodeCallback(const webots_ros::node_get_parent_node::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetParentNodeCallback(webots_ros::node_get_parent_node::Request &req,
                                               webots_ros::node_get_parent_node::Response &res) {
   assert(this);
   if (!req.node)
@@ -508,7 +511,8 @@ bool RosSupervisor::nodeGetParentNodeCallback(const webots_ros::node_get_parent_
   return true;
 }
 
-bool RosSupervisor::nodeGetPositionCallback(const webots_ros::node_get_position::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetPositionCallback(webots_ros::node_get_position::Request &req,
                                             webots_ros::node_get_position::Response &res) {
   assert(this);
   if (!req.node)
@@ -522,7 +526,8 @@ bool RosSupervisor::nodeGetPositionCallback(const webots_ros::node_get_position:
   return true;
 }
 
-bool RosSupervisor::nodeGetOrientationCallback(const webots_ros::node_get_orientation::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetOrientationCallback(webots_ros::node_get_orientation::Request &req,
                                                webots_ros::node_get_orientation::Response &res) {
   assert(this);
   if (!req.node)
@@ -534,7 +539,8 @@ bool RosSupervisor::nodeGetOrientationCallback(const webots_ros::node_get_orient
   return true;
 }
 
-bool RosSupervisor::nodeGetCenterOfMassCallback(const webots_ros::node_get_center_of_mass::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_mass::Request &req,
                                                 webots_ros::node_get_center_of_mass::Response &res) {
   assert(this);
   if (!req.node)
@@ -548,7 +554,8 @@ bool RosSupervisor::nodeGetCenterOfMassCallback(const webots_ros::node_get_cente
   return true;
 }
 
-bool RosSupervisor::nodeGetNumberOfContactPointsCallback(const webots_ros::node_get_number_of_contact_points::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetNumberOfContactPointsCallback(webots_ros::node_get_number_of_contact_points::Request &req,
                                                          webots_ros::node_get_number_of_contact_points::Response &res) {
   assert(this);
   if (!req.node)
@@ -558,7 +565,7 @@ bool RosSupervisor::nodeGetNumberOfContactPointsCallback(const webots_ros::node_
   return true;
 }
 
-bool RosSupervisor::nodeGetContactPointCallback(const webots_ros::node_get_contact_point::Request &req,
+bool RosSupervisor::nodeGetContactPointCallback(webots_ros::node_get_contact_point::Request &req,
                                                 webots_ros::node_get_contact_point::Response &res) {
   assert(this);
   if (!req.node)
@@ -572,7 +579,8 @@ bool RosSupervisor::nodeGetContactPointCallback(const webots_ros::node_get_conta
   return true;
 }
 
-bool RosSupervisor::nodeGetStaticBalanceCallback(const webots_ros::node_get_static_balance::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetStaticBalanceCallback(webots_ros::node_get_static_balance::Request &req,
                                                  webots_ros::node_get_static_balance::Response &res) {
   assert(this);
   if (!req.node)
@@ -582,7 +590,8 @@ bool RosSupervisor::nodeGetStaticBalanceCallback(const webots_ros::node_get_stat
   return true;
 }
 
-bool RosSupervisor::nodeGetVelocityCallback(const webots_ros::node_get_velocity::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeGetVelocityCallback(webots_ros::node_get_velocity::Request &req,
                                             webots_ros::node_get_velocity::Response &res) {
   assert(this);
   if (!req.node)
@@ -599,7 +608,8 @@ bool RosSupervisor::nodeGetVelocityCallback(const webots_ros::node_get_velocity:
   return true;
 }
 
-bool RosSupervisor::nodeSetVelocityCallback(const webots_ros::node_set_velocity::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeSetVelocityCallback(webots_ros::node_set_velocity::Request &req,
                                             webots_ros::node_set_velocity::Response &res) {
   assert(this);
   if (!req.node)
@@ -617,7 +627,7 @@ bool RosSupervisor::nodeSetVelocityCallback(const webots_ros::node_set_velocity:
   return true;
 }
 
-bool RosSupervisor::nodeAddForceCallback(const webots_ros::node_add_force_or_torque::Request &req,
+bool RosSupervisor::nodeAddForceCallback(webots_ros::node_add_force_or_torque::Request &req,
                                          webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
   if (!req.node)
@@ -632,7 +642,7 @@ bool RosSupervisor::nodeAddForceCallback(const webots_ros::node_add_force_or_tor
   return true;
 }
 
-bool RosSupervisor::nodeAddForceWithOffsetCallback(const webots_ros::node_add_force_with_offset::Request &req,
+bool RosSupervisor::nodeAddForceWithOffsetCallback(webots_ros::node_add_force_with_offset::Request &req,
                                                    webots_ros::node_add_force_with_offset::Response &res) {
   assert(this);
   if (!req.node)
@@ -651,7 +661,7 @@ bool RosSupervisor::nodeAddForceWithOffsetCallback(const webots_ros::node_add_fo
   return true;
 }
 
-bool RosSupervisor::nodeAddTorqueCallback(const webots_ros::node_add_force_or_torque::Request &req,
+bool RosSupervisor::nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::Request &req,
                                           webots_ros::node_add_force_or_torque::Response &res) {
   assert(this);
   if (!req.node)
@@ -666,8 +676,7 @@ bool RosSupervisor::nodeAddTorqueCallback(const webots_ros::node_add_force_or_to
   return true;
 }
 
-bool RosSupervisor::nodeGetFieldCallback(const webots_ros::node_get_field::Request &req,
-                                         webots_ros::node_get_field::Response &res) {
+bool RosSupervisor::nodeGetFieldCallback(webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -676,7 +685,8 @@ bool RosSupervisor::nodeGetFieldCallback(const webots_ros::node_get_field::Reque
   return true;
 }
 
-bool RosSupervisor::nodeMoveViewpointCallback(const webots_ros::node_move_viewpoint::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::Request &req,
                                               webots_ros::node_move_viewpoint::Response &res) {
   assert(this);
   if (!req.node)
@@ -687,7 +697,7 @@ bool RosSupervisor::nodeMoveViewpointCallback(const webots_ros::node_move_viewpo
   return true;
 }
 
-bool RosSupervisor::nodeSetVisibilityCallback(const webots_ros::node_set_visibility::Request &req,
+bool RosSupervisor::nodeSetVisibilityCallback(webots_ros::node_set_visibility::Request &req,
                                               webots_ros::node_set_visibility::Response &res) {
   assert(this);
   if (!req.node)
@@ -699,7 +709,8 @@ bool RosSupervisor::nodeSetVisibilityCallback(const webots_ros::node_set_visibil
   return true;
 }
 
-bool RosSupervisor::nodeRemoveCallback(const webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeRemoveCallback(webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res) {
   assert(this);
   if (!req.node)
     return false;
@@ -709,7 +720,8 @@ bool RosSupervisor::nodeRemoveCallback(const webots_ros::node_remove::Request &r
   return true;
 }
 
-bool RosSupervisor::nodeResetPhysicsCallback(const webots_ros::node_reset_functions::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeResetPhysicsCallback(webots_ros::node_reset_functions::Request &req,
                                              webots_ros::node_reset_functions::Response &res) {
   assert(this);
   if (!req.node)
@@ -720,7 +732,8 @@ bool RosSupervisor::nodeResetPhysicsCallback(const webots_ros::node_reset_functi
   return true;
 }
 
-bool RosSupervisor::nodeRestartControllerCallback(const webots_ros::node_reset_functions::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::nodeRestartControllerCallback(webots_ros::node_reset_functions::Request &req,
                                                   webots_ros::node_reset_functions::Response &res) {
   assert(this);
   if (!req.node)
@@ -731,8 +744,8 @@ bool RosSupervisor::nodeRestartControllerCallback(const webots_ros::node_reset_f
   return true;
 }
 
-bool RosSupervisor::fieldGetTypeCallback(const webots_ros::field_get_type::Request &req,
-                                         webots_ros::field_get_type::Response &res) {
+// cppcheck-suppress constParameter
+bool RosSupervisor::fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res) {
   assert(this);
   if (!req.field)
     return false;
@@ -741,7 +754,8 @@ bool RosSupervisor::fieldGetTypeCallback(const webots_ros::field_get_type::Reque
   return true;
 }
 
-bool RosSupervisor::fieldGetTypeNameCallback(const webots_ros::field_get_type_name::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::fieldGetTypeNameCallback(webots_ros::field_get_type_name::Request &req,
                                              webots_ros::field_get_type_name::Response &res) {
   assert(this);
   if (!req.field)
@@ -751,7 +765,8 @@ bool RosSupervisor::fieldGetTypeNameCallback(const webots_ros::field_get_type_na
   return true;
 }
 
-bool RosSupervisor::fieldGetCountCallback(const webots_ros::field_get_count::Request &req,
+// cppcheck-suppress constParameter
+bool RosSupervisor::fieldGetCountCallback(webots_ros::field_get_count::Request &req,
                                           webots_ros::field_get_count::Response &res) {
   assert(this);
   if (!req.field)
@@ -761,8 +776,7 @@ bool RosSupervisor::fieldGetCountCallback(const webots_ros::field_get_count::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetBoolCallback(const webots_ros::field_get_bool::Request &req,
-                                         webots_ros::field_get_bool::Response &res) {
+bool RosSupervisor::fieldGetBoolCallback(webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res) {
   assert(this);
   if (!req.field)
     return false;
@@ -774,7 +788,7 @@ bool RosSupervisor::fieldGetBoolCallback(const webots_ros::field_get_bool::Reque
   return true;
 }
 
-bool RosSupervisor::fieldGetInt32Callback(const webots_ros::field_get_int32::Request &req,
+bool RosSupervisor::fieldGetInt32Callback(webots_ros::field_get_int32::Request &req,
                                           webots_ros::field_get_int32::Response &res) {
   assert(this);
   if (!req.field)
@@ -787,7 +801,7 @@ bool RosSupervisor::fieldGetInt32Callback(const webots_ros::field_get_int32::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetFloatCallback(const webots_ros::field_get_float::Request &req,
+bool RosSupervisor::fieldGetFloatCallback(webots_ros::field_get_float::Request &req,
                                           webots_ros::field_get_float::Response &res) {
   assert(this);
   if (!req.field)
@@ -800,7 +814,7 @@ bool RosSupervisor::fieldGetFloatCallback(const webots_ros::field_get_float::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetVec2fCallback(const webots_ros::field_get_vec2f::Request &req,
+bool RosSupervisor::fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &req,
                                           webots_ros::field_get_vec2f::Response &res) {
   assert(this);
   if (!req.field)
@@ -816,7 +830,7 @@ bool RosSupervisor::fieldGetVec2fCallback(const webots_ros::field_get_vec2f::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetVec3fCallback(const webots_ros::field_get_vec3f::Request &req,
+bool RosSupervisor::fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &req,
                                           webots_ros::field_get_vec3f::Response &res) {
   assert(this);
   if (!req.field)
@@ -833,7 +847,7 @@ bool RosSupervisor::fieldGetVec3fCallback(const webots_ros::field_get_vec3f::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetRotationCallback(const webots_ros::field_get_rotation::Request &req,
+bool RosSupervisor::fieldGetRotationCallback(webots_ros::field_get_rotation::Request &req,
                                              webots_ros::field_get_rotation::Response &res) {
   assert(this);
   if (!req.field)
@@ -848,7 +862,7 @@ bool RosSupervisor::fieldGetRotationCallback(const webots_ros::field_get_rotatio
   return true;
 }
 
-bool RosSupervisor::fieldGetColorCallback(const webots_ros::field_get_color::Request &req,
+bool RosSupervisor::fieldGetColorCallback(webots_ros::field_get_color::Request &req,
                                           webots_ros::field_get_color::Response &res) {
   assert(this);
   if (!req.field)
@@ -866,7 +880,7 @@ bool RosSupervisor::fieldGetColorCallback(const webots_ros::field_get_color::Req
   return true;
 }
 
-bool RosSupervisor::fieldGetStringCallback(const webots_ros::field_get_string::Request &req,
+bool RosSupervisor::fieldGetStringCallback(webots_ros::field_get_string::Request &req,
                                            webots_ros::field_get_string::Response &res) {
   assert(this);
   if (!req.field)
@@ -879,8 +893,7 @@ bool RosSupervisor::fieldGetStringCallback(const webots_ros::field_get_string::R
   return true;
 }
 
-bool RosSupervisor::fieldGetNodeCallback(const webots_ros::field_get_node::Request &req,
-                                         webots_ros::field_get_node::Response &res) {
+bool RosSupervisor::fieldGetNodeCallback(webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res) {
   assert(this);
   if (!req.field)
     return false;

--- a/projects/default/controllers/ros/RosSupervisor.hpp
+++ b/projects/default/controllers/ros/RosSupervisor.hpp
@@ -118,57 +118,53 @@ public:
   bool getFromIdCallback(webots_ros::supervisor_get_from_id::Request &req, webots_ros::supervisor_get_from_id::Response &res);
   bool getSelectedCallback(webots_ros::get_uint64::Request &req, webots_ros::get_uint64::Response &res);
 
-  bool nodeGetIdCallback(const webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res);
-  bool nodeGetTypeCallback(const webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res);
-  bool nodeGetTypeNameCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetDefCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetBaseTypeNameCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetParentNodeCallback(const webots_ros::node_get_parent_node::Request &req,
+  bool nodeGetIdCallback(webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res);
+  bool nodeGetTypeCallback(webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res);
+  bool nodeGetTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetDefCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetParentNodeCallback(webots_ros::node_get_parent_node::Request &req,
                                  webots_ros::node_get_parent_node::Response &res);
-  bool nodeGetPositionCallback(const webots_ros::node_get_position::Request &req, webots_ros::node_get_position::Response &res);
-  bool nodeGetOrientationCallback(const webots_ros::node_get_orientation::Request &req,
+  bool nodeGetPositionCallback(webots_ros::node_get_position::Request &req, webots_ros::node_get_position::Response &res);
+  bool nodeGetOrientationCallback(webots_ros::node_get_orientation::Request &req,
                                   webots_ros::node_get_orientation::Response &res);
-  bool nodeGetCenterOfMassCallback(const webots_ros::node_get_center_of_mass::Request &req,
+  bool nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_mass::Request &req,
                                    webots_ros::node_get_center_of_mass::Response &res);
-  bool nodeGetNumberOfContactPointsCallback(const webots_ros::node_get_number_of_contact_points::Request &req,
+  bool nodeGetNumberOfContactPointsCallback(webots_ros::node_get_number_of_contact_points::Request &req,
                                             webots_ros::node_get_number_of_contact_points::Response &res);
-  bool nodeGetContactPointCallback(const webots_ros::node_get_contact_point::Request &req,
+  bool nodeGetContactPointCallback(webots_ros::node_get_contact_point::Request &req,
                                    webots_ros::node_get_contact_point::Response &res);
-  bool nodeGetStaticBalanceCallback(const webots_ros::node_get_static_balance::Request &req,
+  bool nodeGetStaticBalanceCallback(webots_ros::node_get_static_balance::Request &req,
                                     webots_ros::node_get_static_balance::Response &res);
-  bool nodeGetVelocityCallback(const webots_ros::node_get_velocity::Request &req, webots_ros::node_get_velocity::Response &res);
-  bool nodeSetVelocityCallback(const webots_ros::node_set_velocity::Request &req, webots_ros::node_set_velocity::Response &res);
-  bool nodeAddForceCallback(const webots_ros::node_add_force_or_torque::Request &req,
+  bool nodeGetVelocityCallback(webots_ros::node_get_velocity::Request &req, webots_ros::node_get_velocity::Response &res);
+  bool nodeSetVelocityCallback(webots_ros::node_set_velocity::Request &req, webots_ros::node_set_velocity::Response &res);
+  bool nodeAddForceCallback(webots_ros::node_add_force_or_torque::Request &req,
                             webots_ros::node_add_force_or_torque::Response &res);
-  bool nodeAddForceWithOffsetCallback(const webots_ros::node_add_force_with_offset::Request &req,
+  bool nodeAddForceWithOffsetCallback(webots_ros::node_add_force_with_offset::Request &req,
                                       webots_ros::node_add_force_with_offset::Response &res);
-  bool nodeAddTorqueCallback(const webots_ros::node_add_force_or_torque::Request &req,
+  bool nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::Request &req,
                              webots_ros::node_add_force_or_torque::Response &res);
-  bool nodeGetFieldCallback(const webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res);
-  bool nodeMoveViewpointCallback(const webots_ros::node_move_viewpoint::Request &req,
-                                 webots_ros::node_move_viewpoint::Response &res);
-  bool nodeSetVisibilityCallback(const webots_ros::node_set_visibility::Request &req,
-                                 webots_ros::node_set_visibility::Response &res);
-  bool nodeRemoveCallback(const webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res);
-  bool nodeResetPhysicsCallback(const webots_ros::node_reset_functions::Request &req,
+  bool nodeGetFieldCallback(webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res);
+  bool nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::Request &req, webots_ros::node_move_viewpoint::Response &res);
+  bool nodeSetVisibilityCallback(webots_ros::node_set_visibility::Request &req, webots_ros::node_set_visibility::Response &res);
+  bool nodeRemoveCallback(webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res);
+  bool nodeResetPhysicsCallback(webots_ros::node_reset_functions::Request &req,
                                 webots_ros::node_reset_functions::Response &res);
-  bool nodeRestartControllerCallback(const webots_ros::node_reset_functions::Request &req,
+  bool nodeRestartControllerCallback(webots_ros::node_reset_functions::Request &req,
                                      webots_ros::node_reset_functions::Response &res);
 
-  bool fieldGetTypeCallback(const webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res);
-  bool fieldGetTypeNameCallback(const webots_ros::field_get_type_name::Request &req,
-                                webots_ros::field_get_type_name::Response &res);
-  bool fieldGetCountCallback(const webots_ros::field_get_count::Request &req, webots_ros::field_get_count::Response &res);
-  bool fieldGetBoolCallback(const webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res);
-  bool fieldGetInt32Callback(const webots_ros::field_get_int32::Request &req, webots_ros::field_get_int32::Response &res);
-  bool fieldGetFloatCallback(const webots_ros::field_get_float::Request &req, webots_ros::field_get_float::Response &res);
-  bool fieldGetVec2fCallback(const webots_ros::field_get_vec2f::Request &req, webots_ros::field_get_vec2f::Response &res);
-  bool fieldGetVec3fCallback(const webots_ros::field_get_vec3f::Request &req, webots_ros::field_get_vec3f::Response &res);
-  bool fieldGetRotationCallback(const webots_ros::field_get_rotation::Request &req,
-                                webots_ros::field_get_rotation::Response &res);
-  bool fieldGetColorCallback(const webots_ros::field_get_color::Request &req, webots_ros::field_get_color::Response &res);
-  bool fieldGetStringCallback(const webots_ros::field_get_string::Request &req, webots_ros::field_get_string::Response &res);
-  bool fieldGetNodeCallback(const webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res);
+  bool fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res);
+  bool fieldGetTypeNameCallback(webots_ros::field_get_type_name::Request &req, webots_ros::field_get_type_name::Response &res);
+  bool fieldGetCountCallback(webots_ros::field_get_count::Request &req, webots_ros::field_get_count::Response &res);
+  bool fieldGetBoolCallback(webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res);
+  bool fieldGetInt32Callback(webots_ros::field_get_int32::Request &req, webots_ros::field_get_int32::Response &res);
+  bool fieldGetFloatCallback(webots_ros::field_get_float::Request &req, webots_ros::field_get_float::Response &res);
+  bool fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &req, webots_ros::field_get_vec2f::Response &res);
+  bool fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &req, webots_ros::field_get_vec3f::Response &res);
+  bool fieldGetRotationCallback(webots_ros::field_get_rotation::Request &req, webots_ros::field_get_rotation::Response &res);
+  bool fieldGetColorCallback(webots_ros::field_get_color::Request &req, webots_ros::field_get_color::Response &res);
+  bool fieldGetStringCallback(webots_ros::field_get_string::Request &req, webots_ros::field_get_string::Response &res);
+  bool fieldGetNodeCallback(webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res);
   bool fieldSetBoolCallback(webots_ros::field_set_bool::Request &req, webots_ros::field_set_bool::Response &res);
   bool fieldSetInt32Callback(webots_ros::field_set_int32::Request &req, webots_ros::field_set_int32::Response &res);
   bool fieldSetFloatCallback(webots_ros::field_set_float::Request &req, webots_ros::field_set_float::Response &res);

--- a/projects/default/controllers/ros/RosSupervisor.hpp
+++ b/projects/default/controllers/ros/RosSupervisor.hpp
@@ -118,53 +118,57 @@ public:
   bool getFromIdCallback(webots_ros::supervisor_get_from_id::Request &req, webots_ros::supervisor_get_from_id::Response &res);
   bool getSelectedCallback(webots_ros::get_uint64::Request &req, webots_ros::get_uint64::Response &res);
 
-  bool nodeGetIdCallback(webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res);
-  bool nodeGetTypeCallback(webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res);
-  bool nodeGetTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetDefCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetBaseTypeNameCallback(webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
-  bool nodeGetParentNodeCallback(webots_ros::node_get_parent_node::Request &req,
+  bool nodeGetIdCallback(const webots_ros::node_get_id::Request &req, webots_ros::node_get_id::Response &res);
+  bool nodeGetTypeCallback(const webots_ros::node_get_type::Request &req, webots_ros::node_get_type::Response &res);
+  bool nodeGetTypeNameCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetDefCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetBaseTypeNameCallback(const webots_ros::node_get_name::Request &req, webots_ros::node_get_name::Response &res);
+  bool nodeGetParentNodeCallback(const webots_ros::node_get_parent_node::Request &req,
                                  webots_ros::node_get_parent_node::Response &res);
-  bool nodeGetPositionCallback(webots_ros::node_get_position::Request &req, webots_ros::node_get_position::Response &res);
-  bool nodeGetOrientationCallback(webots_ros::node_get_orientation::Request &req,
+  bool nodeGetPositionCallback(const webots_ros::node_get_position::Request &req, webots_ros::node_get_position::Response &res);
+  bool nodeGetOrientationCallback(const webots_ros::node_get_orientation::Request &req,
                                   webots_ros::node_get_orientation::Response &res);
-  bool nodeGetCenterOfMassCallback(webots_ros::node_get_center_of_mass::Request &req,
+  bool nodeGetCenterOfMassCallback(const webots_ros::node_get_center_of_mass::Request &req,
                                    webots_ros::node_get_center_of_mass::Response &res);
-  bool nodeGetNumberOfContactPointsCallback(webots_ros::node_get_number_of_contact_points::Request &req,
+  bool nodeGetNumberOfContactPointsCallback(const webots_ros::node_get_number_of_contact_points::Request &req,
                                             webots_ros::node_get_number_of_contact_points::Response &res);
-  bool nodeGetContactPointCallback(webots_ros::node_get_contact_point::Request &req,
+  bool nodeGetContactPointCallback(const webots_ros::node_get_contact_point::Request &req,
                                    webots_ros::node_get_contact_point::Response &res);
-  bool nodeGetStaticBalanceCallback(webots_ros::node_get_static_balance::Request &req,
+  bool nodeGetStaticBalanceCallback(const webots_ros::node_get_static_balance::Request &req,
                                     webots_ros::node_get_static_balance::Response &res);
-  bool nodeGetVelocityCallback(webots_ros::node_get_velocity::Request &req, webots_ros::node_get_velocity::Response &res);
-  bool nodeSetVelocityCallback(webots_ros::node_set_velocity::Request &req, webots_ros::node_set_velocity::Response &res);
-  bool nodeAddForceCallback(webots_ros::node_add_force_or_torque::Request &req,
+  bool nodeGetVelocityCallback(const webots_ros::node_get_velocity::Request &req, webots_ros::node_get_velocity::Response &res);
+  bool nodeSetVelocityCallback(const webots_ros::node_set_velocity::Request &req, webots_ros::node_set_velocity::Response &res);
+  bool nodeAddForceCallback(const webots_ros::node_add_force_or_torque::Request &req,
                             webots_ros::node_add_force_or_torque::Response &res);
-  bool nodeAddForceWithOffsetCallback(webots_ros::node_add_force_with_offset::Request &req,
+  bool nodeAddForceWithOffsetCallback(const webots_ros::node_add_force_with_offset::Request &req,
                                       webots_ros::node_add_force_with_offset::Response &res);
-  bool nodeAddTorqueCallback(webots_ros::node_add_force_or_torque::Request &req,
+  bool nodeAddTorqueCallback(const webots_ros::node_add_force_or_torque::Request &req,
                              webots_ros::node_add_force_or_torque::Response &res);
-  bool nodeGetFieldCallback(webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res);
-  bool nodeMoveViewpointCallback(webots_ros::node_move_viewpoint::Request &req, webots_ros::node_move_viewpoint::Response &res);
-  bool nodeSetVisibilityCallback(webots_ros::node_set_visibility::Request &req, webots_ros::node_set_visibility::Response &res);
-  bool nodeRemoveCallback(webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res);
-  bool nodeResetPhysicsCallback(webots_ros::node_reset_functions::Request &req,
+  bool nodeGetFieldCallback(const webots_ros::node_get_field::Request &req, webots_ros::node_get_field::Response &res);
+  bool nodeMoveViewpointCallback(const webots_ros::node_move_viewpoint::Request &req,
+                                 webots_ros::node_move_viewpoint::Response &res);
+  bool nodeSetVisibilityCallback(const webots_ros::node_set_visibility::Request &req,
+                                 webots_ros::node_set_visibility::Response &res);
+  bool nodeRemoveCallback(const webots_ros::node_remove::Request &req, webots_ros::node_remove::Response &res);
+  bool nodeResetPhysicsCallback(const webots_ros::node_reset_functions::Request &req,
                                 webots_ros::node_reset_functions::Response &res);
-  bool nodeRestartControllerCallback(webots_ros::node_reset_functions::Request &req,
+  bool nodeRestartControllerCallback(const webots_ros::node_reset_functions::Request &req,
                                      webots_ros::node_reset_functions::Response &res);
 
-  bool fieldGetTypeCallback(webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res);
-  bool fieldGetTypeNameCallback(webots_ros::field_get_type_name::Request &req, webots_ros::field_get_type_name::Response &res);
-  bool fieldGetCountCallback(webots_ros::field_get_count::Request &req, webots_ros::field_get_count::Response &res);
-  bool fieldGetBoolCallback(webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res);
-  bool fieldGetInt32Callback(webots_ros::field_get_int32::Request &req, webots_ros::field_get_int32::Response &res);
-  bool fieldGetFloatCallback(webots_ros::field_get_float::Request &req, webots_ros::field_get_float::Response &res);
-  bool fieldGetVec2fCallback(webots_ros::field_get_vec2f::Request &req, webots_ros::field_get_vec2f::Response &res);
-  bool fieldGetVec3fCallback(webots_ros::field_get_vec3f::Request &req, webots_ros::field_get_vec3f::Response &res);
-  bool fieldGetRotationCallback(webots_ros::field_get_rotation::Request &req, webots_ros::field_get_rotation::Response &res);
-  bool fieldGetColorCallback(webots_ros::field_get_color::Request &req, webots_ros::field_get_color::Response &res);
-  bool fieldGetStringCallback(webots_ros::field_get_string::Request &req, webots_ros::field_get_string::Response &res);
-  bool fieldGetNodeCallback(webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res);
+  bool fieldGetTypeCallback(const webots_ros::field_get_type::Request &req, webots_ros::field_get_type::Response &res);
+  bool fieldGetTypeNameCallback(const webots_ros::field_get_type_name::Request &req,
+                                webots_ros::field_get_type_name::Response &res);
+  bool fieldGetCountCallback(const webots_ros::field_get_count::Request &req, webots_ros::field_get_count::Response &res);
+  bool fieldGetBoolCallback(const webots_ros::field_get_bool::Request &req, webots_ros::field_get_bool::Response &res);
+  bool fieldGetInt32Callback(const webots_ros::field_get_int32::Request &req, webots_ros::field_get_int32::Response &res);
+  bool fieldGetFloatCallback(const webots_ros::field_get_float::Request &req, webots_ros::field_get_float::Response &res);
+  bool fieldGetVec2fCallback(const webots_ros::field_get_vec2f::Request &req, webots_ros::field_get_vec2f::Response &res);
+  bool fieldGetVec3fCallback(const webots_ros::field_get_vec3f::Request &req, webots_ros::field_get_vec3f::Response &res);
+  bool fieldGetRotationCallback(const webots_ros::field_get_rotation::Request &req,
+                                webots_ros::field_get_rotation::Response &res);
+  bool fieldGetColorCallback(const webots_ros::field_get_color::Request &req, webots_ros::field_get_color::Response &res);
+  bool fieldGetStringCallback(const webots_ros::field_get_string::Request &req, webots_ros::field_get_string::Response &res);
+  bool fieldGetNodeCallback(const webots_ros::field_get_node::Request &req, webots_ros::field_get_node::Response &res);
   bool fieldSetBoolCallback(webots_ros::field_set_bool::Request &req, webots_ros::field_set_bool::Response &res);
   bool fieldSetInt32Callback(webots_ros::field_set_int32::Request &req, webots_ros::field_set_int32::Response &res);
   bool fieldSetFloatCallback(webots_ros::field_set_float::Request &req, webots_ros::field_set_float::Response &res);

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/DeviceManager.hpp
@@ -55,7 +55,7 @@ private:
   DeviceManager();
   DeviceManager(const DeviceManager &);             // non constructor-copyable
   DeviceManager &operator=(const DeviceManager &);  // non copyable
-  virtual ~DeviceManager();
+  ~DeviceManager();
 
   void clear();
 

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Wrapper.hpp
@@ -48,7 +48,7 @@ public:
 
 private:
   Wrapper() {}
-  virtual ~Wrapper() {}
+  ~Wrapper() {}
 
   static void initializeCamera();
 

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/DeviceManager.hpp
@@ -56,7 +56,7 @@ private:
   DeviceManager();
   DeviceManager(const DeviceManager &);             // non constructor-copyable
   DeviceManager &operator=(const DeviceManager &);  // non copyable
-  virtual ~DeviceManager();
+  ~DeviceManager();
 
   void clear();
 

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.hpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/Wrapper.hpp
@@ -47,7 +47,7 @@ public:
 
 private:
   Wrapper() {}
-  virtual ~Wrapper() {}
+  ~Wrapper() {}
   static Communication *cCommunication;
   static Time *cTime;
   static bool cSuccess;

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/test.c
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_wifi/test.c
@@ -133,6 +133,7 @@ int main(int argc, char *argv[]) {
   command[i++] = 0;     // LED8 green
   command[i++] = 0;     // LED8 blue
   command[i++] = 0;     // speaker
+  // cppcheck-suppress knownArgument
   // cppcheck-suppress constArgument
   assert(i == sizeof(command));
   for (int j = 0; j < 3000; j++) {

--- a/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.cpp
+++ b/projects/robots/mobsya/thymio/controllers/thymio2_aseba/Thymio2Model.cpp
@@ -206,7 +206,7 @@ void Thymio2Model::updateEvents(const Thymio2AsebaHub *hub, bool events[]) {
 
         // check that the timer period is a multiple of WorldInfo::timeStep
         // but only for small periods (arbitrarily: < 2*timeStep) because after the generated error is less important
-        if (hub->variables.timers[i] > 0 && hub->variables.timers[i] < 2 * mTimeStep && hub->variables.timers[i] != mTimeStep)
+        if (hub->variables.timers[i] < 2 * mTimeStep && hub->variables.timers[i] != mTimeStep)
           cout << "In simulation, timer " << i << " period should be above or equal to WorldInfo::timeStep" << endl;
       } else
         mTimerStepStart[i] = -1;

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/DeviceManager.hpp
@@ -54,7 +54,7 @@ private:
   DeviceManager();
   DeviceManager(const DeviceManager &);             // non constructor-copyable
   DeviceManager &operator=(const DeviceManager &);  // non copyable
-  virtual ~DeviceManager();
+  ~DeviceManager();
 
   void clear();
 

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/FireBird6InputPacket.cpp
@@ -104,9 +104,11 @@ void FireBird6InputPacket::decode(int simulationTime, const FireBird6OutputPacke
   if (outputPacket.isMagnetometerRequested()) {
     double values[3];
     values[0] = readShortAt_MSBFirst(currentPos) / 1100.0;
+    // cppcheck-suppress knownArgument
     // cppcheck-suppress constArgument
     values[1] = readShortAt_MSBFirst(currentPos + 2) / 1100.0;
     // different scaling for Z Axis
+    // cppcheck-suppress knownArgument
     // cppcheck-suppress constArgument
     values[2] = readShortAt_MSBFirst(currentPos + 4) / 980.0;
 

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.hpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Wrapper.hpp
@@ -48,7 +48,7 @@ public:
 
 private:
   Wrapper() {}
-  virtual ~Wrapper() {}
+  ~Wrapper() {}
 
   static void initializeCamera();
 

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/DeviceManager.hpp
@@ -53,7 +53,7 @@ private:
   DeviceManager();
   DeviceManager(const DeviceManager &);             // non constructor-copyable
   DeviceManager &operator=(const DeviceManager &);  // non copyable
-  virtual ~DeviceManager();
+  ~DeviceManager();
 
   void clear();
 

--- a/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.hpp
+++ b/projects/robots/robotis/darwin-op/plugins/remote_controls/robotis-op2_tcpip/Wrapper.hpp
@@ -52,7 +52,7 @@ public:
 
 private:
   Wrapper() {}
-  virtual ~Wrapper() {}
+  ~Wrapper() {}
 
   static Communication *cCommunication;
   static Time *cTime;

--- a/projects/robots/robotis/darwin-op/remote_control/main.cpp
+++ b/projects/robots/robotis/darwin-op/remote_control/main.cpp
@@ -26,8 +26,6 @@
 #include <unistd.h>
 #include <iostream>
 
-#define INVALID_SOCKET -1
-#define SOCKET_ERROR -1
 #define closesocket(s) close(s)
 
 typedef int SOCKET;
@@ -70,7 +68,7 @@ int main(int argc, char *argv[]) {
   sock = socket(AF_INET, SOCK_STREAM, 0);
 
   // If  socket is valid
-  if (sock != INVALID_SOCKET) {
+  if (sock != -1) {
     // Configuration
     sin.sin_addr.s_addr = htonl(INADDR_ANY);     // Adresse IP automatic
     sin.sin_family = AF_INET;                    // Protocole familial (IP)
@@ -84,12 +82,12 @@ int main(int argc, char *argv[]) {
 
     // If socket works
     SOCKET csock = 0;
-    if (sock_err != SOCKET_ERROR) {
+    if (sock_err != -1) {
       // Starting port Listening (server mode)
       sock_err = listen(sock, 1);  // only one connexion
 
       // If socket works
-      if (sock_err != SOCKET_ERROR) {
+      if (sock_err != -1) {
         // Wait until a client connect
         cout << "Waiting for client connection on port " << PORT << "..." << endl;
         csock = accept(sock, (SOCKADDR *)&csin, &crecsize);
@@ -279,7 +277,8 @@ int main(int argc, char *argv[]) {
     free(receiveBuffer);
     free(sendBuffer);
   } else
-    perror("socket");  // cppcheck-suppress resourceLeak ; for socket (which is -1 here)
+    perror("socket");
+  // cppcheck-suppress resourceLeak ; for socket (which is -1 here)
   return EXIT_SUCCESS;
 }
 

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.c
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization/pso.c
@@ -229,8 +229,10 @@ void SaveNetworkWeights(network_t *n, const char *filename) {
   FILE *fp;
   int i;
 
-  if ((fp = fopen(filename, "w+b")) == NULL)
-    printf("Cannot open %s\n", filename);
+  if ((fp = fopen(filename, "w+b")) == NULL) {
+    fprintf(stderr, "Cannot open %s\n", filename);
+    return;
+  }
 
   for (i = 0; i < n->size; i++)
     SaveLayerWeights(&n->layers[i], fp);
@@ -242,8 +244,10 @@ void SaveNetworkWeightsHDT(network_t *n, const char *filename) {
   FILE *fp;
   int i;
 
-  if ((fp = fopen(filename, "w+b")) == NULL)
-    printf("Cannot open %s\n", filename);
+  if ((fp = fopen(filename, "w+b")) == NULL) {
+    fprintf(stderr, "Cannot open %s\n", filename);
+    return;
+  }
 
   for (i = 0; i < n->size; i++)
     SaveLayerWeightsHDT(&n->layers[i], fp);
@@ -255,9 +259,10 @@ void LoadNetworkWeights(network_t *n, const char *filename) {
   FILE *fp;
   int i;
 
-  if ((fp = fopen(filename, "rb")) == NULL)
-    printf("Cannot open %s\n", filename);
-
+  if ((fp = fopen(filename, "rb")) == NULL) {
+    fprintf(stderr, "Cannot open %s\n", filename);
+    return;
+  }
   for (i = 0; i < n->size; i++)
     LoadLayerWeights(&n->layers[i], fp);
 

--- a/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/advanced_particle_swarm_optimization_supervisor.c
+++ b/projects/samples/curriculum/controllers/advanced_particle_swarm_optimization_supervisor/advanced_particle_swarm_optimization_supervisor.c
@@ -212,18 +212,14 @@ int main() {
 
     step();
 
+    outbuffer[0] = -1;
     if (NOISE_RESISTANT == 1 && run_counter % 3 == 2) {
       gbest = 0;
       // broadcast EVAL_PBEST again
-      outbuffer[0] = -1;
       outbuffer[1] = EVAL_PBEST;
-      wb_emitter_send(emitter, outbuffer, 2 * sizeof(float));
-    } else {
-      // broadcast RESET message
-      outbuffer[0] = -1;
+    } else  // broadcast RESET message
       outbuffer[1] = RESET;
-      wb_emitter_send(emitter, outbuffer, 2 * sizeof(float));
-    }
+    wb_emitter_send(emitter, outbuffer, 2 * sizeof(float));
 
     step();
 

--- a/projects/samples/curriculum/lib/backprop.c
+++ b/projects/samples/curriculum/lib/backprop.c
@@ -249,8 +249,10 @@ void SaveNetworkWeights(network_t *n, const char *filename) {
   FILE *fp;
   int i;
 
-  if ((fp = fopen(filename, "w+b")) == NULL)
-    printf("Cannot open %s\n", filename);
+  if ((fp = fopen(filename, "w+b")) == NULL) {
+    fprintf(stderr, "Cannot open %s\n", filename);
+    return;
+  }
 
   for (i = 0; i < n->size; i++)
     SaveLayerWeights(&n->layers[i], fp);
@@ -262,9 +264,10 @@ void LoadNetworkWeights(network_t *n, const char *filename) {
   FILE *fp;
   int i;
 
-  if ((fp = fopen(filename, "rb")) == NULL)
-    printf("Cannot open %s\n", filename);
-
+  if ((fp = fopen(filename, "rb")) == NULL) {
+    fprintf(stderr, "Cannot open %s\n", filename);
+    return;
+  }
   for (i = 0; i < n->size; i++)
     LoadLayerWeights(&n->layers[i], fp);
 

--- a/resources/projects/libraries/qt_utils/motion_editor/Motion.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/Motion.cpp
@@ -307,12 +307,8 @@ void Motion::newPoseAt(int index) {
     }
 
     if (!hasFixedStep()) {
-      Pose *previousPose = NULL, *nextPose = NULL;
-      if (index > 0)
-        previousPose = mPoses.at(index - 1);
-      if (index < mPoses.count())
-        nextPose = mPoses.at(index);
-
+      Pose *previousPose = index > 0 ? mPoses.at(index - 1) : NULL;
+      Pose *nextPose = index < mPoses.count() ? mPoses.at(index) : NULL;
       if (previousPose && nextPose)
         pose->setTime(0.5 * (previousPose->time() + nextPose->time()));
       else if (previousPose)

--- a/resources/projects/libraries/qt_utils/motion_editor/Motion.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/Motion.cpp
@@ -307,8 +307,8 @@ void Motion::newPoseAt(int index) {
     }
 
     if (!hasFixedStep()) {
-      Pose *previousPose = index > 0 ? mPoses.at(index - 1) : NULL;
-      Pose *nextPose = index < mPoses.count() ? mPoses.at(index) : NULL;
+      const Pose *previousPose = index > 0 ? mPoses.at(index - 1) : NULL;
+      const Pose *nextPose = index < mPoses.count() ? mPoses.at(index) : NULL;
       if (previousPose && nextPose)
         pose->setTime(0.5 * (previousPose->time() + nextPose->time()));
       else if (previousPose)

--- a/resources/projects/libraries/qt_utils/motion_editor/MotionGlobalSettings.hpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/MotionGlobalSettings.hpp
@@ -22,7 +22,7 @@ namespace webotsQtUtils {
     static QList<Motor *> cMotors;
 
     MotionGlobalSettings() {}
-    virtual ~MotionGlobalSettings() {}
+    ~MotionGlobalSettings() {}
   };
 }  // namespace webotsQtUtils
 

--- a/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
@@ -71,6 +71,7 @@ void MotionPlayer::writeActuators() {
   Pose *afterPose = NULL;
   foreach (Pose *pose, mMotion->poses()) {
     int poseTime = pose->time();
+    // cppcheck-suppress knownConditionTrueFalse
     if (!beforePose && poseTime <= currentTime) {
       beforePose = pose;
       continue;

--- a/src/lib/Controller/api/motion.c
+++ b/src/lib/Controller/api/motion.c
@@ -402,8 +402,8 @@ WbMotionRef wbu_motion_new(const char *filename) {
   if (!motion_check_file(file, filename, &n_joints, &n_poses))
     return NULL;
 
-  if (!file) {
-    fprintf(stderr, "Error: wbu_motion_new(): file '%s' needs to contains at least one joint and one pose.\n", filename);
+  if (n_joints == 0 || n_poses == 0) {
+    fprintf(stderr, "Error: wbu_motion_new(): file '%s' must contain at least one joint and one pose.\n", filename);
     return NULL;
   }
 

--- a/src/lib/Controller/api/robot.c
+++ b/src/lib/Controller/api/robot.c
@@ -962,13 +962,12 @@ int wb_robot_init() {  // API initialization
   if (WEBOTS_SERVER && WEBOTS_SERVER[0])
     pipe = strdup(WEBOTS_SERVER);
   else {
-    unsigned int trial = 0;
+    int trial = 0;
     while (trial < 10) {
       trial++;
       const char *WEBOTS_TMP_PATH = wbu_system_webots_tmp_path();
       if (!WEBOTS_TMP_PATH) {
-        if (trial <= 10)
-          fprintf(stderr, "Webots doesn't seems to be ready yet: (retrying in %u second%s)\n", trial, trial > 1 ? "s" : "");
+        fprintf(stderr, "Webots doesn't seems to be ready yet: (retrying in %d second%s)\n", trial, trial > 1 ? "s" : "");
         sleep(trial);
       } else {
         char buffer[1024];
@@ -984,16 +983,14 @@ int wb_robot_init() {  // API initialization
           }
           fclose(fd);
         } else {
-          if (trial <= 10)
-            fprintf(stderr, "Cannot open file: %s (retrying in %u second%s)\n", buffer, trial, trial > 1 ? "s" : "");
+          fprintf(stderr, "Cannot open file: %s (retrying in %d second%s)\n", buffer, trial, trial > 1 ? "s" : "");
           pipe = NULL;
         }
-        if (trial > 10)
-          fprintf(stderr, "Impossible to communicate with Webots: aborting\n");
-        else
-          sleep(trial);
+        sleep(trial);
       }
     }
+    if (trial == 10)
+      fprintf(stderr, "Impossible to communicate with Webots: aborting\n");
   }
   if (!pipe || !scheduler_init(pipe)) {
     if (!pipe)

--- a/src/lib/Controller/api/scheduler.c
+++ b/src/lib/Controller/api/scheduler.c
@@ -85,14 +85,11 @@ void scheduler_send_request(WbRequest *r) {
 
 WbRequest *scheduler_read_data() {
   int delay = 0;
-  unsigned int tcp = 0;
-  if (scheduler_pipe || tcp) {
+  if (scheduler_pipe) {
     int size = 0, socket_size = 0;
-    if (scheduler_pipe) {
-      do
-        size += g_pipe_receive(scheduler_pipe, scheduler_data + size, sizeof(int) - size);
-      while (size != sizeof(int));
-    }
+    do
+      size += g_pipe_receive(scheduler_pipe, scheduler_data + size, sizeof(int) - size);
+    while (size != sizeof(int));
     // read the size of the socket chunk
     socket_size = scheduler_read_int32(scheduler_data);
     // if more than 1KB needs to be downloaded, show a progress bar

--- a/src/webots/core/WbTranslator.hpp
+++ b/src/webots/core/WbTranslator.hpp
@@ -40,7 +40,7 @@ private:
   WbTranslator();
   WbTranslator(const WbTranslator &);             // non construction-copyable
   WbTranslator &operator=(const WbTranslator &);  // non copyable
-  virtual ~WbTranslator();
+  ~WbTranslator();
 
   void updateSupportedLanguages();
 

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -409,6 +409,7 @@ void WbAnimationRecorder::stopRecording() {
     // store only ids of nodes that changed during the animation
     if (command->isChangedFromStart()) {
       commandsChangedFromStart << command;
+      // cppcheck-suppress knownConditionTrueFalse
       if (!firstCommand)
         out << ";";
       else

--- a/src/webots/nodes/WbBaseNode.cpp
+++ b/src/webots/nodes/WbBaseNode.cpp
@@ -219,6 +219,7 @@ WbBaseNode *WbBaseNode::getSingleFinalizedProtoInstance() {
   foreach (WbNode *node, nodeInstances) {
     WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(node);
     if (baseNode && baseNode->isPostFinalizedCalled()) {
+      // cppcheck-suppress knownConditionTrueFalse
       if (finalizedInstance)
         // multiple finilized instances found
         return NULL;

--- a/src/webots/nodes/utils/WbDictionary.hpp
+++ b/src/webots/nodes/utils/WbDictionary.hpp
@@ -54,7 +54,7 @@ public:
 private:
   static WbDictionary *cInstance;
   WbDictionary();
-  virtual ~WbDictionary();
+  ~WbDictionary();
 
   bool updateDef(WbBaseNode *&node, WbSFNode *sfNode = NULL, WbMFNode *mfNode = NULL, int index = -1);
   void updateProtosDef(WbBaseNode *&node, WbSFNode *sfNode = NULL, WbMFNode *mfNode = NULL, int index = -1);

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -68,7 +68,7 @@ private:
   static WbPerformanceLog *cInstance;
   WbPerformanceLog(const QString &fileName, int stepsCount);
   WbPerformanceLog(const WbPerformanceLog &);  // non constructor-copyable
-  virtual ~WbPerformanceLog();
+  ~WbPerformanceLog();
 
   bool openFile();
   void closeFile();

--- a/src/webots/wren/WbWrenLabelOverlay.hpp
+++ b/src/webots/wren/WbWrenLabelOverlay.hpp
@@ -79,7 +79,7 @@ private:
   static const float HORIZONTAL_MARGIN;
 
   WbWrenLabelOverlay(int id, const QString &font);
-  virtual ~WbWrenLabelOverlay();
+  ~WbWrenLabelOverlay();
 
   void createTexture();
   void updateTextureSize();

--- a/src/webots/wren/WbWrenRenderingContext.cpp
+++ b/src/webots/wren/WbWrenRenderingContext.cpp
@@ -37,8 +37,8 @@ WbWrenRenderingContext::WbWrenRenderingContext(int width, int height) :
   mLineScale(0.0),
   mSolidLineScale(0.0),
   mRenderingMode(RM_PLAIN),
-  mProjectionMode(PM_PERSPECTIVE) {
-  mOptionalRenderingsMask = VM_MAIN;
+  mProjectionMode(PM_PERSPECTIVE),
+  mOptionalRenderingsMask(VM_MAIN) {
 }
 
 WbWrenRenderingContext::~WbWrenRenderingContext() {


### PR DESCRIPTION
The source tests failed last night due to an upgrade of cppcheck from version 1.9 to version 2.0 which detects more problems.
This PR fixes the source code of this repository to pass the cppcheck-2.0 tests.