### PR TITLE
Fix appveyor pacman update

### DIFF
--- a/.appveyor-build-tag.yml
+++ b/.appveyor-build-tag.yml
@@ -16,6 +16,9 @@ init:
 
 install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;%PATH%
+  - ps: Start-FileDownload 'http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz'
+  - pacman -U --noconfirm pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - del pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - echo export WEBOTS_HOME="%APPVEYOR_BUILD_FOLDER%" >> C:\msys64\home\appveyor\.bash_profile

--- a/.appveyor-build-tag.yml
+++ b/.appveyor-build-tag.yml
@@ -16,9 +16,9 @@ init:
 
 install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;%PATH%
-  - ps: Start-FileDownload 'http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz'
-  - pacman -U --noconfirm pacman-5.2.1-6-x86_64.pkg.tar.xz
-  - del pacman-5.2.1-6-x86_64.pkg.tar.xz
+  # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
+  # See: https://github.com/msys2/MSYS2-packages/issues/1967
+  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - echo export WEBOTS_HOME="%APPVEYOR_BUILD_FOLDER%" >> C:\msys64\home\appveyor\.bash_profile

--- a/.appveyor-build-tag.yml
+++ b/.appveyor-build-tag.yml
@@ -18,7 +18,7 @@ install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;%PATH%
   # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
   # See: https://github.com/msys2/MSYS2-packages/issues/1967
-  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - echo export WEBOTS_HOME="%APPVEYOR_BUILD_FOLDER%" >> C:\msys64\home\appveyor\.bash_profile

--- a/.appveyor-build.yml
+++ b/.appveyor-build.yml
@@ -16,7 +16,7 @@ install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;%PATH%
   # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
   # See: https://github.com/msys2/MSYS2-packages/issues/1967
-  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - echo export WEBOTS_HOME="%APPVEYOR_BUILD_FOLDER%" >> C:\msys64\home\appveyor\.bash_profile

--- a/.appveyor-build.yml
+++ b/.appveyor-build.yml
@@ -14,6 +14,9 @@ init:
 
 install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;%PATH%
+  # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
+  # See: https://github.com/msys2/MSYS2-packages/issues/1967
+  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - echo export WEBOTS_HOME="%APPVEYOR_BUILD_FOLDER%" >> C:\msys64\home\appveyor\.bash_profile

--- a/.appveyor-test-sources-scheduled.yml
+++ b/.appveyor-test-sources-scheduled.yml
@@ -6,7 +6,7 @@ install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%
   # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
   # See: https://github.com/msys2/MSYS2-packages/issues/1967
-  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
+  - pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - pacman --noconfirm -S mingw-w64-x86_64-cppcheck

--- a/.appveyor-test-sources-scheduled.yml
+++ b/.appveyor-test-sources-scheduled.yml
@@ -4,6 +4,9 @@ clone_depth: 1
 
 install:
   - set PATH=C:\Python38-x64;C:\Python38-x64\Scripts;C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%
+  # The following line is needed to work around a bug in MSYS2 pacman, it should be removed when fixed.
+  # See: https://github.com/msys2/MSYS2-packages/issues/1967
+  - pacman -U --noconfirm pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz
   - pacman --noconfirm --ask 20 --sync --refresh --refresh --sysupgrade --sysupgrade
   - pacman --noconfirm -Syuu
   - pacman --noconfirm -S mingw-w64-x86_64-cppcheck


### PR DESCRIPTION
Since a couple of days, appveyor build are broken, originally due to a general update problem and now due to a [pacman update problem](https://github.com/msys2/MSYS2-packages/issues/1967). Since it is not sure the problem will be quickly fixed on the MSYS2 side, this PR aims at patching it.