### PR TITLE
Fix appveyor build

### DIFF
--- a/src/install_scripts/msys64_installer.sh
+++ b/src/install_scripts/msys64_installer.sh
@@ -19,6 +19,7 @@ declare -a BASE_PACKAGES=(
 )
 
 declare -a OPTIONAL_PACKAGES=(
+  "pacman-contrib"            # Distribution script (pactree)
   "swig"                      # Python and Java API wrappers
   "mingw-w64-x86_64-libssh"   # Robotis OP2 robot window
   "mingw-w64-x86_64-libzip"   # Robotis OP2 robot window


### PR DESCRIPTION
`pactree` moved to the `pacman-contrib` package which is now a new dependency of our distribution script.