### PR TITLE
Fix icon path

### DIFF
--- a/src/packaging/webots_distro.c
+++ b/src/packaging/webots_distro.c
@@ -1076,7 +1076,11 @@ static void create_file(const char *name, int m) {
       fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots_doc.png usr/share/pixmaps/\n");
       fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots.applications usr/share/application-registry/\n");
       fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots.desktop usr/share/applications/\n");
+#ifdef WEBOTS_UBUNTU_16_04
+      fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots_snap.desktop usr/share/app-install/desktop/webots.desktop\n");
+#else
       fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots.desktop usr/share/app-install/desktop/\n");
+#endif
       fprintf(fd, "mkdir usr/local/bin\n");
       fprintf(fd, "ln -s /usr/local/%s/webots usr/local/bin/webots\n", application_name_lowercase_and_dashes);
       fprintf(fd, "cd %s/debian\n", distribution_path);
@@ -1201,7 +1205,7 @@ static void create_file(const char *name, int m) {
       fprintf(fd, "mkdir $DESTDIR/usr/share/webots/include/libzip\n");
       fprintf(fd, "cp -a /usr/include/zip.h $DESTDIR/usr/share/webots/include/libzip/\n");
       fprintf(fd, "cp /usr/include/x86_64-linux-gnu/zipconf.h $DESTDIR/usr/share/webots/include/libzip/\n");
-      fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots.desktop $DESTDIR/usr/share/webots/resources/\n");
+      fprintf(fd, "cp $WEBOTS_HOME/src/packaging/webots_snap.desktop $DESTDIR/usr/share/webots/resources/webots.desktop\n");
       break;
     }
     default:

--- a/src/packaging/webots_snap.desktop
+++ b/src/packaging/webots_snap.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Webots
+Comment=Webots mobile robot simulator
+Exec=webots
+Icon=/usr/share/webots/resources/icons/core/webots.png
+Terminal=false
+Type=Application
+X-AppInstall-Package=webots


### PR DESCRIPTION
**Description**
The fix introduced in #1607 was correct, but only for Ubuntu 18.04 and more recent, not for Ubuntu 16.04 and snap (regardless of the Ubuntu version).