### PR TITLE
corrected typo in listing of tree view nodes

### DIFF
--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -52,7 +52,7 @@ It should currently list the following nodes:
 - [WorldInfo](../reference/worldinfo.md): contains global parameters of the simulation.
 - [Viewpoint](../reference/viewpoint.md): defines the main viewpoint camera parameters.
 - [TexturedBackground](object-backgrounds.md#texturedbackground): defines the background of the scene (you should see mountains far away if you rotate a little bit the viewpoint)
-- [TexturedBackroundLight](object-backgrounds.md#texturedbackgroundlight): defines the light associated with the above background.
+- [TexturedBackgroundLight](object-backgrounds.md#texturedbackgroundlight): defines the light associated with the above background.
 - [RectangleArena](object-floors.md#rectanglearena): define the only object you see so far in this scene.
 
 Each node has some customizable properties called **Fields**.


### PR DESCRIPTION
**Description**
Small typo in documentation when listing the default nodes in the tree view.

**Related Issues**
No related issues.

**Tasks**
  - [x] Change label 'TexturedBackroundLight' to 'TexturedBackgroundLight'

**Documentation**
https://cyberbotics.com/doc/guide/tutorial-1-your-first-simulation-in-webots#create-a-new-world
