### PR TITLE
FIx Crossroad Bottom Appearance

### DIFF
--- a/projects/objects/road/protos/Crossroad.proto
+++ b/projects/objects/road/protos/Crossroad.proto
@@ -61,7 +61,7 @@ PROTO Crossroad [
         }
         %{ if fields.bottom.value then }%
           Shape {
-            appearance USE CROSSROAD_APPEARANCE
+            appearance IS appearance
             geometry IndexedFaceSet {
               coord Coordinate {
                 point IS shape


### PR DESCRIPTION
The `CROSSROAD_APPEARANCE` appearance was never defined.
This was reported by a user on Discord.