### PR TITLE
Fix Tiago Gripper

### DIFF
--- a/projects/robots/pal_robotics/tiago_extensions/protos/TiagoGripper.proto
+++ b/projects/robots/pal_robotics/tiago_extensions/protos/TiagoGripper.proto
@@ -15,8 +15,6 @@ PROTO TiagoGripper [
       side = "left_hand_"
     elseif fields.name.value == "right" then
       side = "right_hand_"
-    else
-      side = ""
     end
   }%
     Solid {


### PR DESCRIPTION
This assignment is useless as the variable is already assigned to the empty string by default.