### PR TITLE
Fix tiago++ Gripper Names

### DIFF
--- a/docs/guide/scenes/tiagopp/tiagopp.meta.json
+++ b/docs/guide/scenes/tiagopp/tiagopp.meta.json
@@ -166,16 +166,7 @@
       "axis": "-1 0 0",
       "maxPosition": 0.045,
       "minPosition": 0,
-      "name": "gripper_left_finger_joint",
-      "position": 0,
-      "transformID": "n65387",
-      "type": "LinearMotor"
-    },
-    {
-      "axis": "-1 0 0",
-      "maxPosition": 0.045,
-      "minPosition": 0,
-      "name": "gripper_left_finger_joint",
+      "name": "left_hand_gripper_left_finger_joint",
       "position": 0,
       "transformID": "n68162",
       "type": "LinearMotor"
@@ -184,18 +175,27 @@
       "axis": "1 0 0",
       "maxPosition": 0.045,
       "minPosition": 0,
-      "name": "gripper_right_finger_joint",
+      "name": "left_hand_gripper_right_finger_joint",
       "position": 0,
-      "transformID": "n65420",
+      "transformID": "n68195",
+      "type": "LinearMotor"
+    },
+    {
+      "axis": "-1 0 0",
+      "maxPosition": 0.045,
+      "minPosition": 0,
+      "name": "right_hand_gripper_left_finger_joint",
+      "position": 0,
+      "transformID": "n65387",
       "type": "LinearMotor"
     },
     {
       "axis": "1 0 0",
       "maxPosition": 0.045,
       "minPosition": 0,
-      "name": "gripper_right_finger_joint",
+      "name": "right_hand_gripper_right_finger_joint",
       "position": 0,
-      "transformID": "n68195",
+      "transformID": "n65420",
       "type": "LinearMotor"
     },
     {
@@ -303,26 +303,6 @@
       "type": "DistanceSensor"
     },
     {
-      "name": "gripper_left_finger_joint_sensor",
-      "transformID": "n65387",
-      "type": "PositionSensor"
-    },
-    {
-      "name": "gripper_left_finger_joint_sensor",
-      "transformID": "n68162",
-      "type": "PositionSensor"
-    },
-    {
-      "name": "gripper_right_finger_joint_sensor",
-      "transformID": "n65420",
-      "type": "PositionSensor"
-    },
-    {
-      "name": "gripper_right_finger_joint_sensor",
-      "transformID": "n68195",
-      "type": "PositionSensor"
-    },
-    {
       "name": "gyro",
       "transformID": "n1890",
       "type": "Gyro"
@@ -346,6 +326,26 @@
       "name": "inertial unit",
       "transformID": "n1890",
       "type": "InertialUnit"
+    },
+    {
+      "name": "left_hand_gripper_left_finger_joint_sensor",
+      "transformID": "n68162",
+      "type": "PositionSensor"
+    },
+    {
+      "name": "left_hand_gripper_right_finger_joint_sensor",
+      "transformID": "n68195",
+      "type": "PositionSensor"
+    },
+    {
+      "name": "right_hand_gripper_left_finger_joint_sensor",
+      "transformID": "n65387",
+      "type": "PositionSensor"
+    },
+    {
+      "name": "right_hand_gripper_right_finger_joint_sensor",
+      "transformID": "n65420",
+      "type": "PositionSensor"
     },
     {
       "name": "torso_lift_joint_sensor",

--- a/docs/guide/tiagopp.md
+++ b/docs/guide/tiagopp.md
@@ -27,8 +27,8 @@ Tiago++ {
   SFBool      synchronization       TRUE
   SFBool      selfCollision         FALSE
   MFNode      lidarSlot             []
-  MFNode      endEffectorRightSlot  TiagoGripper{}
-  MFNode      endEffectorLeftSlot   TiagoGripper{}
+  MFNode      endEffectorRightSlot  TiagoGripper { name "right" }
+  MFNode      endEffectorLeftSlot   TiagoGripper { name "left" }
 }
 ```
 > **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago++/protos/Tiago++.proto](https://github.com/cyberbotics/webots/tree/master/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto)"

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -39,6 +39,7 @@ Released on XXX.
     - Windows: Fixed JPEG texture errors when typing `webots` from a DOS console (`cmd.exe`) by renaming `webots.exe` to `webots-bin.exe` and creating two launchers named `webotsw.exe` and `webots.exe`.
     - Fixed the physics behavior of [Connector](connector.md) nodes sometimes remaining idle after being detached from each other (thanks to Giorgio).
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images.
+    - Fixed default name of the left and right grippers of the [Tiago++](../guide/tiagopp.md) robot.
     - Fixed the motor torque and force feedback of the ros controller.
     - Fixed reset of [Lidar](lidar.md) rotation when resetting the simulation (thanks to Jajafarov).
     - Fixed horizontal resolution of Velodyne HDL-32E and HDL-64E [Lidars](lidar.md) (thanks to jrcblue).

--- a/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto
+++ b/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto
@@ -14,11 +14,11 @@ PROTO Tiago++ [
   field  SFString    customData            ""
   field  SFBool      supervisor            FALSE
   field  SFBool      synchronization       TRUE
-  field  SFBool      selfCollision         FALSE                 # Enables/disables the detection of collisions within the robot.
-  field  MFNode      cameraSlot            []                    # Extends the robot with a camera at head level.
-  field  MFNode      endEffectorRightSlot  TiagoGripper{}        # Extends the robot with a right end-effector (such as the TiagoRightHey5 for example).
-  field  MFNode      endEffectorLeftSlot   TiagoGripper{}        # Extends the robot with a left end-effector (such as the TiagoLeftHey5 for example).
-  field  MFNode      lidarSlot             HokuyoUrg04lxug01{}   # Extends the robot with a lidar sensor (such as Sick TIM551 or Hokuyo URG 04LX_UG01 for example).
+  field  SFBool      selfCollision         FALSE                          # Enables/disables the detection of collisions within the robot.
+  field  MFNode      cameraSlot            []                             # Extends the robot with a camera at head level.
+  field  MFNode      endEffectorRightSlot  TiagoGripper { name "right" }  # Extends the robot with a right end-effector (such as the TiagoRightHey5 for example).
+  field  MFNode      endEffectorLeftSlot   TiagoGripper { name "left" }   # Extends the robot with a left end-effector (such as the TiagoLeftHey5 for example).
+  field  MFNode      lidarSlot             HokuyoUrg04lxug01{}            # Extends the robot with a lidar sensor (such as Sick TIM551 or Hokuyo URG 04LX_UG01 for example).
 ]
 {
   TiagoBase {


### PR DESCRIPTION
**Description**
The two gripper were having the same name which was causing device name conflicts.