### PR TITLE
Added Cyberbotics for GitHub sponsor

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [omichel, DavidMansolino, stefaniapedrazzi] # [fabienrohrer] # uncomment when we get enrolled in GitHub Sponsors
+github: [cyberbotics, omichel, DavidMansolino, stefaniapedrazzi]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
Cyberbotics was officially accepted for GitHub sponsor as an organization.
This PR adds Cyberbotics in the list of sponsored beneficiaries for Webots.