### PR TITLE
Streaming server: use RotatingFileHandler and disable tornado.access info logs

### DIFF
--- a/resources/web/server/session_server.py
+++ b/resources/web/server/session_server.py
@@ -312,13 +312,16 @@ def main():
         if config['debug']:
             file_handler = logging.StreamHandler(sys.stdout)
         else:
-            file_handler = logging.FileHandler(logFile)
+            file_handler = logging.handlers.RotatingFileHandler(logFile, maxBytes=500000, backupCount=10)
         formatter = logging.Formatter('%(asctime)-15s [%(levelname)-7s]  %(message)s')
         file_handler.setFormatter(formatter)
         file_handler.setLevel(logging.INFO)
         root_logger.addHandler(file_handler)
     except (OSError, IOError) as e:
         sys.exit("Log file '" + logFile + "' cannot be created: " + str(e))
+    # disable tornado.access INFO logs
+    tornado_access_log = logging.getLogger('tornado.access')
+    tornado_access_log.setLevel(logging.WARNING)
 
     simulation_server_loads = [0] * len(config['simulationServers'])
     config['WEBOTS_HOME'] = os.getenv('WEBOTS_HOME', '../../..').replace('\\', '/')

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -724,12 +724,16 @@ def main():
     try:
         if not os.path.exists(simulationLogDir):
             os.makedirs(simulationLogDir)
-        file_handler = logging.StreamHandler(sys.stdout) if config['debug'] else logging.FileHandler(logFile)
+        file_handler = logging.StreamHandler(sys.stdout) if config['debug'] else \
+            logging.handlers.RotatingFileHandler(logFile, maxBytes=500000, backupCount=10)
         file_handler.setFormatter(log_formatter)
         file_handler.setLevel(logging.INFO)
         root_logger.addHandler(file_handler)
     except (OSError, IOError) as e:
         sys.exit("Log file '" + logFile + "' cannot be created: " + str(e))
+    # disable tornado.access INFO logs
+    tornado_access_log = logging.getLogger('tornado.access')
+    tornado_access_log.setLevel(logging.WARNING)
 
     # create monitor.csv used by Snapshot if needed
     if 'monitorLogEnabled' not in config:


### PR DESCRIPTION
Address #1381:
* use `RotatingFileHandler` that automatically moves to a new file when the maximum size is reached
* discard tornado.access info logs (all the GET requests)

For the `RotatingFileHandler`, I set the maximum size to 500Kb and the maximum number of files to 10, so we keep the last 5Mb of logs.
For comparison in one months (May) the simulation/output.log is about 42Mb but most of lines are tornado.access INFO logs like the following one that are now skipped:
``2020-05-06 10:41:53,014 [INFO   ]  200 GET /load (192.168.123.254) 0.54ms``