### PR TITLE
Use the controller environment over process environment

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -252,7 +252,7 @@ void WbController::start() {
 
     // extract the controller resources from runtime.ini and add them in the firejail whitelist
     // the runtime.ini itself has to be put in the blacklist of firejail
-    QStringList env = QProcessEnvironment::systemEnvironment().toStringList();
+    QStringList env = mProcess.environment();
     const QString &runtimeFilePath = mControllerPath + "runtime.ini";
     if (QFile::exists(runtimeFilePath)) {
       WbIniParser iniParser(runtimeFilePath);


### PR DESCRIPTION
**Description**

By using the controller environment, additional variables such as those set in `setProcessEnvironment` are accessible if needed.

**Related Issues**

**Tasks**

**Documentation**

**Screenshots**

**Additional context**


