### PR TITLE
Fix self node in supervisor.c for a Robot proto parameter node

### DIFF
--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1585,12 +1585,15 @@ void WbSupervisorUtilities::writeAnswer(QDataStream &stream) {
 }
 
 void WbSupervisorUtilities::writeConfigure(QDataStream &stream) {
+  WbNode *selfNode = mRobot;
+  while (selfNode->protoParameterNode())
+    selfNode = selfNode->protoParameterNode();
   stream << (short unsigned int)0;
   stream << (unsigned char)C_CONFIGURE;
-  stream << (int)mRobot->uniqueId();
-  QByteArray s = mRobot->modelName().toUtf8();
+  stream << (int)selfNode->uniqueId();
+  const QByteArray &s = selfNode->modelName().toUtf8();
   stream.writeRawData(s.constData(), s.size() + 1);
-  QByteArray ba = mRobot->defName().toUtf8();
+  const QByteArray &ba = selfNode->defName().toUtf8();
   stream.writeRawData(ba.constData(), ba.size() + 1);
 }
 


### PR DESCRIPTION
Fix #1604:
in case of PROTO and nested robots, the node passed during the supervisor `C_CONFIGURE` message is a PROTO parameter instance and not the node visible in the scene tree.
But the `wb_supervisor_node_get_from_def` function (and `wb_supervisor_node_get_self`) are supposed to return by default the visible nodes and not the instances, so that changes to the node are applied correctly from the Supervisor API in the exact same way they are applied from the scene tree.