### PR TITLE
Fix Qt 5.15 deprecation warnings reintroduced during merge

### DIFF
--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -2209,7 +2209,7 @@ void WbView3D::wheelEvent(QWheelEvent *event) {
 
 #ifndef __APPLE__  // bug in qt on Mac: -> QWheelEvent->orientation() is wrong when SHIFT + MOUSE_WHEEL_VERTICAL_SCROLL
   // Some mouse wheels can be scrolled horizontally
-  if (event->orientation() != Qt::Vertical)
+  if (event->angleDelta().x() != 0)
     return;
 #endif
 
@@ -2218,7 +2218,7 @@ void WbView3D::wheelEvent(QWheelEvent *event) {
     if (mDisabledUserInteractionsMap.value(WbAction::DISABLE_OBJECT_MOVE, false))
       return;
     if (mWheel) {
-      mWheel->apply(event->delta());
+      mWheel->apply(event->angleDelta().y());
       renderLater();
       return;
     }
@@ -2228,12 +2228,12 @@ void WbView3D::wheelEvent(QWheelEvent *event) {
     if (!uppermostSolid || uppermostSolid->isLocked())
       return;
     mWheel = new WbWheelLiftSolidEvent(viewpoint, uppermostSolid);
-    mWheel->apply(event->delta());
+    mWheel->apply(event->angleDelta().y());
     renderLater();
   } else if (!mDisabledUserInteractionsMap.value(WbAction::LOCK_VIEWPOINT, false)) {
     // WHEEL MOUSE only -> zoom
     if (mProjectionMode == WR_CAMERA_PROJECTION_MODE_ORTHOGRAPHIC) {
-      if (event->delta() > 0)
+      if (event->angleDelta().y() > 0)
         viewpoint->decOrthographicViewHeight();
       else
         viewpoint->incOrthographicViewHeight();
@@ -2252,7 +2252,7 @@ void WbView3D::wheelEvent(QWheelEvent *event) {
         distanceToPickPosition = 0.001;
     }
 
-    const double scaleFactor = -0.02 * (event->delta() < 0.0 ? -1 : 1) * distanceToPickPosition;
+    const double scaleFactor = -0.02 * (event->angleDelta().y() < 0.0 ? -1 : 1) * distanceToPickPosition;
     const WbVector3 zDisplacement(scaleFactor * viewpoint->orientation()->value().direction());
     WbSFVector3 *const position = viewpoint->position();
     position->setValue(position->value() + zDisplacement);


### PR DESCRIPTION
Readd the deprecation warnings fixes that were mistakenly removed in #1754.