### PR TITLE
Update call to ``inverse_kinematics``

### DIFF
--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -80,7 +80,7 @@ for motorName in ['A motor', 'B motor', 'C motor', 'D motor', 'E motor', 'F moto
 
 # Get the arm and target nodes.
 target = supervisor.getFromDef('TARGET')
-arm = supervisor.getFromDef('ARM')
+arm = supervisor.getSelf()
 
 # Loop 1: Draw a circle on the paper sheet.
 print('Draw a circle on the paper sheet...')

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -80,7 +80,7 @@ for motorName in ['A motor', 'B motor', 'C motor', 'D motor', 'E motor', 'F moto
 
 # Get the arm and target nodes.
 target = supervisor.getFromDef('TARGET')
-arm = supervisor.getSelf()
+arm = supervisor.getFromDef('ARM')
 
 # Loop 1: Draw a circle on the paper sheet.
 print('Draw a circle on the paper sheet...')
@@ -93,12 +93,7 @@ while supervisor.step(timeStep) != -1:
     z = 0.23
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    ikResults = armChain.inverse_kinematics([
-        [1, 0, 0, x],
-        [0, 1, 0, y],
-        [0, 0, 1, z],
-        [0, 0, 0, 1]
-    ])
+    ikResults = armChain.inverse_kinematics([x, y, z])
 
     # Actuate the 3 first arm motors with the IK results.
     for i in range(3):
@@ -129,12 +124,7 @@ while supervisor.step(timeStep) != -1:
     z = targetPosition[1] - armPosition[1]
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    ikResults = armChain.inverse_kinematics([
-        [1, 0, 0, x],
-        [0, 1, 0, y],
-        [0, 0, 1, z],
-        [0, 0, 0, 1]
-    ])
+    ikResults = armChain.inverse_kinematics([x, y, z])
 
     # Actuate the 3 first arm motors with the IK results.
     for i in range(3):


### PR DESCRIPTION
The library only allows to pass 3D vectors as arguments now, the orientations is handled by the second argument
Reference: https://ikpy.readthedocs.io/en/latest/chain.html#ikpy.chain.Chain.inverse_kinematics

**Description**
Without this change, the corresponding controller throws the following warning
```
[inverse_kinematics] Draw a circle on the paper sheet...
[inverse_kinematics] Traceback (most recent call last):
[inverse_kinematics]   File "inverse_kinematics.py", line 100, in <module>
[inverse_kinematics]     [0, 0, 0, 1]
[inverse_kinematics]   File "F:\Programme\Anaconda3\lib\site-packages\ikpy\chain.py", line 137, in inverse_kinematics
[inverse_kinematics]     frame_target[:3, 3] = target_position
[inverse_kinematics] ValueError: cannot copy sequence with size 4 to array axis with dimension 3
WARNING: 'inverse_kinematics' controller exited with status: 1.
```

**Related Issues**
https://github.com/Phylliade/ikpy/issues/85

