### PR TITLE
Removed useless paths added to the controllers PATH variable on Windows

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -361,9 +361,6 @@ void WbController::setProcessEnvironment() {
   // in order to be able to add easily dynamic libraries there
   // Note: on windows, this is the default behavior
   addPathEnvironmentVariable(env, ldEnvironmentVariable, mControllerPath, false, true);
-#else
-  addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "usr/bin", false, true);
-  addPathEnvironmentVariable(env, ldEnvironmentVariable, WbStandardPaths::webotsMsys64Path() + "mingw64/bin", false, true);
 #endif
 
   if (QFile::exists(mControllerPath + "runtime.ini")) {


### PR DESCRIPTION
Following #1765, these two paths are now redundant.