### PR TITLE
Fix Typo in Node-Chart

### DIFF
--- a/docs/reference/node-chart.md
+++ b/docs/reference/node-chart.md
@@ -124,7 +124,7 @@ graph LR
 
   class AbstractClass,Device,Geometry,Joint,JointDevice,Light,Motor,SolidDevice AbstractClassStyle;
   class BoundingObject,Capsule,Plane secondaryNode;
-  class Box,Cylinder,EleveationGrid,IndexedFaceSet,Sphere highlightedSecondaryNode;
+  class Box,Cylinder,ElevationGrid,IndexedFaceSet,Sphere highlightedSecondaryNode;
   class Appearance,Background,Color,Cone,Coordinate,DirectionalLight,Fog,Group,ImageTexture,IndexedLineSet,Material,Normal,PointLight,PointSet,Shape,SpotLight,TextureCoordinate,TextureTransform,Transform,Viewpoint,WorldInfo highlightedNode;
   class AbstractClassDefinition,BoundingObjectDefinition,VRML97Definition DefinitionStyle;
 %end


### PR DESCRIPTION
This typo was making the ElevationGrid appears as non-valid in bounding object:
https://www.cyberbotics.com/doc/reference/node-chart

New version:
https://www.cyberbotics.com/doc/reference/node-chart?version=fix-node-chart-typo