### PR TITLE
Add Github Action Sources Test

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,0 +1,39 @@
+name: Test Sources
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-sources:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        python: [2.7, 3.8]
+        include:
+          - os: ubuntu-16.04
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+          - os: ubuntu-18.04
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+          - os: ubuntu-20.04
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+          - os: macos-10.15
+            DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Test
+      run: |
+        echo "test"
+        ${{ matrix.DEPENDENCIES_INSTALLATION }}
+        clang-format --version
+        cp dependencies/.clang-format-9 .clang-format
+        pip install -r tests/sources/requirements.txt
+        export WEBOTS_HOME=$PWD
+        python -m unittest discover -s tests/sources

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,6 +1,6 @@
 name: Test Sources
 
-on: [push, pull_request]
+on: pull_request
 
 defaults:
   run:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -28,11 +28,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Test
+    - name: Tests
       run: |
-        echo "test"
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
-        clang-format --version
         cp dependencies/.clang-format-9 .clang-format
         pip install -r tests/sources/requirements.txt
         export WEBOTS_HOME=$PWD

--- a/tests/sources/test_cppcheck.py
+++ b/tests/sources/test_cppcheck.py
@@ -17,6 +17,7 @@
 """Test quality of the source code using Cppcheck."""
 import unittest
 import os
+import sys
 import multiprocessing
 
 from distutils.spawn import find_executable
@@ -29,7 +30,7 @@ class TestCppCheck(unittest.TestCase):
         """Set up called before each test."""
         self.WEBOTS_HOME = os.environ['WEBOTS_HOME']
         self.reportFilename = os.path.join(self.WEBOTS_HOME, 'tests', 'cppcheck_report.txt')
-        if 'TRAVIS' in os.environ and 'TRAVIS_OS_NAME' in os.environ and os.environ['TRAVIS_OS_NAME'] == 'linux':
+        if ('TRAVIS' in os.environ or 'GITHUB_ACTIONS' in os.environ) and sys.platform.startswith('linux'):
             self.cppcheck = self.WEBOTS_HOME + '/tests/sources/bin/cppcheck'
         else:
             self.cppcheck = 'cppcheck'


### PR DESCRIPTION
**Description**
This PR creates a Github action workflow that runs the test doc at each commit/pull request.

For now, for a transitional test period, the test will be duplicated with the Travis/Appveyor ones (but this will not hurt).

Tests output: https://github.com/cyberbotics/webots/actions/runs/143593466

Note: for now Windows is not included as I am having issues installing packages with pacman.