### PR TITLE
Hotfix infra red distance sensors

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -50,7 +50,7 @@ Released on XXX.
     - Fixed reset of [Lidar](lidar.md) rotation when resetting the simulation (thanks to Jajafarov).
     - Fixed horizontal resolution of Velodyne HDL-32E and HDL-64E [Lidars](lidar.md) (thanks to jrcblue).
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
-    - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow). 
+    - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
     - Fixed warnings about duplicated `name` fields in the `TruckTank` PROTO node.
     - **Fixed value returned by [DistanceSensor](distancesensor.md) devices when sensing untextured shapes.**
     - Fixed contact points optional rendering not updated when the `lineScale` field of the [WorldInfo](worldinfo.md) node was changed.

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -52,6 +52,7 @@ Released on XXX.
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
     - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
     - Fixed warnings about duplicated `name` fields in the `TruckTank` PROTO node.
+    - fixed value returned by [DistanceSensor](distancesensor.md) devices when sensing untextured shapes.
     - Fixed contact points optional rendering not updated when the `lineScale` field of the [WorldInfo](worldinfo.md) node was changed.
     - Fixed the C/C++ Makefiles to handle spaces in the Webots installation directory.
     - Fixed crash when resetting worlds with motorized [BallJoint](balljoint.md) nodes (thanks to lordNil).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -50,9 +50,9 @@ Released on XXX.
     - Fixed reset of [Lidar](lidar.md) rotation when resetting the simulation (thanks to Jajafarov).
     - Fixed horizontal resolution of Velodyne HDL-32E and HDL-64E [Lidars](lidar.md) (thanks to jrcblue).
     - Fixed the TurtleBot3Burger robot maximum velocity (thanks to Dorteel).
-    - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow).
+    - Fixed the TurtleBot3Burger robot center of mass (thanks to Nitrow). 
     - Fixed warnings about duplicated `name` fields in the `TruckTank` PROTO node.
-    - fixed value returned by [DistanceSensor](distancesensor.md) devices when sensing untextured shapes.
+    - **Fixed value returned by [DistanceSensor](distancesensor.md) devices when sensing untextured shapes.**
     - Fixed contact points optional rendering not updated when the `lineScale` field of the [WorldInfo](worldinfo.md) node was changed.
     - Fixed the C/C++ Makefiles to handle spaces in the Webots installation directory.
     - Fixed crash when resetting worlds with motorized [BallJoint](balljoint.md) nodes (thanks to lordNil).

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -379,12 +379,10 @@ void WbShape::pickColor(WbRgb &pickedColor, const WbRay &ray, double *roughness,
           pbrApp->pickRoughnessInTexture(roughness, uv);
         if (occlusion && pbrApp->isOcclusionTextureLoaded())
           pbrApp->pickOcclusionInTexture(occlusion, uv);
-      } else {
-        if (paintTexture)
-          pickedColor = paintColor;
-        // else default value
-        return;
       }
+    } else if (paintTexture) {
+      pickedColor = paintColor;
+      return;
     } else
       return;  // default value
 

--- a/tests/api/controllers/distance_sensor_infra-red/distance_sensor_infra-red.c
+++ b/tests/api/controllers/distance_sensor_infra-red/distance_sensor_infra-red.c
@@ -43,10 +43,10 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);  // no texture
-  ts_assert_double_in_delta(value, 812.5, 0.001,
-                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object with white texture "
+  ts_assert_double_in_delta(value, 1019.3725, 0.001,
+                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object without texture "
                             "(expected = %f, received = %f)",
-                            812.5, value);
+                            1019.3725, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);  // green texture
@@ -63,10 +63,10 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 1046.401497, 0.001,
-                            "Distance sensor 'ds0' doesn't return the right distance when hitting a object with white texture "
+  ts_assert_double_in_delta(value, 1281.5175, 0.001,
+                            "Distance sensor 'ds0' doesn't return the right distance when hitting a object without texture "
                             "painted green (expected = %f, received = %f)",
-                            1046.401497, value);
+                            1281.5175, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);
@@ -83,10 +83,10 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 1017.679087, 0.001,
-                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object with white texture "
+  ts_assert_double_in_delta(value, 1250.002, 0.001,
+                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object without texture "
                             "painted in violet (expected = %f, received = %f)",
-                            1017.679087, value);
+                            1250.002, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);
@@ -103,10 +103,10 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 865.171422, 0.001,
-                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object with white texture "
+  ts_assert_double_in_delta(value, 1079.5153, 0.001,
+                            "Distance sensor 'ds0' doesn't return the right distance when hitting an object without texture "
                             "painted in red (expected = %f, received = %f)",
-                            865.171422, value);
+                            1079.5153, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);

--- a/tests/api/worlds/distance_sensor_infra-red_vs_transformed_planes.wbt
+++ b/tests/api/worlds/distance_sensor_infra-red_vs_transformed_planes.wbt
@@ -14,8 +14,8 @@ DEF REGULAR_OBSTACLE Transform {
   rotation 0 0 1 1.5708
   children [
     Shape {
-      appearance PBRAppearance {
-        baseColor 0.65 0.22 1
+      appearance DEF APPEARANCE PBRAppearance {
+        baseColor 1 0.22 1
         roughness 1
         metalness 0
       }
@@ -30,11 +30,7 @@ DEF ROTATED_OBSTACLE Transform {
   rotation -0.35740681862788 0.3574058186283875 -0.8628565621288802 -1.7177753071795863
   children [
     Shape {
-      appearance PBRAppearance {
-        baseColor 0.65 0.22 1
-        roughness 1
-        metalness 0
-      }
+      appearance USE APPEARANCE
       geometry Plane {
         size 0.13 0.07
       }


### PR DESCRIPTION
**Description**
In the untextured case, the color (red component) was not taken into account when computing the distance of infra-red distance sensors.