### PR TITLE
Fix cppcheck Warnings

### DIFF
--- a/projects/languages/ros/webots_ros/src/e_puck_line.cpp
+++ b/projects/languages/ros/webots_ros/src/e_puck_line.cpp
@@ -577,12 +577,10 @@ int main(int argc, char **argv) {
       ROS_ERROR("Failed to call service time_step to update robot's time step.");
 
     // get sensors value
-    if (nStep % 1 == 0) {
-      countDist = 0;
-      countGnd = 0;
-      while (countDist < NB_DIST_SENS || countGnd < NB_GROUND_SENS)
-        ros::spinOnce();
-    }
+    countDist = 0;
+    countGnd = 0;
+    while (countDist < NB_DIST_SENS || countGnd < NB_GROUND_SENS)
+      ros::spinOnce();
 
     // Speed initialization
     speed[LEFT] = 0;

--- a/src/lib/Controller/api/remote_control.c
+++ b/src/lib/Controller/api/remote_control.c
@@ -65,6 +65,7 @@ static bool check_remote_interface(void) {
   int i;
 
   for (i = 0; i < sizeof(remoteInterface.mandatory) / sizeof(void *); i++) {
+    // cppcheck-suppress objectIndex
     if (ptr[i] == NULL)
       return false;
   }

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -1359,8 +1359,7 @@ bool wb_supervisor_world_save(const char *filename) {
   save_request = true;
 
   robot_mutex_lock_step();
-  if (filename)
-    save_filename = supervisor_strdup(filename);
+  save_filename = supervisor_strdup(filename);
   wb_robot_flush_unlocked();
   robot_mutex_unlock_step();
 

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -709,6 +709,7 @@ void WbDisplay::drawText(const char *txt, int x, int y) {
 #ifdef _WIN32  // mbstowcs doesn't work properly on Windows
   l = MultiByteToWideChar(CP_UTF8, 0, txt, -1, text, l + 1) - 1;
 #else
+  // cppcheck-suppress uninitdata
   l = mbstowcs(text, txt, l + 1);
 #endif
   int fontSize = mDisplayFont->fontSize();

--- a/src/wren/DrawableTexture.cpp
+++ b/src/wren/DrawableTexture.cpp
@@ -51,6 +51,7 @@ namespace wren {
 #ifdef _WIN32  // mbstowcs doesn't work properly on Windows
     l = MultiByteToWideChar(CP_UTF8, 0, text, -1, wcharText, l + 1) - 1;
 #else
+    // cppcheck-suppress uninitdata
     l = mbstowcs(wcharText, text, l + 1);
 #endif
 

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -96,6 +96,7 @@ namespace wren {
 #ifdef _WIN32  // mbstowcs doesn't work properly on Windows
     l = MultiByteToWideChar(CP_UTF8, 0, text, -1, wcharText, l + 1) - 1;
 #else
+    // cppcheck-suppress uninitdata
     l = mbstowcs(wcharText, text, l + 1);
 #endif
 

--- a/src/wren/PostProcessingEffect.cpp
+++ b/src/wren/PostProcessingEffect.cpp
@@ -147,11 +147,12 @@ namespace wren {
     mUseAlphaBlending(true) {}
 
   PostProcessingEffect::Pass::~Pass() {
-    for (TextureRtt *texture : mFrameBuffer->outputTextures())
-      Texture::deleteTexture(texture);
+    if (mFrameBuffer) {
+      for (TextureRtt *texture : mFrameBuffer->outputTextures())
+        Texture::deleteTexture(texture);
 
-    if (mFrameBuffer)
       FrameBuffer::deleteFrameBuffer(mFrameBuffer);
+    }
 
     StaticMesh::deleteMesh(mMesh);
   }


### PR DESCRIPTION
**Description**
A new version of cppcheck is available on macOS with homebrew and gives new warnings:
```
 projects/languages/ros/webots_ros/src/e_puck_line.cpp:580:15: style: Modulo of one is always equal to zero [moduloofone]
    if (nStep % 1 == 0) {
src/lib/Controller/api/remote_control.c:68:12: warning: The address of local variable 'mandatory' might be accessed at non-zero index. [objectIndex]
    if (ptr[i] == NULL)
           ^
src/lib/Controller/api/remote_control.c:64:28: note: Address of variable taken here.
  void (**ptr)() = (void *)&remoteInterface.mandatory;
                           ^
src/lib/Controller/api/remote_control.c:68:12: note: The address of local variable 'mandatory' might be accessed at non-zero index.
    if (ptr[i] == NULL)
           ^
src/lib/Controller/api/supervisor.c:1362:7: style: Condition 'filename' is always true [knownConditionTrueFalse]
  if (filename)
      ^
src/lib/Controller/api/supervisor.c:1340:7: note: Assuming that condition 'filename' is not redundant
  if (filename) {
      ^
src/lib/Controller/api/supervisor.c:1362:7: note: Condition 'filename' is always true
  if (filename)
      ^
src/webots/nodes/WbDisplay.cpp:712:16: error: Memory is allocated but not initialized: text [uninitdata]
  l = mbstowcs(text, txt, l + 1);
               ^
src/wren/DrawableTexture.cpp:54:18: error: Memory is allocated but not initialized: wcharText [uninitdata]
    l = mbstowcs(wcharText, text, l + 1);
                 ^
src/wren/Font.cpp:99:18: error: Memory is allocated but not initialized: wcharText [uninitdata]
    l = mbstowcs(wcharText, text, l + 1);
                 ^
src/wren/PostProcessingEffect.cpp:150:32: warning: Either the condition 'if(mFrameBuffer)' is redundant or there is possible null pointer dereference: mFrameBuffer. [nullPointerRedundantCheck]
    for (TextureRtt *texture : mFrameBuffer->outputTextures())
                               ^
src/wren/PostProcessingEffect.cpp:153:8: note: Assuming that condition 'if(mFrameBuffer)' is not redundant
    if (mFrameBuffer)
       ^
src/wren/PostProcessingEffect.cpp:150:32: note: Null pointer dereference
    for (TextureRtt *texture : mFrameBuffer->outputTextures())
                               ^
```