### PR TITLE
Fix parent methods in qobject

### DIFF
--- a/src/webots/app/WbProtoCachedInfo.cpp
+++ b/src/webots/app/WbProtoCachedInfo.cpp
@@ -166,16 +166,16 @@ WbProtoCachedInfo *WbProtoCachedInfo::computeInfo(const QString &protoFileName) 
   tokenizer.rewind();
   WbProtoModel *protoModel = NULL;
   bool prevInstantiateMode = WbNode::instantiateMode();
-  WbNode *previousParent = WbNode::globalParent();
+  WbNode *previousParent = WbNode::globalParentNode();
   try {
-    WbNode::setGlobalParent(NULL);
+    WbNode::setGlobalParentNode(NULL);
     WbNode::setInstantiateMode(false);
     protoModel = new WbProtoModel(&tokenizer, WbWorld::instance() ? WbWorld::instance()->fileName() : "", protoFileName);
     WbNode::setInstantiateMode(prevInstantiateMode);
-    WbNode::setGlobalParent(previousParent);
+    WbNode::setGlobalParentNode(previousParent);
   } catch (...) {
     WbNode::setInstantiateMode(prevInstantiateMode);
-    WbNode::setGlobalParent(previousParent);
+    WbNode::setGlobalParentNode(previousParent);
     return NULL;
   }
 

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -200,7 +200,7 @@ void WbX3dStreamingServer::propagateNodeAddition(WbNode *node) {
     node->write(writer);
     foreach (QWebSocket *client, mWebSocketClients)
       // add root <nodes> element to handle correctly multiple root elements like in case of PBRAppearance node.
-      client->sendTextMessage(QString("node:%1:<nodes>%2</nodes>").arg(node->parent()->uniqueId()).arg(nodeString));
+      client->sendTextMessage(QString("node:%1:<nodes>%2</nodes>").arg(node->parentNode()->uniqueId()).arg(nodeString));
   }
 }
 

--- a/src/webots/nodes/WbBaseNode.cpp
+++ b/src/webots/nodes/WbBaseNode.cpp
@@ -139,8 +139,8 @@ void WbBaseNode::reset() {
 void WbBaseNode::createWrenObjects() {
   mWrenObjectsCreatedCalled = true;
 
-  if (parent()) {
-    const WbBaseNode *const p = static_cast<WbBaseNode *>(parent());
+  if (parentNode()) {
+    const WbBaseNode *const p = static_cast<WbBaseNode *>(parentNode());
     mWrenNode = p->wrenNode();
   } else
     mWrenNode = wr_scene_get_root(wr_scene_get_instance());
@@ -263,13 +263,13 @@ bool WbBaseNode::exportNodeHeader(WbVrmlWriter &writer) const {
 }
 
 bool WbBaseNode::isUrdfRootLink() const {
-  if (findSFString("name") || dynamic_cast<WbBasicJoint *>(parent()))
+  if (findSFString("name") || dynamic_cast<WbBasicJoint *>(parentNode()))
     return true;
   return false;
 }
 
 void WbBaseNode::exportURDFJoint(WbVrmlWriter &writer) const {
-  if (!dynamic_cast<WbBasicJoint *>(parent())) {
+  if (!dynamic_cast<WbBasicJoint *>(parentNode())) {
     WbVector3 translation;
     WbVector3 rotationEuler;
     const WbNode *const upperLinkRoot = findUrdfLinkRoot();

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -311,7 +311,7 @@ WbSolidReference *WbBasicJoint::solidReference() const {
 }
 
 WbSolid *WbBasicJoint::solidParent() const {
-  return dynamic_cast<WbSolid *>(parent());
+  return dynamic_cast<WbSolid *>(parentNode());
 }
 
 WbVector3 WbBasicJoint::anchor() const {

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -85,36 +85,36 @@ void WbGroup::postFinalize() {
   connect(mChildren, &WbMFNode::changed, this, &WbGroup::childrenChanged);
   connect(mChildren, &WbMFNode::itemInserted, this, &WbGroup::insertChildPrivate);
   // if parent is a slot, it needs to be notified when a new node is inserted
-  WbSlot *ps = dynamic_cast<WbSlot *>(parent());
+  WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
   if (ps)
     connect(this, &WbGroup::notifyParentSlot, ps, &WbSlot::endPointInserted);
 
-  const WbGroup *const parentNode = dynamic_cast<const WbGroup *const>(parent());
-  if (parentNode && parentNode->mHasNoSolidAncestor) {
+  const WbGroup *const parent = dynamic_cast<const WbGroup *const>(parentNode());
+  if (parent && parent->mHasNoSolidAncestor) {
     connect(mChildren, &WbMFNode::changed, this, &WbGroup::topLevelListsUpdateRequested);
-    connect(this, &WbGroup::topLevelListsUpdateRequested, parentNode, &WbGroup::topLevelListsUpdateRequested);
+    connect(this, &WbGroup::topLevelListsUpdateRequested, parent, &WbGroup::topLevelListsUpdateRequested);
   } else if (mHasNoSolidAncestor)
     connect(mChildren, &WbMFNode::changed, this, &WbGroup::topLevelListsUpdateRequested);
 }
 
 void WbGroup::insertChild(int index, WbNode *child) {
-  child->setParent(this);
+  child->setParentNode(this);
   mChildren->insertItem(index, child);
 }
 
 void WbGroup::setChild(int index, WbNode *child) {
-  child->setParent(this);
+  child->setParentNode(this);
   mChildren->setItem(index, child);
 }
 
 void WbGroup::addChild(WbNode *child) {
-  child->setParent(this);
+  child->setParentNode(this);
   mChildren->addItem(child);
 }
 
 bool WbGroup::removeChild(WbNode *node) {
   if (mChildren->removeNode(node)) {
-    node->setParent(NULL);
+    node->setParentNode(NULL);
     return true;
   } else
     return false;
@@ -124,7 +124,7 @@ void WbGroup::clear() {
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
     WbNode *const n = it.next();
-    n->setParent(NULL);
+    n->setParentNode(NULL);
   }
   mChildren->clear();
 }
@@ -227,9 +227,9 @@ bool WbGroup::isAValidBoundingObject(bool checkOde, bool warning) const {
 }
 
 void WbGroup::descendantNodeInserted(WbBaseNode *decendant) {
-  if (parent()) {
-    WbGroup *pg = dynamic_cast<WbGroup *>(parent());
-    WbSlot *ps = dynamic_cast<WbSlot *>(parent());
+  if (parentNode()) {
+    WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
+    WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
     if (pg)
       pg->descendantNodeInserted(decendant);
     if (ps)

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -256,7 +256,7 @@ void WbImageTexture::modifyWrenMaterial(WrMaterial *wrenMaterial, const int main
     wr_material_set_texture_enable_interpolation(wrenMaterial, mFiltering->value(), mWrenTextureIndex);
     wr_material_set_texture_enable_mip_maps(wrenMaterial, mFiltering->value(), mWrenTextureIndex);
 
-    if (mExternalTexture && !(static_cast<WbAppearance *>(parent())->textureTransform())) {
+    if (mExternalTexture && !(static_cast<WbAppearance *>(parentNode())->textureTransform())) {
       wr_texture_transform_delete(mWrenTextureTransform);
       mWrenTextureTransform = wr_texture_transform_new();
       wr_texture_transform_set_scale(mWrenTextureTransform, mExternalTextureRatio.x(), mExternalTextureRatio.y());

--- a/src/webots/nodes/WbJointDevice.cpp
+++ b/src/webots/nodes/WbJointDevice.cpp
@@ -61,15 +61,15 @@ void WbJointDevice::postFinalize() {
 }
 
 WbJoint *WbJointDevice::joint() const {
-  return dynamic_cast<WbJoint *>(parent());
+  return dynamic_cast<WbJoint *>(parentNode());
 }
 
 WbPropeller *WbJointDevice::propeller() const {
-  return dynamic_cast<WbPropeller *>(parent());
+  return dynamic_cast<WbPropeller *>(parentNode());
 }
 
 WbTrack *WbJointDevice::track() const {
-  return dynamic_cast<WbTrack *>(parent());
+  return dynamic_cast<WbTrack *>(parentNode());
 }
 
 WbLogicalDevice *WbJointDevice::getSiblingDeviceByType(int nodeType) const {

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -118,14 +118,14 @@ void WbLed::findMaterialsAndLights(const WbGroup *group) {
           mMaterials.append(material);
 
         connect(appearance, &WbAppearance::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
-        connect(appearance->parent(), &WbShape::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
+        connect(appearance->parentNode(), &WbShape::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
       } else {
         WbPbrAppearance *pbrAppearance = dynamic_cast<WbShape *>(n)->pbrAppearance();
         if (pbrAppearance) {
           mPbrAppearances.append(pbrAppearance);
 
           connect(pbrAppearance, &WbPbrAppearance::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
-          connect(pbrAppearance->parent(), &WbShape::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
+          connect(pbrAppearance->parentNode(), &WbShape::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
         }
       }
     } else if (light)

--- a/src/webots/nodes/WbLinearMotor.cpp
+++ b/src/webots/nodes/WbLinearMotor.cpp
@@ -56,7 +56,7 @@ void WbLinearMotor::turnOffMotor() {
 }
 
 double WbLinearMotor::computeFeedback() const {
-  if (dynamic_cast<WbTrack *>(parent())) {
+  if (dynamic_cast<WbTrack *>(parentNode())) {
     warn(tr("Force feedback is not available for a LinearMotor node inside a Track node."));
     return 0.0;
   }

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -155,7 +155,7 @@ void WbMotor::setupJointFeedback() {
 }
 
 double WbMotor::energyConsumption() const {
-  if (dynamic_cast<WbTrack *>(parent()))
+  if (dynamic_cast<WbTrack *>(parentNode()))
     return 0.0;
 
   return fabs(computeFeedback()) * mConsumptionFactor->value();
@@ -170,7 +170,7 @@ void WbMotor::updateMinAndMaxPosition() {
     // no limits
     return;
 
-  WbJoint *parentJoint = dynamic_cast<WbJoint *>(parent());
+  WbJoint *parentJoint = dynamic_cast<WbJoint *>(parentNode());
   double p = 0.0;
   if (parentJoint && parentJoint->parameters())
     p = parentJoint->parameters()->position();
@@ -556,7 +556,7 @@ void WbMotor::awake() const {
   }
 
   const WbPropeller *const p = propeller();
-  const WbTrack *const t = dynamic_cast<WbTrack *>(parent());
+  const WbTrack *const t = dynamic_cast<WbTrack *>(parentNode());
   if (p || t) {
     WbSolid *const s = upperSolid();
     assert(s);

--- a/src/webots/nodes/WbMuscle.cpp
+++ b/src/webots/nodes/WbMuscle.cpp
@@ -120,7 +120,7 @@ void WbMuscle::postFinalize() {
   WbBaseNode::postFinalize();
 
   mParentTransform = WbNodeUtilities::findUpperTransform(this);
-  const WbJoint *joint = dynamic_cast<WbJoint *>(parent()->parent());
+  const WbJoint *joint = dynamic_cast<WbJoint *>(parentNode()->parentNode());
   updateEndPoint(joint->solidEndPoint());
   WbWrenVertexArrayFrameListener::instance()->subscribeMuscle(this);
   updateMaterial();
@@ -197,7 +197,7 @@ void WbMuscle::updateEndPointPosition() {
 
 void WbMuscle::updateEndPoint(WbBaseNode *node) {
   const WbSolid *solid = dynamic_cast<WbSolid *>(node);
-  const WbJoint *joint = dynamic_cast<WbJoint *>(parent()->parent());
+  const WbJoint *joint = dynamic_cast<WbJoint *>(parentNode()->parentNode());
   if (mEndPoint != solid) {
     if (mEndPoint) {
       disconnect(mEndPoint->translationFieldValue(), &WbSFVector3::changedByOde, this, &WbMuscle::stretch);
@@ -220,7 +220,7 @@ void WbMuscle::updateEndPoint(WbBaseNode *node) {
 }
 
 void WbMuscle::updateStretchForce(double forcePercentage, bool immediateUpdate, int motorIndex) {
-  const WbMotor *motor = dynamic_cast<WbMotor *>(parent());
+  const WbMotor *motor = dynamic_cast<WbMotor *>(parentNode());
   if (motor->positionIndex() != motorIndex)
     return;
   mStatus = forcePercentage;

--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -320,7 +320,7 @@ void WbSliderJoint::writeExport(WbVrmlWriter &writer) const {
 
     writer.increaseIndent();
     writer.indent();
-    writer << QString("<parent link=\"%1\"/>\n").arg(parent()->urdfName());
+    writer << QString("<parent link=\"%1\"/>\n").arg(parentNode()->urdfName());
     writer.indent();
     writer << QString("<child link=\"%1\"/>\n").arg(solidEndPoint()->urdfName());
     writer.indent();

--- a/src/webots/nodes/WbSlot.cpp
+++ b/src/webots/nodes/WbSlot.cpp
@@ -56,10 +56,10 @@ void WbSlot::preFinalize() {
   WbBaseNode::preFinalize();
 
   connect(mEndPoint, &WbSFString::changed, this, &WbSlot::endPointChanged);
-  WbGroup *pg = dynamic_cast<WbGroup *>(parent());
+  WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
   if (pg)  // parent is a group
     connect(this, &WbSlot::endPointInserted, pg, &WbGroup::insertChildFromSlot);
-  WbSlot *ps = dynamic_cast<WbSlot *>(parent());
+  WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
   if (ps)  // parent is another slot
     connect(this, &WbSlot::endPointInserted, ps, &WbSlot::endPointInserted);
 
@@ -80,7 +80,7 @@ void WbSlot::postFinalize() {
 
 void WbSlot::updateType() {
   QString connectedType;
-  const WbSlot *const parentSlot = dynamic_cast<WbSlot *>(parent());
+  const WbSlot *const parentSlot = dynamic_cast<WbSlot *>(parentNode());
   const WbSlot *const childSlot = slotEndPoint();
   if (parentSlot)
     connectedType = parentSlot->slotType();
@@ -171,7 +171,7 @@ WbBoundingSphere *WbSlot::boundingSphere() const {
 void WbSlot::endPointChanged() {
   WbBaseNode *const e = static_cast<WbBaseNode *>(mEndPoint->value());
   if (e) {
-    e->setParent(this);
+    e->setParentNode(this);
     emit endPointInserted(e);
   }
 }

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1059,7 +1059,7 @@ void WbSolid::removeBoundingGeometry() {
 // this method is overridden in the WbTouchSensor class
 dJointID WbSolid::createJoint(dBodyID body, dBodyID parentBody, dWorldID world) const {
   dJointID joint;
-  const WbDifferentialWheels *const dw = dynamic_cast<WbDifferentialWheels *>(parent());
+  const WbDifferentialWheels *const dw = dynamic_cast<WbDifferentialWheels *>(parentNode());
   if (dw && (this == dw->leftWheel() || this == dw->rightWheel())) {
     // special case: the (Solid) wheels of a DifferentialWheels robot
     // must be attached using hinge joints in order to allow rotation
@@ -1075,7 +1075,7 @@ dJointID WbSolid::createJoint(dBodyID body, dBodyID parentBody, dWorldID world) 
 }
 
 void WbSolid::setJoint(dJointID joint, dBodyID body, dBodyID parentBody) const {
-  const WbDifferentialWheels *const dw = dynamic_cast<WbDifferentialWheels *>(parent());
+  const WbDifferentialWheels *const dw = dynamic_cast<WbDifferentialWheels *>(parentNode());
   if (dw && (this == dw->leftWheel() || this == dw->rightWheel())) {
     // special case: the (Solid) wheels of a DifferentialWheels robot
     // must be attached using hinge joints in order to allow them to rotate
@@ -1945,14 +1945,14 @@ void WbSolid::updateTransformAfterPhysicsStep() {
   applyPhysicsTransform();
 
   WbSolid *s = NULL;
-  WbNode *p = parent();
+  WbNode *p = parentNode();
   while (p != NULL && !p->isWorldRoot()) {
     s = dynamic_cast<WbSolid *>(p);
     if (s != NULL) {
       s->applyPhysicsTransform();
       s->mUpdatedAfterStep = true;
     }
-    p = p->parent();
+    p = p->parentNode();
   }
   mUpdatedAfterStep = true;
 }
@@ -2086,13 +2086,13 @@ void WbSolid::prePhysicsStep(double ms) {
 // Accessors to relatives
 
 WbBasicJoint *WbSolid::jointParent() const {
-  WbSlot *parentSlot = dynamic_cast<WbSlot *>(parent());
+  WbSlot *parentSlot = dynamic_cast<WbSlot *>(parentNode());
   if (parentSlot) {
-    WbSlot *granParentSlot = dynamic_cast<WbSlot *>(parentSlot->parent());
+    WbSlot *granParentSlot = dynamic_cast<WbSlot *>(parentSlot->parentNode());
     if (granParentSlot)
-      return dynamic_cast<WbBasicJoint *>(granParentSlot->parent());
+      return dynamic_cast<WbBasicJoint *>(granParentSlot->parentNode());
   }
-  return dynamic_cast<WbBasicJoint *>(parent());
+  return dynamic_cast<WbBasicJoint *>(parentNode());
 }
 
 dBodyID WbSolid::upperSolidBody() const {
@@ -2160,7 +2160,7 @@ void WbSolid::addTorque(const WbVector3 &torque) {
 // Selection management
 void WbSolid::propagateSelection(bool selected) {
   if (wrenNode() && mIsPermanentlyKinematic) {
-    const WbPropeller *const propeller = dynamic_cast<WbPropeller *>(parent());
+    const WbPropeller *const propeller = dynamic_cast<WbPropeller *>(parentNode());
     if (propeller) {
       const bool active = propeller->helix() == this;
       wr_node_set_visible(WR_NODE(wrenNode()), selected || active);
@@ -2283,11 +2283,11 @@ void WbSolid::jerk(bool resetVelocities, bool rootJerk) {
 }
 
 void WbSolid::notifyChildJerk(WbTransform *childNode) {
-  WbNode *node = childNode->parent();
+  WbNode *node = childNode->parentNode();
   while (node != this && node != NULL) {
     if (mMovedChildren.contains(dynamic_cast<WbTransform *>(node)))
       return;
-    node = node->parent();
+    node = node->parentNode();
   }
 
   mMovedChildren.append(childNode);

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -69,11 +69,11 @@ bool WbSolidReference::isClosedLoop() const {
   if (!mSolid)
     return false;
 
-  WbNode *parentNode = parent();
-  while (parentNode && !parentNode->isWorldRoot()) {
-    if (parentNode == mSolid)
+  WbNode *parent = parentNode();
+  while (parent && !parent->isWorldRoot()) {
+    if (parent == mSolid)
       return true;
-    parentNode = parentNode->parent();
+    parent = parent->parentNode();
   }
   return false;
 }

--- a/src/webots/nodes/utils/WbBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "WbBaseNode.hpp"
 #include "WbBoundingSphere.hpp"
+
+#include "WbBaseNode.hpp"
 #include "WbMatrix3.hpp"
 #include "WbNodeUtilities.hpp"
 #include "WbRay.hpp"

--- a/src/webots/nodes/utils/WbBoundingSphere.hpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.hpp
@@ -115,7 +115,7 @@ public:
 private:
   WbVector3 mCenter;
   double mRadius;
-  WbBoundingSphere *mParent;
+  WbBoundingSphere *mParentBoundingSphere;
   QList<WbBoundingSphere *> mSubBoundingSpheres;
   const WbBaseNode *mOwner;
   const WbGeometry *mGeomOwner;
@@ -138,7 +138,7 @@ private:
   double radiusInParentCoordinates();
   const WbVector3 &centerInParentCoordinates();
   void parentUpdateNotification() const;
-  void setParent(WbBoundingSphere *parent) { mParent = parent; }
+  void setParentBoundingSphere(WbBoundingSphere *parent) { mParentBoundingSphere = parent; }
 
   // setOwner doesn't work correctly if called from the 'node' constructors
   // because of dynamic_cast

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
@@ -289,7 +289,7 @@ WbNode *WbConcreteNodeFactory::createNode(const QString &modelName, WbTokenizer 
 
   // reset global parent that could be changed while parsing the PROTO model
   if (parentNode)
-    WbNode::setGlobalParent(parentNode);
+    WbNode::setGlobalParentNode(parentNode);
   WbNode *protoInstance =
     WbNode::createProtoInstance(model, tokenizer, WbWorld::instance() ? WbWorld::instance()->fileName() : "");
   if (protoInstance)

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -97,8 +97,8 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       for (int defIndex = 0; (!match) && defIndex < numberOfDefs; ++defIndex) {
         definitionNode = static_cast<WbBaseNode *>(defNodes[defIndex]);
         QString error;
-        assert(node->parentField() && node->parent());
-        typeMatch = WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parent(),
+        assert(node->parentField() && node->parentNode());
+        typeMatch = WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parentNode(),
                                                        error, nodeUse, QString(), QStringList(definitionNode->nodeModelName()));
         match = typeMatch && !definitionNode->isAnAncestorOf(node);
       }
@@ -113,9 +113,9 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
         if (matchingNode && matchingNode->isUseNode()) {
           definitionNode = static_cast<WbBaseNode *>(matchingNode->defNode());
           QString error;
-          assert(node->parentField() && node->parent());
+          assert(node->parentField() && node->parentNode());
           typeMatch =
-            WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parent(), error,
+            WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parentNode(), error,
                                                nodeUse, QString(), QStringList(definitionNode->nodeModelName()));
         }
       }
@@ -125,10 +125,10 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
           QString deviceModelName;
           if (node->isInBoundingObject() != definitionNode->isInBoundingObject() &&
               !checkBoundingObjectConstraints(definitionNode, warning)) {
-            node->parent()->parsingWarn(QObject::tr("Deleted invalid USE %1 node: %3").arg(useName).arg(warning));
+            node->parentNode()->parsingWarn(QObject::tr("Deleted invalid USE %1 node: %3").arg(useName).arg(warning));
             WbNodeOperations::instance()->deleteNode(node);
             return false;
-          } else if (!checkChargerAndLedConstraints(node->parent(), definitionNode, deviceModelName, index == 0)) {
+          } else if (!checkChargerAndLedConstraints(node->parentNode(), definitionNode, deviceModelName, index == 0)) {
             node->parsingWarn(
               QObject::tr("Non-admissible USE %1 node inside first child of %2 node.\n"
                           "Invalid USE nodes that refer to DEF nodes defined outside the %2 node are turned into DEF nodes "
@@ -138,7 +138,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
             makeDefNodeAndUpdateDictionary(node, true);
           } else {
             if (!mLoad) {
-              WbNode *const parent = node->parent();
+              WbNode *const parent = node->parentNode();
               WbNode::setGlobalParent(parent);
               WbBaseNode *const newUseNode = static_cast<WbBaseNode *>(definitionNode->cloneDefNode());
               WbNode::setGlobalParent(NULL);
@@ -161,7 +161,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
 
       if (matchingNode && matchingNode->isDefNode()) {
         if (!mLoad) {
-          WbNode *const parent = node->parent();
+          WbNode *const parent = node->parentNode();
           WbNode::setGlobalParent(parent);
           WbBaseNode *const newDefNode = static_cast<WbBaseNode *>(matchingNode->cloneAndReferenceProtoInstance());
           newDefNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -139,9 +139,9 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
           } else {
             if (!mLoad) {
               WbNode *const parent = node->parentNode();
-              WbNode::setGlobalParent(parent);
+              WbNode::setGlobalParentNode(parent);
               WbBaseNode *const newUseNode = static_cast<WbBaseNode *>(definitionNode->cloneDefNode());
-              WbNode::setGlobalParent(NULL);
+              WbNode::setGlobalParentNode(NULL);
               newUseNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
               if (sfNode)
                 sfNode->setValue(newUseNode);
@@ -162,7 +162,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       if (matchingNode && matchingNode->isDefNode()) {
         if (!mLoad) {
           WbNode *const parent = node->parentNode();
-          WbNode::setGlobalParent(parent);
+          WbNode::setGlobalParentNode(parent);
           WbBaseNode *const newDefNode = static_cast<WbBaseNode *>(matchingNode->cloneAndReferenceProtoInstance());
           newDefNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
           if (sfNode)

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -155,7 +155,7 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
     WbSelection::instance()->selectTransformFromView3D(NULL);
 
   // read node
-  WbNode::setGlobalParent(parentNode);
+  WbNode::setGlobalParentNode(parentNode);
   WbNodeReader nodeReader;
   // set available DEF nodes to be used while reading the new nodes
   QList<WbNode *> defNodes = WbDictionary::instance()->computeDefForInsertion(parentNode, field, itemIndex, false);
@@ -243,7 +243,7 @@ WbNodeOperations::OperationResult WbNodeOperations::importVrml(const QString &fi
   // read node
   QString errorMessage;
   WbGroup *root = WbWorld::instance()->root();
-  WbNode::setGlobalParent(root);
+  WbNode::setGlobalParentNode(root);
   WbNodeReader nodeReader;
   QList<WbNode *> nodes = nodeReader.readVrml(&tokenizer, WbWorld::instance()->fileName());
   WbBaseNode *lastBaseNodeCreated = NULL;

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -471,7 +471,7 @@ WbNodeOperations::OperationResult WbNodeOperations::initNewNode(WbNode *newNode,
 
   WbBaseNode *const baseNode = dynamic_cast<WbBaseNode *>(newNode);
   // set parent node
-  newNode->setParent(parentNode);
+  newNode->setParentNode(parentNode);
   WbNode *upperTemplate = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, parentNode);
   bool isInsideATemplateRegenerator = upperTemplate && (upperTemplate != baseNode);
 
@@ -524,7 +524,7 @@ void WbNodeOperations::resolveSolidNameClashIfNeeded(WbNode *node) const {
     solidNodes << WbNodeUtilities::findSolidDescendants(node);
   while (!solidNodes.isEmpty()) {
     WbSolid *s = solidNodes.takeFirst();
-    const WbBaseNode *const parentBaseNode = dynamic_cast<WbBaseNode *>(s->parent());
+    const WbBaseNode *const parentBaseNode = dynamic_cast<WbBaseNode *>(s->parentNode());
     const WbSolid *parentSolidNode = dynamic_cast<const WbSolid *>(parentBaseNode);
     const WbSolid *upperSolid = parentSolidNode ? parentSolidNode : parentBaseNode->upperSolid();
     s->resolveNameClashIfNeeded(true, true,

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -140,10 +140,10 @@ namespace {
     }
 
     if (dynamic_cast<const WbSlot *>(node) && (fieldName == "endPoint")) {  // add something in the endPoint field of a slot
-      if (dynamic_cast<const WbSlot *>(node->parent())) {  // pair of slots, we can add everything that is allowed in the
-                                                           // children field of the parent of first Slot node
-        WbNode *parentNode = node->parent();
-        const WbNode *upperNode = parentNode->parent();
+      if (dynamic_cast<const WbSlot *>(node->parentNode())) {  // pair of slots, we can add everything that is allowed in the
+                                                               // children field of the parent of first Slot node
+        WbNode *parentNode = node->parentNode();
+        const WbNode *upperNode = parentNode->parentNode();
         const WbField *upperField = parentNode->parentField(true);
         if (!upperNode || !upperField) {
           assert(false);
@@ -157,7 +157,7 @@ namespace {
       // not in a pair => we can only add a Slot of same type
       QString slotType = WbNodeUtilities::slotType(node);
       // if node is a proto and is a parameter of another proto, the pair of slot is not detected
-      if (WbNodeReader::current() && node->isProtoInstance() && node->parent() && node->parent()->isProtoInstance())
+      if (WbNodeReader::current() && node->isProtoInstance() && node->parentNode() && node->parentNode()->isProtoInstance())
         return true;
       if (nodeName != "Slot") {
         errorMessage =
@@ -550,11 +550,11 @@ WbNode *WbNodeUtilities::findUpperNodeByType(const WbNode *node, int nodeType, i
     return NULL;
 
   int count = searchDegrees > 0 ? searchDegrees : -1;
-  WbBaseNode *n = dynamic_cast<WbBaseNode *>(node->parent());
+  WbBaseNode *n = dynamic_cast<WbBaseNode *>(node->parentNode());
   while (n && count != 0) {
     if (n->nodeType() == nodeType)
       return n;
-    n = dynamic_cast<WbBaseNode *>(n->parent());
+    n = dynamic_cast<WbBaseNode *>(n->parentNode());
     count--;
   }
   return NULL;
@@ -575,14 +575,14 @@ WbMatter *WbNodeUtilities::findUpperMatter(const WbNode *node) {
   if (node == NULL)
     return NULL;
 
-  WbNode *n = node->parent();
+  WbNode *n = node->parentNode();
 
   while (n) {
     WbMatter *const matter = dynamic_cast<WbMatter *>(n);
     if (matter)
       return matter;
     else
-      n = n->parent();
+      n = n->parentNode();
   }
   return NULL;
 }
@@ -609,7 +609,7 @@ WbTransform *WbNodeUtilities::findUppermostTransform(const WbNode *node) {
     const WbTransform *transform = dynamic_cast<const WbTransform *>(n);
     if (transform)
       uppermostTransform = const_cast<WbTransform *>(transform);
-    n = n->parent();
+    n = n->parentNode();
   };
   return uppermostTransform;
 }
@@ -621,7 +621,7 @@ WbSolid *WbNodeUtilities::findUppermostSolid(const WbNode *node) {
     const WbSolid *solid = dynamic_cast<const WbSolid *>(n);
     if (solid)
       uppermostSolid = const_cast<WbSolid *>(solid);
-    n = n->parent();
+    n = n->parentNode();
   };
   return uppermostSolid;
 }
@@ -633,7 +633,7 @@ WbMatter *WbNodeUtilities::findUppermostMatter(WbNode *node) {
     const WbMatter *matter = dynamic_cast<const WbMatter *>(n);
     if (matter)
       uppermostMatter = const_cast<WbMatter *>(matter);
-    n = n->parent();
+    n = n->parentNode();
   };
   return uppermostMatter;
 }
@@ -646,13 +646,13 @@ WbTransform *WbNodeUtilities::findUpperTransform(const WbNode *node) {
   if (node == NULL)
     return NULL;
 
-  WbNode *n = node->parent();
+  WbNode *n = node->parentNode();
   while (n) {
     WbTransform *const transform = dynamic_cast<WbTransform *>(n);
     if (transform)
       return transform;
     else
-      n = n->parent();
+      n = n->parentNode();
   }
   return NULL;
 }
@@ -672,13 +672,13 @@ WbNode *WbNodeUtilities::findUpperTemplateNeedingRegeneration(WbNode *modifiedNo
     return NULL;
 
   WbField *field = modifiedNode->parentField();
-  WbNode *node = modifiedNode->parent();
+  WbNode *node = modifiedNode->parentNode();
   while (node && field && !node->isWorldRoot()) {
     if (node->isTemplate() && field->isTemplateRegenerator())
       return node;
 
     field = node->parentField();
-    node = node->parent();
+    node = node->parentNode();
   }
 
   return NULL;
@@ -689,13 +689,13 @@ const WbNode *WbNodeUtilities::findTopNode(const WbNode *node) {
     return NULL;
 
   const WbNode *n = node;
-  const WbNode *parent = n->parent();
+  const WbNode *parent = n->parentNode();
   while (parent) {
     if (parent->isWorldRoot())
       return n;
 
     n = parent;
-    parent = n->parent();
+    parent = n->parentNode();
   }
   return NULL;
 }
@@ -735,11 +735,11 @@ bool WbNodeUtilities::hasADefNodeAncestor(const WbNode *node) {
   if (node->isDefNode())
     return true;
 
-  const WbNode *p = node->parent();
+  const WbNode *p = node->parentNode();
   while (p) {
     if (p->isDefNode())
       return true;
-    p = p->parent();
+    p = p->parentNode();
   }
 
   return false;
@@ -752,11 +752,11 @@ bool WbNodeUtilities::hasAUseNodeAncestor(const WbNode *node) {
   if (node->isUseNode())
     return true;
 
-  const WbNode *p = node->parent();
+  const WbNode *p = node->parentNode();
   while (p) {
     if (p->isUseNode())
       return true;
-    p = p->parent();
+    p = p->parentNode();
   }
 
   return false;
@@ -772,7 +772,7 @@ QList<WbNode *> WbNodeUtilities::findUseNodeAncestors(WbNode *node) {
   while (n && !n->isWorldRoot()) {
     if (n->isUseNode())
       list.prepend(n);
-    n = n->parent();
+    n = n->parentNode();
   }
 
   return list;
@@ -788,13 +788,13 @@ WbRobot *WbNodeUtilities::findRobotAncestor(const WbNode *node) {
   if (!node)
     return NULL;
 
-  while (node->parent()) {
+  while (node->parentNode()) {
     if (isRobotTypeName(node->nodeModelName())) {
       const WbRobot *robot = reinterpret_cast<const WbRobot *>(node);
       return const_cast<WbRobot *>(robot);
     }
 
-    node = node->parent();
+    node = node->parentNode();
   }
   return NULL;
 }
@@ -803,14 +803,14 @@ bool WbNodeUtilities::isFieldDescendant(const WbNode *node, const QString &field
   if (node == NULL)
     return false;
 
-  WbNode *n = node->parent();
+  WbNode *n = node->parentNode();
   WbField *field = node->parentField(true);
   while (n && !n->isWorldRoot() && field) {
     if (field->name() == fieldName)
       return true;
 
     field = n->parentField(true);
-    n = n->parent();
+    n = n->parentNode();
   }
 
   return false;
@@ -838,7 +838,7 @@ WbNode::NodeUse WbNodeUtilities::checkNodeUse(const WbNode *n) {
     return nodeUse;
   }
 
-  const WbNode *const p = n->parent();
+  const WbNode *const p = n->parentNode();
   if (p) {
     const WbMatter *const m = dynamic_cast<const WbMatter *>(p);
     if (m)
@@ -852,7 +852,7 @@ WbNode::NodeUse WbNodeUtilities::checkNodeUse(const WbNode *n) {
 }
 
 bool WbNodeUtilities::isInBoundingObject(const WbNode *node) {
-  const WbNode *const p = node->parent();
+  const WbNode *const p = node->parentNode();
   if (p) {
     const WbSolid *const s = dynamic_cast<const WbSolid *>(p);
     if (s)
@@ -872,21 +872,21 @@ WbMatter *WbNodeUtilities::findBoundingObjectAncestor(const WbBaseNode *node) {
   if (!node || !node->isInBoundingObject())
     return NULL;
 
-  WbNode *ancestor = node->parent();
+  WbNode *ancestor = node->parentNode();
   while (ancestor && !ancestor->isWorldRoot()) {
     WbMatter *solidAncestor = dynamic_cast<WbMatter *>(ancestor);
     if (solidAncestor)
       return solidAncestor;
-    ancestor = ancestor->parent();
+    ancestor = ancestor->parentNode();
   }
 
   return NULL;
 }
 
 bool WbNodeUtilities::isTopNode(const WbNode *node) {
-  if (!node->parent())
+  if (!node->parentNode())
     return false;
-  return (node->parent()->parent() == NULL);
+  return (node->parentNode()->parentNode() == NULL);
 }
 
 bool WbNodeUtilities::isSelected(const WbNode *node) {
@@ -917,7 +917,7 @@ WbProtoModel *WbNodeUtilities::findContainingProto(const WbNode *node) {
       if (proto)
         return proto;
 
-      n = n->parent();
+      n = n->parentNode();
     }
   } while (n);
   return NULL;
@@ -928,7 +928,7 @@ bool WbNodeUtilities::isVisible(const WbNode *node) {
     return false;
 
   const WbNode *n = node;
-  const WbNode *p = n->parent();
+  const WbNode *p = n->parentNode();
   while (n && p && !n->isTopLevel()) {
     if (p->isProtoInstance()) {
       if (p->fields().contains(n->parentField(true)))
@@ -936,7 +936,7 @@ bool WbNodeUtilities::isVisible(const WbNode *node) {
         return false;
     }
     n = p;
-    p = p->parent();
+    p = p->parentNode();
   }
   return true;
 }
@@ -970,7 +970,7 @@ WbMatter *WbNodeUtilities::findUpperVisibleMatter(WbNode *node) {
     while (parent->protoParameterNode())
       parent = parent->protoParameterNode();
     nodeStack.push(parent);
-    parent = parent->parent();
+    parent = parent->parentNode();
   }
 
   if (nodeStack.isEmpty())
@@ -1079,7 +1079,7 @@ bool WbNodeUtilities::isNodeOrAncestorLocked(WbNode *node) {
     if (matter && matter->isLocked())
       return true;
 
-    n = n->parent();
+    n = n->parentNode();
   }
 
   return false;
@@ -1122,12 +1122,12 @@ bool WbNodeUtilities::isTrackAnimatedGeometry(const WbNode *node) {
     return false;
 
   const WbNode *n = node;
-  const WbNode *p = n->parent();
+  const WbNode *p = n->parentNode();
   while (p) {
     if (dynamic_cast<const WbTrack *>(p) != NULL)
       return (n->parentField() && n->parentField()->model()->name() == "animatedGeometry");
     n = p;
-    p = p->parent();
+    p = p->parentNode();
   }
 
   return false;
@@ -1349,7 +1349,7 @@ bool WbNodeUtilities::validateInsertedNode(WbField *field, const WbNode *newNode
         else if (dynamic_cast<const WbSlot *>(internalParentNode)) {
           // upper slot
           WbField *internalParentField = internalParentNode->parentField(true);
-          internalParentNode = internalParentNode->parent();
+          internalParentNode = internalParentNode->parentNode();
           newNode->validate(internalParentNode, internalParentField, isInBoundingObject);
         } else  // invalid structure
           newNode->validate(internalParentNode, internalField, isInBoundingObject);
@@ -1496,7 +1496,7 @@ WbNodeUtilities::Answer WbNodeUtilities::isSuitableForTransform(const WbNode *co
     }
     if (destModelName == "Solid" || isSolidDeviceTypeName(destModelName)) {
       const QString &topNodeModelName = findTopNode(srcNode)->nodeModelName();
-      const QString &parentModelName = srcNode->parent()->nodeModelName();
+      const QString &parentModelName = srcNode->parentNode()->nodeModelName();
       if (isRobotTypeName(topNodeModelName))
         return SUITABLE;
       if (destModelName == "Solid" && isSolidTypeName(parentModelName))
@@ -1684,7 +1684,7 @@ bool WbNodeUtilities::hasASubsequentUseOrDefNode(const WbNode *defNode, const QS
   }
 
   const WbNode *node = defNode;
-  const WbNode *parentNode = node->parent();
+  const WbNode *parentNode = node->parentNode();
 
   while (parentNode) {
     WbField *const parentField = node->parentField();
@@ -1732,7 +1732,7 @@ bool WbNodeUtilities::hasASubsequentUseOrDefNode(const WbNode *defNode, const QS
     }
 
     node = parentNode;
-    parentNode = parentNode->parent();
+    parentNode = parentNode->parentNode();
   }
 
   return useOverlap;
@@ -1750,7 +1750,7 @@ WbBoundingSphere *WbNodeUtilities::boundingSphereAncestor(const WbNode *node) {
     }
     if (n->isTopLevel())
       break;
-    n = n->parent();
+    n = n->parentNode();
   }
   return NULL;
 }

--- a/src/webots/nodes/utils/WbSolidUtilities.cpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.cpp
@@ -283,6 +283,6 @@ WbGeometry *WbSolidUtilities::geometry(WbNode *const node) {
 }
 
 bool WbSolidUtilities::isPermanentlyKinematic(const WbNode *node) {
-  const WbBaseNode *const p = node ? static_cast<WbBaseNode *>(node->parent()) : NULL;
+  const WbBaseNode *const p = node ? static_cast<WbBaseNode *>(node->parentNode()) : NULL;
   return p && p->nodeType() == WB_NODE_PROPELLER;
 }

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -432,7 +432,7 @@ void WbSupervisorUtilities::updateDeletedNodeList(WbNode *node) {
 
   struct WbDeletedNodeInfo nodeInfo;
   nodeInfo.nodeId = node->uniqueId();
-  nodeInfo.parent = node->parent();
+  nodeInfo.parent = node->parentNode();
   nodeInfo.parentField = node->parentField();
   mNodesDeletedSinceLastStep.push_back(nodeInfo);
 }
@@ -560,7 +560,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
         mFoundNodeUniqueId = node->uniqueId();
         mFoundNodeType = node->nodeType();
         mFoundNodeModelName = node->modelName();
-        mFoundNodeParentUniqueId = (node->parent() ? node->parent()->uniqueId() : -1);
+        mFoundNodeParentUniqueId = (node->parentNode() ? node->parentNode()->uniqueId() : -1);
         connect(node, &WbNode::defUseNameChanged, this, &WbSupervisorUtilities::notifyNodeUpdate, Qt::UniqueConnection);
       }
 
@@ -578,9 +578,9 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       mFoundNodeModelName = baseNode ? baseNode->modelName() : QString();
       mFoundNodeParentUniqueId = -1;
       if (baseNode) {
-        if (baseNode->parent()) {
-          if (baseNode->parent() != WbWorld::instance()->root())
-            mFoundNodeParentUniqueId = baseNode->parent()->uniqueId();
+        if (baseNode->parentNode()) {
+          if (baseNode->parentNode() != WbWorld::instance()->root())
+            mFoundNodeParentUniqueId = baseNode->parentNode()->uniqueId();
           else
             mFoundNodeParentUniqueId = 0;
         }
@@ -597,9 +597,9 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
         mFoundNodeType = baseNode->nodeType();
         mFoundNodeModelName = baseNode->modelName();
         mFoundNodeParentUniqueId = -1;
-        if (baseNode->parent()) {
-          if (baseNode->parent() != WbWorld::instance()->root())
-            mFoundNodeParentUniqueId = baseNode->parent()->uniqueId();
+        if (baseNode->parentNode()) {
+          if (baseNode->parentNode() != WbWorld::instance()->root())
+            mFoundNodeParentUniqueId = baseNode->parentNode()->uniqueId();
           else
             mFoundNodeParentUniqueId = 0;
         }
@@ -1236,7 +1236,7 @@ void WbSupervisorUtilities::writeNode(QDataStream &stream, const WbBaseNode *bas
   assert(baseNode);
   stream << (int)baseNode->uniqueId();
   stream << (int)baseNode->nodeType();
-  stream << (int)(baseNode->parent() ? baseNode->parent()->uniqueId() : -1);
+  stream << (int)(baseNode->parentNode() ? baseNode->parentNode()->uniqueId() : -1);
   const QByteArray &modelName = baseNode->modelName().toUtf8();
   const QByteArray &defName = baseNode->defName().toUtf8();
   stream.writeRawData(modelName.constData(), modelName.size() + 1);

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -215,7 +215,7 @@ void WbTemplateManager::regenerateNode(WbNode *node) {
     node->setRegenerationRequired(false);
 
   // 1. get stuff
-  WbNode *parent = node->parent();
+  WbNode *parent = node->parentNode();
   WbProtoModel *proto = node->proto();
   assert(parent && proto);
   if (!parent || !proto)

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -257,7 +257,7 @@ void WbTemplateManager::regenerateNode(WbNode *node) {
   if (isWorldInitialized)
     emit preNodeRegeneration(node, nested);
 
-  WbNode::setGlobalParent(parent);
+  WbNode::setGlobalParentNode(parent);
 
   WbNode *newNode = WbNode::regenerateProtoInstanceFromParameters(proto, parameters, node->isTopLevel(),
                                                                   WbWorld::instance()->fileName(), true, uniqueId);
@@ -271,7 +271,7 @@ void WbTemplateManager::regenerateNode(WbNode *node) {
   }
 
   newNode->setDefName(node->defName());
-  WbNode::setGlobalParent(NULL);
+  WbNode::setGlobalParentNode(NULL);
 
   WbNodeUtilities::validateInsertedNode(parentField, newNode, parent, isInBoundingObject);
 

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -60,7 +60,7 @@ QStringList WbUrl::orderedSearchPaths(const WbNode *node) {
         projectPROTOSearchPath.append(proto->projectPath() + "/protos");
       proto = WbProtoList::current()->findModel(proto->ancestorProtoName(), "");
     }
-    currentNode = currentNode->parent();
+    currentNode = currentNode->parentNode();
   }
 
   QStringList searchPaths;

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -449,7 +449,8 @@ void WbWorld::createX3DMetaFile(const QString &filename) const {
         deviceObject.insert("minPosition", motor->minPosition());
         deviceObject.insert("maxPosition", motor->maxPosition());
       } else {  // case: other WbDevice nodes.
-        const WbBaseNode *parent = jointDevice ? dynamic_cast<const WbBaseNode *>(deviceBaseNode->parent()) : deviceBaseNode;
+        const WbBaseNode *parent =
+          jointDevice ? dynamic_cast<const WbBaseNode *>(deviceBaseNode->parentNode()) : deviceBaseNode;
         // Retrieve closest exported Transform parent, and compute its translation offset.
         WbMatrix4 m;
         while (parent) {
@@ -466,7 +467,7 @@ void WbWorld::createX3DMetaFile(const QString &filename) const {
             if (transform)
               m *= transform->vrmlMatrix();
           }
-          parent = dynamic_cast<const WbBaseNode *>(parent->parent());
+          parent = dynamic_cast<const WbBaseNode *>(parent->parentNode());
         }
         // LED case: export color data.
         const WbLed *led = dynamic_cast<const WbLed *>(device);

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -88,10 +88,10 @@ WbWorld::WbWorld(WbProtoList *protos, WbTokenizer *tokenizer) :
   mIsCleaning(false) {
   gInstance = this;
   WbNode::setInstantiateMode(true);
-  WbNode::setGlobalParent(NULL);
+  WbNode::setGlobalParentNode(NULL);
   mRoot = new WbGroup();
   mRoot->setUniqueId(0);
-  WbNode::setGlobalParent(mRoot);
+  WbNode::setGlobalParentNode(mRoot);
   mRadarTargets.clear();
   mCameraRecognitionObjects.clear();
 
@@ -152,7 +152,7 @@ WbWorld::WbWorld(WbProtoList *protos, WbTokenizer *tokenizer) :
     mRoot->addChild(mViewpoint);
   }
 
-  WbNode::setGlobalParent(NULL);
+  WbNode::setGlobalParentNode(NULL);
   updateTopLevelLists();
 
   // world loading stuff

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -62,7 +62,7 @@ WbAddNodeDialog::WbAddNodeDialog(WbNode *currentNode, WbField *field, int index,
 
   // check if top node is a robot node
   const WbNode *const topNode =
-    field ? WbNodeUtilities::findTopNode(mCurrentNode) : WbNodeUtilities::findTopNode(mCurrentNode->parent());
+    field ? WbNodeUtilities::findTopNode(mCurrentNode) : WbNodeUtilities::findTopNode(mCurrentNode->parentNode());
   mHasRobotTopNode = topNode ? WbNodeUtilities::isRobotTypeName(topNode->nodeModelName()) : false;
 
   setWindowTitle(tr("Add a node"));

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -544,9 +544,9 @@ void WbSceneTree::reset() {
     if (sfnode) {
       WbNode *defaultNode = dynamic_cast<const WbSFNode *>(defaultValue)->value();
       if (defaultNode) {
-        WbNode::setGlobalParent(parentNode);
+        WbNode::setGlobalParentNode(parentNode);
         WbNode *newNode = WbConcreteNodeFactory::instance()->createCopy(*defaultNode);
-        WbNode::setGlobalParent(NULL);
+        WbNode::setGlobalParentNode(NULL);
         newNode->setParentNode(parentNode);
 
 #ifndef NDEBUG
@@ -562,9 +562,9 @@ void WbSceneTree::reset() {
       int i = 0;
       while (it.hasNext()) {
         const WbNode *defaultNode = it.next();
-        WbNode::setGlobalParent(parentNode);
+        WbNode::setGlobalParentNode(parentNode);
         WbNode *newNode = WbConcreteNodeFactory::instance()->createCopy(*defaultNode);
-        WbNode::setGlobalParent(NULL);
+        WbNode::setGlobalParentNode(NULL);
         newNode->setParentNode(parentNode);
 #ifndef NDEBUG
         const WbNodeOperations::OperationResult result =
@@ -617,7 +617,7 @@ void WbSceneTree::transform(const QString &modelName) {
   const bool isExpanded = mTreeView->isExpanded(currentModelIndex);
 
   // create new node
-  WbNode::setGlobalParent(currentNode->parentNode());
+  WbNode::setGlobalParentNode(currentNode->parentNode());
   WbNode *const newNode = WbConcreteNodeFactory::instance()->createNode(modelName, 0, currentNode->parentNode());
   if (!newNode) {
     WbLog::error(tr("Transformation aborted: impossible to create a node of type %1.").arg(modelName));
@@ -626,7 +626,7 @@ void WbSceneTree::transform(const QString &modelName) {
   }
 
   // copy fields and adopt children
-  WbNode::setGlobalParent(newNode);
+  WbNode::setGlobalParentNode(newNode);
   QVector<WbField *> fields = currentNode->fieldsOrParameters();
   foreach (WbField *originalField, fields) {
     // copy field if it exists
@@ -635,7 +635,7 @@ void WbSceneTree::transform(const QString &modelName) {
       newField->copyValueFrom(originalField);
   }
   newNode->setDefName(currentNode->defName());
-  WbNode::setGlobalParent(NULL);
+  WbNode::setGlobalParentNode(NULL);
 
   // reassign pointer in parent
   WbField *parentField = mSelectedItem->parent()->field();
@@ -897,7 +897,7 @@ void WbSceneTree::addNew() {
   } else {  // CREATE
 
     // create node
-    WbNode::setGlobalParent(selectedNodeParent);
+    WbNode::setGlobalParentNode(selectedNodeParent);
     WbNode *newNode;
     if (dialog.isUseNode()) {
       // find last DEF node to be copied

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -380,7 +380,7 @@ void WbSceneTree::pasteInMFValue() {
     index = mSelectedItem->row() + 1;
     parentItem = static_cast<WbMultipleValue *>(field->value());
     if (mSelectedItem->isNode())
-      parentNode = mSelectedItem->node()->parent();
+      parentNode = mSelectedItem->node()->parentNode();
   }
 
   if (mClipboard->type() == WB_SF_NODE) {
@@ -546,7 +546,7 @@ void WbSceneTree::reset() {
         WbNode::setGlobalParent(parentNode);
         WbNode *newNode = WbConcreteNodeFactory::instance()->createCopy(*defaultNode);
         WbNode::setGlobalParent(NULL);
-        newNode->setParent(parentNode);
+        newNode->setParentNode(parentNode);
 
 #ifndef NDEBUG
         const WbNodeOperations::OperationResult result =
@@ -564,7 +564,7 @@ void WbSceneTree::reset() {
         WbNode::setGlobalParent(parentNode);
         WbNode *newNode = WbConcreteNodeFactory::instance()->createCopy(*defaultNode);
         WbNode::setGlobalParent(NULL);
-        newNode->setParent(parentNode);
+        newNode->setParentNode(parentNode);
 #ifndef NDEBUG
         const WbNodeOperations::OperationResult result =
 #endif
@@ -616,8 +616,8 @@ void WbSceneTree::transform(const QString &modelName) {
   const bool isExpanded = mTreeView->isExpanded(currentModelIndex);
 
   // create new node
-  WbNode::setGlobalParent(currentNode->parent());
-  WbNode *const newNode = WbConcreteNodeFactory::instance()->createNode(modelName, 0, currentNode->parent());
+  WbNode::setGlobalParent(currentNode->parentNode());
+  WbNode *const newNode = WbConcreteNodeFactory::instance()->createNode(modelName, 0, currentNode->parentNode());
   if (!newNode) {
     WbLog::error(tr("Transformation aborted: impossible to create a node of type %1.").arg(modelName));
     mRowsAreAboutToBeRemoved = false;
@@ -638,7 +638,8 @@ void WbSceneTree::transform(const QString &modelName) {
 
   // reassign pointer in parent
   WbField *parentField = mSelectedItem->parent()->field();
-  WbNode *upperTemplate = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, currentNode->parent());
+  WbNode *upperTemplate =
+    WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, currentNode->parentNode());
   bool isInsideATemplateRegenerator = upperTemplate && upperTemplate != currentNode;
   if (mSelectedItem->isSFNode()) {
     WbSFNode *const sfnode = dynamic_cast<WbSFNode *>(mSelectedItem->field()->value());
@@ -701,7 +702,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     const bool isFollowedNode = (solid && viewpoint->followedSolid() == solid);
     int index;
     WbField *parentField = currentNode->parentFieldAndIndex(index);
-    WbNode *parentNode = currentNode->parent();
+    WbNode *parentNode = currentNode->parentNode();
     QString nodeString;
     WbVrmlWriter writer(&nodeString, currentNode->modelName() + ".proto");
     if (rootOnly)
@@ -870,7 +871,7 @@ void WbSceneTree::addNew() {
     newNodeIndex = mSelectedItem->row() + 1;
     selectedFieldItem = mSelectedItem->parent();
     selectedField = selectedFieldItem->field();
-    selectedNodeParent = mSelectedItem->node()->parent();
+    selectedNodeParent = mSelectedItem->node()->parentNode();
   }
 
   assert(selectedNodeParent && selectedField);
@@ -984,7 +985,7 @@ bool WbSceneTree::isPasteAllowed() {
       parentNode = mSelectedItem->parent()->node();
     } else {  // else sibling node
       field = mSelectedItem->parent()->field();
-      parentNode = mSelectedItem->node()->parent();
+      parentNode = mSelectedItem->node()->parentNode();
     }
 
     // prevent pasting a node between WorldInfo and Viewpoint nodes
@@ -1255,7 +1256,7 @@ void WbSceneTree::prepareNodeRegeneration(WbNode *node, bool nested) {
       mSelectionInsideTreeStateRecovery = true;
       break;
     }
-    n = n->parent();
+    n = n->parentNode();
   }
   if (!mSelectionInsideTreeStateRecovery)
     mSelectionBeforeTreeStateRegeneration = mModel->indexToItem(mTreeView->currentIndex());

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -366,7 +366,6 @@ void WbField::parameterChanged() {
       sfnode = dynamic_cast<WbSFNode *>(internalField->value());
       sfnode->setValue(instance);
     }
-    setParent(NULL);
 
   } else {
     foreach (WbField *const field, mInternalFields)
@@ -386,7 +385,6 @@ void WbField::parameterNodeInserted(int index) {
     mfnode = dynamic_cast<WbMFNode *>(internalField->value());
     mfnode->insertItem(index, instance);
   }
-  setParent(NULL);
 }
 
 // propagate node remotion to internal fields of parameter

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -361,7 +361,7 @@ void WbField::parameterChanged() {
 
     WbNode *instance = NULL;
     foreach (WbField *internalField, mInternalFields) {
-      WbNode::setGlobalParent(internalField->parentNode(), true);
+      WbNode::setGlobalParentNode(internalField->parentNode(), true);
       instance = node->cloneAndReferenceProtoInstance();
       sfnode = dynamic_cast<WbSFNode *>(internalField->value());
       sfnode->setValue(instance);
@@ -380,7 +380,7 @@ void WbField::parameterNodeInserted(int index) {
 
   WbNode *instance = NULL;
   foreach (WbField *internalField, mInternalFields) {
-    WbNode::setGlobalParent(internalField->parentNode(), true);
+    WbNode::setGlobalParentNode(internalField->parentNode(), true);
     instance = node->cloneAndReferenceProtoInstance();
     mfnode = dynamic_cast<WbMFNode *>(internalField->value());
     mfnode->insertItem(index, instance);

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -820,7 +820,7 @@ int WbNode::findSubFieldIndex(const WbField *const searched) const {
   return -1;
 }
 
-WbField *WbNode::findSubField(int index, WbNode *&parent) const {
+WbField *WbNode::findSubField(int index, WbNode *&parentNode) const {
   int count = 0;
   QList<WbNode *> list(subNodes(true));
   list.prepend(const_cast<WbNode *>(this));

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -91,7 +91,7 @@ bool WbNode::instantiateMode() {
   return gInstantiateMode;
 }
 
-void WbNode::setGlobalParent(WbNode *parent, bool protoParameterNodeFlag) {
+void WbNode::setGlobalParentNode(WbNode *parent, bool protoParameterNodeFlag) {
   gParent = parent;
 
   if (parent)
@@ -100,7 +100,7 @@ void WbNode::setGlobalParent(WbNode *parent, bool protoParameterNodeFlag) {
     gProtoParameterNodeFlag = false;
 }
 
-WbNode *WbNode::globalParent() {
+WbNode *WbNode::globalParentNode() {
   return gParent;
 }
 
@@ -780,12 +780,12 @@ void WbNode::notifyFieldChanged() {
           if (!subField || subField->type() != field->type() || subField->name() != field->name())
             continue;
           assert(parent);
-          setGlobalParent(parent);
+          setGlobalParentNode(parent);
           subField->copyValueFrom(field);
           subField->defHasChanged();
         }
 
-        setGlobalParent(NULL);
+        setGlobalParentNode(NULL);
       }
     }
 
@@ -820,7 +820,7 @@ int WbNode::findSubFieldIndex(const WbField *const searched) const {
   return -1;
 }
 
-WbField *WbNode::findSubField(int index, WbNode *&parentNode) const {
+WbField *WbNode::findSubField(int index, WbNode *&parent) const {
   int count = 0;
   QList<WbNode *> list(subNodes(true));
   list.prepend(const_cast<WbNode *>(this));

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -74,8 +74,8 @@ public:
   virtual ~WbNode();
 
   // set the parent that will be used by the next WbNode constructor
-  static void setGlobalParent(WbNode *parent, bool protoParameterNodeFlag = false);
-  static WbNode *globalParent();
+  static void setGlobalParentNode(WbNode *parent, bool protoParameterNodeFlag = false);
+  static WbNode *globalParentNode();
 
   // unique node number
   int uniqueId() const { return mUniqueId; }
@@ -91,7 +91,7 @@ public:
   QStringList documentationBookAndPage(bool isRobot) const;
 
   // hierarchy
-  void setParentNode(WbNode *parentNode) { mParentNode = parentNode; }
+  void setParentNode(WbNode *node) { mParentNode = node; }
   WbNode *parentNode() const { return mParentNode; }
   bool isTopLevel() const { return parentNode() && parentNode()->isWorldRoot(); }
   bool isWorldRoot() const { return !parentNode() && mUniqueId != -1; }
@@ -395,7 +395,7 @@ private:
   int findSubFieldIndex(const WbField *const searched) const;
   static void subNodeIndex(const WbNode *currentNode, const WbNode *targetNode, int &index, bool &subNodeFound);
   static WbNode *findNode(int &index, WbNode *root);
-  WbField *findSubField(int index, WbNode *&parentNode) const;
+  WbField *findSubField(int index, WbNode *&parent) const;
   void readFieldValue(WbField *field, WbTokenizer *tokenizer, const QString &worldPath) const;
   static void copyAliasValue(WbField *field, const QString &alias);
 };

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -91,11 +91,11 @@ public:
   QStringList documentationBookAndPage(bool isRobot) const;
 
   // hierarchy
-  void setParent(WbNode *parent) { mParent = parent; }
-  WbNode *parent() const { return mParent; }
-  bool isTopLevel() const { return mParent && mParent->isWorldRoot(); }
-  bool isWorldRoot() const { return !mParent && mUniqueId != -1; }
-  bool isProtoRoot() const { return !mParent && mUniqueId == -1; }
+  void setParentNode(WbNode *parentNode) { mParentNode = parentNode; }
+  WbNode *parentNode() const { return mParentNode; }
+  bool isTopLevel() const { return parentNode() && parentNode()->isWorldRoot(); }
+  bool isWorldRoot() const { return !parentNode() && mUniqueId != -1; }
+  bool isProtoRoot() const { return !parentNode() && mUniqueId == -1; }
   bool isAnAncestorOf(const WbNode *node) const;
 
   // level in the scene tree
@@ -334,7 +334,7 @@ private:
   QString mUrdfPrefix;
 
   // for all nodes
-  WbNode *mParent;
+  WbNode *mParentNode;
   WbNodeModel *mModel;
   int mUniqueId;
   bool mIsBeingDeleted;


### PR DESCRIPTION
Fixed #1829, including the removal of apparently useless calls to QObject::setParent() in WbField.cpp.
✔️ passed the test suite locally on Windows.