### PR TITLE
Fixed rendering of tracks and muscles in robot cameras

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -26,6 +26,7 @@ Released on XXX.
   - Dependency Updates
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1419](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
+    - Fixed rendering of Track and Muscle nodes when the main window was minimized.
     - Fixed mismatch between the bounding object and visual shape of the [UnevenTerrain](https://www.cyberbotics.com/doc/guide/object-floors#uneventerrain), **and removed the `textureScale` field** ([#1792](https://github.com/cyberbotics/webots/pull/1792)).
     - Fixed crash when using a [Normal](normal.md) node in a PROTO node ([#1813](https://github.com/cyberbotics/webots/pull/1813)).
   - Cleanup

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -215,16 +215,16 @@ namespace wren {
     // debug::printCacheContents();
     // debug::printSceneTree();
 
-    DEBUG("Notify frame listeners...");
-
-    for (auto listener : mListeners)
-      listener();
-
     renderToViewports({mMainViewport}, culling);
   }
 
   void Scene::renderToViewports(std::vector<Viewport *> viewports, bool culling) {
     assert(glstate::isInitialized());
+
+    DEBUG("Notify frame listeners...");
+
+    for (auto listener : mListeners)
+      listener();
 
     DEBUG("\nScene::renderToViewports: viewports.size()=" << viewports.size());
 


### PR DESCRIPTION
Fixes #1808.

The rendering of muscles and tracks was not correct if the main rendering was disabled which happens when the main window is minimized. The callback functions need to be called also before robot camera rendering, not just before main scene rendering.