### PR TITLE
Fixed grammatical mistakes and typos in Tutorial 6

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -1,6 +1,8 @@
 name: Test Sources
 
-on: pull_request
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 defaults:
   run:
@@ -8,7 +10,6 @@ defaults:
 
 jobs:
   test-sources:
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
@@ -22,13 +23,17 @@ jobs:
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
           - os: macos-10.15
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+      if: (matrix.os == 'ubuntu-18.04' && matrix.python == '3.8') || github.event.pull_request.draft == false
     - name: Set up Python ${{ matrix.python }}
+      if: (matrix.os == 'ubuntu-18.04' && matrix.python == '3.8') || github.event.pull_request.draft == false
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Tests
+      if: (matrix.os == 'ubuntu-18.04' && matrix.python == '3.8') || github.event.pull_request.draft == false
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         cp dependencies/.clang-format-9 .clang-format

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -1,9 +1,9 @@
-## Tutorial 6: 4-Wheels Robot (60 Minutes)
+## Tutorial 6: 4-Wheeled Robot (60 Minutes)
 
-The aim of this tutorial is to create your first robot from scratch.
-This robot will be made of a body, four wheels, and two distance sensors.
+This tutorial aims at creating your first robot from scratch.
+The robot will consist of a body, four wheels, and two distance sensors.
 The result is depicted on [this figure](#3d-view-of-the-4-wheels-robot-note-that-the-coordinate-system-representations-of-the-robot-body-and-of-its-wheels-are-oriented-the-same-way-their-px-vector-defines-the-left-of-the-robot-their-py-vector-defines-the-top-of-the-robot-and-their-pz-vector-defines-the-front-of-the-robot-the-distance-sensors-are-oriented-in-a-different-way-their-px-vector-indicates-the-direction-of-the-sensor).
-The [next figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-devices) shows the robot from a top view.
+The [next figure](#top-view-of-the-4-wheeled-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-device) shows the robot from a top view.
 
 %figure "3D view of the 4 wheels robot. Note that the coordinate system representations of the robot body and of its wheels are oriented the same way. Their +x-vector (in red) defines the left of the robot, their +y-vector (in green) defines the top of the robot, and their +z-vector (in blue) defines the front of the robot. The distance sensors are oriented in a different way, their +x-vector indicates the direction of the sensor."
 
@@ -11,7 +11,7 @@ The [next figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-
 
 %end
 
-%figure "Top view of the 4 wheels robot. The grid behind the robot has a dimension of 0.2 x 0.3 meters. The text labels correspond to the name of the devices."
+%figure "Top view of the 4 wheeled robot. The grid behind the robot has a dimension of 0.2 x 0.3 meters. The text labels correspond to the name of the device."
 
 ![tutorial_4_wheels_top_schema.png](images/tutorial_4_wheels_top_schema.thumbnail.jpg)
 
@@ -19,62 +19,66 @@ The [next figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-
 
 ### New Simulation
 
-> **Hands on #1**: Save the world of the previous tutorial as `4_wheels_robot.wbt`.
+> **Hands on #1**: Save the world of the previous tutorial as `4_wheeled_robot.wbt`.
 Remove the nodes defining the e-puck, the ball, the dumbbell and the contact properties.
 The ground, the walls and the lighting are kept.
 
 ### Separating the Robot in Solid Nodes
 
-Some definitions are required before giving rules to create a robot model.
+Some definitions and rules to create the robot model:
 
-The set containing the [Solid](../reference/solid.md) node and all its derived nodes is called the *solid nodes*.
-A similar definition is applied for the [Device](../reference/device.md), [Robot](../reference/robot.md), [Joint](../reference/joint.md) and [Motor](../reference/motor.md) nodes.
+- The set containing the [Solid](../reference/solid.md) node and all its derived nodes are called the *solid nodes*.
+
+- A similar definition is applied for the [Device](../reference/device.md), [Robot](../reference/robot.md), [Joint](../reference/joint.md) and [Motor](../reference/motor.md) nodes.
 You can get more information about the node hierarchy in the [nodes chart diagram](../reference/node-chart.md).
-Most sensors and actuators are both [Solid](../reference/solid.md) and [Device](../reference/device.md) nodes at the same time.
 
-The main structure of a [Robot](../reference/robot.md) model is a tree of [Solid](../reference/solid.md) nodes linked together.
+- Most sensors and actuators are both [Solid](../reference/solid.md) and [Device](../reference/device.md) nodes at the same time.
+
+- The main structure of a [Robot](../reference/robot.md) model is a tree of [Solid](../reference/solid.md) nodes linked together.
 The root node of this tree should be a [Robot](../reference/robot.md) node.
-The solids are linked together by [Joint](../reference/joint.md) nodes.
+
+- The solids are linked together by [Joint](../reference/joint.md) nodes.
 A [Device](../reference/device.md) node should be the direct child of either a [Robot](../reference/robot.md) node, a [Solid](../reference/solid.md) node or a [Joint](../reference/joint.md) node.
 
-A [Joint](../reference/joint.md) node is used to add one (or two) degree(s) of freedom (DOF), between its parent and its child.
+- A [Joint](../reference/joint.md) node is used to add one (or two) degree(s) of freedom (DOF), between its parent and its child.
 The direct parent and child of a [Joint](../reference/joint.md) node are both [Solid](../reference/solid.md) nodes.
 
-The nodes derived from [Joint](../reference/joint.md) allow creating different kinds of constraints between the linked [Solid](../reference/solid.md) nodes.
+- The nodes derived from [Joint](../reference/joint.md) allow creating different kinds of constraints between the linked [Solid](../reference/solid.md) nodes.
 The most used one in robotics, is the [HingeJoint](../reference/hingejoint.md) allowing to model amongst others rotational motors including wheels.
 
-A [Joint](../reference/joint.md) node can be monitored or actuated by adding respectively a [PositionSensor](../reference/positionsensor.md) node, or a motor node to its `device` field.
+- A [Joint](../reference/joint.md) node can be monitored or actuated by adding a [PositionSensor](../reference/positionsensor.md) node, or a motor node to its `device` field respectively.
 
-Having these rules in mind, we can start to design the node hierarchy used to model the robot.
+
+Having these rules in mind, we can start designing the node hierarchy used to model the robot.
 The first step is to determine which part of the robot should be modeled as a [Solid](../reference/solid.md) node.
 
 In our example, this operation is quite obvious.
 The robot has 4 DOF corresponding to the wheel motors.
 It can be divided in five solid nodes: the body and the four wheels.
 
-Depending on the expected application of the robot model, reducing the number of DOF when modeling could be important to get an efficient simulation.
+Depending on the expected application of the robot model, reducing the DOF while modelling might be necessary to get an efficient simulation.
 For example, when modeling a caster wheel, a realistic approach implies to model 2 DOF.
 But if this degree of precision is useless for the simulation, a more efficient approach can be found.
 For example, to model the caster wheel as a [Sphere](../reference/sphere.md) having a null friction coefficient with the ground.
 
 The second step is to determine which [Solid](../reference/solid.md) node is the [Robot](../reference/robot.md) node (the root node).
 This choice is arbitrary, but a solution is often much easier to implement.
-For example, in the case of an humanoid robot, the robot node would be typically the robot chest, because the robot symmetry facilitates the computation of the joint parameters.
+For example, in the case of a humanoid robot, the robot node would be typically the robot chest, because the robot symmetry facilitates the computation of the joint parameters.
 
 In our case, the body box is obviously the better choice.
-The [figure](#high-level-representation-of-the-4-wheels-robot) depicts the solid nodes hierarchy of the robot.
+The [figure](#high-level-representation-of-the-4-wheeled-robot) depicts the solid nodes hierarchy of the robot.
 
 > **Hands on #2**: At the end of the scene tree, add a [Robot](../reference/robot.md) node having four [HingeJoint](../reference/hingejoint.md) nodes having a [Solid](../reference/solid.md) node as `endPoint`.
-Please refer to [this figure](#high-level-representation-of-the-4-wheels-robot).
+Please refer to [this figure](#high-level-representation-of-the-4-wheeled-robot).
 Add a [Shape](../reference/shape.md) node containing a Box geometry to the [Robot](../reference/robot.md) node.
 Set the color of the [Shape](../reference/shape.md) to red.
-Use the [Shape](../reference/shape.md) to define also the `boundingObject` field of the [Robot](../reference/robot.md) node.
+Use the [Shape](../reference/shape.md) to define the `boundingObject` field of the [Robot](../reference/robot.md) node.
 The dimension of the box is `(0.1, 0.05, 0.2)`.
 Add a [Physics](../reference/physics.md) node to the [Robot](../reference/robot.md).
-The [figure](#low-level-representation-of-the-4-wheels-robot) represents all the nodes defining the robot.
-So far only the direct children nodes of the root [Robot](../reference/robot.md) node are implemented.
+The [figure](#high-level-representation-of-the-4-wheeled-robot) represents all the nodes defining the robot.
+So far, only the direct children nodes of the root [Robot](../reference/robot.md) node has been implemented.
 
-%figure "High level representation of the 4 wheels robot"
+%figure "High level representation of the 4 wheeled robot"
 %chart
 graph TD
   Robot[[Robot](../reference/robot.md)] -->|children| HingeJoint[[HingeJoint](../reference/hingejoint.md)]
@@ -85,7 +89,7 @@ graph TD
 %end
 %end
 
-%figure "Low level representation of the 4 wheels robot"
+%figure "Low level representation of the 4 wheeled robot"
 %chart
 graph TD
   Robot[[Robot](../reference/robot.md)] -->|physics| Physics1[[Physics](../reference/physics.md)]
@@ -112,8 +116,9 @@ graph TD
 
 ### `HingeJoint`
 
-The initial position of the Wheel is defined by the translation and the rotation fields of the [Solid](../reference/solid.md) node.
-While the rotation origin (anchor) and the rotation axis (axis) are defined by the optional [HingeJointParameters](../reference/hingejointparameters.md) child of the [HingeJoint](../reference/hingejoint.md) node.
+The initial position of the wheel is defined by the translation and the rotation fields of the [Solid](../reference/solid.md) node.
+
+The rotation origin (anchor) and the rotation axis (axis) are defined by the optional [HingeJointParameters](../reference/hingejointparameters.md) child of the [HingeJoint](../reference/hingejoint.md) node.
 
 %figure "Representation of a hinge joint"
 
@@ -123,34 +128,34 @@ While the rotation origin (anchor) and the rotation axis (axis) are defined by t
 
 For the first wheel, the [Solid](../reference/solid.md) translation should be defined to `(0.06, 0, 0.05)` in order to define the relative gap between the body and the wheel, and the rotation to `(0 0 1 1.5708)` for the wheel cylinder to be correctly oriented.
 The [HingeJointParameters](../reference/hingejointparameters.md) anchor should also be defined to `(0.06, 0, 0.05)` to define the rotation origin (relatively to the body).
-Finally the [HingeJointParameters](../reference/hingejointparameters.md) axis should define the rotation axis.
+Finally, the [HingeJointParameters](../reference/hingejointparameters.md) axis should define the rotation axis.
 In our case it's along the x-axis (so `(1, 0, 0)`).
 
 > **Hands on #3**: Add a [HingeJointParameters](../reference/hingejointparameters.md) node, and enter the field values as described above.
 Some signs obviously have to be updated for other wheels.
 
-We want now to implement the cylinder shape of the wheels.
+Now, let's implement the cylinder shape of the wheels.
 
-> **Hands on #4**: Complete the missing nodes to get the same structure as the one depicted in [this figure](#low-level-representation-of-the-4-wheels-robot).
+> **Hands on #4**: Complete the missing nodes to get the same structure as the one depicted in [this figure](#low-level-representation-of-the-4-wheeled-robot).
 Don't forget the [Physics](../reference/physics.md) nodes.
 
 For each [HingeJoint](../reference/hingejoint.md), there are three fields in which nodes need to be added.
 - **jointParameters**: Add a [HingeJointParameters](../reference/hingejointparameters.md) and configure the anchor (0.06 0 -0.05) and axis fields (1 0 0). These values have to be modified according to the location of the wheel.
-- **device**: Add a [RotationalMotor](../reference/rotationalmotor.md) in order to be able to actuate the wheels. Change their `name` fields from `wheel1` to `wheel4` according to [this figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-devices). These labels will be used to reference the wheels from the controller.
+- **device**: Add a [RotationalMotor](../reference/rotationalmotor.md) in order to be able to actuate the wheels. Change their `name` fields from `wheel1` to `wheel4` according to [this figure](#top-view-of-the-4-wheeled-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-device). These labels will be used to reference the wheels from the controller.
 - **endPoint**: Add a [Solid](../reference/solid.md) node, then a [Shape](../reference/shape.md) node in the `children` field of the [Solid](../reference/solid.md), and finally, add a [Cylinder](../reference/cylinder.md) in the `geometry` field of the [Shape](../reference/shape.md) node. The [Cylinder](../reference/cylinder.md) should have a `radius` of `0.04` and a `height` of `0.02`.
 Set the color of the wheels to green.
 
 
 ### Sensors
 
-The sensors used on the e-puck of [Tutorial 4](tutorial-4-more-about-controllers.md) are not the same as those used in this section. Pay attention to their measuring interval which is between `0 cm = 0` and `10 cm = 1000`.
+The sensors used on the e-puck of [Tutorial 4](tutorial-4-more-about-controllers.md) are not the same as the ones used in this section. Pay attention to their measuring interval which is between `0 cm = 0` and `10 cm = 1000`.
 Find more information about the `lookupTable` field [here](../reference/distancesensor.md#lookup-table).
 
 
 The last part of the robot modeling is to add the two distance sensors to the robot.
 This can be done by adding two [DistanceSensor](../reference/distancesensor.md) nodes as direct children of the [Robot](../reference/robot.md) node.
 Note that the distance sensor acquires its data along the +*x*-axis.
-So rotating the distance sensors in order to point their *x*-axis outside the robot is necessary (see the [figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-devices)).
+So, it is necessary to rotate the distance sensor to point their x-axis outside the robot (see the [figure](#top-view-of-the-4-wheeled-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-device)).
 
 %spoiler "**Reminder**: How to know the orientation of the distance sensor?"
 
@@ -159,10 +164,10 @@ As already says in [Tutorial 3](tutorial-3-appearance.md), the distance sensor r
 %end
 
 > **Hands on #5**: Add the two distance sensors as explained above.
-The distance sensors are at an angle to 0.3 [rad] with the robot front vector.
-Set their graphical and physical shape to a cube (not transformed) having a edge of `0.01` [m].
-Set their color to blue.
-Set their `name` field according to the labels of [this figure](#top-view-of-the-4-wheels-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-devices).
+The distance sensors are at an angle to 0.3 [rad] with the front vector of the robot.
+Set the graphical and physical shape to a cube (not transformed) having a edge of `0.01` [m].
+Set the color to blue.
+Set the `name` field according to the labels of [this figure](#top-view-of-the-4-wheeled-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-device).
 
 %spoiler "**Tips**: How to precisely orient distance sensors?"
 
@@ -266,7 +271,7 @@ end
 
 A [Motor](../reference/motor.md) can be actuated by setting its position, its velocity, its acceleration or its force.
 Here we are interested in setting its velocity.
-This can be achieved by setting its position at infinity, and by bounding its velocity:
+This can be achieved by setting its position to infinity, and by bounding its velocity:
 
 %tab-component "language"
 %tab "C"
@@ -310,9 +315,9 @@ wb_motor_set_velocity(wheels(1), speed);
 %tab-end
 %end
 
-> **Hands on #6**: Implement a controller called `four_wheels_collision_avoidance` moving the robot and avoiding obstacles by detecting them by the distance sensors.
+> **Hands on #6**: Implement a controller called `four_wheeled_collision_avoidance` moving the robot and avoiding obstacles by detecting them by the distance sensors.
 
-Note that the `lookupTable` field of the [DistanceSensor](../reference/distancesensor.md) nodes indicates which values are returned by the sensor.
+Note that the `lookupTable` field of the [DistanceSensor](../reference/distancesensor.md) nodes indicates the values returned by the sensor.
 To help in the debugging with the sensors, it is possible to see the value of the sensors in the real-time in the [robot-window](controller-plugin.md#robot-window).
 To open the [robot-window](controller-plugin.md#robot-window), double-click on the robot body and it will bring up a menu on the left with the [DistanceSensor](../reference/distancesensor.md) and [RotationalMotor](../reference/rotationalmotor.md) graph.
 Run the simulation to see the evolution.
@@ -559,4 +564,4 @@ To compare your world with the solution, go to your files and find the folder na
 
 You are now able to design simple robot models, to implement them and to create their controllers.
 
-More specifically, you learnt the different kinds of nodes involved in the building of the robot models, the way to translate and rotate a solid relative to another and the way that a rotational motor is actuated by the controller.
+More specifically, you learnt all the different nodes involved in the design of a robot model, methods to translate and rotate a solid relative to another and the way that a rotational motor is actuated by the controller.

--- a/docs/reference/solidreference.md
+++ b/docs/reference/solidreference.md
@@ -16,3 +16,26 @@ The only constraint when referring to a [Solid](solid.md) is that both [Solid](s
 
 - `solidName`: This field specifies either the static environment (if the value is `<static environment>`) or the name of an existing [Solid](solid.md) node to be linked with the [Joint](joint.md)'s closest upper [Solid](solid.md) node.
 Referring to the [Joint](joint.md) closest upper [Solid](solid.md) node or to a [Solid](solid.md) node which has no common upper [Solid](solid.md) with the [Joint](joint.md) is prohibited.
+
+### Mechanical Loop Example
+
+The [SolidReference](solidreference.md) node is particularly useful to create closed mechanical loops, here is a very simple example:
+
+```
+HingeJoint {
+  jointParameters HingeJointParameters {
+    anchor 0 0 1
+  }
+  endPoint Solid {
+    name "front axle"
+  }
+}
+HingeJoint {
+  jointParameters HingeJointParameters {
+    anchor 0 0 -1
+  }
+  endPoint SolidReference {
+    solidName "front axle"
+  }
+}
+```


### PR DESCRIPTION
Fixed almost all of the grammatical mistakes and typos in the 4 Wheels Robot tutorial. It will make it easier for new learners to understand easily.

**Description**
There were a lot of grammatical mistakes and typos in Tutorial 6 that bottlenecks the understanding of the tutorial. 


**Tasks**
Add the list of tasks of this PR.
  - [ x ] Fix Grammatical mistakes
  - [  x ] Fix typos

**Documentation**
https://cyberbotics.com/doc/guide/tutorial-6-4-wheels-robot?tab-language=c++


**Additional context**
This would make it easier to read and understand the tutorial
