### PR TITLE
Fix warning for is datatype mismatch in procedural protos

### DIFF
--- a/projects/objects/road/protos/LaneSeparation.proto
+++ b/projects/objects/road/protos/LaneSeparation.proto
@@ -281,7 +281,9 @@ PROTO LaneSeparation [
         %{ end }%
         bottom IS bottom
         roadBorderHeight IS roadBorderHeight
-        roadBorderWidth IS roadBorderWidth
+        roadBorderWidth [
+          %{= borderWidth }%
+        ]
         appearance IS appearance
         pavementAppearance IS pavementAppearance
         roadBoundingObject IS roadBoundingObject

--- a/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto
+++ b/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto
@@ -10,7 +10,7 @@ PROTO P-Rob3 [
   field SFRotation rotation        0 0 1 0          # Is `Transform.rotation`.
   field SFString   name            "P-Rob3"         # Is `Solid.name`.
   field SFString   controller      "void"           # Is `Robot.controller`.
-  field SFString   controllerArgs  ""               # Is `Robot.controllerArgs`.
+  field MFString   controllerArgs  ""               # Is `Robot.controllerArgs`.
   field SFBool     supervisor      FALSE            # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE             # Is `Robot.synchronization`.
   field SFBool     selfCollision   TRUE             # Is `Robot.selfCollision`.

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -101,11 +101,6 @@ void WbField::readValue(WbTokenizer *tokenizer, const QString &worldPath) {
 }
 
 void WbField::write(WbVrmlWriter &writer) const {
-  if (!alias().isEmpty() && writer.isWebots() && !writer.isProto()) {
-    writer.indent();
-    writer << name() << " IS " << alias() << "\n";
-    return;
-  }
   if (isDefault())
     return;
   if (writer.isX3d())

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -387,8 +387,8 @@ WbNode *WbProtoModel::generateRoot(const QVector<WbField *> &parameters, const Q
 
   // aliasing error reports are based on the header, so the error offset has no sense here
   tokenizer.setErrorOffset(0);
-  if (!isTemplate())
-    verifyAliasing(root, &tokenizer);
+
+  verifyAliasing(root, &tokenizer);
 
   if (mTemplate) {
     root->setProtoInstanceTemplateContent(content.toUtf8());
@@ -497,7 +497,7 @@ void WbProtoModel::verifyAliasing(WbNode *root, WbTokenizer *tokenizer) const {
       continue;
     bool ok = false;
     verifyNodeAliasing(root, param, tokenizer, isDerived(), ok);
-    if (!ok)
+    if (!isTemplate() && !ok)
       tokenizer->reportError(tr("PROTO parameter '%1' has no matching IS field").arg(param->name()), param->nameToken());
   }
 }


### PR DESCRIPTION
Fixes #1843.

This PR:
- removes some useless piece of code: we never need to write the IS keyword in a `.wbt` file.
- fixes missing warning about IS datatype mismatch for procedural protos.

It doesn't automatically fixes the backwards compatibility problem related to the controllerArgs datatype change (which should be nevertheless relatively rare).