### PR TITLE
Fix Ubuntu 20.04 Clang-Format File

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -32,7 +32,12 @@ cleanse: $(PACKAGES_CLEAN)
 
 ../.clang-format:
 	@echo "# copying clang-format configuration file"
+ifeq ($(UBUNTU_VERSION), 20.04)
+	@cp .clang-format-9 $@
+else
 	@cp .clang-format-6 $@
+endif
+
 
 qt-clean:
 	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/webots-qt-*-linux64-release.tar.bz2 $(WEBOTS_HOME)/$(QT_PACKAGE)* $(WEBOTS_HOME_LIB)/libQt* $(WEBOTS_HOME_LIB)/libicu* $(WEBOTS_HOME_LIB)/qt $(WEBOTS_HOME)/include/qt $(WEBOTS_HOME)/bin/qt/lrelease $(WEBOTS_HOME)/bin/qt/lupdate $(WEBOTS_HOME)/bin/qt/moc $(WEBOTS_HOME)/resources/web/local/qwebchannel.js


### PR DESCRIPTION
**Description**
Ubuntu 20.04 is using clang-format version 10, which is not compatible with our clang-format6 configuration file, but it is with the clang-format9 one.