### PR TITLE
Disable Screen Specific Perspective Save

### DIFF
--- a/src/install_scripts/bash_profile.mac
+++ b/src/install_scripts/bash_profile.mac
@@ -8,9 +8,9 @@
 # Edit these WEBOTS environment variables when needed #
 #######################################################
 
-export WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save perspective changes when closed.
-export WEBOTS_ALLOW_MODIFY_INSTALLATION=1          # If defined, you are allowed to modify files in the Webots home using Webots.
-# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1     # If defined, the loading world progress dialog will never be displayed.
+export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save screen specific perspective changes when closed.
+export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are allowed to modify files in the Webots home using Webots.
+# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1            # If defined, the loading world progress dialog will never be displayed.
 
 #########################################################################
 # These environment variables are necessaries to compile and run Webots #

--- a/src/install_scripts/bash_profile.windows
+++ b/src/install_scripts/bash_profile.windows
@@ -15,9 +15,9 @@
 # Edit these WEBOTS environment variables when needed #
 #######################################################
 
-export WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save perspective changes when closed.
-export WEBOTS_ALLOW_MODIFY_INSTALLATION=1          # If defined, you are allowed to modify files in the Webots home using Webots.
-# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1       # If defined, the loading world progress dialog will never be displayed.
+export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save screen specific perspective changes when closed.
+export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are allowed to modify files in the Webots home using Webots.
+# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1            # If defined, the loading world progress dialog will never be displayed.
 
 
 ############################################################################

--- a/src/install_scripts/bashrc.linux
+++ b/src/install_scripts/bashrc.linux
@@ -8,9 +8,9 @@
 # Edit these WEBOTS environment variables when needed #
 #######################################################
 
-export WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save perspective changes when closed.
-export WEBOTS_ALLOW_MODIFY_INSTALLATION=1          # If defined, you are allowed to modify files in the Webots home using Webots.
-# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1     # If defined, the loading world progress dialog will never be displayed.
+export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=1  # If defined, Webots will not save screen specific perspective changes when closed.
+export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are allowed to modify files in the Webots home using Webots.
+# export WEBOTS_DISABLE_WORLD_LOADING_DIALOG=1            # If defined, the loading world progress dialog will never be displayed.
 
 #########################################################################
 # These environment variables are necessaries to compile and run Webots #

--- a/src/webots/app/WbPerspective.cpp
+++ b/src/webots/app/WbPerspective.cpp
@@ -294,7 +294,7 @@ bool WbPerspective::save() const {
     out << "consoles: " << mConsolesSettings.at(i).name << ":" << mConsolesSettings.at(i).enabledFilters.join(";") << ":"
         << mConsolesSettings.at(i).enabledLevels.join(";") << "\n";
 
-  QHash<QString, QStringList>::const_iterator it;
+  QMap<QString, QStringList>::const_iterator it;
   for (it = mRenderingDevicesPerspectiveList.constBegin(); it != mRenderingDevicesPerspectiveList.constEnd(); ++it)
     out << "renderingDevicePerspectives: " << it.key() << ";" << it.value().join(";") << "\n";
 

--- a/src/webots/app/WbPerspective.hpp
+++ b/src/webots/app/WbPerspective.hpp
@@ -22,8 +22,8 @@
 #include "WbAction.hpp"
 #include "WbVersion.hpp"
 
-#include <QtCore/QHash>
 #include <QtCore/QList>
+#include <QtCore/QMap>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
 
@@ -112,7 +112,7 @@ public:
   void setUserInteractionDisabled(WbAction::WbActionKind action, bool disabled) {
     mDisabledUserInteractionsMap[action] = disabled;
   }
-  QHash<WbAction::WbActionKind, bool> disabledUserInteractionsMap() const { return mDisabledUserInteractionsMap; }
+  QMap<WbAction::WbActionKind, bool> disabledUserInteractionsMap() const { return mDisabledUserInteractionsMap; }
   bool isUserInteractionDisabled(WbAction::WbActionKind action) const {
     return mDisabledUserInteractionsMap.value(action, false);
   }
@@ -128,7 +128,7 @@ public:
   void setRenderingDevicePerspective(const QString &deviceUniqueName, const QStringList &perspective);
   QStringList renderingDevicePerspective(const QString &deviceUniqueName) const;
 
-  QHash<QString, QString> &x3dExportParameters() { return mX3dExportParameters; }
+  QMap<QString, QString> &x3dExportParameters() { return mX3dExportParameters; }
   void setX3dExportParameter(const QString &key, QString value);
 
   // load/save perspective
@@ -149,7 +149,7 @@ private:
   QString mDocumentationBook;
   QString mDocumentationPage;
   double mOrthographicViewHeight;
-  QHash<WbAction::WbActionKind, bool> mDisabledUserInteractionsMap;
+  QMap<WbAction::WbActionKind, bool> mDisabledUserInteractionsMap;
   QString mProjectionMode;
   QString mRenderingMode;
   QStringList mEnabledOptionalRenderingList;
@@ -158,8 +158,8 @@ private:
   QStringList mCenterOfBuoyancyNodeNames;
   QStringList mSupportPolygonNodeNames;
   QVector<ConsoleSettings> mConsolesSettings;
-  QHash<QString, QStringList> mRenderingDevicesPerspectiveList;
-  QHash<QString, QString> mX3dExportParameters;
+  QMap<QString, QStringList> mRenderingDevicesPerspectiveList;
+  QMap<QString, QString> mX3dExportParameters;
 
   bool readContent(QTextStream &in, bool reloading);
   void addDefaultConsole();

--- a/src/webots/gui/WbHtmlExportDialog.cpp
+++ b/src/webots/gui/WbHtmlExportDialog.cpp
@@ -125,7 +125,7 @@ WbHtmlExportDialog::WbHtmlExportDialog(const QString &title, const QString &worl
   mainLayout->addWidget(mButtonBox);
 
   // read intial export values
-  const QHash<QString, QString> parameters = WbWorld::instance()->perspective()->x3dExportParameters();
+  const QMap<QString, QString> parameters = WbWorld::instance()->perspective()->x3dExportParameters();
   QString mapValueString;
   if (parameters.contains(gShadowMapSizeString))
     mapValueString = parameters.value(gShadowMapSizeString);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1148,7 +1148,8 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
     perspective->clearRenderingDevicesPerspectiveList();
   }
 
-  if (qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty()) {
+  const bool saveScreenPerspective = qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty();
+  if (saveScreenPerspective) {
     perspective->setMainWindowState(saveState());
     perspective->setMinimizedState(mMinimizedDockState);
     perspective->setSimulationViewState(mSimulationView->saveState());
@@ -1197,15 +1198,17 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
   }
   perspective->setConsolesSettings(settingsList);
 
-  // save rendering devices perspective
-  const QList<WbRenderingDevice *> renderingDevices = WbRenderingDevice::renderingDevices();
-  foreach (const WbRenderingDevice *device, renderingDevices) {
-    if (device->overlay() != NULL)
-      perspective->setRenderingDevicePerspective(device->computeShortUniqueName(), device->perspective());
-  }
+  if (saveScreenPerspective) {
+    // save rendering devices perspective
+    const QList<WbRenderingDevice *> renderingDevices = WbRenderingDevice::renderingDevices();
+    foreach (const WbRenderingDevice *device, renderingDevices) {
+      if (device->overlay() != NULL)
+        perspective->setRenderingDevicePerspective(device->computeShortUniqueName(), device->perspective());
+    }
 
-  // save rendering devices perspective of external window
-  WbRenderingDeviceWindowFactory::instance()->saveWindowsPerspective(*perspective);
+    // save rendering devices perspective of external window
+    WbRenderingDeviceWindowFactory::instance()->saveWindowsPerspective(*perspective);
+  }
 
   // save our new perspective in the file
   if (saveToFile)

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1155,7 +1155,7 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
     perspective->clearEnabledOptionalRenderings();
     perspective->clearRenderingDevicesPerspectiveList();
   }
-  if (qgetenv("WEBOTS_DISABLE_SAVE_PERSPECTIVE_ONLY_ON_CLOSE").isEmpty()) {
+  if (qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty()) {
     perspective->setMainWindowState(saveState());
     perspective->setMinimizedState(mMinimizedDockState);
     const int id = mDockWidgets.indexOf(mMaximizedWidget);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1158,11 +1158,12 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
   if (qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty()) {
     perspective->setMainWindowState(saveState());
     perspective->setMinimizedState(mMinimizedDockState);
-    const int id = mDockWidgets.indexOf(mMaximizedWidget);
-    perspective->setMaximizedDockId(id);
-    perspective->setCentralWidgetVisible(mSimulationView->isVisible());
-    perspective->setSimulationViewState(mSimulationView->saveState());
   }
+
+  const int id = mDockWidgets.indexOf(mMaximizedWidget);
+  perspective->setMaximizedDockId(id);
+  perspective->setCentralWidgetVisible(mSimulationView->isVisible());
+  perspective->setSimulationViewState(mSimulationView->saveState());
 
   if (mTextEditor) {
     perspective->setFilesList(mTextEditor->openFiles());

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1155,12 +1155,15 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
     perspective->clearEnabledOptionalRenderings();
     perspective->clearRenderingDevicesPerspectiveList();
   }
-  perspective->setMainWindowState(saveState());
-  perspective->setMinimizedState(mMinimizedDockState);
-  const int id = mDockWidgets.indexOf(mMaximizedWidget);
-  perspective->setMaximizedDockId(id);
-  perspective->setCentralWidgetVisible(mSimulationView->isVisible());
-  perspective->setSimulationViewState(mSimulationView->saveState());
+  if (qgetenv("WEBOTS_DISABLE_SAVE_PERSPECTIVE_ONLY_ON_CLOSE").isEmpty()) {
+    perspective->setMainWindowState(saveState());
+    perspective->setMinimizedState(mMinimizedDockState);
+    const int id = mDockWidgets.indexOf(mMaximizedWidget);
+    perspective->setMaximizedDockId(id);
+    perspective->setCentralWidgetVisible(mSimulationView->isVisible());
+    perspective->setSimulationViewState(mSimulationView->saveState());
+  }
+
   if (mTextEditor) {
     perspective->setFilesList(mTextEditor->openFiles());
     perspective->setSelectedTab(mTextEditor->selectedTab());

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1151,12 +1151,12 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
   if (qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty()) {
     perspective->setMainWindowState(saveState());
     perspective->setMinimizedState(mMinimizedDockState);
+    perspective->setSimulationViewState(mSimulationView->saveState());
   }
 
   const int id = mDockWidgets.indexOf(mMaximizedWidget);
   perspective->setMaximizedDockId(id);
   perspective->setCentralWidgetVisible(mSimulationView->isVisible());
-  perspective->setSimulationViewState(mSimulationView->saveState());
 
   if (mTextEditor) {
     perspective->setFilesList(mTextEditor->openFiles());

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1134,14 +1134,6 @@ void WbMainWindow::editPhysicsPlugin() {
 }
 
 void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
-  bool savingIsAllowed = true;
-
-  if (!qgetenv("WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE").isEmpty())
-    savingIsAllowed = false;
-
-  if (!savingIsAllowed && saveToFile)
-    return;
-
   const WbWorld *world = WbWorld::instance();
   if (!world || world->isUnnamed() || WbFileUtil::isLocatedInInstallationDirectory(world->fileName()))
     return;
@@ -1155,6 +1147,7 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
     perspective->clearEnabledOptionalRenderings();
     perspective->clearRenderingDevicesPerspectiveList();
   }
+
   if (qgetenv("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE").isEmpty()) {
     perspective->setMainWindowState(saveState());
     perspective->setMinimizedState(mMinimizedDockState);
@@ -1215,7 +1208,7 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
   WbRenderingDeviceWindowFactory::instance()->saveWindowsPerspective(*perspective);
 
   // save our new perspective in the file
-  if (savingIsAllowed && saveToFile)
+  if (saveToFile)
     perspective->save();
 }
 

--- a/src/webots/gui/WbView3D.hpp
+++ b/src/webots/gui/WbView3D.hpp
@@ -128,7 +128,7 @@ private:
   int mRefreshCounter;
   QElapsedTimer *mMousePressTimer;
   QPoint mMousePressPosition;
-  QHash<WbAction::WbActionKind, bool> mDisabledUserInteractionsMap;
+  QMap<WbAction::WbActionKind, bool> mDisabledUserInteractionsMap;
   double mAspectRatio;
   WbWrenFullScreenOverlay *mFastModeOverlay;
   WbWrenFullScreenOverlay *mLoadingWorldOverlay;

--- a/src/webots/nodes/WbLight.cpp
+++ b/src/webots/nodes/WbLight.cpp
@@ -235,7 +235,7 @@ void WbLight::exportNodeFields(WbVrmlWriter &writer) const {
   findField("intensity", true)->write(writer);
   findField("castShadows", true)->write(writer);
   if (writer.isX3d() && castShadows()) {
-    QHash<QString, QString> x3dExportParameters = WbWorld::instance()->perspective()->x3dExportParameters();
+    QMap<QString, QString> x3dExportParameters = WbWorld::instance()->perspective()->x3dExportParameters();
     if (x3dExportParameters.contains("shadowMapSize"))
       writer << " shadowMapSize=\'" << x3dExportParameters.value("shadowMapSize") << "\'";
     else

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -351,7 +351,7 @@ void WbWorld::write(WbVrmlWriter &writer) const {
   }
 
   assert(mPerspective);
-  QHash<QString, QString> parameters = mPerspective->x3dExportParameters();
+  QMap<QString, QString> parameters = mPerspective->x3dExportParameters();
   writer.setX3DFrustumCullingValue(parameters.value("frustumCulling"));
   writer.writeHeader(worldInfo()->title());
 


### PR DESCRIPTION
**Description**
The goal of this PR is instead of providing a way to disable all the wbproj update (with the current `WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE`), disable only those who are computer (more precisely screen) specific.

This should help us maintaining the wbproj up to date (they were updated a few weeks ago and already most of them outdated), it will also allow us to test from the test suite that they are up to date.

@cyberbotics/maintainers a few questions remains:
  - should this replace `WEBOTS_DISABLE_SAVE_PERSPECTIVE_ON_CLOSE`.
  - what can be a good name for this new environment variable?
  - the goal yet is to disable only the window perspective update, all the rest (e.g. files open in the text editor) will be saved. Do you see something else important to disable?