### PR TITLE
Fix Display reset

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -52,7 +52,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710), [#1736](https://github.com/cyberbotics/webots/pull/1736)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
-    - Fixed crash occurring when resetting a simulation containing a [Display](display.md) device ([#1865](https://github.com/cyberbotics/webots/pull/1865)).
+    - Fixed crash occurring when reloading or resetting a simulation containing a [Display](display.md) device ([#1865](https://github.com/cyberbotics/webots/pull/1865)).
     - Fixed crash with Python [`RangeFinder.rangeImageGetDepth`](rangefinder.md#wb_range_finder_image_get_depth) function ([#1858](https://github.com/cyberbotics/webots/pull/1858)).
     - Fixed mismatch between the bounding object and visual shape of the [UnevenTerrain](https://www.cyberbotics.com/doc/guide/object-floors#uneventerrain), **and removed the `textureScale` field** ([#1792](https://github.com/cyberbotics/webots/pull/1792)).
     - Fixed crash when using a [Normal](normal.md) node in a PROTO node ([#1813](https://github.com/cyberbotics/webots/pull/1813)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -52,6 +52,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710), [#1736](https://github.com/cyberbotics/webots/pull/1736)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
+    - Fixed crash occurring when resetting a simulation containing a [Display](display.md) device ([#1865](https://github.com/cyberbotics/webots/pull/1865)).
     - Fixed crash with Python [`RangeFinder.rangeImageGetDepth`](rangefinder.md#wb_range_finder_image_get_depth) function ([#1858](https://github.com/cyberbotics/webots/pull/1858)).
     - Fixed mismatch between the bounding object and visual shape of the [UnevenTerrain](https://www.cyberbotics.com/doc/guide/object-floors#uneventerrain), **and removed the `textureScale` field** ([#1792](https://github.com/cyberbotics/webots/pull/1792)).
     - Fixed crash when using a [Normal](normal.md) node in a PROTO node ([#1813](https://github.com/cyberbotics/webots/pull/1813)).

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -14,7 +14,7 @@ Display {
 The [Display](#display) node allows to handle a 2D pixel array using simple API functions, and render it into a 2D overlay on the 3D view, into a 2D texture of any [Shape](shape.md) node, or both.
 It can model an embedded screen or it can display any graphical information such as graphs, text, robot trajectory, filtered camera images and so on.
 
-To model an embedded screen, the first child of the [Display](#display) node should be or contain (recursive search if the first node is a [Group](group.md)) a [Shape](shape.md) node having an appearance and an [ImageTexture](imagetexture.md) node set, then the internal texture of the [ImageTexture](imagetexture.md) node is replaced by the texture of the [Display](#display).
+To model an embedded screen, the first child of the [Display](#display) node should be or contain (recursive search if the first node is a [Group](group.md)) a [Shape](shape.md) node having an appearance and an [ImageTexture](imagetexture.md) node, then the internal texture of the [ImageTexture](imagetexture.md) node is replaced by the texture of the [Display](#display).
 Both [Appearance](appearance.md) and [PBRAppearance](pbrappearance.md) nodes are supported.
 In case of [PBRAppearance](pbrappearance.md) node, at least `PBRAppearance.baseColorMap` or `PBRAppearance.emissiveColorMap` [ImageTexture](imagetexture.md) node should be defined. If both are defined, then both textures will be replaced by the [Display](#display) texture.
 Using the [Appearance](appearance.md) node and setting the [Material](material.md).emissiveColor field to `1 1 1` helps preserving the original colors of the loaded [Display](#display) texture.

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -14,9 +14,11 @@ Display {
 The [Display](#display) node allows to handle a 2D pixel array using simple API functions, and render it into a 2D overlay on the 3D view, into a 2D texture of any [Shape](shape.md) node, or both.
 It can model an embedded screen or it can display any graphical information such as graphs, text, robot trajectory, filtered camera images and so on.
 
-If the first child of the [Display](#display) node is or contains (recursive search if the first node is a [Group](group.md)) a [Shape](shape.md) node having a [ImageTexture](imagetexture.md), then the internal texture of the(se) [ImageTexture](imagetexture.md) node(s) is replaced by the texture of the [Display](#display).
-In this case, the `Shape.appearance` field should contain an [Appearance](appearance.md) node (rather than a [PBRAppearance](pbrappearance.md) node).
-It is necessary to set the `filtering` field of the(se) [ImageTexture](imagetexture.md) node(s) to 0 in order to prevent issues when distancing oneself from the display.
+To model an embedded screen, the first child of the [Display](#display) node should be or contain (recursive search if the first node is a [Group](group.md)) a [Shape](shape.md) node having an appearance and an [ImageTexture](imagetexture.md) node set, then the internal texture of the [ImageTexture](imagetexture.md) node is replaced by the texture of the [Display](#display).
+Both [Appearance](appearance.md) and [PBRAppearance](pbrappearance.md) nodes are supported.
+In case of [PBRAppearance](pbrappearance.md) node, at least `PBRAppearance.baseColorMap` or `PBRAppearance.emissiveColorMap` [ImageTexture](imagetexture.md) node should be defined. If both are defined, then both textures will be replaced by the [Display](#display) texture.
+Using the [Appearance](appearance.md) node and setting the [Material](material.md).emissiveColor field to `1 1 1` helps preserving the original colors of the loaded [Display](#display) texture.
+Additionally, it is necessary to set the `filtering` field of the [ImageTexture](imagetexture.md) nodes to 0 in order to prevent issues when distancing oneself from the display.
 
 ### Field Summary
 

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -16,7 +16,7 @@ It can model an embedded screen or it can display any graphical information such
 
 To model an embedded screen, the first child of the [Display](#display) node should be or contain (recursive search if the first node is a [Group](group.md)) a [Shape](shape.md) node having an appearance and an [ImageTexture](imagetexture.md) node, then the internal texture of the [ImageTexture](imagetexture.md) node is replaced by the texture of the [Display](#display).
 Both [Appearance](appearance.md) and [PBRAppearance](pbrappearance.md) nodes are supported.
-In case of [PBRAppearance](pbrappearance.md) node, at least `PBRAppearance.baseColorMap` or `PBRAppearance.emissiveColorMap` [ImageTexture](imagetexture.md) node should be defined. If both are defined, then both textures will be replaced by the [Display](#display) texture.
+In case of [PBRAppearance](pbrappearance.md) node, at least `PBRAppearance.baseColorMap` or `PBRAppearance.emissiveColorMap` [ImageTexture](imagetexture.md) node should be defined. If both are defined, then both textures will be internally replaced by the [Display](#display) texture.
 Using the [Appearance](appearance.md) node and setting the [Material](material.md).emissiveColor field to `1 1 1` helps preserving the original colors of the loaded [Display](#display) texture.
 Additionally, it is necessary to set the `filtering` field of the [ImageTexture](imagetexture.md) nodes to 0 in order to prevent issues when distancing oneself from the display.
 

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -193,6 +193,7 @@ void WbDisplay::findImageTextures() {
 }
 
 void WbDisplay::removeImageTexture(QObject *object) {
+  assert(dynamic_cast<WbImageTexture *>(object));
   mImageTextures.removeAll(static_cast<WbImageTexture *>(object));
 }
 

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -1078,8 +1078,13 @@ void WbDisplay::createWrenOverlay() {
 }
 
 void WbDisplay::removeExternalTextures() {
+  // first remove all the references to deleted external textures
   for (int i = 0; i < mImageTextures.size(); ++i)
     mImageTextures.at(i)->removeExternalTexture();
+  // then, trigger the appearance update
+  // two steps needed for PBRAppearance nodes if both baseColorMap and emissiveColorMap are defined
+  for (int i = 0; i < mImageTextures.size(); ++i)
+    emit mImageTextures.at(i)->changed();
 }
 
 void WbDisplay::setTransparentTextureIfNeeded() {

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -184,9 +184,16 @@ void WbDisplay::findImageTextures() {
       findImageTextures(group);
   }
 
+  for (int i = 0; i < mImageTextures.size(); ++i)
+    connect(mImageTextures.at(i), &QObject::destroyed, this, &WbDisplay::removeImageTexture);
+
   // debug code - print the found materials
   // foreach (WbImageTexture *texture, mImageTextures)
   //   parsingWarn(QString("found image texture %1").arg(texture->usefulName()));
+}
+
+void WbDisplay::removeImageTexture(QObject *object) {
+  mImageTextures.removeAll(static_cast<WbImageTexture *>(object));
 }
 
 void WbDisplay::clearImageTextures() {

--- a/src/webots/nodes/WbDisplay.hpp
+++ b/src/webots/nodes/WbDisplay.hpp
@@ -105,6 +105,7 @@ private:
   QList<WbImageTexture *> mImageTextures;
 
 private slots:
+  void removeImageTexture(QObject *object);
   void removeExternalTextures();
   void detachCamera();
 };

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -14,7 +14,7 @@
 
 #include "WbImageTexture.hpp"
 
-#include "WbAppearance.hpp"
+#include "WbAbstractAppearance.hpp"
 #include "WbField.hpp"
 #include "WbFieldChecker.hpp"
 #include "WbImage.hpp"
@@ -249,7 +249,7 @@ void WbImageTexture::modifyWrenMaterial(WrMaterial *wrenMaterial, const int main
     wr_material_set_texture_enable_interpolation(wrenMaterial, mUsedFiltering, mWrenTextureIndex);
     wr_material_set_texture_enable_mip_maps(wrenMaterial, mUsedFiltering, mWrenTextureIndex);
 
-    if (mExternalTexture && !(static_cast<WbAppearance *>(parentNode())->textureTransform())) {
+    if (mExternalTexture && !(static_cast<WbAbstractAppearance *>(parentNode())->textureTransform())) {
       wr_texture_transform_delete(mWrenTextureTransform);
       mWrenTextureTransform = wr_texture_transform_new();
       wr_texture_transform_set_scale(mWrenTextureTransform, mExternalTextureRatio.x(), mExternalTextureRatio.y());
@@ -295,6 +295,7 @@ void WbImageTexture::removeExternalTexture() {
 
   mExternalTexture = false;
   mExternalTextureRatio.setXy(1.0, 1.0);
+  mExternalTextureData = NULL;
 
   updateWrenTexture();
 }

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -297,8 +297,6 @@ void WbImageTexture::removeExternalTexture() {
   mExternalTextureRatio.setXy(1.0, 1.0);
 
   updateWrenTexture();
-
-  emit changed();
 }
 
 void WbImageTexture::setBackgroundTexture(WrTexture *backgroundTexture) {


### PR DESCRIPTION
Fix #1329.

The crash is caused by an update of the Display's PBRAppearance triggered too early on reset just after the textures are delete, i.e. before all the references to deleted external texture are removed:
https://github.com/cyberbotics/webots/blob/master/src/webots/nodes/WbImageTexture.cpp#L308
So the fix consists in postponing the wren material updated after all the external texture references are removed.


Currently in the Display doc, it is also stated that "PBRAppearance" should not be used for Display:
https://www.cyberbotics.com/doc/reference/display#description
But this is not the case for the distributed samples (including the problematic `apartment.wbt`).

The only problem I see with the `PBRAppearance` is that the resulting displayed image colors don't match as good the original loaded image (because both the emissive and baseColor map are updated with the loaded image).
**Up** a Display with the `Appearance` node, **down** the same Display with the `PBRAppearance`:
![appearance_comparison](https://user-images.githubusercontent.com/5910449/86336155-c2829f00-bc4f-11ea-9710-45581b1e1757.png)