### PR TITLE
Fix Chaining URDF Link Translations

### DIFF
--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -414,7 +414,7 @@ WbVector3 WbTransform::translationFrom(const WbNode *fromNode) const {
   while (parentNode != fromNode) {
     childNode = parentNode;
     parentNode = WbNodeUtilities::findUpperTransform(parentNode);
-    translationResult -= childNode->translation();
+    translationResult += childNode->translation();
     assert(parentNode);
   }
   return translationResult;


### PR DESCRIPTION
**Description**
`translationFrom()` doesn't return correct translation when multiple nodes are involved.

**Tasks**
  - [x] Fix chaining URDF link translations
  - [x] Update test
  - [x] Test with a few robots
