### PR TITLE
Add URDF `base_footprint` link

### DIFF
--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1435,30 +1435,31 @@ const QString WbRobot::urdfName() const {
 }
 
 void WbRobot::writeExport(WbVrmlWriter &writer) const {
-    writer.increaseIndent();
-    writer.indent();
-    writer << QString("<link name=\"%1\"></link>\n").arg(getUrdfPrefix() + "base_footprint");
-    writer.indent();
-    writer << QString("<joint name=\"%1\" type=\"fixed\">\n").arg(getUrdfPrefix() + "base_joint");
-    writer.increaseIndent();
-    writer.indent();
-    writer << QString("<parent link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_link");
-    writer.indent();
-    writer << QString("<child link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_footprint");
-    writer.indent();
-    writer << QString("<axis xyz=\"0 0 0\"/>\n");
-    writer.indent();
-    writer << QString("<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n");
-    writer.decreaseIndent();
-    writer.indent();
-    writer << QString("</joint>\n");
+  writer.increaseIndent();
+  writer.indent();
+  writer << QString("<link name=\"%1\"></link>\n").arg(getUrdfPrefix() + "base_footprint");
 
-    writer.indent();
-    writer << QString("<link name=\"%1\">\n").arg(getUrdfPrefix() + "base_link");
-    exportNodeSubNodes(writer);
-    writer.indent();
-    writer << QString("</link>\n");
-    writer.decreaseIndent();
+  writer.indent();
+  writer << QString("<joint name=\"%1\" type=\"fixed\">\n").arg(getUrdfPrefix() + "base_joint");
+  writer.increaseIndent();
+  writer.indent();
+  writer << QString("<parent link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_link");
+  writer.indent();
+  writer << QString("<child link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_footprint");
+  writer.indent();
+  writer << QString("<axis xyz=\"0 0 0\"/>\n");
+  writer.indent();
+  writer << QString("<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n");
+  writer.decreaseIndent();
+  writer.indent();
+  writer << QString("</joint>\n");
+
+  writer.indent();
+  writer << QString("<link name=\"%1\">\n").arg(getUrdfPrefix() + "base_link");
+  exportNodeSubNodes(writer);
+  writer.indent();
+  writer << QString("</link>\n");
+  writer.decreaseIndent();
 }
 
 int WbRobot::computeSimulationMode() {

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1434,6 +1434,33 @@ const QString WbRobot::urdfName() const {
   return getUrdfPrefix() + QString("base_link");
 }
 
+void WbRobot::writeExport(WbVrmlWriter &writer) const {
+    writer.increaseIndent();
+    writer.indent();
+    writer << QString("<link name=\"%1\"></link>\n").arg(getUrdfPrefix() + "base_footprint");
+    writer.indent();
+    writer << QString("<joint name=\"%1\" type=\"fixed\">\n").arg(getUrdfPrefix() + "base_joint");
+    writer.increaseIndent();
+    writer.indent();
+    writer << QString("<parent link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_link");
+    writer.indent();
+    writer << QString("<child link=\"%1\"/>\n").arg(getUrdfPrefix() + "base_footprint");
+    writer.indent();
+    writer << QString("<axis xyz=\"0 0 0\"/>\n");
+    writer.indent();
+    writer << QString("<origin xyz=\"0 0 0\" rpy=\"0 0 0\"/>\n");
+    writer.decreaseIndent();
+    writer.indent();
+    writer << QString("</joint>\n");
+
+    writer.indent();
+    writer << QString("<link name=\"%1\">\n").arg(getUrdfPrefix() + "base_link");
+    exportNodeSubNodes(writer);
+    writer.indent();
+    writer << QString("</link>\n");
+    writer.decreaseIndent();
+}
+
 int WbRobot::computeSimulationMode() {
   WbSimulationState *state = WbSimulationState::instance();
   switch (state->mode()) {

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -161,6 +161,7 @@ protected:
   // export
   void exportNodeFields(WbVrmlWriter &writer) const override;
   const QString urdfName() const override;
+  void writeExport(WbVrmlWriter &writer) const override;
 
   WbKinematicDifferentialWheels *mKinematicDifferentialWheels;
   const bool isRobot() const override { return true; };

--- a/tests/api/controllers/robot_urdf/reference_robot.urdf
+++ b/tests/api/controllers/robot_urdf/reference_robot.urdf
@@ -1,5 +1,12 @@
 <?xml version="1.0"?>
 <robot name="UR5e" xmlns:xacro="http://ros.org/wiki/xacro">
+  <link name="base_footprint"></link>
+  <joint name="base_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="base_footprint"/>
+    <axis xyz="0 0 0"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
   <link name="base_link">
     <visual name="transform_8">
       <geometry>


### PR DESCRIPTION
**Description**
Turtlebot3 and Husky have `base_footprint` link as a parent:
https://github.com/husky/husky/blob/4647d303365b17ccb455f4345bd14320f49f1134/husky_description/urdf/husky.urdf.xacro#L95
https://github.com/ROBOTIS-GIT/turtlebot3/blob/41e43d4a10aada68b8a7d05675550550091586d6/turtlebot3_description/urdf/turtlebot3_burger.urdf#L47
Probably, it is similar to the other robots as well.

This is important because some packages depend on `base_footprint` link, e.g. `turtlebot3_navigation2`:
https://github.com/ROBOTIS-GIT/turtlebot3/blob/41e43d4a10aada68b8a7d05675550550091586d6/turtlebot3_navigation2/param/burger.yaml#L9

Usually, this can be changed by overriding configuration or by adding static transform in a launch file. However, this may be a cleaner solution and closer to what the community has been doing.

**Related Issues**
https://github.com/cyberbotics/webots_ros2/pull/110

**Tasks**
  - [x] Add `base_footprint` link
  - [x] Update tests