### PR TITLE
Make wb_supervisor_movie_is_ready Function Immediate

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -13,6 +13,7 @@ Released on XXX.
     - Added a model of the [P-Rob 3](../guide/p-rob3.md) robot from [F&P Robotics](https://www.fp-robotics.com/en/) ([#1657](https://github.com/cyberbotics/webots/pull/1657)).
     - Added the `mjpeg` web streaming mode ([#1352](https://github.com/cyberbotics/webots/pull/1352)).
     - Exposed global texture maximum filtering as a parameter in the Webots preferences ([#1851](https://github.com/cyberbotics/webots/pull/1851)).
+    - Added a [`wb_robot_get_urdf`](robot.md#wb_robot_get_urdf) function to the [Robot](robot.md) node which allows URDF export ([#1706](https://github.com/cyberbotics/webots/pull/1706)).
     - Added a new 'Show Normals' optional rendering ([#1740](https://github.com/cyberbotics/webots/pull/1740)).
     - macOS and Windows: Added support for Python 3.8 ([#1299](https://github.com/cyberbotics/webots/pull/1299), [#1311](https://github.com/cyberbotics/webots/pull/1311)).
     - Added a model of a Mercedes-Benz Sprinter ([#1540](https://github.com/cyberbotics/webots/pull/1540)).
@@ -33,7 +34,7 @@ Released on XXX.
     - Improved the `ros_python` and `universal_robots_ros` ROS simulations to use extern controllers instead of embedding the ROS libraries ([#1876](https://github.com/cyberbotics/webots/pull/1876)).
     - Added a `supervisor` field to the [RobotisOp2](../guide/robotis-op2.md) and [RobotisOp3](../guide/robotis-op3.md) PROTO nodes ([#1790](https://github.com/cyberbotics/webots/pull/1790)).
     - Added a [Gyro](gyro.md) node to e-puck PROTO ([#1484](https://github.com/cyberbotics/webots/pull/1484)).
-    - Added a [`wb_robot_get_urdf`](robot.md#wb_robot_get_urdf) function to the [Robot](robot.md) node which allows URDF export ([#1706](https://github.com/cyberbotics/webots/pull/1706))
+    - Improved the [`wb_supervisor_movie_is_ready`](supervisor.md#wb_supervisor_movie_is_ready) and [`wb_supervisor_movie_failed`](supervisor.md#wb_supervisor_movie_failed) functions to return an updated value even if the [`wb_robot_step`](robot.md#wb_robot_step) function is not called ([#1908](https://github.com/cyberbotics/webots/pull/1908)).
     - Console
       - Added a context menu to the console allowing the user to define what should be displayed, by filtering the logs by type and source ([#1595](https://github.com/cyberbotics/webots/pull/1595)).
       - Added the possibility to open several consoles at the same time ([#1595](https://github.com/cyberbotics/webots/pull/1595)).

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -833,7 +833,7 @@ Where *p* is a point whose coordinates are given with respect to the local coord
 %spoiler "**Python Example**: How to calculate relative positions and orientations?"
 
 The following Python example calculates the position and orientation of a node relatively to another node.
-It should be easily adaptable to any other language, as it uses simple matrix and vector calculations. 
+It should be easily adaptable to any other language, as it uses simple matrix and vector calculations.
 
 ```python
 from controller import Supervisor
@@ -868,7 +868,7 @@ box_pos_world = np.subtract(box_pos_world, pos_ur10e)
 box_pos_robot = np.dot(rot_ur10e, box_pos_world)
 
 # Calculate the orientation of the box, relative to the robot, all in one line.
-box_rot_robot = np.dot(rot_ur10e, np.array(box.getOrientation()).reshape(3, 3)) 
+box_rot_robot = np.dot(rot_ur10e, np.array(box.getOrientation()).reshape(3, 3))
 ```
 
 %end
@@ -2556,13 +2556,13 @@ The `acceleration` specifies the acceleration factor of the created movie with r
 Default value is 1, i.e. no acceleration.
 If `caption` parameters is set to true, a default caption is printed on the top right corner of the movie showing the current `acceleration` value.
 
-The `wb_supervisor_movie_is_ready` function returns `TRUE` if the application is ready to start recording a movie, i.e. if another recording process is not already running.
+The `wb_supervisor_movie_is_ready` function returns `true` if the application is ready to start recording a movie, i.e. if another recording process is not already running.
 So it could be used to check if the encoding process is completed and the file has been created.
-Note that if the recording process failed, this function will return `TRUE`.
+Note that if the recording process failed, this function will return `true`.
 In order to detect a failure the `wb_supervisor_movie_failed` function has to be called.
 
-The `wb_supervisor_movie_failed` function returns `TRUE` if the recording process failed.
-After starting a new recording process the returned value is reset to `FALSE`.
+The `wb_supervisor_movie_failed` function returns `true` if the recording process failed.
+After starting a new recording process the returned value is reset to `false`.
 
 ---
 

--- a/src/lib/Controller/api/supervisor.c
+++ b/src/lib/Controller/api/supervisor.c
@@ -1194,12 +1194,20 @@ bool wb_supervisor_movie_is_ready() {
   if (!robot_check_supervisor(__FUNCTION__))
     return false;
 
-  return movie_status == WB_SUPERVISOR_MOVIE_READY || wb_supervisor_movie_failed();
+  robot_mutex_lock_step();
+  wb_robot_flush_unlocked();
+  robot_mutex_unlock_step();
+
+  return movie_status == WB_SUPERVISOR_MOVIE_READY || movie_status > WB_SUPERVISOR_MOVIE_SAVING;
 }
 
 bool wb_supervisor_movie_failed() {
   if (!robot_check_supervisor(__FUNCTION__))
     return true;
+
+  robot_mutex_lock_step();
+  wb_robot_flush_unlocked();
+  robot_mutex_unlock_step();
 
   return movie_status > WB_SUPERVISOR_MOVIE_SAVING;
 }

--- a/tests/api/controllers/supervisor_start_stop_movie/supervisor_start_stop_movie.c
+++ b/tests/api/controllers/supervisor_start_stop_movie/supervisor_start_stop_movie.c
@@ -42,7 +42,6 @@ int main(int argc, char **argv) {
   for (i = 0; i < 50; i++) {
     usleep(100000);
 
-    wb_robot_step(TIME_STEP);
     if (wb_supervisor_movie_is_ready()) {
       ts_assert_boolean_not_equal(wb_supervisor_movie_failed(), "Error while recording the movie file.");
 


### PR DESCRIPTION
**Description**
Currently, the `wb_supervisor_movie_is_ready` function requires a step to be updated, but this is often unwanted (we don't want to have to let the simulation run while waiting for the movie to be finalized).

**Related Issues**
This pull-request fixes issue #1905
