### PR TITLE
Fix video recording with asynchronous controllers.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -65,6 +65,7 @@ Released on XXX.
     - Fixed crash occurring when setting a 3D coordinate to a huge value (greater than 1e+151) ([#1639](https://github.com/cyberbotics/webots/pull/1639)).
     - Fixed crash occurring when Webots was streaming a 3D scene and some object was inserted into a PROTO node ([#1614](https://github.com/cyberbotics/webots/pull/1614)).
     - Fixed the restoration of the 3D view which was sometimes not re-appearing after being hidden ([#1573](https://github.com/cyberbotics/webots/pull/1573)).
+    - Fixed video recording when using [asynchronous controllers](robot.md#synchronous-versus-asynchronous-controllers) ([#1927](https://github.com/cyberbotics/webots/pull/1927)).
     - Windows: Fixed JPEG texture errors when typing `webots` from a DOS console (`cmd.exe`) by renaming `webots.exe` to `webots-bin.exe` and creating two launchers named `webotsw.exe` and `webots.exe` ([#1532](https://github.com/cyberbotics/webots/pull/1532)).
     - Fixed the physics behavior of [Connector](connector.md) nodes sometimes remaining idle after being detached from each other (thanks to Giorgio) ([#1415](https://github.com/cyberbotics/webots/pull/1415)).
     - Fixed the [`wb_camera_save_image`](camera.md#wb_camera_save_image) function when used to save jpeg images ([#1285](https://github.com/cyberbotics/webots/pull/1285)).

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -168,18 +168,18 @@ bool WbVideoRecorder::setMainWindowFullScreen(bool fullScreen) {
 }
 
 void WbVideoRecorder::estimateMovieInfo(double basicTimeStep) {
-  int roundedBasicTimeStep = round(basicTimeStep);
-  double refresh = EXPECTED_FRAME_STEP / (double)roundedBasicTimeStep;
-  int floorRefresh = floor(refresh);
-  int ceilRefresh = ceil(refresh);
-  int frameStep0 = floorRefresh * roundedBasicTimeStep;
-  int frameStep1 = ceilRefresh * roundedBasicTimeStep;
+  const int roundedBasicTimeStep = round(basicTimeStep);
+  const double refresh = mVideoAcceleration * EXPECTED_FRAME_STEP / (double)roundedBasicTimeStep;
+  const int floorRefresh = floor(refresh);
+  const int ceilRefresh = ceil(refresh);
+  const int frameStep0 = floorRefresh * roundedBasicTimeStep;
+  const int frameStep1 = ceilRefresh * roundedBasicTimeStep;
 
   if (frameStep0 == 0 || abs(frameStep0 - EXPECTED_FRAME_STEP) > abs(frameStep1 - EXPECTED_FRAME_STEP)) {
-    mMovieFPS = 1000.0 / frameStep1;
+    mMovieFPS = mVideoAcceleration * 1000.0 / frameStep1;
     cDisplayRefresh = frameStep1;
   } else {
-    mMovieFPS = 1000.0 / frameStep0;
+    mMovieFPS = mVideoAcceleration * 1000.0 / frameStep0;
     cDisplayRefresh = frameStep0;
   }
 }

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -177,10 +177,10 @@ void WbVideoRecorder::estimateMovieInfo(double basicTimeStep) {
 
   if (frameStep0 == 0 || abs(frameStep0 - EXPECTED_FRAME_STEP) > abs(frameStep1 - EXPECTED_FRAME_STEP)) {
     mMovieFPS = 1000.0 / frameStep1;
-    cDisplayRefresh = ceilRefresh * mVideoAcceleration;
+    cDisplayRefresh = frameStep1;
   } else {
     mMovieFPS = 1000.0 / frameStep0;
-    cDisplayRefresh = floorRefresh * mVideoAcceleration;
+    cDisplayRefresh = frameStep0;
   }
 }
 

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -92,7 +92,6 @@ WbView3D::WbView3D() :
   WbWrenWindow(),
   mParentWidget(NULL),
   mLastRefreshTimer(),
-  mRefreshCounter(0),
   mMousePressTimer(NULL),
   mAspectRatio(1.0),
   mFastModeOverlay(NULL),
@@ -930,9 +929,6 @@ void WbView3D::prepareWorldLoading() {
   hideFastModeOverlay();
   mLoadingWorldOverlay->setVisible(true);
   WbWrenWindow::renderNow();
-
-  // restart refresh counter
-  mRefreshCounter = 0;
 
   // Resets the background if no Background node exists
   const float clearColor[] = {1.0f, 1.0f, 1.0f};

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -329,11 +329,13 @@ void WbView3D::refresh() {
     renderLater();
   else if (sim->isStep() || sim->isRealTime() || sim->isRunning()) {
     if (WbVideoRecorder::instance()->isRecording()) {
-      const int displayRefresh = WbVideoRecorder::displayRefresh();
-      mRefreshCounter = (mRefreshCounter + 1) % displayRefresh;
-      if (mRefreshCounter == 0)
+      const double time = WbSimulationState::instance()->time();
+      static double lastRefreshTime = time;
+      if (time - lastRefreshTime >= WbVideoRecorder::displayRefresh() || time < lastRefreshTime) {
         // render main window immediately even if it is not exposed
+        lastRefreshTime = time;
         renderNow();
+      }
     } else if (sim->isPaused())
       renderLater();
     else {

--- a/src/webots/gui/WbView3D.hpp
+++ b/src/webots/gui/WbView3D.hpp
@@ -125,7 +125,6 @@ private:
   static int cView3DNumber;
   WrCameraProjectionMode mProjectionMode;
   WrViewportPolygonMode mRenderingMode;
-  int mRefreshCounter;
   QElapsedTimer *mMousePressTimer;
   QPoint mMousePressPosition;
   QMap<WbAction::WbActionKind, bool> mDisabledUserInteractionsMap;


### PR DESCRIPTION
**Description**
Fix #1407.

Using a counter in the `WbView3D::refresh` to take a video frame is not a good idea as several events can trigger this slot, even in synchornous mode (controller, supervisor world edition, mouse, etc.).