### PR TITLE
Fixed libController compilation dependencies

### DIFF
--- a/src/lib/Controller/Makefile
+++ b/src/lib/Controller/Makefile
@@ -166,6 +166,7 @@ $(OBJDIR)/%.d:%.c
 	@echo "# updating " $@
 	@echo $(basename $(OBJDIR)/$(notdir $@)).o: $(basename $@).d > $(OBJDIR)/$(notdir $@)
 	@echo >> $(OBJDIR)/$(notdir $@)
+	@echo -n $(OBJDIR)/ >> $(OBJDIR)/$(notdir $@)
 	@$(CC) $(CFLAGS) -MM -w $(INCLUDE) $< >> $(OBJDIR)/$(notdir $@)
 
 clean:


### PR DESCRIPTION
The Makefile automatic dependency system was broken for the libController.
For example, after recompiling the libController, if you would modify `robot_private.h` and type `make release`, it would say: `make: Nothing to be done for 'release'.` which is obviously wrong as at least `robot.c` needs to be recompiled because it includes `robot_private.h`.
This PR fixes this problem.
