### PR TITLE
Fix set_commit_and_date_in_version.py

### DIFF
--- a/src/packaging/set_commit_and_date_in_version.py
+++ b/src/packaging/set_commit_and_date_in_version.py
@@ -21,7 +21,7 @@ import sys
 if 'WEBOTS_HOME' in os.environ:
     path = os.environ['WEBOTS_HOME']
 else:
-    path = '../..'
+    path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if len(sys.argv) != 2:  # no commit id passed as an argument
     sys.exit('Commit id not passed as argument.')
 else:


### PR DESCRIPTION
**Description**
This script was failing when WEBOTS_HOME was not set and not called from the script directory:
  - https://github.com/cyberbotics/webots/runs/887859883?check_suite_focus=true#step:6:7
