### PR TITLE
Fix hinge2joint Documentation

### DIFF
--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -37,7 +37,7 @@ It contains, among others, the joint position, the axis anchor expressed in rela
 
 - `jointParameters2` and `jointParameters3`: These fields optionally specifiy a [JointParameters](jointparameters.md) node for the second and third axis.
 They contain, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
-If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` used are those of the [BallJointParameters](balljointparameters.md) node from the `jointParameters` field.
+If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` used are those of the first axis defined in the [BallJointParameters](balljointparameters.md) node from the `jointParameters` field.
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.

--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -35,7 +35,7 @@ If the `jointParameters2` and/or `jointParameters3` fields are empty, the defaul
 - `jointParameters`: This field optionally specifies a [BallJointParameters](balljointparameters.md) node.
 It contains, among others, the joint position, the axis anchor expressed in relative coordinates and the stop positions.
 
-- `jointParameters2` and `jointParameters3`: These fields optionally specifiy a [JointParameters](jointparameters.md) node.
+- `jointParameters2` and `jointParameters3`: These fields optionally specifiy a [JointParameters](jointparameters.md) node for the second and third axis.
 They contain, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
 If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` used are those of the [BallJointParameters](balljointparameters.md) node from the `jointParameters` field.
 

--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -4,6 +4,8 @@ Derived from [Hinge2Joint](hinge2joint.md).
 
 ```
 BallJoint {
+  SFNode  jointParameters  NULL   # {BallJointParameters, PROTO}
+  SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   SFNode  jointParameters3 NULL   # {JointParameters, PROTO}
   MFNode  device3          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
   SFFloat position3        0      # [0, inf)
@@ -30,9 +32,12 @@ If the `jointParameters2` and/or `jointParameters3` fields are empty, the defaul
 
 ### Field Summary
 
-- `jointParameters3`: This field optionally specifies a [JointParameters](jointparameters.md) node.
-It contains, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
-If this field is empty, the `springConstant`, `dampingConstant` and `staticFriction` are homogeneous along each rotation axes.
+- `jointParameters`: This field optionally specifies a [BallJointParameters](balljointparameters.md) node.
+It contains, among others, the joint position, the axis anchor expressed in relative coordinates and the stop positions.
+
+- `jointParameters2` and `jointParameters3`: These fields optionally specifiy a [JointParameters](jointparameters.md) node.
+They contain, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
+If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` are homogeneous along each rotation axes.
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.

--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -37,7 +37,7 @@ It contains, among others, the joint position, the axis anchor expressed in rela
 
 - `jointParameters2` and `jointParameters3`: These fields optionally specifiy a [JointParameters](jointparameters.md) node.
 They contain, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
-If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` are homogeneous along each rotation axes.
+If these fields are empty, the `springConstant`, `dampingConstant` and `staticFriction` used are those of the [BallJointParameters](balljointparameters.md) node from the `jointParameters` field.
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -4,6 +4,7 @@ Derived from [HingeJoint](hingejoint.md).
 
 ```
 Hinge2Joint {
+  SFNode  jointParameters  NULL   # {HingeJointParameters, PROTO}
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   MFNode  device2          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
   SFFloat position2        0      # [0, inf)
@@ -20,7 +21,7 @@ Hinge2Joint {
 
 The [Hinge2Joint](#hinge2joint) node can be used to model a hinge2 joint, i.e. a joint allowing only rotational motions around two intersecting axes (2 degrees of freedom).
 These axes cross at the `anchor` point and need not to be perpendicular.
-The suspension fields defined in a [HingeJointParameters](hingejointparameters.md) node allow for spring and damping effects along the suspension axis.
+The suspension fields defined in the [HingeJointParameters](hingejointparameters.md) node of the `jointParameters` field allow for spring and damping effects along the suspension axis.
 
 Note that a universal joint boils down to a hinge2 joint with orthogonal axes and (default) zero suspension.
 
@@ -30,6 +31,10 @@ Typically, [Hinge2Joint](#hinge2joint) can be used to model a steering wheel wit
 In other words, this joint cannot be statically based.
 
 ### Field Summary
+
+- `jointParameters`: This field optionally specifies a [HingeJointParameters](hingejointparameters.md) node.
+It contains, among others, the joint position, the axis position expressed in relative coordinates, the stop positions and suspension parameters.
+If the `jointParameters` field is left empty, default values of the [HingeJointParameters](hingejointparameters.md) node apply.
 
 - `jointParameters2`: This field optionally specifies a [JointParameters](jointparameters.md) node.
 It contains, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -33,7 +33,7 @@ In other words, this joint cannot be statically based.
 
 - `jointParameters2`: This field optionally specifies a [JointParameters](jointparameters.md) node.
 It contains, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
-If the `jointParameters` field is left empty, default values of the HingeJointParameters node apply.
+If the `jointParameters2` field is left empty, default values of the [JointParameters](jointparameters.md) node apply.
 
 - `device2`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached to the second axis.
 If no motor is specified, this part of the joint is passive.

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -31,8 +31,8 @@ In other words, this joint cannot be statically based.
 
 ### Field Summary
 
-- `jointParameters2`: This field optionally specifies a [HingeJointParameters](hingejointparameters.md) node.
-It contains, among others, the joint position, the axis position expressed in relative coordinates, the stop positions and suspension parameters.
+- `jointParameters2`: This field optionally specifies a [JointParameters](jointparameters.md) node.
+It contains, among others, the joint position, the axis position expressed in relative coordinates and the stop positions.
 If the `jointParameters` field is left empty, default values of the HingeJointParameters node apply.
 
 - `device2`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached to the second axis.


### PR DESCRIPTION
**Description**
The `HingeJointParameters` node is included in the `jointParameters` field and not in the `jointParameters2` one.