### PR TITLE
Fixed accelerometer measurements

### DIFF
--- a/docs/reference/accelerometer.md
+++ b/docs/reference/accelerometer.md
@@ -17,6 +17,7 @@ Accelerometer {
 The [Accelerometer](#accelerometer) node can be used to model accelerometer devices such as those commonly found in mobile electronics, robots and game input devices.
 The [Accelerometer](#accelerometer) node measures acceleration and gravity induced reaction forces over 1, 2 or 3 axes.
 It can be used for example to detect fall, the up/down direction, etc.
+The parent node of an [Accelerometer](#accelerometer) node should have a [Physics](physics.md) node defined in its `physics` field, so that correct measurements can be performed.
 
 ### Field Summary
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -55,6 +55,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710), [#1736](https://github.com/cyberbotics/webots/pull/1736)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
+    - Fixed wrong measurements of [Accelerometer](accelerometer.md) device (thanks to [MauroMombelli](https://github.com/MauroMombelli)) ([#1947](https://github.com/cyberbotics/webots/pull/1947)).
     - Fixed issues with context menu available items when requested from the scene tree (thanks to MaxGaukler) ([#1889](https://github.com/cyberbotics/webots/pull/1889)).
     - Fixed crash occurring when reloading or resetting a simulation containing a [Display](display.md) device ([#1865](https://github.com/cyberbotics/webots/pull/1865)).
     - Fixed crash with Python [`RangeFinder.rangeImageGetDepth`](rangefinder.md#wb_range_finder_image_get_depth) function ([#1858](https://github.com/cyberbotics/webots/pull/1858)).

--- a/src/webots/nodes/WbAccelerometer.cpp
+++ b/src/webots/nodes/WbAccelerometer.cpp
@@ -153,19 +153,20 @@ void WbAccelerometer::computeValue() {
   dBodyID upperSolidBodyId = upperSolid()->bodyMerger();
   if (upperSolidBodyId) {
     dVector3 newVelocity;
-    const WbVector3 &t = translation();
-    dBodyGetRelPointVel(upperSolidBodyId, t.x(), t.y(), t.z(), newVelocity);
-    const double InvDt = 1000.0 / mSensor->elapsedTime();
+    const WbVector3 &t = position();
+    dBodyGetPointVel(upperSolidBodyId, t.x(), t.y(), t.z(), newVelocity);
+    const double inverseDt = 1000.0 / mSensor->elapsedTime();
 
     for (int i = 0; i < 3; ++i) {
-      acceleration[i] += (newVelocity[i] - mVelocity[i]) * InvDt;
+      acceleration[i] += (newVelocity[i] - mVelocity[i]) * inverseDt;
       mVelocity[i] = newVelocity[i];
     }
-  }
+  } else
+    warn(tr("Parent of Accelerometer node has no physics: measurements may be wrong."));
 
   const WbVector3 &result = acceleration * matrix();
 
-  // lookup
+  // apply lookup table
   mValues[0] = mXAxis->isTrue() ? mLut->lookup(result.x()) : NAN;
   mValues[1] = mYAxis->isTrue() ? mLut->lookup(result.y()) : NAN;
   mValues[2] = mZAxis->isTrue() ? mLut->lookup(result.z()) : NAN;


### PR DESCRIPTION
Fixes #1693.
There was actually two problems:

1. If an `Accelerometer` has a parent node without a `Physics` node, it cannot determine its velocity from ODE needed to compute the acceleration and will return a wrong value. This is now fixed by displaying a warning in this case.

2. The computation of the velocity was not taking into account the complete offset of the accelerometer in case the parent node of the accelerometer was merged with an upper solid (solid merger). The computation of velocity is now based on the absolute point position instead of the wrong relative point position to work around this problem.

The code snipped provide in #1693 now returns correct values (after fixing the missing Physics node).
