### PR TITLE
Fixed random triangle mesh collision detection bug

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -55,6 +55,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 on Windows and Linux ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
+    - Fixed random collision detection bugs and with triangle meshes ([#1994](https://github.com/cyberbotics/webots/pull/1994)). 
     - Fixed crash occurring when reverting the world while an animation was being recorded (thanks to [Jenny](https://github.com/JennyLynnFletcher)) ([#1957](https://github.com/cyberbotics/webots/pull/1957)).
     - Fixed wrong measurements of [Accelerometer](accelerometer.md) device (thanks to [MauroMombelli](https://github.com/MauroMombelli)) ([#1947](https://github.com/cyberbotics/webots/pull/1947)).
     - Fixed issues with nodes and fields references in controller program after procedural PROTO regeneration ([#1922](https://github.com/cyberbotics/webots/pull/1922)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -55,7 +55,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 on Windows and Linux ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
-    - Fixed random collision detection bugs and with triangle meshes ([#1994](https://github.com/cyberbotics/webots/pull/1994)). 
+    - Fixed random collision detection bugs with triangle meshes ([#1994](https://github.com/cyberbotics/webots/pull/1994)). 
     - Fixed crash occurring when reverting the world while an animation was being recorded (thanks to [Jenny](https://github.com/JennyLynnFletcher)) ([#1957](https://github.com/cyberbotics/webots/pull/1957)).
     - Fixed wrong measurements of [Accelerometer](accelerometer.md) device (thanks to [MauroMombelli](https://github.com/MauroMombelli)) ([#1947](https://github.com/cyberbotics/webots/pull/1947)).
     - Fixed issues with nodes and fields references in controller program after procedural PROTO regeneration ([#1922](https://github.com/cyberbotics/webots/pull/1922)).

--- a/src/webots/nodes/WbTriangleMeshGeometry.cpp
+++ b/src/webots/nodes/WbTriangleMeshGeometry.cpp
@@ -38,7 +38,7 @@ WbTriangleMeshMap WbTriangleMeshGeometry::cTriangleMeshMap;
 void WbTriangleMeshGeometry::init() {
   mTrimeshData = NULL;
   mTriangleMesh = NULL;
-  mScaledVerticesNeedUpdate = true;
+  mScaledCoordinatesNeedUpdate = true;
   mCorrectSolidMass = true;
   mIsOdeDataApplied = false;
   mNormalsMesh = NULL;
@@ -299,10 +299,9 @@ void WbTriangleMeshGeometry::setOdeTrimeshData() {
   const int n = mTriangleMesh->numberOfVertices();
   const int nt = mTriangleMesh->numberOfTriangles();
   mTrimeshData = dGeomTriMeshDataCreate();
-  mScaledVerticesNeedUpdate = true;
-  updateScaledVertices();
-
-  dGeomTriMeshDataBuildDouble(mTrimeshData, mTriangleMesh->scaledVerticesData(), 3 * sizeof(double), n,
+  mScaledCoordinatesNeedUpdate = true;
+  updateScaledCoordinates();
+  dGeomTriMeshDataBuildDouble(mTrimeshData, mTriangleMesh->scaledCoordinatesData(), 3 * sizeof(double), n,
                               mTriangleMesh->indicesData(), 3 * nt, 3 * sizeof(int));
 }
 
@@ -420,7 +419,7 @@ double WbTriangleMeshGeometry::computeLocalCollisionPoint(WbVector3 &point, int 
   int nTriangles = mTriangleMesh->numberOfTriangles();
   double closestDistance = std::numeric_limits<double>::infinity();
   bool found = false;
-  updateScaledVertices();
+  updateScaledCoordinates();
   for (int t = 0; t < nTriangles; ++t) {
     WbVector4 v0(mTriangleMesh->scaledVertex(t, 0, 0), mTriangleMesh->scaledVertex(t, 0, 1),
                  mTriangleMesh->scaledVertex(t, 0, 2), 1.0);
@@ -491,17 +490,17 @@ void WbTriangleMeshGeometry::recomputeBoundingSphere() const {
   }
 }
 
-void WbTriangleMeshGeometry::updateScaledVertices() const {
-  if (mScaledVerticesNeedUpdate) {
+void WbTriangleMeshGeometry::updateScaledCoordinates() const {
+  if (mScaledCoordinatesNeedUpdate) {
     const WbVector3 &s = absoluteScale();
-    mTriangleMesh->updateScaledVertices(s.x(), s.y(), s.z());
-    mScaledVerticesNeedUpdate = false;
+    mTriangleMesh->updateScaledCoordinates(s.x(), s.y(), s.z());
+    mScaledCoordinatesNeedUpdate = false;
     return;
   }
 }
 
 void WbTriangleMeshGeometry::setScaleNeedUpdate() {
-  mScaledVerticesNeedUpdate = true;
+  mScaledCoordinatesNeedUpdate = true;
 }
 
 void WbTriangleMeshGeometry::updateOptionalRendering(int option) {

--- a/src/webots/nodes/WbTriangleMeshGeometry.hpp
+++ b/src/webots/nodes/WbTriangleMeshGeometry.hpp
@@ -131,8 +131,8 @@ private:
   // ray tracing
   // compute local collision point and return the distance
   double computeLocalCollisionPoint(WbVector3 &point, int &triangleIndex, const WbRay &ray) const;
-  void updateScaledVertices() const;
-  mutable bool mScaledVerticesNeedUpdate;
+  void updateScaledCoordinates() const;
+  mutable bool mScaledCoordinatesNeedUpdate;
 
   // Hashmap key for this instance's mesh
   WbTriangleMeshCache::TriangleMeshGeometryKey mMeshKey;

--- a/src/webots/nodes/utils/WbTriangleMesh.hpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.hpp
@@ -50,7 +50,7 @@ public:
   bool areTextureCoordinatesValid() const { return mTextureCoordinatesValid; }
 
   int numberOfTriangles() const { return mNTriangles; }
-  int numberOfVertices() const { return mVertices.size(); }
+  int numberOfVertices() const { return mVertices.size() / 3; }
 
   static int index(int triangle, int vertex) { return 3 * triangle + vertex; }
   double vertex(int triangle, int vertex, int component) const {

--- a/src/webots/nodes/utils/WbTriangleMesh.hpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.hpp
@@ -41,8 +41,8 @@ public:
                const WbMFVector2 *texCoord, const WbMFInt *texCoordIndex, double creaseAngle, bool counterClockwise,
                bool normalPerVertex);
   // to be initialized from a WbMesh
-  QString init(const double *coord, const double *normal, const double *texCoord, const unsigned int *index, int coordSize,
-               int indexSize);
+  QString init(const double *coord, const double *normal, const double *texCoord, const unsigned int *index,
+               int numberOfVertices, int indexSize);
 
   void cleanup();
 
@@ -50,11 +50,11 @@ public:
   bool areTextureCoordinatesValid() const { return mTextureCoordinatesValid; }
 
   int numberOfTriangles() const { return mNTriangles; }
-  int numberOfVertices() const { return mVertices.size() / 3; }
+  int numberOfVertices() const { return mCoordinates.size() / 3; }
 
   static int index(int triangle, int vertex) { return 3 * triangle + vertex; }
   double vertex(int triangle, int vertex, int component) const {
-    return mVertices[coordinateIndex(triangle, vertex, component)];
+    return mCoordinates[coordinateIndex(triangle, vertex, component)];
   }
   double normal(int triangle, int vertex, int component) const { return mNormals[3 * index(triangle, vertex) + component]; }
   bool isNormalCreased(int triangle, int vertex) const { return mIsNormalCreased[index(triangle, vertex)]; }
@@ -66,17 +66,17 @@ public:
   }
 
   const int *indicesData() const { return mCoordIndices.data(); }
-  const double *verticesData() const { return mVertices.data(); }
+  const double *coordinatesData() const { return mCoordinates.data(); }
   const double *normalsData() const { return mNormals.data(); }
   const double *textureCoordinatesData() const { return mTextureCoordinates.data(); }
 
   const QStringList &warnings() const { return mWarnings; }
-  const double *scaledVerticesData() const { return mScaledVertices.data(); }
-  void updateScaledVertices(double x, double y, double z);
+  const double *scaledCoordinatesData() const { return mScaledCoordinates.data(); }
+  void updateScaledCoordinates(double x, double y, double z);
   double scaledVertex(int triangle, int vertex, int component) const {
-    return mScaledVertices[coordinateIndex(triangle, vertex, component)];
+    return mScaledCoordinates[coordinateIndex(triangle, vertex, component)];
   }
-  bool areScaledVerticesEmpty() const { return mScaledVertices.isEmpty(); }
+  bool areScaledCoordinatesEmpty() const { return mScaledCoordinates.isEmpty(); }
 
   double max(int coordinate) const { return mMax[coordinate]; }
   double min(int coordinate) const { return mMin[coordinate]; }
@@ -111,14 +111,14 @@ private:
   QVarLengthArray<WbVector3, 1> mTmpTriangleNormals;
   // contains a map coordIndex->triangleIndex
   QMultiHash<int, int> mTmpVertexToTriangle;
-  // populate mIndices, mVertices, mTextureCoordinates and mNormals
+  // populate mIndices, mCoordinates, mTextureCoordinates and mNormals
   void finalPass(const WbMFVector3 *coord, const WbMFVector3 *normal, const WbMFVector2 *texCoord, double creaseAngle);
   // populate mTextureCoordinates with default values
   void setDefaultTextureCoordinates(const WbMFVector3 *coord);
-  // contains triplets representing the vertices (match with the mIndices order)
-  QVarLengthArray<double, 1> mVertices;
-  // contains triplets representing the vertices coordinates scaled by an absolute factor
-  QVarLengthArray<double, 1> mScaledVertices;
+  // contains triplets representing the vertex coordinates (match with the mIndices order)
+  QVarLengthArray<double, 1> mCoordinates;
+  // contains triplets representing the vertex coordinates scaled by an absolute factor
+  QVarLengthArray<double, 1> mScaledCoordinates;
   // contains doublet representing the texture coordinates (match with the mIndices order or default values)
   QVarLengthArray<double, 1> mTextureCoordinates;
   // contains doublet representing the non-recursive texture coordinates (match with the mIndices order) or nothing


### PR DESCRIPTION
Fixes #1975.

The triangle mesh passed to ODE trimesh constructor was wrong. The number of vertices was three times too much causing ODE to read uninitialized garbage data beyond the actual vertices data, sometimes including nan values and other oddities. This was causing the AABB of the resulting mesh to be wrong, and the ODE "near" callback was never called, thus missing the collision detection.