### PR TITLE
Check for ikpy version in inverse_kinematic controller

### DIFF
--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -28,7 +28,7 @@ from controller import Supervisor
 
 if ikpy.__version__[0] < '3':
     sys.exit('The "ikpy" Python module version is too old. '
-             'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install ikpy"')
+             'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install --upgrade ikpy"')
 
 # Create the arm chain.
 # The constants below have been manually extracted from the Irb4600-40.proto file, looking at the HingeJoint node fields.

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -14,22 +14,21 @@
 
 """Demonstration of inverse kinematics using the "ikpy" Python module."""
 
+import sys
 try:
     import ikpy
     from ikpy.chain import Chain
     from ikpy.link import OriginLink, URDFLink
 except ImportError:
-    import sys
     sys.exit('The "ikpy" Python module is not installed. '
              'To run this sample, please upgrade "pip" and install ikpy with this command: "pip install ikpy"')
 
-if ikpy.__version__[0] < '3':
-    import sys
-    sys.exit('The "ikpy" Python module version is too old. '
-             'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install ikpy"')
-
 import math
 from controller import Supervisor
+
+if ikpy.__version__[0] < '3':
+    sys.exit('The "ikpy" Python module version is too old. '
+             'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install ikpy"')
 
 # Create the arm chain.
 # The constants below have been manually extracted from the Irb4600-40.proto file, looking at the HingeJoint node fields.

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -15,12 +15,18 @@
 """Demonstration of inverse kinematics using the "ikpy" Python module."""
 
 try:
+    import ikpy
     from ikpy.chain import Chain
     from ikpy.link import OriginLink, URDFLink
 except ImportError:
     import sys
     sys.exit('The "ikpy" Python module is not installed. '
              'To run this sample, please upgrade "pip" and install ikpy with this command: "pip install ikpy"')
+
+if ikpy.__version__[0] < '3':
+    import sys
+    sys.exit('The "ikpy" Python module version is too old. '
+             'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install ikpy"')
 
 import math
 from controller import Supervisor


### PR DESCRIPTION
Print a warning if the ikpy available version is too old and not compatible with the provided controller.
Following  #1782.