### PR TITLE
Add instructions to install rosdep

### DIFF
--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -15,6 +15,7 @@ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 sudo apt-get update
 sudo apt-get install ros-melodic-desktop-full # takes time, get a coffee :)
+sudo apt-get install python-resdep
 sudo rosdep init
 rosdep update
 sudo apt-get install ros-melodic-webots-ros

--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -15,7 +15,7 @@ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 sudo apt-get update
 sudo apt-get install ros-melodic-desktop-full # takes time, get a coffee :)
-sudo apt-get install python-resdep
+sudo apt-get install python-rosdep
 sudo rosdep init
 rosdep update
 sudo apt-get install ros-melodic-webots-ros


### PR DESCRIPTION
`rosdep` is not automatically installed on a fresh Ubuntu 18.04 machine and should me installed manually.