### PR TITLE
Add auto-cancel for source test workflow

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -13,6 +13,12 @@ defaults:
   run:
     shell: bash
 jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.draft == false }}
     strategy:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -20,6 +20,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:
+    needs: cleanup-runs
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.draft == false }}
     strategy:
       matrix:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 jobs:
-  cleanup-runs:   
+  cleanup-runs:
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -16,6 +16,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-sources:
+    needs: cleanup-runs
     strategy:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 jobs:
-  cleanup-runs:  
+  cleanup-runs:   
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 jobs:
-  cleanup-runs: 
+  cleanup-runs:  
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -9,7 +9,7 @@ defaults:
     shell: bash
 
 jobs:
-  cleanup-runs:
+  cleanup-runs: 
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -9,6 +9,12 @@ defaults:
     shell: bash
 
 jobs:
+  cleanup-runs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-sources:
     strategy:
       matrix:


### PR DESCRIPTION
**Description**
To avoid saturating the Github action, auto-cancel previous workflow when a new commit is set on a branch.