### PR TITLE
Fixed Makefile of libController

### DIFF
--- a/src/lib/Controller/Makefile
+++ b/src/lib/Controller/Makefile
@@ -164,8 +164,8 @@ $(OBJDIR)/mingw32/%o:%c
 
 $(OBJDIR)/%.d:%.c
 	@echo "# updating " $@
-	@echo $(basename $(OBJDIR)/$(notdir $@)).o: $(basename $@).d $(OBJDIR)/ > $(OBJDIR)/$(notdir $@)
-	@echo >> $(OBJDIR)/$(notdir $@)
+	@echo $(basename $(OBJDIR)/$(notdir $@)).o: $(basename $@).d > $(OBJDIR)/$(notdir $@)
+	@printf "%s" "$(OBJDIR)/" >> $(OBJDIR)/$(notdir $@)
 	@$(CC) $(CFLAGS) -MM -w $(INCLUDE) $< >> $(OBJDIR)/$(notdir $@)
 
 clean:


### PR DESCRIPTION
Fixes #2009.

It seems the printf command is more portable than echo when it comes to prevent new lines.