### PR TITLE
Fixed wrong conversion from WbVector3 to WbVector4

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -55,6 +55,7 @@ Released on XXX.
     - Upgraded to Qt 5.15.0 on Windows and Linux ([#1709](https://github.com/cyberbotics/webots/pull/1709), [#1710](https://github.com/cyberbotics/webots/pull/1710)).
     - Upgraded to Assimp 5.0.1 on Linux and macOS ([#1463](https://github.com/cyberbotics/webots/pull/1463)).
   - Bug fixes
+    - Fixed usability of rotation handles in the 3D view ([#2019](https://github.com/cyberbotics/webots/pull/2019)).
     - Fixed random collision detection bugs with triangle meshes ([#1994](https://github.com/cyberbotics/webots/pull/1994)). 
     - Fixed crash occurring when reverting the world while an animation was being recorded (thanks to [Jenny](https://github.com/JennyLynnFletcher)) ([#1957](https://github.com/cyberbotics/webots/pull/1957)).
     - Fixed wrong measurements of [Accelerometer](accelerometer.md) device (thanks to [MauroMombelli](https://github.com/MauroMombelli)) ([#1947](https://github.com/cyberbotics/webots/pull/1947)).

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -296,7 +296,7 @@ WbDragRotateAroundAxisEvent::WbDragRotateAroundAxisEvent(const QPoint &initialMo
   const WbVector3 absoluteScale = mInitialMatrix.scale();
   mInitialMatrix.scale(1.0f / absoluteScale.x(), 1.0f / absoluteScale.y(), 1.0f / absoluteScale.z());
 
-  WbVector4 scaledPos = WbVector4(mManipulator->relativeHandlePosition(mHandleNumber)) * mViewDistanceUnscaling;
+  WbVector4 scaledPos(mManipulator->relativeHandlePosition(mHandleNumber) * mViewDistanceUnscaling);
   WbVector4 handlePos = mInitialMatrix * scaledPos;
   mZEye = viewpoint->zEye(handlePos.toVector3());
 


### PR DESCRIPTION
Fix issue #2007 introduced in R2019b revision 1 (#693): when converting from WbVector3 to WbVector4 the forth value was scaled too.