### PR TITLE
Fixed stability of motor sample

### DIFF
--- a/projects/samples/devices/controllers/motor/motor.c
+++ b/projects/samples/devices/controllers/motor/motor.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
   int counter = 0;
   while (wb_robot_step(time_step) != -1) {
     wb_motor_set_position(motor, target);
-    if (counter++ == 100) {
+    if (counter++ == 50) {
       target += M_PI_4;
       counter = 0;
     }

--- a/projects/samples/devices/worlds/motor.wbt
+++ b/projects/samples/devices/worlds/motor.wbt
@@ -4,7 +4,7 @@ WorldInfo {
     "Example world demonstrating the use of a simple Motor device."
   ]
   title "Motor"
-  basicTimeStep 4
+  basicTimeStep 8
   coordinateSystem "NUE"
 }
 Viewpoint {
@@ -36,65 +36,90 @@ DEF ROBOT Robot {
       endPoint Solid {
         rotation 0 1 0 1.5708
         children [
-          DEF AXIS Group {
+          Transform {
+            translation 0 0.063 0
             children [
-              Transform {
-                translation 0 0.063 0
-                children [
-                  Shape {
-                    appearance DEF METAL_APPEARANCE PBRAppearance {
-                      baseColor 0.5 0.5 0.5
-                      roughness 1
-                      metalness 0
-                    }
-                    geometry Cylinder {
-                      bottom FALSE
-                      height 0.005
-                      radius 0.04
-                    }
-                  }
-                ]
+              Shape {
+                appearance DEF METAL_APPEARANCE PBRAppearance {
+                  baseColor 0.5 0.5 0.5
+                  roughness 1
+                  metalness 0
+                }
+                geometry Cylinder {
+                  bottom FALSE
+                  height 0.005
+                  radius 0.04
+                }
               }
-              Transform {
-                translation 0 0.063 0
-                children [
-                  Shape {
-                    appearance DEF METAL_APPEARANCE PBRAppearance {
-                      baseColor 0.666667 0.666667 0.498039
-                      roughness 1
-                      metalness 0
-                    }
-                    geometry Cylinder {
-                      bottom FALSE
-                      height 0.008
-                      radius 0.03
-                      subdivision 6
-                    }
-                  }
-                ]
+            ]
+          }
+          Transform {
+            translation 0 0.063 0
+            children [
+              Shape {
+                appearance DEF METAL_APPEARANCE PBRAppearance {
+                  baseColor 0.666667 0.666667 0.498039
+                  roughness 1
+                  metalness 0
+                }
+                geometry Cylinder {
+                  bottom FALSE
+                  height 0.008
+                  radius 0.03
+                  subdivision 6
+                }
               }
-              Transform {
-                translation 0 0.063 0.05
-                rotation 1 0 0 1.5708
-                children [
-                  Shape {
-                    appearance PBRAppearance {
-                      baseColor 1 0.333333 0.498039
-                      roughness 1
-                      metalness 0
-                    }
-                    geometry Cylinder {
-                      bottom FALSE
-                      height 0.02
-                      radius 0.001
-                    }
-                  }
-                ]
+            ]
+          }
+          Transform {
+            translation 0 0.063 0.05
+            rotation 1 0 0 1.5708
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 1 0.333333 0.498039
+                  roughness 1
+                  metalness 0
+                }
+                geometry Cylinder {
+                  bottom FALSE
+                  height 0.02
+                  radius 0.001
+                }
               }
             ]
           }
         ]
-        boundingObject USE AXIS
+        boundingObject Group {
+          children [
+            Transform {
+              translation 0 0.063 0
+              children [
+                Shape {
+                  geometry Cylinder {
+                    bottom FALSE
+                    height 0.008
+                    radius 0.03
+                    subdivision 16
+                  }
+                }
+              ]
+            }
+            Transform {
+              translation 0 0.063 0.05
+              rotation 1 0 0 1.5708
+              children [
+                Shape {
+                  geometry Cylinder {
+                    bottom FALSE
+                    height 0.02
+                    radius 0.001
+                  }
+                }
+              ]
+            }
+          ]
+        }
         physics Physics {
           density -1
           mass 1
@@ -104,7 +129,7 @@ DEF ROBOT Robot {
     DEF BASIS_GROUP Group {
       children [
         Transform {
-          translation 0 0.02 0
+          translation 0 0.019 0
           children [
             Shape {
               appearance USE METAL_APPEARANCE
@@ -116,56 +141,13 @@ DEF ROBOT Robot {
             }
           ]
         }
-        Transform {
-          translation 0 0.04 0
-          children [
-            Shape {
-              appearance PBRAppearance {
-                baseColorMap ImageTexture {
-                  url [
-                    "textures/compass.jpg"
-                  ]
-                }
-                roughness 1
-                metalness 0
-                textureTransform TextureTransform {
-                  rotation 1.5708
-                }
-              }
-              geometry Cylinder {
-                bottom FALSE
-                height 0.04
-                radius 0.07
-                side FALSE
-              }
-            }
-          ]
-        }
-        Transform {
-          translation 0 0.04 0
-          children [
-            Shape {
-              appearance PBRAppearance {
-                baseColor 1 0.866667 0
-                roughness 1
-                metalness 0
-              }
-              geometry Cylinder {
-                bottom FALSE
-                height 0.04
-                radius 0.07
-                top FALSE
-              }
-            }
-          ]
-        }
       ]
     }
   ]
   boundingObject USE BASIS_GROUP
   physics Physics {
     density -1
-    mass 8
+    mass 10
   }
   controller "motor"
   battery [
@@ -173,8 +155,50 @@ DEF ROBOT Robot {
   ]
   cpuConsumption 5
 }
+Solid {
+  translation 0 0.05 0
+  children [
+    Shape {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "textures/compass.jpg"
+          ]
+        }
+        roughness 1
+        metalness 0
+        textureTransform TextureTransform {
+          rotation 1.5708
+        }
+      }
+      geometry Cylinder {
+        bottom FALSE
+        height 0.02
+        radius 0.07
+        side FALSE
+      }
+    }
+    Shape {
+      appearance PBRAppearance {
+        baseColor 1 0.866667 0
+        roughness 1
+        metalness 0
+      }
+      geometry Cylinder {
+        bottom FALSE
+        height 0.02
+        radius 0.07
+        top FALSE
+      }
+    }
+  ]
+  boundingObject Cylinder {
+    height 0.02
+    radius 0.07
+  }
+}
 SolidBox {
-  translation 0.04741181 0.0655 -0.019659258
+  translation 0.04741181 0.0646 -0.019659258
   rotation 0 1 0 0.26179939
   size 0.01 0.01 0.01
   appearance PBRAppearance {
@@ -188,6 +212,6 @@ SolidBox {
   }
   physics Physics {
     density -1
-    mass 10
+    mass 1
   }
 }


### PR DESCRIPTION
Fixes #1966 (last item).
The instability was due to a closed mechanical loop.
Making the box lie on a the static world (instead of the dynamics object hitting it with the needle) broke this loop and made the simulation rock stable.