### PR TITLE
Improve instructions to use pycharm

### DIFF
--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -367,7 +367,7 @@ If you are using other libraries (e.g., the `vehicle libraries`, `DARwIn-OP libr
 #### Run the Controller
 
 Once the [PyCharm](https://www.jetbrains.com/pycharm) project configured, you can start Webots and open the desired world.
-To allow [PyCharm](https://www.jetbrains.com/pycharm) to start the controller instead of Webots, set the controller of the robot to `<extern>` (see the [Running Extern Robot Controllers](https://www.cyberbotics.com/doc/guide/running-extern-robot-controllers) chapter for more information about external controller).
+To allow [PyCharm](https://www.jetbrains.com/pycharm) to start the controller instead of Webots, set the controller of the robot to `<extern>` and set the environment variables as explained in the [Running Extern Robot Controllers](https://cyberbotics.com/doc/guide/running-extern-robot-controllers#environment-variables) chapter.
 
 %figure "Robot controller to external"
 


### PR DESCRIPTION
**Description**
Many users have issues when using pycharm because they do not read the documentation of extern controllers and don't set the environment variables.
So this PR aims at making more clear that also the variables requires for extern controllers have to be set when using pycharm.

**Documentation**
https://cyberbotics.com/doc/guide/using-your-ide?version=documentation-enhacement-pycharm-instructions#run-the-controller