### PR TITLE
Removed ROS controller on macOS.

### DIFF
--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -21,14 +21,13 @@ The user contributed packages are licensed under a variety of open source licens
 There are two ways to use ROS with Webots.
 
 The first solution and the easiest one is to use the **standard ROS controller**.
-This solution however doesn't work on Windows, it works only on Linux and macOS.
+This solution however doesn't work on Windows and macOS, it works only on Linux.
 It is part of the Webots default controllers and is available in any project.
 This controller can be used on any robot in Webots and acts as a ROS node, providing all the Webots functions as services or topics to other ROS nodes.
 
 The second solution named **custom ROS controller** requires that you build your own Webots controller that will also be a ROS node using Webots and ROS libraries.
-It is therefore a bit more complicated than the first solution.
-This solution works on Windows (in Python) in addition to Linux and macOS.
-It should only be used for specific applications that cannot be done with the standard ROS controller.
+This solution works on Windows and macOS (in Python) in addition to Linux.
+It is a bit more difficult to set up but allows for more flexibility.
 
 ### Standard ROS Controller
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -6,6 +6,7 @@ Released on XXX YYth, 2020.
   - Bug fixes
     - Fixed the `near` field of the `Robotino3Webcam` [Camera](camera.md) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed orientation of the [Lights](light.md) in the [`robotino3` world](../guide/robotino3.md#robotino3-wbt) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
+    - **macOS: Removed the `ros` controller**, the [custom Python ROS controller](https://www.cyberbotics.com/doc/guide/using-ros#custom-ros-controller) should be used instead ([#2053](https://github.com/cyberbotics/webots/pull/2053)).
 
 ## [Webots R2020b](../blog/Webots-2020-b-release.md)
 Released on July 29th, 2020.

--- a/projects/default/Makefile
+++ b/projects/default/Makefile
@@ -20,7 +20,7 @@ include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
 TARGETS = controllers/braitenberg.Makefile libraries/vehicle.Makefile resources.Makefile
 
-ifneq ($(OSTYPE),windows)
+ifeq ($(OSTYPE),linux)
 TARGETS += controllers/ros.Makefile
 ROS_DEPENDENCIES = controllers/ros/lib.Makefile controllers/ros/include.Makefile
 endif

--- a/projects/vehicles/controllers/Makefile
+++ b/projects/vehicles/controllers/Makefile
@@ -23,7 +23,7 @@ TARGETS = autonomous_vehicle.Makefile \
 	racing_wheel.Makefile \
 	VehicleDriver.Makefile
 
-ifneq ($(OSTYPE),windows)
+ifeq ($(OSTYPE),linux)
 TARGETS += ros_automobile.Makefile
 endif
 

--- a/src/packaging/exist_in_projects_mac.txt
+++ b/src/packaging/exist_in_projects_mac.txt
@@ -1,9 +1,0 @@
-projects/default/controllers/ros/include/xmlrpcpp
-projects/default/controllers/ros/include/geometry_msgs
-projects/default/controllers/ros/include/log4cxx
-projects/default/controllers/ros/include/ros
-projects/default/controllers/ros/include/rosconsole
-projects/default/controllers/ros/include/rosgraph_msgs
-projects/default/controllers/ros/include/sensor_msgs
-projects/default/controllers/ros/include/std_msgs
-projects/default/controllers/ros/lib/ros/libroscpp.dylib


### PR DESCRIPTION
**Description**
The ros controller on Mac is crashing because of RPATH issues:
```
dyld: Library not loaded: @rpath/projects/default/libraries/ros/libroscpp.dylib
  Referenced from: /Applications/Webots.app/projects/default/controllers/ros/ros
  Reason: image not found
```

We can fix the RPATH fo the ros library, but since nobody is using the ros controller on Mac and we have the python external controller interface, it is probably better to drop it on macOS. @cyberbotics/maintainers do you agree?

**Related Issues**
This pull-request fixes issue #2042
