### PR TITLE
Add Warnings when Importing Big Meshes.

### DIFF
--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -329,7 +329,7 @@ void addModelNode(QString &stream, const aiNode *node, const aiScene *scene, con
     const aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
     const aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
     if (mesh->mNumVertices > 100000)
-      WbLog::warning(QString("mesh '%1' has more than 100'000 vertices, it is recommended reducing the number of vertices.")
+      WbLog::warning(QString("mesh '%1' has more than 100'000 vertices, it is recommended to reduce the number of vertices.")
                        .arg(mesh->mName.C_Str()));
     QCoreApplication::processEvents();
     if (defNeedGroup || !importBoundingObjects || !importAsSolid)

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -33,6 +33,7 @@
 #include "WbTokenizer.hpp"
 #include "WbWorld.hpp"
 
+#include <QtCore/QCoreApplication>
 #include <QtCore/QFileInfo>
 
 #include <assimp/postprocess.h>
@@ -327,6 +328,10 @@ void addModelNode(QString &stream, const aiNode *node, const aiScene *scene, con
   for (unsigned int i = 0; i < node->mNumMeshes; ++i) {
     const aiMesh *mesh = scene->mMeshes[node->mMeshes[i]];
     const aiMaterial *material = scene->mMaterials[mesh->mMaterialIndex];
+    if (mesh->mNumVertices > 100000)
+      WbLog::warning(QString("mesh '%1' has more than 100'000 vertices, it is recommended reducing the number of vertices.")
+                       .arg(mesh->mName.C_Str()));
+    QCoreApplication::processEvents();
     if (defNeedGroup || !importBoundingObjects || !importAsSolid)
       stream += " Shape { ";
     else


### PR DESCRIPTION
**Description**
The goal of this PR is to warn the users when he is importing a 3D file that contains meshes with too many vertices.

**Related Issues**
Related to #2048