### PR TITLE
Update test_suite worlds

### DIFF
--- a/tests/api/controllers/camera_checker/camera_checker.c
+++ b/tests/api/controllers/camera_checker/camera_checker.c
@@ -76,21 +76,21 @@ int main(int argc, char **argv) {
     samples_positions[3][1] = height - height / 8;
 
     // brown
-    samples_expected_colors[0][0] = 123;
-    samples_expected_colors[0][1] = 71;
-    samples_expected_colors[0][2] = 58;
+    samples_expected_colors[0][0] = 122;
+    samples_expected_colors[0][1] = 75;
+    samples_expected_colors[0][2] = 65;
     // cyan
-    samples_expected_colors[1][0] = 156;
-    samples_expected_colors[1][1] = 205;
-    samples_expected_colors[1][2] = 195;
+    samples_expected_colors[1][0] = 153;
+    samples_expected_colors[1][1] = 200;
+    samples_expected_colors[1][2] = 191;
     // white
-    samples_expected_colors[2][0] = 207;
-    samples_expected_colors[2][1] = 207;
-    samples_expected_colors[2][2] = 207;
+    samples_expected_colors[2][0] = 202;
+    samples_expected_colors[2][1] = 202;
+    samples_expected_colors[2][2] = 202;
     // dark gray
-    samples_expected_colors[3][0] = 44;
-    samples_expected_colors[3][1] = 44;
-    samples_expected_colors[3][2] = 44;
+    samples_expected_colors[3][0] = 54;
+    samples_expected_colors[3][1] = 54;
+    samples_expected_colors[3][2] = 54;
 
     if (strcmp(argv[1], "camera_color_spherical") == 0) {
       samples_number = 6;
@@ -170,12 +170,12 @@ int main(int argc, char **argv) {
   } else if (strcmp(argv[1], "camera_color_motion_blur") == 0) {
     const unsigned char *image = wb_camera_get_image(camera);
     int red = wb_camera_image_get_red(image, width, 31, 31);
-    ts_assert_int_equal(red, 227, "Image should be red, received %d instead of 255 for the red component", red);
+    ts_assert_int_equal(red, 224, "Image should be red, received %d instead of 224 for the red component", red);
     int i;
     for (i = 0; i < 10; ++i)  // let the red box fall
       wb_robot_step(TIME_STEP);
     image = wb_camera_get_image(camera);
-    unsigned char red_gradient[] = {89, 118, 153, 192, 227};
+    unsigned char red_gradient[] = {87, 115, 150, 188, 224};
     for (i = 0; i < sizeof(red_gradient); ++i) {
       red = wb_camera_image_get_red(image, width, 31, 5 + i * 13);
       ts_assert_int_equal(red, red_gradient[i], "Pixel red level should be %d, but is %d", red_gradient[i], red);

--- a/tests/api/controllers/camera_image_update/camera_image_update.c
+++ b/tests/api/controllers/camera_image_update/camera_image_update.c
@@ -30,7 +30,7 @@ static void check_camera_image(WbDeviceTag tag, int width, const double *expecte
 }
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);
+  ts_setup(argv[0]);
 
   WbNodeRef materialNode = wb_supervisor_node_get_from_def("MATERIAL");
   WbFieldRef colorField = wb_supervisor_node_get_field(materialNode, "diffuseColor");

--- a/tests/api/controllers/camera_noise_mask/camera_noise_mask.c
+++ b/tests/api/controllers/camera_noise_mask/camera_noise_mask.c
@@ -47,7 +47,7 @@ static void check_expected_colors(WbDeviceTag camera, int width, int height, boo
 }
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);
+  ts_setup(argv[0]);
 
   WbNodeRef cameraNode = wb_supervisor_node_get_from_def("CAMERA");
   WbFieldRef noiseMaskUrlField = wb_supervisor_node_get_field(cameraNode, "noiseMaskUrl");

--- a/tests/api/controllers/display_test/display_test.c
+++ b/tests/api/controllers/display_test/display_test.c
@@ -4,8 +4,8 @@
  */
 
 #include <webots/display.h>
-#include <webots/robot.h>
 #include <webots/motor.h>
+#include <webots/robot.h>
 
 #include <stdlib.h>
 #include <time.h>

--- a/tests/api/controllers/display_test/display_test.c
+++ b/tests/api/controllers/display_test/display_test.c
@@ -3,9 +3,9 @@
                  devices.
  */
 
-#include <webots/differential_wheels.h>
 #include <webots/display.h>
 #include <webots/robot.h>
+#include <webots/motor.h>
 
 #include <stdlib.h>
 #include <time.h>
@@ -27,7 +27,12 @@ int main() {
   WbImageRef emoticonsImage =
     wb_display_image_load(emoticon_display, "../../../../projects/samples/devices/controllers/display/emoticons.png");
 
-  wb_differential_wheels_set_speed(SPEED, -SPEED);
+  WbDeviceTag left_motor = wb_robot_get_device("left wheel motor");
+  WbDeviceTag right_motor = wb_robot_get_device("right wheel motor");
+  wb_motor_set_position(left_motor, INFINITY);
+  wb_motor_set_position(right_motor, INFINITY);
+  wb_motor_set_velocity(left_motor, SPEED);
+  wb_motor_set_velocity(right_motor, -SPEED);
 
   while (wb_robot_step(TIME_STEP) != -1) {
     counter++;

--- a/tests/api/worlds/battery.wbt
+++ b/tests/api/worlds/battery.wbt
@@ -12,6 +12,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 1
   intensity 0.5
   location 0 0.345 0
 }

--- a/tests/api/worlds/camera_color.wbt
+++ b/tests/api/worlds/camera_color.wbt
@@ -8,28 +8,25 @@ Viewpoint {
 }
 Background {
   skyColor [
-    0.4 0.7 1
+    1 1 1
   ]
 }
 PointLight {
-  ambientIntensity 1
-  intensity 0
+  attenuation 0 0 1
 }
 Transform {
   translation 0 0 -1
   rotation 1 0 0 1.57
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-          ambientIntensity 1
-          diffuseColor 1 1 1
-        }
-        texture ImageTexture {
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
           url [
             "textures/color_checker_chart.png"
           ]
         }
+        roughness 1
+        metalness 0.2
       }
       geometry Plane {
         size 2 2

--- a/tests/api/worlds/camera_color_motion_blur.wbt
+++ b/tests/api/worlds/camera_color_motion_blur.wbt
@@ -8,7 +8,7 @@ Viewpoint {
 }
 Background {
   skyColor [
-    0 0 1
+    1 1 1
   ]
 }
 DirectionalLight {
@@ -23,10 +23,10 @@ Solid {
   translation 0 0 -0.54
   children [
     DEF SHAPE Shape {
-      appearance Appearance {
-        material Material {
-          diffuseColor 1 0 0
-        }
+      appearance PBRAppearance {
+        baseColor 1 0 0
+        roughness 1
+        metalness 0
       }
       geometry Box {
         size 1 1 0.1
@@ -36,6 +36,20 @@ Solid {
   boundingObject USE SHAPE
   physics Physics {
   }
+}
+Solid {
+  translation 0 0 -0.73
+  children [
+    DEF BACKGROUND Shape {
+      appearance PBRAppearance {
+        baseColor 0 0 1
+      }
+      geometry Box {
+        size 5 5 0.01
+      }
+    }
+  ]
+  name "background"
 }
 Robot {
   children [

--- a/tests/api/worlds/camera_image_update.wbt
+++ b/tests/api/worlds/camera_image_update.wbt
@@ -60,9 +60,6 @@ Robot {
     }
   ]
   controller "camera_image_update"
-  controllerArgs [
-    "camera_image_update"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/api/worlds/compass.wbt
+++ b/tests/api/worlds/compass.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/distance_sensor_enable_disable.wbt
+++ b/tests/api/worlds/distance_sensor_enable_disable.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/extern.wbt
+++ b/tests/api/worlds/extern.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/gps_coordinates.wbt
+++ b/tests/api/worlds/gps_coordinates.wbt
@@ -1,8 +1,8 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
+  coordinateSystem "NUE"
   gpsCoordinateSystem "WGS84"
   gpsReference 40.67 -73.94 10
-  coordinateSystem "NUE"
 }
 Viewpoint {
   orientation 0.9996751479865803 0.009038851338063371 -0.023830603527755522 5.7216
@@ -14,7 +14,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF ROBOT Robot {

--- a/tests/api/worlds/gps_coordinates_north_direction.wbt
+++ b/tests/api/worlds/gps_coordinates_north_direction.wbt
@@ -1,7 +1,7 @@
 #VRML_SIM R2020b utf8
 DEF WORLDINFO WorldInfo {
-  gpsCoordinateSystem "WGS84"
   coordinateSystem "NUE"
+  gpsCoordinateSystem "WGS84"
 }
 Viewpoint {
   orientation -0.6221158786668858 -0.7673188503475173 -0.15554296966399098 0.629982
@@ -13,7 +13,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF ROBOT Robot {

--- a/tests/api/worlds/gps_speed.wbt
+++ b/tests/api/worlds/gps_speed.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF ROBOT Robot {

--- a/tests/api/worlds/gyro.wbt
+++ b/tests/api/worlds/gyro.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/led.wbt
+++ b/tests/api/worlds/led.wbt
@@ -9,6 +9,7 @@ Viewpoint {
 Background {
 }
 PointLight {
+  attenuation 0 0 1
   intensity 0.5
   location 0 0.345 0
 }

--- a/tests/api/worlds/lidar_point_cloud.wbt
+++ b/tests/api/worlds/lidar_point_cloud.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF INCLINED_PLANE Transform {

--- a/tests/api/worlds/lidar_rotating.wbt
+++ b/tests/api/worlds/lidar_rotating.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF INCLINED_PLANE Transform {

--- a/tests/api/worlds/motor2.wbt
+++ b/tests/api/worlds/motor2.wbt
@@ -1,7 +1,7 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
-  lineScale 0.3
   coordinateSystem "NUE"
+  lineScale 0.3
 }
 Viewpoint {
   orientation 0.18073501621974938 0.9827540881955547 0.039105703509473275 5.27826
@@ -13,6 +13,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 1
   intensity 0.5
   location 0 0.345 0
 }

--- a/tests/api/worlds/range_finder.wbt
+++ b/tests/api/worlds/range_finder.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Transform {

--- a/tests/api/worlds/range_finder_spherical.wbt
+++ b/tests/api/worlds/range_finder_spherical.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Transform {

--- a/tests/api/worlds/range_finder_spherical_horizontal_vertical.wbt
+++ b/tests/api/worlds/range_finder_spherical_horizontal_vertical.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 DEF INCLINED_PLANE Transform {

--- a/tests/api/worlds/remote_control.wbt
+++ b/tests/api/worlds/remote_control.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/supervisor_reset_physics_hinge_joint.wbt
+++ b/tests/api/worlds/supervisor_reset_physics_hinge_joint.wbt
@@ -150,6 +150,7 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "supervisor_reset_physics_hinge"
   supervisor TRUE
 }

--- a/tests/api/worlds/supervisor_restart_controller.wbt
+++ b/tests/api/worlds/supervisor_restart_controller.wbt
@@ -15,6 +15,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 1
   location 0 0.3 0
 }
 Floor {

--- a/tests/api/worlds/supervisor_restart_controller_display.wbt
+++ b/tests/api/worlds/supervisor_restart_controller_display.wbt
@@ -4,8 +4,8 @@ WorldInfo {
   coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation 0.5542843582001843 0.8186673773417066 0.15017514951236655 5.574129
-  position -1.2649792 1.0837943 2.0590679
+  orientation 0.8841788126877563 0.45665457075971344 0.09846029757385279 5.706682493837526
+  position -0.10939443176085184 0.42862400583618987 0.6622877553910751
 }
 Background {
   skyColor [
@@ -29,61 +29,9 @@ Robot {
   controller "supervisor_restart_controller_display"
   supervisor TRUE
 }
-DEF MYBOT DifferentialWheels {
+DEF MYBOT Robot {
   rotation 0 1 0 3.1415926
   children [
-    Transform {
-      translation 0 0.0415 0
-      children [
-        Shape {
-          appearance Appearance {
-            material Material {
-              diffuseColor 0.0820075 0.364731 0.8
-            }
-          }
-          geometry DEF BODY Cylinder {
-            height 0.08
-            radius 0.045
-          }
-        }
-      ]
-    }
-    Solid {
-      translation -0.045 0.025 0
-      children [
-        DEF WHEEL Transform {
-          rotation 0 0 1 1.57
-          children [
-            Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 1 0 0
-                }
-              }
-              geometry Cylinder {
-                height 0.01
-                radius 0.025
-              }
-            }
-          ]
-        }
-      ]
-      name "left wheel"
-      boundingObject USE WHEEL
-      physics DEF PHYSICS_WHEEL Physics {
-        density -1
-        mass 0.05
-      }
-    }
-    Solid {
-      translation 0.045 0.025 0
-      children [
-        USE WHEEL
-      ]
-      name "right wheel"
-      boundingObject USE WHEEL
-      physics USE PHYSICS_WHEEL
-    }
     DEF EMOTICONS Display {
       translation 0 0.13 0
       children [
@@ -135,6 +83,89 @@ DEF MYBOT DifferentialWheels {
       width 14
       height 14
     }
+    Transform {
+      translation 0 0.0415 0
+      children [
+        Shape {
+          appearance PBRAppearance {
+            baseColor 0.0820075 0.364731 0.8
+            roughness 1
+            metalness 0
+          }
+          geometry DEF BODY Cylinder {
+            height 0.08
+            radius 0.045
+          }
+        }
+      ]
+    }
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis -1 0 0
+        anchor 0 0.025 0
+      }
+      device [
+        RotationalMotor {
+          name "left wheel motor"
+          consumptionFactor 70
+        }
+        PositionSensor {
+          name "left wheel sensor"
+        }
+      ]
+      endPoint Solid {
+        translation -0.045 0.025 0
+        rotation -1 0 0 0
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 1 0 0
+                  roughness 1
+                  metalness 0
+                }
+                geometry Cylinder {
+                  height 0.01
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "left wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
+      }
+    }
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis -1 0 0
+        anchor 0 0.025 0
+      }
+      device [
+        RotationalMotor {
+          name "right wheel motor"
+          consumptionFactor 70
+        }
+        PositionSensor {
+          name "right wheel sensor"
+        }
+      ]
+      endPoint Solid {
+        translation 0.045 0.025 0
+        rotation -1 0 0 0
+        children [
+          USE WHEEL
+        ]
+        boundingObject USE WHEEL
+        physics USE PHYSICS_WHEEL
+      }
+    }
   ]
   name "MyBot"
   boundingObject Transform {
@@ -148,7 +179,4 @@ DEF MYBOT DifferentialWheels {
     mass 0.5
   }
   controller "display_test"
-  axleLength 0.09
-  wheelRadius 0.025
-  speedUnit 0.1
 }

--- a/tests/api/worlds/supervisor_set_position_orientation.wbt
+++ b/tests/api/worlds/supervisor_set_position_orientation.wbt
@@ -21,6 +21,7 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "supervisor_set_position_orientation"
   supervisor TRUE
 }

--- a/tests/api/worlds/touch_sensor_bumper.wbt
+++ b/tests/api/worlds/touch_sensor_bumper.wbt
@@ -14,7 +14,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/touch_sensor_force.wbt
+++ b/tests/api/worlds/touch_sensor_force.wbt
@@ -14,7 +14,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/touch_sensor_force3d.wbt
+++ b/tests/api/worlds/touch_sensor_force3d.wbt
@@ -14,7 +14,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/api/worlds/touch_sensor_kinematic.wbt
+++ b/tests/api/worlds/touch_sensor_kinematic.wbt
@@ -12,7 +12,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 Robot {

--- a/tests/manual_tests/worlds/selection_when_procedural_proto_regeneration.wbt
+++ b/tests/manual_tests/worlds/selection_when_procedural_proto_regeneration.wbt
@@ -33,6 +33,7 @@ DEF BOX SolidBox {
   translation 3 0 0
 }
 Robot {
+  name "supervisor"
   controller "procedural_proto_regenerator"
   supervisor TRUE
 }

--- a/tests/manual_tests/worlds/transform_proto_parameter.wbt
+++ b/tests/manual_tests/worlds/transform_proto_parameter.wbt
@@ -23,7 +23,7 @@ Background {
   ]
 }
 PointLight {
-  ambientIntensity 1
+  attenuation 0 0 1
   intensity 0
 }
 SolidSlot {

--- a/tests/physics/controllers/distance_sensor_rays/distance_sensor_rays.c
+++ b/tests/physics/controllers/distance_sensor_rays/distance_sensor_rays.c
@@ -1,5 +1,5 @@
-#include <webots/differential_wheels.h>
 #include <webots/distance_sensor.h>
+#include <webots/motor.h>
 #include <webots/robot.h>
 
 #include "../../../lib/ts_assertion.h"
@@ -34,9 +34,15 @@ int main(int argc, char **argv) {
   // stabilize the system
   wb_robot_step(3 * time_step);
 
-  if (dynamic)
+  if (dynamic) {
     // move sensors during ODE physics step
-    wb_differential_wheels_set_speed(20, 20);
+    WbDeviceTag left_motor = wb_robot_get_device("left motor");
+    WbDeviceTag right_motor = wb_robot_get_device("right motor");
+    wb_motor_set_position(left_motor, INFINITY);
+    wb_motor_set_position(right_motor, INFINITY);
+    wb_motor_set_velocity(left_motor, 20);
+    wb_motor_set_velocity(right_motor, 20);
+  }
 
   // static object
 

--- a/tests/physics/controllers/radar_rays/radar_rays.c
+++ b/tests/physics/controllers/radar_rays/radar_rays.c
@@ -1,4 +1,4 @@
-#include <webots/differential_wheels.h>
+#include <webots/motor.h>
 #include <webots/radar.h>
 #include <webots/robot.h>
 
@@ -28,9 +28,15 @@ int main(int argc, char **argv) {
   // stabilize the system
   wb_robot_step(3 * time_step);
 
-  if (dynamic)
+  if (dynamic) {
     // move sensors during ODE physics step
-    wb_differential_wheels_set_speed(100, 100);
+    WbDeviceTag left_motor = wb_robot_get_device("left motor");
+    WbDeviceTag right_motor = wb_robot_get_device("right motor");
+    wb_motor_set_position(left_motor, INFINITY);
+    wb_motor_set_position(right_motor, INFINITY);
+    wb_motor_set_velocity(left_motor, 100);
+    wb_motor_set_velocity(right_motor, 100);
+  }
 
   // without occlusion (no ODE rays)
   count = wb_radar_get_number_of_targets(rs);

--- a/tests/physics/controllers/receiver_rays/receiver_rays.c
+++ b/tests/physics/controllers/receiver_rays/receiver_rays.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     WbDeviceTag right_motor = wb_robot_get_device("right motor");
     wb_motor_set_position(left_motor, INFINITY);
     wb_motor_set_position(right_motor, INFINITY);
-      wb_motor_set_velocity(left_motor, 20);
+    wb_motor_set_velocity(left_motor, 20);
     wb_motor_set_velocity(right_motor, 20);
   }
 

--- a/tests/physics/controllers/receiver_rays/receiver_rays.c
+++ b/tests/physics/controllers/receiver_rays/receiver_rays.c
@@ -1,4 +1,4 @@
-#include <webots/differential_wheels.h>
+#include <webots/motor.h>
 #include <webots/receiver.h>
 #include <webots/robot.h>
 
@@ -51,9 +51,15 @@ int main(int argc, char **argv) {
   // stabilize the system
   wb_robot_step(3 * time_step);
 
-  if (dynamic)
-    // move sensor devices during ODE physics step
-    wb_differential_wheels_set_speed(20, 20);
+  if (dynamic) {
+    // move sensors during ODE physics step
+    WbDeviceTag left_motor = wb_robot_get_device("left motor");
+    WbDeviceTag right_motor = wb_robot_get_device("right motor");
+    wb_motor_set_position(left_motor, INFINITY);
+    wb_motor_set_position(right_motor, INFINITY);
+      wb_motor_set_velocity(left_motor, 20);
+    wb_motor_set_velocity(right_motor, 20);
+  }
 
   // static emitter
   checkQueueLength(rrs, "static radio", 3, nCheck);

--- a/tests/physics/plugins/physics/connector_apply_force/connector_apply_force.c
+++ b/tests/physics/plugins/physics/connector_apply_force/connector_apply_force.c
@@ -19,8 +19,6 @@ void webots_physics_step() {
   dBodyAddRelForce(body, 0, 0, -force);
 }
 
-void webots_physics_draw(int pass, const char *view) {
-}
 
 int webots_physics_collide(dGeomID g1, dGeomID g2) {
   return 0;

--- a/tests/physics/plugins/physics/connector_apply_force/connector_apply_force.c
+++ b/tests/physics/plugins/physics/connector_apply_force/connector_apply_force.c
@@ -19,7 +19,6 @@ void webots_physics_step() {
   dBodyAddRelForce(body, 0, 0, -force);
 }
 
-
 int webots_physics_collide(dGeomID g1, dGeomID g2) {
   return 0;
 }

--- a/tests/physics/worlds/collision_multiple_trimesh.wbt
+++ b/tests/physics/worlds/collision_multiple_trimesh.wbt
@@ -14,6 +14,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 1
   location 0 0.345 0
 }
 DEF ICO_SPHERE Solid {

--- a/tests/physics/worlds/connector_detach.wbt
+++ b/tests/physics/worlds/connector_detach.wbt
@@ -14,6 +14,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 DEF ACTIVE_ROBOT Robot {

--- a/tests/physics/worlds/connector_static_autolock.wbt
+++ b/tests/physics/worlds/connector_static_autolock.wbt
@@ -14,6 +14,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 DEF ACTIVE_ROBOT Robot {

--- a/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
+++ b/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
@@ -1,11 +1,10 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   title "Dynamic distance sensor rays"
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation 0.45181704073175993 -0.8640470778947117 -0.2220000200135247 5.40283
-  position 0.235658 0.239705 0.240214
+  orientation 0.23674854596036402 -0.5299019116554909 -0.8143427349768092 2.4437078042915443
+  position -0.2517328848874564 0.22208975033132536 0.2245641170090223
 }
 Background {
   skyColor [
@@ -13,15 +12,15 @@ Background {
   ]
 }
 PointLight {
-  attenuation 0 0 4
-  location 0 0.3 0
+  attenuation 0 0 1
+  location 0 0 0.3
 }
 Solid {
+  rotation 1 0 0 1.5707996938995747
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-        }
+      appearance PBRAppearance {
+        metalness 0
       }
       geometry DEF PLANE Plane {
       }
@@ -30,17 +29,14 @@ Solid {
   boundingObject USE PLANE
 }
 DEF DYNAMIC_BOX_1 Solid {
-  translation 0 0.14 -0.1
+  translation 0 -0.1 0.14
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-          diffuseColor 1 1 0
-          specularColor 0.564706 0.933333 0.564706
-        }
+      appearance PBRAppearance {
+        baseColor 1 1 0
       }
       geometry DEF BOX0 Box {
-        size 0.09 0.06 0.02
+        size 0.09 0.02 0.06
       }
     }
   ]
@@ -51,68 +47,113 @@ DEF DYNAMIC_BOX_1 Solid {
   }
 }
 DEF STATIC_BOX_1 Solid {
-  translation 0 0.05 0.1
+  translation 0 0.1 0.05
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-          diffuseColor 1 0 0
-          specularColor 0.564706 0.933333 0.564706
-        }
+      appearance PBRAppearance {
+        baseColor 1 0 0
       }
       geometry DEF BOX1 Box {
-        size 0.04 0.04 0.02
+        size 0.04 0.02 0.04
       }
     }
   ]
   name "red box"
   boundingObject USE BOX1
 }
-DEF DYNAMIC_ROBOT DifferentialWheels {
-  translation 0 0.06 0
-  rotation 0 1 0 1.5708
+DEF DYNAMIC_ROBOT Robot {
+  translation 0 0 0.06
+  rotation 0 -1 0 0
   children [
-    Solid {
-      translation -0.045 -0.03 0
-      rotation 1 0 0 4.98467
-      children [
-        DEF WHEEL Transform {
-          rotation 0 0 1 1.57
-          children [
-            Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 0 1
-                }
-              }
-              geometry Cylinder {
-                height 0.03
-                radius 0.025
-              }
-            }
-          ]
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "left motor"
+          maxVelocity 1000
         }
       ]
-      name "left wheel"
-      boundingObject USE WHEEL
-      physics DEF PHYSICS_WHEEL Physics {
-        density -1
-        mass 0.05
+      endPoint Solid {
+        translation 0 0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "left wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
       }
     }
-    Solid {
-      translation 0.045 -0.03 0
-      rotation 1 0 0 4.58735
-      children [
-        USE WHEEL
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 -0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "right motor"
+          maxVelocity 1000
+        }
       ]
-      name "right wheel"
-      boundingObject USE WHEEL
-      physics USE PHYSICS_WHEEL
+      endPoint Solid {
+        translation 0 -0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "right wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
+      }
     }
     DEF GENERIC DistanceSensor {
-      translation -0.05 0 0.001
-      rotation 0 1 0 3.14159
+      translation 0 0.05 0.001
+      rotation 0 0 1 1.5707996938995747
       name "ds_generic_static"
       lookupTable [
         0 500 0
@@ -120,8 +161,8 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       ]
     }
     DEF INFRA-RED DistanceSensor {
-      translation -0.05 0 0
-      rotation 0 1 0 3.14159
+      translation 0 0.05 0
+      rotation 0 0 1 1.5707903061004251
       name "ds_infra_red_static"
       lookupTable [
         0 500 0
@@ -131,7 +172,8 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       aperture 1
     }
     DEF GENERIC DistanceSensor {
-      translation 0.05 0 0.001
+      translation 0.001 -0.05 0
+      rotation 0 0 1 -1.5707996938995747
       name "ds_generic_dynamic"
       lookupTable [
         0 500 0
@@ -140,7 +182,8 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       aperture 1
     }
     DEF INFRA-RED DistanceSensor {
-      translation 0.05 0 0
+      translation 0 -0.05 0
+      rotation 0 0 1 -1.5707996938995747
       name "ds_infra_red_dynamic"
       lookupTable [
         0 500 0
@@ -154,7 +197,7 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   ]
   name "dynamic"
   boundingObject Transform {
-    translation 0 -0.03 0
+    translation 0 0 -0.03
     children [
       Sphere {
         radius 0.02
@@ -169,10 +212,6 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   controllerArgs [
     "dynamic_distance_sensor_rays"
   ]
-  axleLength 0.09
-  wheelRadius 0.025
-  maxSpeed 1000
-  maxAcceleration 1000
 }
 TestSuiteSupervisor {
 }

--- a/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
+++ b/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
@@ -13,6 +13,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 Solid {

--- a/tests/physics/worlds/dynamic_light_sensor_rays.wbt
+++ b/tests/physics/worlds/dynamic_light_sensor_rays.wbt
@@ -44,6 +44,7 @@ DEF DYNAMIC_LIGHT Solid {
   }
 }
 SpotLight {
+  attenuation 0 0 10
   beamWidth 0.22
   cutOffAngle 0.22
   location 0 0.055 0.1

--- a/tests/physics/worlds/dynamic_radar_rays.wbt
+++ b/tests/physics/worlds/dynamic_radar_rays.wbt
@@ -1,11 +1,10 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   title "Dynamic radar rays"
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation 0.29381699931746896 -0.9176480078683219 -0.2675699993784402 4.83703
-  position 0.28569 0.267896 0.0816358
+  orientation 0.25822489743422106 -0.4753048685396449 -0.8410738280838352 2.28437082876568
+  position -0.2618981509009608 0.20601181048673137 0.252846828594311
 }
 Background {
   skyColor [
@@ -13,15 +12,15 @@ Background {
   ]
 }
 PointLight {
-  attenuation 0 0 4
-  location 0 0.3 0
+  attenuation 0 0 1
+  location 0 0 0.3
 }
 Solid {
+  rotation 1 0 0 1.5707996938995747
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-        }
+      appearance PBRAppearance {
+        metalness 0
       }
       geometry DEF PLANE Plane {
       }
@@ -30,17 +29,14 @@ Solid {
   boundingObject USE PLANE
 }
 DEF DYNAMIC_BOX_1 Solid {
-  translation 0 0.13 -0.1
+  translation 0 -0.1 0.14
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-          diffuseColor 1 1 0
-          specularColor 0.564706 0.933333 0.564706
-        }
+      appearance PBRAppearance {
+        baseColor 1 1 0
       }
       geometry DEF BOX0 Box {
-        size 0.02 0.05 0.02
+        size 0.02 0.02 0.05
       }
     }
   ]
@@ -52,17 +48,14 @@ DEF DYNAMIC_BOX_1 Solid {
   radarCrossSection 1
 }
 DEF STATIC_BOX_1 Solid {
-  translation 0 0.05 0.1
+  translation 0 0.1 0.05
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-          diffuseColor 1 0 0
-          specularColor 0.564706 0.933333 0.564706
-        }
+      appearance PBRAppearance {
+        baseColor 1 0 0
       }
       geometry DEF BOX1 Box {
-        size 0.03 0.04 0.02
+        size 0.03 0.02 0.04
       }
     }
   ]
@@ -70,73 +63,121 @@ DEF STATIC_BOX_1 Solid {
   boundingObject USE BOX1
   radarCrossSection 1
 }
-DEF DYNAMIC_ROBOT DifferentialWheels {
-  translation 0 0.06 0
-  rotation 0 1 0 1.5708
+DEF DYNAMIC_ROBOT Robot {
+  translation 0 0 0.06
+  rotation 0 -1 0 0
   children [
-    Solid {
-      translation -0.045 -0.03 0
-      rotation 1 0 0 4.98467
-      children [
-        DEF WHEEL Transform {
-          rotation 0 0 1 1.57
-          children [
-            Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 0 1
-                }
-              }
-              geometry Cylinder {
-                height 0.03
-                radius 0.025
-              }
-            }
-          ]
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "left motor"
+          maxVelocity 1000
         }
       ]
-      name "left wheel"
-      boundingObject USE WHEEL
-      physics DEF PHYSICS_WHEEL Physics {
-        density -1
-        mass 0.05
+      endPoint Solid {
+        translation 0 0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "left wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
       }
     }
-    Solid {
-      translation 0.045 -0.03 0
-      rotation 1 0 0 4.58735
-      children [
-        USE WHEEL
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 -0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "right motor"
+          maxVelocity 1000
+        }
       ]
-      name "right wheel"
-      boundingObject USE WHEEL
-      physics USE PHYSICS_WHEEL
+      endPoint Solid {
+        translation 0 -0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "right wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
+      }
     }
     DEF STATIC Radar {
-      translation -0.05 0 0.001
-      rotation 0 1 0 1.5708
+      translation 0.001 0.05 0.001
+      rotation 1 0 0 1.5708
       name "radar static"
       minRange 0.02
       maxRange 0.2
     }
     DEF DYNAMIC Radar {
-      translation 0.05 0 0
-      rotation 0 1 0 -1.5708
+      translation 0 -0.05 0
+      rotation 0 0.70710528118436 0.707108281185553 3.14159
       name "radar dynamic"
       minRange 0.02
       maxRange 0.2
     }
     DEF STATIC_OCCLUSION Radar {
-      translation -0.05 0 0.001
-      rotation 0 1 0 1.5708
+      translation 0.001 0.05 0
+      rotation 1 0 0 1.5707996938995747
       name "radar occlusion static"
       minRange 0.02
       maxRange 0.2
       occlusion TRUE
     }
     DEF DYNAMIC_OCCLUSION Radar {
-      translation 0.05 0 0
-      rotation 0 1 0 -1.5708
+      translation 0 -0.05 0
+      rotation 0 0.70710528118436 0.707108281185553 3.14159
       name "radar occlusion dynamic"
       minRange 0.02
       maxRange 0.2
@@ -147,7 +188,7 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   ]
   name "dynamic"
   boundingObject Transform {
-    translation 0 -0.03 0
+    translation 0 0 -0.03
     children [
       Sphere {
         radius 0.02
@@ -162,10 +203,6 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   controllerArgs [
     "dynamic_radar_rays"
   ]
-  axleLength 0.09
-  wheelRadius 0.025
-  maxSpeed 1000
-  maxAcceleration 1000
 }
 TestSuiteSupervisor {
 }

--- a/tests/physics/worlds/dynamic_radar_rays.wbt
+++ b/tests/physics/worlds/dynamic_radar_rays.wbt
@@ -13,6 +13,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 Solid {

--- a/tests/physics/worlds/dynamic_receiver_rays.wbt
+++ b/tests/physics/worlds/dynamic_receiver_rays.wbt
@@ -26,6 +26,7 @@ Solid {
   boundingObject USE PLANE
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 DEF DYNAMIC_EMITTER Robot {

--- a/tests/physics/worlds/dynamic_receiver_rays.wbt
+++ b/tests/physics/worlds/dynamic_receiver_rays.wbt
@@ -1,23 +1,26 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   title "Dynamic receiver rays"
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation -0.06366069143242599 0.9941938661995442 0.08675178832478331 1.46997
-  position 0.398982 0.121893 0.0363673
+  orientation 0.33177529915665754 -0.5783889584940578 -0.7452458410227256 2.333640937761726
+  position -0.4290128025486586 0.252091923056615 0.21307187292207724
 }
 Background {
   skyColor [
     0.4 0.7 1
   ]
 }
+PointLight {
+  attenuation 0 0 1
+  location 0 0 0.3
+}
 Solid {
+  rotation 1 0 0 1.5707996938995747
   children [
     Shape {
-      appearance Appearance {
-        material Material {
-        }
+      appearance PBRAppearance {
+        metalness 0
       }
       geometry DEF PLANE Plane {
       }
@@ -25,12 +28,9 @@ Solid {
   ]
   boundingObject USE PLANE
 }
-PointLight {
-  attenuation 0 0 4
-  location 0 0.3 0
-}
 DEF DYNAMIC_EMITTER Robot {
-  translation 0 0.15 -0.1
+  translation 0 -0.1 0.15
+  rotation 1 0 0 -1.5707996938995747
   children [
     Emitter {
       children [
@@ -39,10 +39,7 @@ DEF DYNAMIC_EMITTER Robot {
           rotation 3.3905113482557537e-09 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 1 1
-                }
+              appearance BrushedSteel {
               }
               geometry Cone {
                 bottomRadius 0.025
@@ -64,10 +61,7 @@ DEF DYNAMIC_EMITTER Robot {
           rotation 3.3905113482557537e-09 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 1 1
-                }
+              appearance BrushedSteel {
               }
               geometry Cone {
                 bottomRadius 0.025
@@ -94,8 +88,8 @@ DEF DYNAMIC_EMITTER Robot {
   controller "emitter_rays"
 }
 DEF STATIC_EMITTER Robot {
-  translation 0 0.06 0.1
-  rotation 0 1 0 3.14159
+  translation 0 0.1 0.06
+  rotation 1 0 0 1.5708
   children [
     Emitter {
       children [
@@ -104,10 +98,7 @@ DEF STATIC_EMITTER Robot {
           rotation 3.3905113482557537e-09 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 1 1
-                }
+              appearance BrushedSteel {
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -129,10 +120,7 @@ DEF STATIC_EMITTER Robot {
           rotation 3.3905113482557537e-09 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 1 1
-                }
+              appearance BrushedSteel {
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -158,61 +146,107 @@ DEF STATIC_EMITTER Robot {
   controller "emitter_rays"
   customData "static"
 }
-DEF DYNAMIC_ROBOT DifferentialWheels {
-  translation 0 0.06 0
-  rotation 0 1 0 1.5708
+DEF DYNAMIC_ROBOT Robot {
+  translation 0 0 0.06
+  rotation 0 -1 0 0
   children [
-    Solid {
-      translation -0.045 -0.03 0
-      rotation 1 0 0 4.98467
-      children [
-        DEF WHEEL Transform {
-          rotation 0 0 1 1.57
-          children [
-            Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0 0 1
-                }
-              }
-              geometry Cylinder {
-                height 0.03
-                radius 0.025
-              }
-            }
-          ]
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "left motor"
+          maxVelocity 1000
         }
       ]
-      name "left wheel"
-      boundingObject USE WHEEL
-      physics DEF PHYSICS_WHEEL Physics {
-        density -1
-        mass 0.05
+      endPoint Solid {
+        translation 0 0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "left wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
       }
     }
-    Solid {
-      translation 0.045 -0.03 0
-      rotation 1 0 0 4.58735
-      children [
-        USE WHEEL
+    HingeJoint {
+      jointParameters HingeJointParameters {
+        axis 0 1 0
+        anchor 0 -0.045 -0.03
+      }
+      device [
+        RotationalMotor {
+          name "right motor"
+          maxVelocity 1000
+        }
       ]
-      name "right wheel"
-      boundingObject USE WHEEL
-      physics USE PHYSICS_WHEEL
+      endPoint Solid {
+        translation 0 -0.045 -0.03
+        rotation 0 0 1 -1.5708
+        children [
+          DEF WHEEL Transform {
+            rotation 0 0 1 1.57
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0 0.212802 0.869993
+                  baseColorMap ImageTexture {
+                    url [
+                      "textures/plastic.jpg"
+                    ]
+                  }
+                }
+                geometry Cylinder {
+                  height 0.03
+                  radius 0.025
+                }
+              }
+            ]
+          }
+        ]
+        name "right wheel"
+        boundingObject USE WHEEL
+        physics DEF PHYSICS_WHEEL Physics {
+          density -1
+          mass 0.05
+        }
+      }
     }
     DEF STATIC Receiver {
-      translation -0.02 0 0
-      rotation 0 1 0 -1.5708
+      translation 0 0.02 0
+      rotation 0 0.70710528118436 0.707108281185553 3.14159
       children [
         Transform {
           translation 0 0 0.05
           rotation 0 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0.890196 0.615686 0.380392
-                }
+              appearance GlossyPaint {
+                baseColor 0.960784 0.47451 0
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -227,18 +261,16 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       aperture 0.4
     }
     DEF DYNAMIC Receiver {
-      translation 0.02 0 0
-      rotation 0 1 0 1.5708
+      translation 0 -0.02 0
+      rotation 1 0 0 1.5708
       children [
         Transform {
           translation 0 0 0.05
           rotation 0 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0.890196 0.615686 0.380392
-                }
+              appearance GlossyPaint {
+                baseColor 0.960784 0.47451 0
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -253,18 +285,16 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       aperture 0.4
     }
     DEF STATIC Receiver {
-      translation -0.02 0 0
-      rotation 0 1 0 -1.5708
+      translation 0 0.02 0
+      rotation -1.1001696595529861e-06 0.7071067811861197 0.7071067811861197 3.14159
       children [
         Transform {
           translation 0 0 0.05
           rotation 0 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0.890196 0.615686 0.380392
-                }
+              appearance GlossyPaint {
+                baseColor 0.960784 0.47451 0
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -280,18 +310,16 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
       aperture 0.4
     }
     DEF DYNAMIC Receiver {
-      translation 0.02 0 0
-      rotation 0 1 0 1.5708
+      translation 0 -0.02 0
+      rotation 1 0 0 1.57079
       children [
         Transform {
           translation 0 0 0.05
           rotation 0 -0.707108281185553 0.70710528118436 3.14159
           children [
             Shape {
-              appearance Appearance {
-                material Material {
-                  diffuseColor 0.890196 0.615686 0.380392
-                }
+              appearance GlossyPaint {
+                baseColor 0.960784 0.47451 0
               }
               geometry Cone {
                 bottomRadius 0.02
@@ -311,7 +339,7 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   ]
   name "dynamic robot"
   boundingObject Transform {
-    translation 0 -0.03 0
+    translation 0 0 -0.03
     children [
       Sphere {
         radius 0.02
@@ -326,10 +354,6 @@ DEF DYNAMIC_ROBOT DifferentialWheels {
   controllerArgs [
     "dynamic_receiver_rays"
   ]
-  axleLength 0.09
-  wheelRadius 0.025
-  maxSpeed 1000
-  maxAcceleration 1000
 }
 TestSuiteSupervisor {
 }

--- a/tests/physics/worlds/hinge_2_joint_damping.wbt
+++ b/tests/physics/worlds/hinge_2_joint_damping.wbt
@@ -1,6 +1,7 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   basicTimeStep 16
+  coordinateSystem "NUE"
   contactProperties [
     ContactProperties {
       material2 "body"
@@ -9,7 +10,6 @@ WorldInfo {
       ]
     }
   ]
-  coordinateSystem "NUE"
 }
 Viewpoint {
   orientation -0.285534057832645 -0.9246841872874036 -0.2518520510106233 1.75064
@@ -129,6 +129,7 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "hinge_2_joint_damping_supervisor"
   supervisor TRUE
 }

--- a/tests/physics/worlds/move_hinge_2_joint_with_suspension.wbt
+++ b/tests/physics/worlds/move_hinge_2_joint_with_suspension.wbt
@@ -1,8 +1,8 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   ERP 0.6
-  lineScale 1.7
   coordinateSystem "NUE"
+  lineScale 1.7
 }
 Viewpoint {
   orientation -0.615287128649031 0.7862848882735759 0.05637218987622513 0.4895318
@@ -117,6 +117,7 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "move_hinge_2_joint_with_suspension"
   supervisor TRUE
 }

--- a/tests/physics/worlds/spring_damping_force.wbt
+++ b/tests/physics/worlds/spring_damping_force.wbt
@@ -382,9 +382,6 @@ Robot {
     }
   ]
   controller "spring_damping_force"
-  controllerArgs [
-    "spring_damping_force"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/physics/worlds/static_distance_sensor_rays.wbt
+++ b/tests/physics/worlds/static_distance_sensor_rays.wbt
@@ -13,6 +13,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 Solid {

--- a/tests/physics/worlds/static_light_sensor_rays.wbt
+++ b/tests/physics/worlds/static_light_sensor_rays.wbt
@@ -44,6 +44,7 @@ DEF DYNAMIC_LIGHT Solid {
   }
 }
 SpotLight {
+  attenuation 0 0 10
   beamWidth 0.06
   cutOffAngle 0.06
   location 0 0.06 0.1

--- a/tests/physics/worlds/static_radar_rays.wbt
+++ b/tests/physics/worlds/static_radar_rays.wbt
@@ -13,6 +13,7 @@ Background {
   ]
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 Solid {

--- a/tests/physics/worlds/static_receiver_rays.wbt
+++ b/tests/physics/worlds/static_receiver_rays.wbt
@@ -26,6 +26,7 @@ Solid {
   boundingObject USE PLANE
 }
 PointLight {
+  attenuation 0 0 4
   location 0 0.3 0
 }
 DEF DYNAMIC_EMITTER Robot {

--- a/tests/protos/controllers/derived_proto_automatic_IS_redirection/derived_proto_automatic_IS_redirection.c
+++ b/tests/protos/controllers/derived_proto_automatic_IS_redirection/derived_proto_automatic_IS_redirection.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, TIME_STEP);

--- a/tests/protos/controllers/derived_proto_parameter/derived_proto_parameter.c
+++ b/tests/protos/controllers/derived_proto_parameter/derived_proto_parameter.c
@@ -8,7 +8,7 @@
 
 int main(int argc, char **argv) {
   double value = 0.0;
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag ds1 = wb_robot_get_device("ds1");
   WbDeviceTag ds2 = wb_robot_get_device("ds2");

--- a/tests/protos/controllers/internal_template_proto_update/internal_template_proto_update.c
+++ b/tests/protos/controllers/internal_template_proto_update/internal_template_proto_update.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv) {
   double value;
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbNodeRef boxNode = wb_supervisor_node_get_from_def("BOX");
   WbFieldRef widthField = wb_supervisor_node_get_field(boxNode, "width");

--- a/tests/protos/controllers/mixed_template_derived_proto/mixed_template_derived_proto.c
+++ b/tests/protos/controllers/mixed_template_derived_proto/mixed_template_derived_proto.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag cameraX = wb_robot_get_device("cameraX");
   WbDeviceTag cameraY = wb_robot_get_device("cameraY");

--- a/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
+++ b/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
@@ -9,7 +9,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag ds = wb_robot_get_device("ds");
   wb_distance_sensor_enable(ds, TIME_STEP);

--- a/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
+++ b/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
@@ -13,7 +13,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag cameraX = wb_robot_get_device("cameraX");
   WbDeviceTag cameraY = wb_robot_get_device("cameraY");

--- a/tests/protos/controllers/proto_nested_parameter/proto_nested_parameter.c
+++ b/tests/protos/controllers/proto_nested_parameter/proto_nested_parameter.c
@@ -12,7 +12,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, TIME_STEP);

--- a/tests/protos/controllers/proto_nested_parameter_2/proto_nested_parameter_2.c
+++ b/tests/protos/controllers/proto_nested_parameter_2/proto_nested_parameter_2.c
@@ -12,7 +12,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, TIME_STEP);

--- a/tests/protos/controllers/proto_regeneration_multiple_instances/proto_regeneration_multiple_instances.c
+++ b/tests/protos/controllers/proto_regeneration_multiple_instances/proto_regeneration_multiple_instances.c
@@ -9,7 +9,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbNodeRef protoNode = wb_supervisor_node_get_from_def("TEST_NODE");
   WbFieldRef sizeField = wb_supervisor_node_get_field(protoNode, "size");

--- a/tests/protos/controllers/super_parameter_instances/super_parameter_instances.c
+++ b/tests/protos/controllers/super_parameter_instances/super_parameter_instances.c
@@ -12,7 +12,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbNodeRef node = wb_supervisor_node_get_from_def("SENSOR_SLOT");
   WbFieldRef children_field = wb_supervisor_node_get_field(node, "children");

--- a/tests/protos/controllers/template_internal_proto_regeneration/template_internal_proto_regeneration.c
+++ b/tests/protos/controllers/template_internal_proto_regeneration/template_internal_proto_regeneration.c
@@ -10,7 +10,7 @@
 
 int main(int argc, char **argv) {
   double value;
-  ts_setup(argv[1]);
+  ts_setup(argv[0]);
 
   WbNodeRef object_node = wb_supervisor_node_get_from_def("OBJECT");
   WbFieldRef color_field = wb_supervisor_node_get_field(object_node, "color");

--- a/tests/protos/controllers/template_nested_slot_container/template_nested_slot_container.c
+++ b/tests/protos/controllers/template_nested_slot_container/template_nested_slot_container.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   int time_step = wb_robot_get_basic_time_step();
 

--- a/tests/protos/controllers/template_proto_follow_solid/template_proto_follow_solid.c
+++ b/tests/protos/controllers/template_proto_follow_solid/template_proto_follow_solid.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag motor = wb_robot_get_device("linear motor");
   wb_motor_set_position(motor, INFINITY);

--- a/tests/protos/controllers/template_robot_regenerated/template_robot_regenerated.c
+++ b/tests/protos/controllers/template_robot_regenerated/template_robot_regenerated.c
@@ -9,7 +9,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   wb_robot_step(TIME_STEP);
 

--- a/tests/protos/controllers/template_texture/template_texture.c
+++ b/tests/protos/controllers/template_texture/template_texture.c
@@ -7,7 +7,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[1]);  // give the controller args
+  ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag camera1 = wb_robot_get_device("camera1");
   WbDeviceTag camera2 = wb_robot_get_device("camera2");

--- a/tests/protos/worlds/derived_proto_parameter.wbt
+++ b/tests/protos/worlds/derived_proto_parameter.wbt
@@ -31,9 +31,6 @@ Robot {
     }
   ]
   controller "derived_proto_parameter"
-  controllerArgs [
-    "derived_proto_parameter"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/internal_template_proto.wbt
+++ b/tests/protos/worlds/internal_template_proto.wbt
@@ -1,7 +1,7 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
-  lineScale 1
   coordinateSystem "NUE"
+  lineScale 1
 }
 Viewpoint {
   orientation -0.8999515417256047 0.42450878383113183 0.0993957493855782 0.509061
@@ -42,9 +42,6 @@ Robot {
     }
   ]
   controller "internal_template_proto_update"
-  controllerArgs [
-    "internal_template_proto"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/mixed_template_derived_proto.wbt
+++ b/tests/protos/worlds/mixed_template_derived_proto.wbt
@@ -37,9 +37,6 @@ Robot {
     }
   ]
   controller "mixed_template_derived_proto"
-  controllerArgs [
-    "mixed_template_derived_proto"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_nested_parameter.wbt
+++ b/tests/protos/worlds/proto_nested_parameter.wbt
@@ -34,9 +34,6 @@ Robot {
     }
   ]
   controller "proto_nested_parameter"
-  controllerArgs [
-    "proto_nested_parameter"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_nested_parameter_2.wbt
+++ b/tests/protos/worlds/proto_nested_parameter_2.wbt
@@ -30,9 +30,6 @@ Robot {
     }
   ]
   controller "proto_nested_parameter_2"
-  controllerArgs [
-    "proto_nested_parameter_2"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_regeneration_multiple_instances.wbt
+++ b/tests/protos/worlds/proto_regeneration_multiple_instances.wbt
@@ -49,9 +49,6 @@ Robot {
     }
   ]
   controller "proto_regeneration_multiple_instances"
-  controllerArgs [
-    "proto_regeneration_multiple_instances"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/super_parameter_instances.wbt
+++ b/tests/protos/worlds/super_parameter_instances.wbt
@@ -27,9 +27,6 @@ Robot {
     }
   ]
   controller "super_parameter_instances"
-  controllerArgs [
-    "super_parameter_instances"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_internal_proto_regeneration.wbt
+++ b/tests/protos/worlds/template_internal_proto_regeneration.wbt
@@ -29,9 +29,6 @@ Robot {
     }
   ]
   controller "template_internal_proto_regeneration"
-  controllerArgs [
-    "template_internal_proto_regeneration"
-  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_nested_slot_container.wbt
+++ b/tests/protos/worlds/template_nested_slot_container.wbt
@@ -29,10 +29,8 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "template_nested_slot_container"
-  controllerArgs [
-    "template_nested_slot_container"
-  ]
   supervisor TRUE
 }
 DEF TEST_PROTO TemplateNestedSlotContainer {

--- a/tests/protos/worlds/template_proto_follow_solid.wbt
+++ b/tests/protos/worlds/template_proto_follow_solid.wbt
@@ -61,9 +61,6 @@ TemplateRobotSlotContainer {
     }
   ]
   controller "template_proto_follow_solid"
-  controllerArgs [
-    "template_proto_follow_solid"
-  ]
 }
 TestSuiteSupervisor {
 }

--- a/tests/protos/worlds/template_robot_regenerated.wbt
+++ b/tests/protos/worlds/template_robot_regenerated.wbt
@@ -21,9 +21,6 @@ Robot {
     }
   ]
   controller "template_robot_regenerated"
-  controllerArgs [
-    "template_robot_regenerated"
-  ]
   supervisor TRUE
 }
 DEF ROBOT TemplateRobot {

--- a/tests/protos/worlds/template_texture.wbt
+++ b/tests/protos/worlds/template_texture.wbt
@@ -39,9 +39,6 @@ Robot {
     }
   ]
   controller "template_texture"
-  controllerArgs [
-    "template_texture"
-  ]
 }
 TestSuiteSupervisor {
 }

--- a/tests/rendering/worlds/.mirror.wbproj
+++ b/tests/rendering/worlds/.mirror.wbproj
@@ -4,10 +4,8 @@ simulationViewPerspectives: 000000ff000000010000000200000118000002bf010000000601
 sceneTreePerspectives: 000000ff0000000100000002000000c0000000fc0100000006010000000200
 maximizedDockId: -1
 centralWidgetVisible: 1
-selectionDisabled: 0
-viewpointLocked: 0
 orthographicViewHeight: 1
 textFiles: 0 "controllers/mirror_supervisor/mirror_supervisor.c"
+renderingDevicePerspectives: mirror supervisor:camera;1;1;0.909959;0
 renderingDevicePerspectives: mirror:camera;1;1;0;0
 renderingDevicePerspectives: mirror:display;1;1.02927;0;0.756849
-renderingDevicePerspectives: mirror supervisor:camera;1;1;0.909959;0


### PR DESCRIPTION
Complete  #1906.

These changes have been applied to the worlds:
* [x] fix light attenuation warning when the light conditions were not affecting the simulation
* [x] remove unneeded `controllerArgs`
* [x] fix solid name errors
* [x] convert most of the DifferentialWheels nodes to HingeJoint + Motor (just one remains in `physics/dynamic_light_sensor_rays.wbt`)
* [x] update a couple of worlds to use the ENU coordinate system