### PR TITLE
Added precision to extern controllers setup

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -31,7 +31,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                        | Typical Value                                                                                                        |
 |---------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | WEBOTS\_HOME                                | `C:\Program Files\Webots`                                                                                            |
-| PATH (for C and MATLAB controllers)         | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin`                                             |
+| PATH (for C and MATLAB controllers)         | add `${WEBOTS_HOME}\lib\controller` and `${WEBOTS_HOME}\msys64\mingw64\bin`                                          |
 | PATH (for C++, Python and Java controllers) | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin` and `${WEBOTS_HOME}\msys64\mingw64\bin\cpp` |
 
 %tab-end

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -28,10 +28,11 @@ Generic Webots environment variables needed for all the controller languages:
 %tab-component "os"
 
 %tab "Windows"
-| Environment Variable     | Typical Value                                                                                                        |
-|--------------------------|----------------------------------------------------------------------------------------------------------------------|
-| WEBOTS\_HOME             | `C:\Program Files\Webots`                                                                                            |
-| PATH                     | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin` and `${WEBOTS_HOME}\msys64\mingw64\bin\cpp` |
+| Environment Variable        | Typical Value                                                                                                        |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------|
+| WEBOTS\_HOME                | `C:\Program Files\Webots`                                                                                            |
+| PATH (C and MATLAB)         | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin`                                             |
+| PATH (C++, Python and Java) | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin` and `${WEBOTS_HOME}\msys64\mingw64\bin\cpp` |
 
 %tab-end
 

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -28,11 +28,11 @@ Generic Webots environment variables needed for all the controller languages:
 %tab-component "os"
 
 %tab "Windows"
-| Environment Variable        | Typical Value                                                                                                        |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------|
-| WEBOTS\_HOME                | `C:\Program Files\Webots`                                                                                            |
-| PATH (C and MATLAB)         | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin`                                             |
-| PATH (C++, Python and Java) | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin` and `${WEBOTS_HOME}\msys64\mingw64\bin\cpp` |
+| Environment Variable                        | Typical Value                                                                                                        |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| WEBOTS\_HOME                                | `C:\Program Files\Webots`                                                                                            |
+| PATH (for C and MATLAB controllers)         | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin`                                             |
+| PATH (for C++, Python and Java controllers) | add `${WEBOTS_HOME}\lib\controller`, `${WEBOTS_HOME}\msys64\mingw64\bin` and `${WEBOTS_HOME}\msys64\mingw64\bin\cpp` |
 
 %tab-end
 


### PR DESCRIPTION
C and MATLAB extern controllers on Windows don't need the `PATH` to include the `cpp` folder.
https://cyberbotics.com/doc/guide/running-extern-robot-controllers?version=hotfix-extern-controllers-setup&tab-os=windows