### PR TITLE
Fix nested PROTO field redirection

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,6 +4,7 @@
 Released on XXX YYth, 2020.
 
   - Bug fixes
+    - Fixed field changes not applied in case of nested [PROTO](proto.md) nodes ([ #2063](https://github.com/cyberbotics/webots/pull/2063)).
     - Fixed the `near` field of the `Robotino3Webcam` [Camera](camera.md) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed orientation of the [Lights](light.md) in the [`robotino3` world](../guide/robotino3.md#robotino3-wbt) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - **macOS: Removed the `ros` controller**, the [custom Python ROS controller](https://www.cyberbotics.com/doc/guide/using-ros#custom-ros-controller) should be used instead ([#2053](https://github.com/cyberbotics/webots/pull/2053)).

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -206,6 +206,7 @@ WbNode::WbNode(const WbNode &other) :
   if (gDefCloneFlag || (parentNode() && parentNode()->mHasUseAncestor))
     mHasUseAncestor = true;
 
+  const bool previousNestedProtoFlag = gNestedProtoFlag;
   if (!mHasUseAncestor && !gDefCloneFlag && other.mIsProtoDescendant && gProtoParameterNodeFlag) {
     // clone PROTO parameter node
 
@@ -279,7 +280,7 @@ WbNode::WbNode(const WbNode &other) :
       gNestedProtoFlag = false;
 
     if (other.mProto) {
-      bool tmpFlag = gProtoParameterNodeFlag;
+      const bool previousProtoParameterFlag = gProtoParameterNodeFlag;
       if (gInstantiateMode) {
         gProtoParameterNodeFlag = true;
 
@@ -304,13 +305,14 @@ WbNode::WbNode(const WbNode &other) :
             redirectAliasedFields(parameter, this, other.mProto->isDerived());
       }
 
-      gProtoParameterNodeFlag = tmpFlag;
+      gProtoParameterNodeFlag = previousProtoParameterFlag;
     }
   }
 
   gParent = parentNode();
   if (gTopParameterFlag)
     mIsTopParameterDescendant = true;
+  gNestedProtoFlag = previousNestedProtoFlag;
 }
 
 WbNode::~WbNode() {

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -210,14 +210,13 @@ WbNode::WbNode(const WbNode &other) :
   if (!mHasUseAncestor && !gDefCloneFlag && other.mIsProtoDescendant && gProtoParameterNodeFlag) {
     // clone PROTO parameter node
 
+    if (other.mIsNestedProtoNode)
+      // apply nested PROTO method when copying the internal nodes of the nested PROTO node
+      gNestedProtoFlag = true;
+
     // copy fields
     foreach (WbField *parameterNodeField, other.mFields) {
       WbField *field = NULL;
-
-      if (other.mIsNestedProtoNode)
-        // apply nested PROTO method when copying the internal nodes of the nested PROTO node
-        gNestedProtoFlag = true;
-
       if (gNestedProtoFlag) {
         // create an instance of a nested PROTO parameter node
         // don't redirect PROTO instance fields to PROTO node fields
@@ -234,9 +233,6 @@ WbNode::WbNode(const WbNode &other) :
 
       mFields.append(field);
       connect(field, &WbField::valueChanged, this, &WbNode::notifyFieldChanged);
-
-      if (other.mIsNestedProtoNode)
-        gNestedProtoFlag = false;
     }
 
     // copy parameters
@@ -274,9 +270,6 @@ WbNode::WbNode(const WbNode &other) :
     if (gProtoParameterNodeFlag)
       mIsProtoDescendant = true;
 
-    if (other.mIsNestedProtoNode)
-      gNestedProtoFlag = false;
-
     if (other.mProto) {
       const bool previousProtoParameterFlag = gProtoParameterNodeFlag;
       if (gInstantiateMode) {
@@ -287,7 +280,6 @@ WbNode::WbNode(const WbNode &other) :
       }
 
       // add parameters with values copied from PROTO model
-      bool previousNestedProtoFlag = gNestedProtoFlag;
       gNestedProtoFlag = true;
       foreach (WbField *parameter, other.parameters()) {
         WbField *copy = new WbField(*parameter, this);

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -240,14 +240,12 @@ WbNode::WbNode(const WbNode &other) :
     }
 
     // copy parameters
-    bool previousNestedProtoFlag = gNestedProtoFlag;
     gNestedProtoFlag = true;
     foreach (WbField *parameter, other.parameters()) {
       WbField *copy = new WbField(*parameter, this);
       mParameters.append(copy);
       connect(copy, &WbField::valueChanged, this, &WbNode::notifyParameterChanged);
     }
-    gNestedProtoFlag = previousNestedProtoFlag;
 
     mIsProtoDescendant = true;
 

--- a/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
+++ b/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
@@ -12,13 +12,11 @@
 
 #define TIME_STEP 32
 
-static void check_object_status(WbDeviceTag camera, int color, const char *message) {
+static void check_object_status(WbDeviceTag camera, bool visible, const char *message) {
+  const int expected = visible ? 0 : 255;
   const unsigned char *values = wb_camera_get_image(camera);
-  printf("r %d g %d b %d\n", wb_camera_image_get_red(values, 1, 0, 0), wb_camera_image_get_green(values, 1, 0, 0),
-         wb_camera_image_get_blue(values, 1, 0, 0));
   ts_assert_color_in_delta(wb_camera_image_get_red(values, 1, 0, 0), wb_camera_image_get_green(values, 1, 0, 0),
-                           wb_camera_image_get_blue(values, 1, 0, 0), color, color, color,  // background
-                           1, message);
+                           wb_camera_image_get_blue(values, 1, 0, 0), expected, expected, expected, 1, message);
 }
 
 int main(int argc, char **argv) {
@@ -40,35 +38,35 @@ int main(int argc, char **argv) {
   wb_robot_step(TIME_STEP);
 
   if (strcmp(argv[1], "nested_mixed_template_proto") == 0) {
-    check_object_status(cameraX, 255, "Unexpected cameraX color. The box should not be visible.");
-    check_object_status(cameraY, 255, "Unexpected cameraY color. The box should not be visible.");
+    check_object_status(cameraX, false, "Unexpected cameraX color. The box should not be visible.");
+    check_object_status(cameraY, false, "Unexpected cameraY color. The box should not be visible.");
     wb_supervisor_field_set_sf_float(xField, 0.5);
 
     wb_robot_step(TIME_STEP);
 
-    check_object_status(cameraX, 0, "Unexpected cameraX color after changing x size. The box should be visible.");
-    check_object_status(cameraY, 255, "Unexpected cameraY color after changing x size. The box not should be visible.");
+    check_object_status(cameraX, true, "Unexpected cameraX color after changing x size. The box should be visible.");
+    check_object_status(cameraY, false, "Unexpected cameraY color after changing x size. The box not should be visible.");
 
     const double newPosition[3] = {0.0, 0.2, 0.0};
     wb_supervisor_field_set_sf_vec3f(tField, newPosition);
 
     wb_robot_step(TIME_STEP);
 
-    check_object_status(cameraX, 255, "Unexpected cameraX color after changing translation. The box should not be visible.");
-    check_object_status(cameraY, 0, "Unexpected cameraY color after changing translation. The box should be visible.");
+    check_object_status(cameraX, false, "Unexpected cameraX color after changing translation. The box should not be visible.");
+    check_object_status(cameraY, true, "Unexpected cameraY color after changing translation. The box should be visible.");
 
   } else {  // argv[1] == "proto_nested_2"
-    check_object_status(cameraX, 0, "Unexpected cameraX color. The cylinder should be visible.");
-    check_object_status(cameraY, 255, "Unexpected cameraY color. The cylinder should not be visible.");
+    check_object_status(cameraX, true, "Unexpected cameraX color. The cylinder should be visible.");
+    check_object_status(cameraY, false, "Unexpected cameraY color. The cylinder should not be visible.");
 
     const double newPosition[3] = {0.0, 0.2, 0.0};
     wb_supervisor_field_set_sf_vec3f(tField, newPosition);
 
     wb_robot_step(TIME_STEP);
 
-    check_object_status(cameraX, 255,
+    check_object_status(cameraX, false,
                         "Unexpected cameraX color after changing translation. The cylinder should not be visible.");
-    check_object_status(cameraY, 0, "Unexpected cameraY color after changing translation. The cylinder should be visible.");
+    check_object_status(cameraY, true, "Unexpected cameraY color after changing translation. The cylinder should be visible.");
   }
 
   ts_send_success();

--- a/tests/protos/protos/Empty.proto
+++ b/tests/protos/protos/Empty.proto
@@ -1,0 +1,8 @@
+#VRML_SIM R2020b utf8
+
+PROTO Empty [
+]
+{
+  Group {
+  }
+}

--- a/tests/protos/protos/SlotWithInternalProto.proto
+++ b/tests/protos/protos/SlotWithInternalProto.proto
@@ -1,0 +1,16 @@
+#VRML_SIM R2020b utf8
+
+PROTO SlotWithInternalProto [
+  field MFNode slot NULL
+]
+{
+  Group {
+    children [
+      Empty {
+      }
+      Group {
+        children IS slot
+      }
+    ]
+  }
+}

--- a/tests/protos/protos/SolidCylinder.proto
+++ b/tests/protos/protos/SolidCylinder.proto
@@ -9,6 +9,9 @@ PROTO SolidCylinder [
     translation IS translation
     children [
       Shape {
+        appearance PBRAppearance {
+          baseColor 0 0 0
+        }
         geometry DEF GEOM Cylinder {
           radius 0.2
           height IS height

--- a/tests/protos/worlds/proto_nested_2.wbt
+++ b/tests/protos/worlds/proto_nested_2.wbt
@@ -1,0 +1,56 @@
+#VRML_SIM R2020b utf8
+WorldInfo {
+  coordinateSystem "NUE"
+}
+Viewpoint {
+  orientation -0.059313122717996214 -0.996442922813714 -0.059861966622408704 1.5835629835145255
+  position -2.130213432311385 0.4196025226453858 0.5307846625358822
+  near 0.001
+}
+Background {
+  skyColor [
+    1 1 1
+  ]
+}
+DirectionalLight {
+  direction 0.2 -1 0.55
+}
+SlotContainer {
+  slot [
+    SlotWithInternalProto {
+      slot [
+        DEF TEST_PROTO SolidCylinder {
+          height 0.2
+        }
+      ]
+    }
+  ]
+}
+Robot {
+  translation 0 0 0.2
+  children [
+    Camera {
+      translation 0 0 0.15
+      name "cameraX"
+      fieldOfView 0.01
+      width 1
+      height 1
+    }
+    Camera {
+      translation 0 0.2 0.15
+      name "cameraY"
+      fieldOfView 0.01
+      width 1
+      height 1
+    }
+    TestSuiteEmitter {
+    }
+  ]
+  controller "nested_mixed_template_proto"
+  controllerArgs [
+    "proto_nested_2"
+  ]
+  supervisor TRUE
+}
+TestSuiteSupervisor {
+}


### PR DESCRIPTION
Fix #214: internal PROTO nodes are reset flags needed to correctly redirect fields.