### PR TITLE
Cleanup of the streaming server protocol

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,7 +7,8 @@ Released on XXX YYth, 2020.
     - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
-        - Linux: Fixed the execution of robot controllers with firejail ([#2071](https://github.com/cyberbotics/webots/pull/2071)).
+    - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).
+    - Linux: Fixed the execution of robot controllers with firejail ([#2071](https://github.com/cyberbotics/webots/pull/2071)).
     - Fixed field changes not applied in case of nested [PROTO](proto.md) nodes ([#2063](https://github.com/cyberbotics/webots/pull/2063)).
     - Fixed the `near` field of the `Robotino3Webcam` [Camera](camera.md) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed orientation of the [Lights](light.md) in the [`robotino3` world](../guide/robotino3.md#robotino3-wbt) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -451,7 +451,9 @@ class ClientWebSocketHandler(tornado.websocket.WebSocketHandler):
                 client.streaming_server_port = ClientWebSocketHandler.next_available_port()
                 client.url = data['start']['url']
                 if 'mode' in data['start']:
-                    client.mode = data['start']['mode']  # 'x3d' or 'mjpeg'
+                    client.mode = data['start']['mode']
+                    if client.mode not in ['x3d', 'mjpeg']:
+                        logging.warning("Unsupported client mode: " + client.mode)
                 logging.info('Starting simulation from ' + client.url)
                 self.start_client()
 

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -251,6 +251,8 @@ class Client:
             port = client.streaming_server_port
             command = config['webots'] + ' --batch --mode=pause --minimize '
             command += '--stream="port=' + str(port) + ';monitorActivity'
+            if hasattr(self, 'mode'):
+                command += ';mode=' + self.mode
             if not hasattr(self, 'url'):
                 if self.user1Authentication or not self.user1Id:  # we are running our own or an anonymous simulation
                     command += ';controllerEdit'
@@ -448,6 +450,8 @@ class ClientWebSocketHandler(tornado.websocket.WebSocketHandler):
             elif 'start' in data:  # checkout a github folder and run a simulation in there
                 client.streaming_server_port = ClientWebSocketHandler.next_available_port()
                 client.url = data['start']['url']
+                if 'mode' in data['start']:
+                    client.mode = data['start']['mode']  # 'x3d' or 'mjpeg'
                 logging.info('Starting simulation from ' + client.url)
                 self.start_client()
 

--- a/resources/web/wwi/server.js
+++ b/resources/web/wwi/server.js
@@ -58,9 +58,13 @@ class Server { // eslint-disable-line no-unused-vars
   }
 
   onOpen(event) {
-    if (this.repository)
-      this.socket.send(`{"start":{"url":"${this.repository}"}}`);
-    else { // legacy format
+    if (this.repository) {
+      let message = `{"start":{"url":"${this.repository}"`;
+      if (this.view.mode == 'mjpeg')
+        message += ',"mode":"mjpeg"';
+      message += '}}';
+      this.socket.send(message);
+    } else { // legacy format
       const host = location.protocol + '//' + location.host.replace(/^www./, ''); // remove 'www' prefix
       if (typeof webots.User1Id === 'undefined')
         webots.User1Id = '';

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -66,7 +66,7 @@ class Stream { // eslint-disable-line no-unused-vars
         else if (line.startsWith('robot:')) {
           let robot, message;
           try {
-            let str = data.substring(data.indexOf(':') + 1).trim();
+            let str = data.substring(line.indexOf(':') + 1).trim();
             let dataObject = JSON.parse(str);
             robot = dataObject.name;
             message = dataObject.message;

--- a/resources/web/wwi/stream.js
+++ b/resources/web/wwi/stream.js
@@ -66,7 +66,7 @@ class Stream { // eslint-disable-line no-unused-vars
         else if (line.startsWith('robot:')) {
           let robot, message;
           try {
-            let str = data.substring(line.indexOf(':') + 1).trim();
+            let str = line.substring(line.indexOf(':') + 1).trim();
             let dataObject = JSON.parse(str);
             robot = dataObject.name;
             message = dataObject.message;

--- a/src/webots/gui/WbMultimediaStreamingServer.cpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.cpp
@@ -391,6 +391,17 @@ void WbMultimediaStreamingServer::processTextMessage(QString message) {
 }
 
 void WbMultimediaStreamingServer::sendWorldToClient(QWebSocket *client) {
+  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
+  foreach (const WbRobot *robot, robots) {
+    if (!robot->window().isEmpty()) {
+      QJsonObject windowObject;
+      windowObject.insert("robot", robot->name());
+      windowObject.insert("window", robot->window());
+      const QJsonDocument windowDocument(windowObject);
+      client->sendTextMessage("robot window: " + windowDocument.toJson(QJsonDocument::Compact));
+    }
+  }
+
   const WbWorldInfo *currentWorldInfo = WbWorld::instance()->worldInfo();
   QJsonObject infoObject;
   infoObject.insert("window", currentWorldInfo->window());

--- a/src/webots/gui/WbMultimediaStreamingServer.cpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.cpp
@@ -358,7 +358,7 @@ void WbMultimediaStreamingServer::processTextMessage(QString message) {
       WbLog::info(tr("Streaming server: Ignored new client request of resolution: %1x%2.").arg(width).arg(height));
       args = QString("%1 %2").arg(mImageWidth).arg(mImageHeight);
     }
-    client->sendTextMessage(QString("multimedia: /mjpeg %2 %3").arg(simulationStateString()).arg(args));
+    client->sendTextMessage(QString("multimedia: /mjpeg %2 %3").arg(simulationStateString(false)).arg(args));
     const QString &stateMessage = simulationStateString();
     if (!stateMessage.isEmpty())
       client->sendTextMessage(stateMessage);

--- a/src/webots/gui/WbMultimediaStreamingServer.cpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.cpp
@@ -389,3 +389,14 @@ void WbMultimediaStreamingServer::processTextMessage(QString message) {
   } else
     WbStreamingServer::processTextMessage(message);
 }
+
+void WbMultimediaStreamingServer::sendWorldToClient(QWebSocket *client) {
+  const WbWorldInfo *currentWorldInfo = WbWorld::instance()->worldInfo();
+  QJsonObject infoObject;
+  infoObject.insert("window", currentWorldInfo->window());
+  infoObject.insert("title", currentWorldInfo->title());
+  const QJsonDocument infoDocument(infoObject);
+  client->sendTextMessage("world info: " + infoDocument.toJson(QJsonDocument::Compact));
+
+  WbStreamingServer::sendWorldToClient(client);
+}

--- a/src/webots/gui/WbMultimediaStreamingServer.hpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.hpp
@@ -44,6 +44,7 @@ private slots:
   void processTextMessage(QString message) override;
   void sendImageOnTimeout();
   void processLimiterTimeout();
+  void sendWorldToClient(QWebSocket *client) override;
 
 private:
   void start(int port) override;

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -553,27 +553,20 @@ void WbStreamingServer::propagateNodeAddition(WbNode *node) {
 }
 
 QString WbStreamingServer::simulationStateString(bool pauseTime) {
-  QString string;
   switch (WbSimulationState::instance()->mode()) {
     case WbSimulationState::PAUSE:
-      string = pauseTime ? QString("pause: %1").arg(WbSimulationState::instance()->time()) : "pause";
-      break;
+      return pauseTime ? QString("pause: %1").arg(WbSimulationState::instance()->time()) : "pause";
     case WbSimulationState::STEP:
-      string = "step";
-      break;
+      return "step";
     case WbSimulationState::REALTIME:
-      string = "real-time";
-      break;
+      return "real-time";
     case WbSimulationState::RUN:
-      string = "run";
-      break;
+      return "run";
     case WbSimulationState::FAST:
-      string = "fast";
-      break;
+      return "fast";
     default:
-      break;
+      return "";
   }
-  return string;
 }
 
 void WbStreamingServer::propagateSimulationStateChange() const {

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -616,12 +616,5 @@ void WbStreamingServer::sendWorldToClient(QWebSocket *client) {
     }
   }
 
-  const WbWorldInfo *currentWorldInfo = WbWorld::instance()->worldInfo();
-  QJsonObject infoObject;
-  infoObject.insert("window", currentWorldInfo->window());
-  infoObject.insert("title", currentWorldInfo->title());
-  const QJsonDocument infoDocument(infoObject);
-  client->sendTextMessage("world info: " + infoDocument.toJson(QJsonDocument::Compact));
-
   client->sendTextMessage("scene load completed");
 }

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -552,21 +552,28 @@ void WbStreamingServer::propagateNodeAddition(WbNode *node) {
     connectNewRobot(robot);
 }
 
-QString WbStreamingServer::simulationStateString() {
+QString WbStreamingServer::simulationStateString(bool pauseTime) {
+  QString string;
   switch (WbSimulationState::instance()->mode()) {
     case WbSimulationState::PAUSE:
-      return "pause";
+      string = pauseTime ? QString("pause: %1").arg(WbSimulationState::instance()->time()) : "pause";
+      break;
     case WbSimulationState::STEP:
-      return "step";
+      string = "step";
+      break;
     case WbSimulationState::REALTIME:
-      return "real-time";
+      string = "real-time";
+      break;
     case WbSimulationState::RUN:
-      return "run";
+      string = "run";
+      break;
     case WbSimulationState::FAST:
-      return "fast";
+      string = "fast";
+      break;
     default:
-      return QString();
+      break;
   }
+  return string;
 }
 
 void WbStreamingServer::propagateSimulationStateChange() const {
@@ -576,8 +583,6 @@ void WbStreamingServer::propagateSimulationStateChange() const {
   QString message = simulationStateString();
   if (message.isEmpty())
     return;
-  if (message == "pause")
-    message = QString("pause: %1").arg(WbSimulationState::instance()->time());
   foreach (QWebSocket *client, mWebSocketClients)
     client->sendTextMessage(message);
 }

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -610,16 +610,5 @@ void WbStreamingServer::sendWorldToClient(QWebSocket *client) {
     worlds += (i == 0 ? "" : ";") + QFileInfo(worldList.at(i)).fileName();
   client->sendTextMessage("world:" + QFileInfo(world->fileName()).fileName() + ':' + worlds);
 
-  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
-  foreach (const WbRobot *robot, robots) {
-    if (!robot->window().isEmpty()) {
-      QJsonObject windowObject;
-      windowObject.insert("robot", robot->name());
-      windowObject.insert("window", robot->window());
-      const QJsonDocument windowDocument(windowObject);
-      client->sendTextMessage("robot window: " + windowDocument.toJson(QJsonDocument::Compact));
-    }
-  }
-
   client->sendTextMessage("scene load completed");
 }

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -69,7 +69,7 @@ protected:
   double mPauseTimeout;
 
   static QString clientToId(QWebSocket *client);
-  static QString simulationStateString();
+  static QString simulationStateString(bool pauseState = true);
   static WbMainWindow *cMainWindow;
 
 private slots:

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -69,7 +69,7 @@ protected:
   double mPauseTimeout;
 
   static QString clientToId(QWebSocket *client);
-  static QString simulationStateString(bool pauseState = true);
+  static QString simulationStateString(bool pauseTime = true);
   static WbMainWindow *cMainWindow;
 
 private slots:


### PR DESCRIPTION
Various cleanups and bug fixes for the streaming server:

- [x] Don't send useless 'world info' message in case of X3D streaming.
- [x] Fixed 'pause' message which was missing the time value.
- [x] Fixed 'robot window' messages.
- [x] Fixed bugs in the parsing the 'robot' line in multiple lines messages.
- [x] Support `x3d` and `mpjeg` modes in simulation server.
