### PR TITLE
Add Python Brew API Compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,6 +254,8 @@ jobs:
         homebrew:
           packages:
             - python
+            - python@3.7
+            - python@3.8
             - cmake
             - swig
             - wget
@@ -266,11 +268,9 @@ jobs:
         - sudo mkdir -p /Library/Frameworks/Python.framework/Versions/3.7  # we can't use python3.7 from homebrew for the compilation because it is not compatible with the normal one
         - if [[ ! -f $WEBOTS_HOME/dependencies/python3.7.zip ]]; then wget -qq https://cyberbotics.com/files/repository/dependencies/mac/release/python3.7.zip -P $WEBOTS_HOME/dependencies; fi
         - sudo unzip -o -q $WEBOTS_HOME/dependencies/python3.7.zip -d /Library/Frameworks/Python.framework/Versions/3.7
-        - export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.7/bin
         - sudo mkdir -p /Library/Frameworks/Python.framework/Versions/3.8  # we can't use python3.8 from homebrew for the compilation because it is not compatible with the normal one
         - if [[ ! -f $WEBOTS_HOME/dependencies/python3.8.zip ]]; then wget -qq https://cyberbotics.com/files/repository/dependencies/mac/release/python3.8.zip -P $WEBOTS_HOME/dependencies; fi
         - sudo unzip -o -q $WEBOTS_HOME/dependencies/python3.8.zip -d /Library/Frameworks/Python.framework/Versions/3.8
-        - export PATH=$PATH:/Library/Frameworks/Python.framework/Versions/3.8/bin
       script:
         - if [[ -z "${TRAVIS_TAG}" ]]; then python src/packaging/set_commit_and_date_in_version.py $TRAVIS_COMMIT; fi
         - make distrib -j2

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -74,11 +74,12 @@ No specific setup is needed.
 %tab-end
 
 %tab "Python"
-| Version      | Environment Variable     | Typical Value                                    |
-|--------------|--------------------------|--------------------------------------------------|
-| Python 2.7   | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python27`     |
-| Python 3.X   | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python3X`     |
-| all          | PYTHONIOENCODING         | `UTF-8`                                          |
+| Version               | Environment Variable     | Typical Value                                     |
+|--------------         |--------------------------|---------------------------------------------------|
+| Python 2.7            | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python27`      |
+| Python 3.X            | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python3X`      |
+| Python Homebrew 3.X   | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python3X_brew` |
+| all                   | PYTHONIOENCODING         | `UTF-8`                                           |
 %tab-end
 
 %tab "Java"

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -43,6 +43,8 @@ Python 2.7 installed by default.
 You can install Python 3.7 or 3.8 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
 To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python2.7 --version`, `python3 --version`, etc.
 
+> **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (e.g. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
+
 #### Windows Installation
 
 You should install the latest version of Python 3.7 (64 bit) or Python 2.7 (64 bit) from the official [Python website](https://www.python.org).

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -40,10 +40,8 @@ To check the versions of Python installed on your system, you can type in a term
 #### macOS Installation
 
 Python 2.7 installed by default.
-You can install Python 3.7 or 3.8 from the [Python web site](https://www.python.org).
+You can install Python 3.7 or 3.8 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
 To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python2.7 --version`, `python3 --version`, etc.
-
-> **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (i.e. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
 
 #### Windows Installation
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -3,8 +3,9 @@
 ## Webots R2020b Revision 1
 Released on XXX YYth, 2020.
 
-- Enhancements
-  - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
+  - Enhancements
+    - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
+    - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
         - Linux: Fixed the execution of robot controllers with firejail ([#2071](https://github.com/cyberbotics/webots/pull/2071)).
     - Fixed field changes not applied in case of nested [PROTO](proto.md) nodes ([#2063](https://github.com/cyberbotics/webots/pull/2063)).

--- a/lib/controller/.gitignore
+++ b/lib/controller/.gitignore
@@ -5,4 +5,6 @@
 /python36
 /python37
 /python38
+/python37_brew
+/python38_brew
 /*.so.*

--- a/resources/languages/Makefile
+++ b/resources/languages/Makefile
@@ -47,11 +47,11 @@ ifeq ($(OSTYPE),darwin)
 	@echo "# make" $@ python2.7;
 	+PYTHON_COMMAND=python2.7 make -s -C python $@
 	@echo "# make" $@ python3.7;
-	+PYTHON_COMMAND=python3.7 make -s -C python $@
+	+PYTHON_COMMAND=/Library/Frameworks/Python.framework/Versions/3.7/bin/python3.7 make -s -C python $@
 	@echo "# make" $@ python3.8;
-	+PYTHON_COMMAND=python3.8 make -s -C python $@
+	+PYTHON_COMMAND=/Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8 make -s -C python $@
 	@echo "# make" $@ python3.7 brew;
-	+PYTHON_COMMAND=/usr/local/opt/python@3.7/bin/python3.7 make -s -C python $@
+	+PYTHON_COMMAND=/usr/local/opt/python@3.7/bin/python3.7 SUFFIX=_brew make -s -C python $@
 	@echo "# make" $@ python3.8 brew;
-	+PYTHON_COMMAND=/usr/local/opt/python@3.8/bin/python3.8 make -s -C python $@
+	+PYTHON_COMMAND=/usr/local/opt/python@3.8/bin/python3.8 SUFFIX=_brew make -s -C python $@
 endif

--- a/resources/languages/Makefile
+++ b/resources/languages/Makefile
@@ -45,9 +45,13 @@ ifeq ($(OSTYPE),windows)
 endif
 ifeq ($(OSTYPE),darwin)
 	@echo "# make" $@ python2.7;
-	+make -s -C python $@
+	+PYTHON_COMMAND=python2.7 make -s -C python $@
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $@
 	@echo "# make" $@ python3.8;
 	+PYTHON_COMMAND=python3.8 make -s -C python $@
+	@echo "# make" $@ python3.7 brew;
+	+PYTHON_COMMAND=/usr/local/opt/python@3.7/bin/python3.7 make -s -C python $@
+	@echo "# make" $@ python3.8 brew;
+	+PYTHON_COMMAND=/usr/local/opt/python@3.8/bin/python3.8 make -s -C python $@
 endif

--- a/resources/languages/python/Makefile
+++ b/resources/languages/python/Makefile
@@ -27,12 +27,12 @@ PYTHON_SHORT_VERSION = $(subst .,,$(PYTHON_VERSION))
 PYTHON_FULL_VERSION := $(subst Python ,,$(shell $(PYTHON_COMMAND) --version 2>&1))
 INTERFACE       = controller.i
 SWIG            = swig
-SWIG_OPTS       = -c++ -python -outdir $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/
+SWIG_OPTS       = -c++ -python -outdir $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX)/
 WEBOTS_INCLUDES = -I$(WEBOTS_HOME_PATH)/include/controller/cpp -I$(WEBOTS_HOME_PATH)/include/controller/c
 WRAPPER         = $(INTERFACE:.i=$(PYTHON_SHORT_VERSION).cpp)
 WRAPPER_OBJECT  = $(WRAPPER:.cpp=.o)
-PYOUT           = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/,$(INTERFACE:.i=.py))
-PYTHON_PATH_SETUP := $(shell mkdir -p $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION))
+PYOUT           = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX)/,$(INTERFACE:.i=.py))
+PYTHON_PATH_SETUP := $(shell mkdir -p $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX))
 
 ifeq ($(OSTYPE),windows)
 PYTHON_HOME    := $(subst \ ,$(space),$(dir $(subst $(space),\ ,$(shell which python 2> /dev/null))))
@@ -49,7 +49,7 @@ LIBCPPCONTROLLER= $(WEBOTS_CONTROLLER_LIB_PATH)/CppController.dll
 endif
 
 ifeq ($(OSTYPE),darwin)
-PYTHON_PATH ?= $(subst /Resources/Python.app/Contents/MacOS/Python,,$(subst /bin/python$(PYTHON_VERSION),,$(shell $(PYTHON_COMMAND) -u -c "import sys; print(sys.executable)")))
+PYTHON_PATH = $(shell $(PYTHON_COMMAND) -u -c "import sys; print(sys.exec_prefix)")
 ifeq ($(PYTHON_SHORT_VERSION), 27)
 PYTHON_PYMALLOC =
 else
@@ -66,11 +66,7 @@ C_FLAGS        += -Wno-self-assign
 endif
 LD_FLAGS        = -dynamiclib -install_name @rpath/lib/controller/python$(PYTHON_SHORT_VERSION)/_$(INTERFACE:.i=.dylib) -Wl,-rpath,@loader_path/../../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION)
 LIBS            = -L"$(PYTHON_PATH)/lib" -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController -lCppController -lpython$(PYTHON_VERSION)
-ifneq (,$(findstring /usr/local/opt,$(PYTHON_PATH)))
-LIBOUT = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)_brew/_,$(INTERFACE:.i=.so))
-else
-LIBOUT = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/_,$(INTERFACE:.i=.so))
-endif
+LIBOUT = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX)/_,$(INTERFACE:.i=.so))
 PYTHON_INCLUDES = -isystem "$(PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)"
 LIBCONTROLLER   = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
 LIBCPPCONTROLLER= $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.dylib

--- a/resources/languages/python/Makefile
+++ b/resources/languages/python/Makefile
@@ -49,18 +49,16 @@ LIBCPPCONTROLLER= $(WEBOTS_CONTROLLER_LIB_PATH)/CppController.dll
 endif
 
 ifeq ($(OSTYPE),darwin)
+PYTHON_PATH ?= $(subst /Resources/Python.app/Contents/MacOS/Python,,$(subst /bin/python$(PYTHON_VERSION),,$(shell $(PYTHON_COMMAND) -u -c "import sys; print(sys.executable)")))
 ifeq ($(PYTHON_SHORT_VERSION), 27)
-PYTHON_PATH ?= /System/Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
 PYTHON_PYMALLOC =
 else
-PYTHON_PATH ?= /Library/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
 ifeq ($(PYTHON_SHORT_VERSION), 38)
 PYTHON_PYMALLOC =
 else
 PYTHON_PYMALLOC = m
 endif
 endif
-BREW_PYTHON_PATH = /usr/local/Cellar/python/$(PYTHON_FULL_VERSION)/Frameworks/Python.framework/Versions/$(PYTHON_VERSION)
 PYTHON_BIN       = $(PYTHON_PATH)/bin/
 C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-uninitialized
 ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
@@ -68,14 +66,14 @@ C_FLAGS        += -Wno-self-assign
 endif
 LD_FLAGS        = -dynamiclib -install_name @rpath/lib/controller/python$(PYTHON_SHORT_VERSION)/_$(INTERFACE:.i=.dylib) -Wl,-rpath,@loader_path/../../.. -compatibility_version 1.0 -current_version 1.0.0 -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION)
 LIBS            = -L"$(PYTHON_PATH)/lib" -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController -lCppController -lpython$(PYTHON_VERSION)
-LIBOUT          = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/_,$(INTERFACE:.i=.so))
+ifneq (,$(findstring /usr/local/opt,$(PYTHON_PATH)))
+LIBOUT = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)_brew/_,$(INTERFACE:.i=.so))
+else
+LIBOUT = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/_,$(INTERFACE:.i=.so))
+endif
 PYTHON_INCLUDES = -isystem "$(PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)"
 LIBCONTROLLER   = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
 LIBCPPCONTROLLER= $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.dylib
-ifneq (,$(wildcard $(BREW_PYTHON_PATH)))
-PYTHON_INCLUDES += -I"$(BREW_PYTHON_PATH)/include/python$(PYTHON_VERSION)$(PYTHON_PYMALLOC)"
-LIBS            += -L"$(BREW_PYTHON_PATH)/lib"
-endif
 endif
 
 ifeq ($(OSTYPE),linux)

--- a/src/packaging/files_core.txt
+++ b/src/packaging/files_core.txt
@@ -103,10 +103,18 @@ lib/controller/python37/*.py
 lib/controller/python37/_*.so [linux,mac]
 lib/controller/python37/_*.pyd [windows]
 
+lib/controller/python37_brew/ [mac]
+lib/controller/python37_brew/*.py [mac]
+lib/controller/python37_brew/_*.so [mac]
+
 lib/controller/python38/
 lib/controller/python38/*.py
 lib/controller/python38/_*.so [linux,mac]
 lib/controller/python38/_*.pyd [windows]
+
+lib/controller/python38_brew/ [mac]
+lib/controller/python38_brew/*.py [mac]
+lib/controller/python38_brew/_*.so [mac]
 
 lib/controller/matlab/
 lib/controller/matlab/allincludes.h

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -511,8 +511,23 @@ void WbController::setProcessEnvironment() {
       }
       pythonSourceFile.close();
     }
+#ifdef __APPLE__
+    QProcess process;
+    process.setProcessEnvironment(env);
+    process.start(mPythonCommand, QStringList() << "-c"
+                                                << "import sys; print(sys.exec_prefix);");
+    process.waitForFinished();
+    const QString output = process.readAll();
+    if (output.startsWith("/usr/local/Cellar"))
+      addToPathEnvironmentVariable(
+        env, "PYTHONPATH", WbStandardPaths::controllerLibPath() + "python" + mPythonShortVersion + "_brew", false, true);
+    else
+      addToPathEnvironmentVariable(env, "PYTHONPATH", WbStandardPaths::controllerLibPath() + "python" + mPythonShortVersion,
+                                   false, true);
+#else
     addToPathEnvironmentVariable(env, "PYTHONPATH", WbStandardPaths::controllerLibPath() + "python" + mPythonShortVersion,
                                  false, true);
+#endif
     env.insert("PYTHONIOENCODING", "UTF-8");
   } else if (mType == WbFileUtil::MATLAB) {
     // these variables are read by lib/matlab/launcher.m


### PR DESCRIPTION
**Description**
On MacOs it seems much more common to use the python version coming from Brew (e.g. GitHub action, travis, etc, all of them are using brew, and all the tutorials for installing python3 are mentioning brew).

We should probably use the brew version to compile the Webots Python 3.x API (possibly in addition to the standard Python3.x).

**Related Issues**
This pull-request fixes issue #2066