### PR TITLE
Cleanup hyperlinks

### DIFF
--- a/docs/guide/starting-webots.md
+++ b/docs/guide/starting-webots.md
@@ -73,7 +73,7 @@ Options:
     specifies how many steps are logged. If the --sysinfo option is used, the
     system information is prepended into the log file.
 
-Please report any bug to http://www.cyberbotics.com/bug
+Please report any bug to https://cyberbotics.com/bug
 ```
 
 The optional `worldfile` argument specifies the name of a .wbt file to open.

--- a/src/webots/core/WbTelemetry.cpp
+++ b/src/webots/core/WbTelemetry.cpp
@@ -41,7 +41,7 @@ void WbTelemetry::send(const QString &operation, const QString &file) {
 }
 
 void WbTelemetry::sendRequest(const QString &operation) {
-  QNetworkRequest request(QUrl("https://www.cyberbotics.com/telemetry.php"));
+  QNetworkRequest request(QUrl("https://cyberbotics.com/telemetry.php"));
   QByteArray data;
   data.append("id=");
   const int id = WbPreferences::instance()->value("General/telemetryId", 0).toString().toInt();

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1819,7 +1819,7 @@ void WbMainWindow::openBugReport() {
 }
 
 void WbMainWindow::openNewsletterSubscription() {
-  showDocument("https://www.cyberbotics.com/news/subscribe.php");
+  showDocument("https://cyberbotics.com/newsletter");
 }
 
 void WbMainWindow::openDiscord() {

--- a/src/webots/gui/WbNewVersionDialog.cpp
+++ b/src/webots/gui/WbNewVersionDialog.cpp
@@ -107,7 +107,7 @@ WbNewVersionDialog::WbNewVersionDialog() {
   QVBoxLayout *newsletterLayout = new QVBoxLayout();
   label =
     new QLabel(tr("Stay informed about the latest developments of Webots by subscribing to the <a style='color: #5DADE2;' "
-                  "href='https://cyberbotics.com/news/subscribe.php'>Webots newsletter</a>."));
+                  "href='https://cyberbotics.com/newsletter'>Webots newsletter</a>."));
   connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
   newsletterLayout->addWidget(label);
   newsletterBox->setLayout(newsletterLayout);
@@ -117,7 +117,7 @@ WbNewVersionDialog::WbNewVersionDialog() {
   QGroupBox *telemetryBox = new QGroupBox(tr("Telemetry:"));
   QVBoxLayout *telemetryLayout = new QVBoxLayout();
   label = new QLabel(tr("We need your help to continue to improve Webots: more information <a style='color: #5DADE2;' "
-                        "href='https://www.cyberbotics.com/doc/guide/telemetry'>here</a>."));
+                        "href='https://cyberbotics.com/doc/guide/telemetry'>here</a>."));
   connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
   telemetryLayout->addWidget(label);
   telemetryLayout->addStretch();

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -306,9 +306,9 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   // row 8
   mTelemetryCheckBox = new QCheckBox(tr("Send technical data to Webots developers"), this);
   mTelemetryCheckBox->setToolTip(tr("We need your help to continue to improve Webots: more information at:\n"
-                                    "https://www.cyberbotics.com/doc/guide/telemetry"));
-  QLabel *label = new QLabel(
-    tr("Telemetry (<a style='color: #5DADE2;' href='https://www.cyberbotics.com/doc/guide/telemetry'>info</a>):"), this);
+                                    "https://cyberbotics.com/doc/guide/telemetry"));
+  QLabel *label =
+    new QLabel(tr("Telemetry (<a style='color: #5DADE2;' href='https://cyberbotics.com/doc/guide/telemetry'>info</a>):"), this);
   connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
   layout->addWidget(label, 8, 0);
   layout->addWidget(mTelemetryCheckBox, 8, 1);

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -85,7 +85,7 @@ void WbSingleTaskApplication::showHelp() const {
   cout << tr("    <file> argument. The optional <steps> argument is an integer value that").toUtf8().constData() << endl;
   cout << tr("    specifies how many steps are logged. If the --sysinfo option is used, the").toUtf8().constData() << endl;
   cout << tr("    system information is prepended into the log file.").toUtf8().constData() << endl << endl;
-  cout << tr("Please report any bug to http://www.cyberbotics.com/bug").toUtf8().constData() << endl;
+  cout << tr("Please report any bug to https://cyberbotics.com/bug").toUtf8().constData() << endl;
 }
 
 void WbSingleTaskApplication::showSysInfo() const {


### PR DESCRIPTION
Cleanup the hyperlinks in Webots:
- remove the `www.` header.
- use the `https` protocol.
- change the newsletter subscription URL (which is broken).