### PR TITLE
Improve detection of PROTO template regenerator fields

### DIFF
--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -203,7 +203,7 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
         // condition explanation: if (token contains modelName and not a Lua identifier containing modelName such as
         // "my_awesome_modelName")
         if (token->word().contains(
-              QRegExp(QString("(^|[^a-zA-Z0-9_])%1($|[^a-zA-Z0-9_])").arg(QRegExp::escape(model->name()))))) {
+              QRegExp(QString("(^|[^a-zA-Z0-9_])fields\.%1($|[^a-zA-Z0-9_])").arg(QRegExp::escape(model->name()))))) {
           // qDebug() << "TemplateRegenerator" << mName << model->name();
           model->setTemplateRegenerator(true);
         }

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -203,7 +203,7 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
         // condition explanation: if (token contains modelName and not a Lua identifier containing modelName such as
         // "my_awesome_modelName")
         if (token->word().contains(
-              QRegExp(QString("(^|[^a-zA-Z0-9_])fields\.%1($|[^a-zA-Z0-9_])").arg(QRegExp::escape(model->name()))))) {
+              QRegExp(QString("(^|[^a-zA-Z0-9_])fields\\.%1($|[^a-zA-Z0-9_])").arg(QRegExp::escape(model->name()))))) {
           // qDebug() << "TemplateRegenerator" << mName << model->name();
           model->setTemplateRegenerator(true);
         }


### PR DESCRIPTION
Address  #1867: try to reduce the false positive detection of template regenerator fields.

An example are the deprecation field warnings where previously the new field "floorAppearance" was detected as regenerator just because used in the text message:
https://github.com/cyberbotics/webots/blob/323d9231584325b0da9106c2bea2f91a90199df7/projects/objects/floors/protos/RectangleArena.proto#L36-L38