### PR TITLE
Fix DEF not found on load for default PROTO parameter values

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,16 +7,17 @@ Released on XXX YYth, 2020.
     - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
-    - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
     - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).
     - Fixed the `roadBorderWidth` field of the [HelicoidalRoadSegment](../guide/object-road.md#helicoidalroadsegment) PROTO node ([#2099](https://github.com/cyberbotics/webots/pull/2099)).
     - Linux: Fixed the execution of robot controllers with firejail ([#2071](https://github.com/cyberbotics/webots/pull/2071)).
-    - Fixed field changes not applied in case of nested [PROTO](proto.md) nodes ([#2063](https://github.com/cyberbotics/webots/pull/2063)).
     - Fixed the `near` field of the `Robotino3Webcam` [Camera](camera.md) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed orientation of the [Lights](light.md) in the [`robotino3` world](../guide/robotino3.md#robotino3-wbt) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed missing `limit` element when exporting joints with the [`wb_robot_get_urdf`](robot.md#wb_robot_get_urdf) function ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - Fixed wrong color of the first log in the console ([#2088](https://github.com/cyberbotics/webots/pull/2088)).
     - **macOS: Removed the `ros` controller**, the [custom Python ROS controller](https://www.cyberbotics.com/doc/guide/using-ros#custom-ros-controller) should be used instead ([#2053](https://github.com/cyberbotics/webots/pull/2053)).
+    - Fixed DEF node not found if defined in PROTO default parameter value ([#2107](https://github.com/cyberbotics/webots/pull/2107)).
+    - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
+    - Fixed field changes not applied in case of nested [PROTO](proto.md) nodes ([#2063](https://github.com/cyberbotics/webots/pull/2063)).
     - Windows: Fixed generation of procedural PROTO nodes using the `gd` module ([#2070](https://github.com/cyberbotics/webots/pull/2070)).
 
 ## [Webots R2020b](../blog/Webots-2020-b-release.md)

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1442,8 +1442,23 @@ WbNode *WbNode::createProtoInstance(WbProtoModel *proto, WbTokenizer *tokenizer,
 
   // 2. create the parameters list from the model (default values)
   QVector<WbField *> parameters;
-  foreach (WbFieldModel *model, protoFieldModels)
-    parameters.append(new WbField(model, NULL));
+  QVector<QMap<QString, WbNode *>> parametersDefMap;
+  bool hasDefaultDefNodes = false;
+  foreach (WbFieldModel *model, protoFieldModels) {
+    WbField *defaultParameter = new WbField(model, NULL);
+    parameters.append(defaultParameter);
+
+    parametersDefMap.append(QMap<QString, WbNode *>());
+    if (tokenizer && WbNodeReader::current()) {
+      // extract DEF nodes defined in default PROTO parameter
+      QList<WbNode *> defNodes = subNodes(defaultParameter, true, false, false);
+      foreach (WbNode *node, defNodes) {
+        if (!node->defName().isEmpty())
+          parametersDefMap.last().insert(node->defName(), node);
+      }
+      hasDefaultDefNodes = hasDefaultDefNodes || !parametersDefMap.last().isEmpty();
+    }
+  }
 
   const bool previousParameterNodeFlag = gProtoParameterNodeFlag;
   gProtoParameterNodeFlag = true;
@@ -1453,6 +1468,9 @@ WbNode *WbNode::createProtoInstance(WbProtoModel *proto, WbTokenizer *tokenizer,
   if (tokenizer) {
     tokenizer->skipToken("{");
 
+    int nextParameterIndex = 0;
+    int currentParameterIndex = 0;
+    bool fieldOrderWarning = true;
     while (tokenizer->peekWord() != "}") {
       QString parameterName = tokenizer->nextWord();
       WbFieldModel *parameterModel = NULL;
@@ -1468,11 +1486,34 @@ WbNode *WbNode::createProtoInstance(WbProtoModel *proto, WbTokenizer *tokenizer,
         if (pos1 != -1 && pos2 != -1 && cHiddenParameterNames.indexOf(rx2.cap(0)) != -1)
           parameterModel = new WbFieldModel(tokenizer, worldPath);
       } else {
-        foreach (WbFieldModel *model, protoFieldModels) {
+        for (currentParameterIndex = 0; currentParameterIndex < protoFieldModels.size(); ++currentParameterIndex) {
+          WbFieldModel *model = protoFieldModels.at(currentParameterIndex);
           if (parameterName == model->name()) {
             parameterModel = model;
             break;
           }
+        }
+      }
+
+      if (hasDefaultDefNodes) {
+        if (currentParameterIndex < nextParameterIndex) {
+          // if the parameters are not listed using the order defined in the PROTO declaration the DEF map could be wrong
+          if (fieldOrderWarning) {
+            tokenizer->reportFileError(
+              tr("Wrong order of fields in the instance of PROTO %1: USE nodes might refer to the wrong DEF nodes")
+                .arg(proto->name()));
+            fieldOrderWarning = false;
+          }
+          // remove DEF nodes from default parameter if any
+          foreach (WbNode *defNode, parametersDefMap[currentParameterIndex])
+            WbNodeReader::current()->removeDefNode(defNode);
+        } else {
+          // add DEF nodes from default parameter defined before the current parameter
+          for (int i = nextParameterIndex; i < currentParameterIndex; ++i) {
+            foreach (WbNode *defNode, parametersDefMap[i])
+              WbNodeReader::current()->addDefNode(defNode);
+          }
+          nextParameterIndex = currentParameterIndex + 1;
         }
       }
 
@@ -1520,9 +1561,17 @@ WbNode *WbNode::createProtoInstance(WbProtoModel *proto, WbTokenizer *tokenizer,
         tokenizer->reportFileError(tr("Parameter %1 not supported in PROTO %2").arg(parameterName).arg(proto->name()));
     }
 
+    if (hasDefaultDefNodes) {
+      // add DEF nodes from the last default parameters
+      for (int i = nextParameterIndex; i < protoFieldModels.size(); ++i) {
+        foreach (WbNode *defNode, parametersDefMap[i])
+          WbNodeReader::current()->addDefNode(defNode);
+      }
+    }
     tokenizer->skipToken("}");
   }
 
+  parametersDefMap.clear();
   gProtoParameterNodeFlag = previousParameterNodeFlag;
   gDerivedProtoFlag = gDerivedProtoParentFlag;
   gDerivedProtoParentFlag = previousDerivedProtoFlag;
@@ -1834,24 +1883,29 @@ QList<WbNode *> WbNode::subNodes(bool recurse, bool searchInFields, bool searchI
   if (!searchInFields && !searchInParameters)
     fields += fieldsOrParameters();
 
-  QVector<WbField *>::iterator field;
-  for (field = fields.begin(); field != fields.end(); ++field) {
-    const WbValue *const value = (*field)->value();
-    const WbSFNode *const sfnode = dynamic_cast<const WbSFNode *>(value);
-    if (sfnode && sfnode->value()) {
-      WbNode *const node = sfnode->value();
-      result.append(node);
-      if (recurse)
-        result.append(node->subNodes(recurse, searchInFields, searchInParameters));
-    } else {
-      const WbMFNode *const mfnode = dynamic_cast<const WbMFNode *>(value);
-      if (mfnode) {
-        for (int i = 0; i < mfnode->size(); ++i) {
-          WbNode *const node = mfnode->item(i);
-          result.append(node);
-          if (recurse)
-            result.append(node->subNodes(recurse, searchInFields, searchInParameters));
-        }
+  QVector<WbField *>::iterator fieldIt;
+  for (fieldIt = fields.begin(); fieldIt != fields.end(); ++fieldIt)
+    result.append(subNodes((*fieldIt), recurse, searchInFields, searchInParameters));
+  return result;
+}
+
+QList<WbNode *> WbNode::subNodes(const WbField *field, bool recurse, bool searchInFields, bool searchInParameters) {
+  QList<WbNode *> result;
+  const WbValue *const value = field->value();
+  const WbSFNode *const sfnode = dynamic_cast<const WbSFNode *>(value);
+  if (sfnode && sfnode->value()) {
+    WbNode *const node = sfnode->value();
+    result.append(node);
+    if (recurse)
+      result.append(node->subNodes(recurse, searchInFields, searchInParameters));
+  } else {
+    const WbMFNode *const mfnode = dynamic_cast<const WbMFNode *>(value);
+    if (mfnode) {
+      for (int i = 0; i < mfnode->size(); ++i) {
+        WbNode *const node = mfnode->item(i);
+        result.append(node);
+        if (recurse)
+          result.append(node->subNodes(recurse, searchInFields, searchInParameters));
       }
     }
   }

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -109,6 +109,8 @@ public:
   // if both 'searchInFields' and 'searchInParameters' are false:
   //    search in parameters if proto node and in fields otherwise
   QList<WbNode *> subNodes(bool recurse, bool searchInFields = true, bool searchInParameters = false) const;
+  static QList<WbNode *> subNodes(const WbField *field, bool recurse, bool searchInFields = true,
+                                  bool searchInParameters = false);
 
   // names
   const QString &defName() const { return mDefName; }

--- a/src/webots/vrml/WbNodeReader.cpp
+++ b/src/webots/vrml/WbNodeReader.cpp
@@ -113,7 +113,7 @@ WbNode *WbNodeReader::readNode(WbTokenizer *tokenizer, const QString &worldPath)
     if (previousDefNode == mDefs.value(defName, NULL))
       // check if descendant nodes have the same DEF name
       // if it is the case, then we should not overwrite the value
-      mDefs.insert(defName, node);
+      addDefNode(node);
   }
 
   return node;
@@ -158,4 +158,9 @@ QList<WbNode *> WbNodeReader::readVrml(WbTokenizer *tokenizer, const QString &wo
 
 void WbNodeReader::addDefNode(WbNode *defNode) {
   mDefs.insert(defNode->defName(), defNode);
+}
+
+void WbNodeReader::removeDefNode(WbNode *defNode) {
+  if (mDefs.value(defNode->defName()) == defNode)
+    mDefs.remove(defNode->defName());
 }

--- a/src/webots/vrml/WbNodeReader.hpp
+++ b/src/webots/vrml/WbNodeReader.hpp
@@ -67,6 +67,8 @@ public:
 
   // Add DEF node that can be referenced by the read node
   void addDefNode(WbNode *defNode);
+  // Remove DEF node that becomes invalid
+  void removeDefNode(WbNode *defNode);
 
 public slots:
   void cancelReadNodes();

--- a/tests/parser/expected_results.txt
+++ b/tests/parser/expected_results.txt
@@ -16,6 +16,7 @@ parser/worlds/nested_def_name.wbt VOID
 parser/worlds/nested_proto_missing_ending_curly_bracket.wbt "Expected parameter name or '}', found end of file."
 parser/worlds/node_without_brackets.wbt "Expected '{', found 'RectangleArena'."
 parser/worlds/proto_concatenated_comment.wbt VOID
+parser/worlds/proto_default_def_parameter.wbt "Wrong order of fields in the instance of PROTO DefaultDef: USE nodes might refer to the wrong DEF nodes."
 parser/worlds/proto_mismatch_field_type.wbt "Type mismatch between 'fieldTexture' PROTO parameter and field 'url'."
 parser/worlds/proto_mismatch_file_name.wbt "ProtoMismatchFileName.proto': error: 'ProtoMismatchFileName2' PROTO identifier does not match filename."
 parser/worlds/proto_missing_ending_curly_bracket.wbt "Expected field name or '}', found end of file."

--- a/tests/parser/protos/DefaultDef.proto
+++ b/tests/parser/protos/DefaultDef.proto
@@ -1,0 +1,37 @@
+#VRML_SIM R2020b utf8
+
+PROTO DefaultDef [
+  field SFNode geom1 DEF BOX Box { size 0.1 0.1 0.1 }
+  field SFNode geom2 DEF SPHERE Sphere { radius 0.1 }
+  field SFNode geom3 NULL
+]
+{
+  Group {
+    children [
+      Transform {
+      translation 0.3 0 0
+        children [
+          Shape {
+            geometry IS geom1
+          }
+        ]
+      }
+      Transform {
+        translation 0.6 0 0
+        children [
+          Shape {
+            geometry IS geom2
+          }
+        ]
+      }
+      Transform {
+        translation 0.9 0 0
+        children [
+          Shape {
+            geometry IS geom3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/parser/worlds/proto_default_def_parameter.wbt
+++ b/tests/parser/worlds/proto_default_def_parameter.wbt
@@ -1,0 +1,35 @@
+#VRML_SIM R2020b utf8
+WorldInfo {
+}
+Viewpoint {
+  orientation 0.7470290283624516 0.646616024550071 0.15438700586161153 5.42889
+  position -1.4630600483703184 1.9830125885322203 2.3484348789299285
+}
+Background {
+  skyColor [
+    0.4 0.7 1
+  ]
+}
+Solid {
+  children [
+    DefaultDef {
+      # field order is wrong on purpose
+      geom3 Cylinder {
+        height 0.1
+        radius 0.05
+      }
+      geom1 DEF SPHERE Box {
+        size 0.1 0.1 0.1
+      }
+    }
+  ]
+  boundingObject USE SPHERE
+}
+DirectionalLight {
+  ambientIntensity 1
+  direction -0.33 -1 -0.5
+  castShadows TRUE
+}
+ParserTestSupervisor {
+  hidden translation_0 0.1 0 0.1
+}

--- a/tests/protos/controllers/proto_default_def_node/.gitignore
+++ b/tests/protos/controllers/proto_default_def_node/.gitignore
@@ -1,0 +1,1 @@
+/proto_default_def_node

--- a/tests/protos/controllers/proto_default_def_node/Makefile
+++ b/tests/protos/controllers/proto_default_def_node/Makefile
@@ -1,0 +1,25 @@
+# Copyright 1996-2020 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Webots Makefile system 
+#
+# You may add some variable definitions hereafter to customize the build process
+# See documentation in $(WEBOTS_HOME_PATH)/resources/Makefile.include
+
+
+# Do not modify the following: this includes Webots global Makefile.include
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/tests/protos/controllers/proto_default_def_node/proto_default_def_node.c
+++ b/tests/protos/controllers/proto_default_def_node/proto_default_def_node.c
@@ -1,0 +1,30 @@
+#include <webots/distance_sensor.h>
+#include <webots/robot.h>
+
+#include "../../../lib/ts_assertion.h"
+#include "../../../lib/ts_utils.h"
+
+#define TIME_STEP 32
+
+int main(int argc, char **argv) {
+  ts_setup(argv[0]);  // give the controller args
+
+  WbDeviceTag box_sensor = wb_robot_get_device("box sensor");
+  WbDeviceTag sphere_sensor = wb_robot_get_device("sphere sensor");
+
+  wb_distance_sensor_enable(box_sensor, TIME_STEP);
+  wb_distance_sensor_enable(sphere_sensor, TIME_STEP);
+
+  wb_robot_step(TIME_STEP);
+
+  // test default DEF BOX parameter is found at load
+  double value = wb_distance_sensor_get_value(box_sensor);
+  ts_assert_double_in_delta(value, 300.0, 0.1, "Default DEF node not found at load.");
+
+  // test DEF dictionary is correct at load even if the fields are stored in the wrong order
+  value = wb_distance_sensor_get_value(sphere_sensor);
+  ts_assert_double_in_delta(value, 300.0, 0.1, "USE SPHERE refers to wrong DEF node at load.");
+
+  ts_send_success();
+  return EXIT_SUCCESS;
+}

--- a/tests/protos/controllers/proto_default_def_node/proto_default_def_node.c
+++ b/tests/protos/controllers/proto_default_def_node/proto_default_def_node.c
@@ -10,20 +10,14 @@ int main(int argc, char **argv) {
   ts_setup(argv[0]);  // give the controller args
 
   WbDeviceTag box_sensor = wb_robot_get_device("box sensor");
-  WbDeviceTag sphere_sensor = wb_robot_get_device("sphere sensor");
 
   wb_distance_sensor_enable(box_sensor, TIME_STEP);
-  wb_distance_sensor_enable(sphere_sensor, TIME_STEP);
 
   wb_robot_step(TIME_STEP);
 
   // test default DEF BOX parameter is found at load
   double value = wb_distance_sensor_get_value(box_sensor);
   ts_assert_double_in_delta(value, 300.0, 0.1, "Default DEF node not found at load.");
-
-  // test DEF dictionary is correct at load even if the fields are stored in the wrong order
-  value = wb_distance_sensor_get_value(sphere_sensor);
-  ts_assert_double_in_delta(value, 300.0, 0.1, "USE SPHERE refers to wrong DEF node at load.");
 
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/protos/protos/DefaultDef.proto
+++ b/tests/protos/protos/DefaultDef.proto
@@ -3,8 +3,6 @@
 PROTO DefaultDef [
   field SFNode slot1 DEF BOX Shape { geometry Box { size 0.1 0.1 0.1 } }
   field SFNode slot2 NULL
-  field SFNode slot3 NULL
-  field SFNode slot4 NULL
 ]
 {
 Group {
@@ -21,7 +19,7 @@ Group {
       boundingObject IS slot1
     }
     Solid {
-      translation 0.2 0 0
+      translation 0.6 0 0
       children [
         Slot {
           endPoint Slot {
@@ -31,30 +29,6 @@ Group {
       ]
       name "solid 2"
       boundingObject IS slot2
-    }
-    Solid {
-      translation 0.4 0 0
-      children [
-        Slot {
-          endPoint Slot {
-            endPoint IS slot3
-          }
-        }
-      ]
-      name "solid 3"
-      boundingObject IS slot3
-    }
-    Solid {
-      translation 0.6 0 0
-      children [
-        Slot {
-          endPoint Slot {
-            endPoint IS slot4
-          }
-        }
-      ]
-      name "solid 4"
-      boundingObject IS slot4
     }
   ]
 }

--- a/tests/protos/protos/DefaultDef.proto
+++ b/tests/protos/protos/DefaultDef.proto
@@ -1,0 +1,61 @@
+#VRML_SIM R2020b utf8
+
+PROTO DefaultDef [
+  field SFNode slot1 DEF BOX Shape { geometry Box { size 0.1 0.1 0.1 } }
+  field SFNode slot2 NULL
+  field SFNode slot3 NULL
+  field SFNode slot4 NULL
+]
+{
+Group {
+  children [
+    Solid {
+      children [
+        Slot {
+          endPoint Slot {
+            endPoint IS slot1
+          }
+        }
+      ]
+      name "solid 1"
+      boundingObject IS slot1
+    }
+    Solid {
+      translation 0.2 0 0
+      children [
+        Slot {
+          endPoint Slot {
+            endPoint IS slot2
+          }
+        }
+      ]
+      name "solid 2"
+      boundingObject IS slot2
+    }
+    Solid {
+      translation 0.4 0 0
+      children [
+        Slot {
+          endPoint Slot {
+            endPoint IS slot3
+          }
+        }
+      ]
+      name "solid 3"
+      boundingObject IS slot3
+    }
+    Solid {
+      translation 0.6 0 0
+      children [
+        Slot {
+          endPoint Slot {
+            endPoint IS slot4
+          }
+        }
+      ]
+      name "solid 4"
+      boundingObject IS slot4
+    }
+  ]
+}
+}

--- a/tests/protos/worlds/proto_default_def_node.wbt
+++ b/tests/protos/worlds/proto_default_def_node.wbt
@@ -6,30 +6,11 @@ Viewpoint {
   position 0.24700875425257085 0.6417414696227373 1.8176426671149408
 }
 DefaultDef {
-  # the field order is wrong on purpose to test the DEF dictionary at load
-  slot3 DEF SPHERE Shape {
-    geometry Capsule {
-      height 0.2
-      radius 0.05
-      subdivision 16
-    }
-  }
-  slot2 DEF SPHERE Shape {
-    geometry Sphere {
-      radius 0.07
-    }
-  }
-  slot4 Group {
+  slot2 Group {
     children [
       Transform {
         children [
           USE BOX
-        ]
-      }
-      Transform {
-        translation 0 0.4 0
-        children [
-          USE SPHERE
         ]
       }
     ]
@@ -41,10 +22,6 @@ Robot {
   children [
     DistanceSensor {
       name "box sensor"
-    }
-    DistanceSensor {
-      translation 0 0.3 0
-      name "sphere sensor"
     }
     TestSuiteEmitter {
     }

--- a/tests/protos/worlds/proto_default_def_node.wbt
+++ b/tests/protos/worlds/proto_default_def_node.wbt
@@ -1,0 +1,55 @@
+#VRML_SIM R2020b utf8
+WorldInfo {
+}
+Viewpoint {
+  orientation -0.9836196728275075 -0.02459561612092397 0.17857041998701564 0.2782506603994355
+  position 0.24700875425257085 0.6417414696227373 1.8176426671149408
+}
+DefaultDef {
+  # the field order is wrong on purpose to test the DEF dictionary at load
+  slot3 DEF SPHERE Shape {
+    geometry Capsule {
+      height 0.2
+      radius 0.05
+      subdivision 16
+    }
+  }
+  slot2 DEF SPHERE Shape {
+    geometry Sphere {
+      radius 0.07
+    }
+  }
+  slot4 Group {
+    children [
+      Transform {
+        children [
+          USE BOX
+        ]
+      }
+      Transform {
+        translation 0 0.4 0
+        children [
+          USE SPHERE
+        ]
+      }
+    ]
+  }
+}
+Robot {
+  translation 0.6 0 0.08
+  rotation 0 1 0 1.5708
+  children [
+    DistanceSensor {
+      name "box sensor"
+    }
+    DistanceSensor {
+      translation 0 0.3 0
+      name "sphere sensor"
+    }
+    TestSuiteEmitter {
+    }
+  ]
+  controller "proto_default_def_node"
+}
+TestSuiteSupervisor {
+}


### PR DESCRIPTION
Fix #1231: 

* [x] add DEF nodes from default PROTO parameter values to the WbNodeReader DEF map if not overridden
* [x] print a warning about wrong field order if any default PROTO parameter value contains a DEF node
* [x] add a test in the test suite
* [x] update ChangeLog