### PR TITLE
Fix scaled matrix returned by wb_supervisor_node_get_orientation

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -8,6 +8,7 @@ Released on XXX YYth, 2020.
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
     - Remove scaling factor in matrix returned by `wb_supervisor_node_get_orientation` ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
+    - Fixed conversion of identity matrix to quaternion in ROS API ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
     - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).
     - Fixed the `roadBorderWidth` field of the [HelicoidalRoadSegment](../guide/object-road.md#helicoidalroadsegment) PROTO node ([#2099](https://github.com/cyberbotics/webots/pull/2099)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,6 +7,7 @@ Released on XXX YYth, 2020.
     - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
+    - Remove scaling factor in matrix returned by `wb_supervisor_node_get_orientation` ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
     - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).
     - Fixed the `roadBorderWidth` field of the [HelicoidalRoadSegment](../guide/object-road.md#helicoidalroadsegment) PROTO node ([#2099](https://github.com/cyberbotics/webots/pull/2099)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,7 +7,7 @@ Released on XXX YYth, 2020.
     - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
-    - Remove scaling factor in matrix returned by `wb_supervisor_node_get_orientation` ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
+    - Remove scaling factor in matrix returned by [`wb_supervisor_node_get_orientation`](supervisor.md#wb_supervisor_node_get_orientation) ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed conversion of identity matrix to quaternion in ROS API ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
     - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).

--- a/projects/default/controllers/ros/RosMathUtils.cpp
+++ b/projects/default/controllers/ros/RosMathUtils.cpp
@@ -17,9 +17,9 @@
 void RosMathUtils::matrixToQuaternion(const double *matrix, geometry_msgs::Quaternion &q) {
   if (matrix[0] == matrix[4] && matrix[0] == matrix[8] && matrix[0] == 1.0) {
     // exception
-    q.w = 0.0;
+    q.w = 1.0;
     q.x = 0.0;
-    q.y = 1.0;
+    q.y = 0.0;
     q.z = 0.0;
     return;
   }

--- a/src/webots/maths/WbMatrix4.cpp
+++ b/src/webots/maths/WbMatrix4.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "WbMatrix4.hpp"
+
 #include "WbMatrix3.hpp"
 #include "WbRotation.hpp"
 
@@ -349,10 +350,6 @@ void WbMatrix4::toOpenGlMatrix(double m[16]) const {
   m[13] = mM[7];
   m[14] = mM[11];
   m[15] = mM[15];
-}
-
-void WbMatrix4::extract3x3Matrix(WbMatrix3 &m) const {
-  m = WbMatrix3(mM[0], mM[1], mM[2], mM[4], mM[5], mM[6], mM[8], mM[9], mM[10]);
 }
 
 WbMatrix3 WbMatrix4::extracted3x3Matrix() const {

--- a/src/webots/maths/WbMatrix4.hpp
+++ b/src/webots/maths/WbMatrix4.hpp
@@ -112,8 +112,6 @@ public:
   void scale(double sx, double sy, double sz);
 
   // extracts the rotation submatrix
-  void extract3x3Matrix(WbMatrix3 &m) const;
-  void extract3x3Matrix(WbMatrix3 &m, double scale) const;
   WbMatrix3 extracted3x3Matrix() const;
   WbVector3 sub3x3MatrixDot(const WbVector3 &v) const;
 
@@ -219,7 +217,7 @@ inline void WbMatrix4::fromVrml(double tx, double ty, double tz, double rx, doub
   mM[12] = mM[13] = mM[14] = 0.0;
   mM[15] = 1.0;
 
-  // rotate ans scale (assuming the rotation vector is normalized)
+  // rotate and scale (assuming the rotation vector is normalized)
   mM[0] = (rx * rx * t1 + c) * sx;
   mM[1] = (t3 - rz * s) * sy;
   mM[2] = (t2 + ry * s) * sz;

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1309,6 +1309,7 @@ void WbSupervisorUtilities::writeNode(QDataStream &stream, const WbBaseNode *bas
     connect(baseNode, &WbNode::defUseNameChanged, this, &WbSupervisorUtilities::notifyNodeUpdate, Qt::UniqueConnection);
 }
 
+#include <QtCore/QDebug>
 void WbSupervisorUtilities::writeAnswer(QDataStream &stream) {
   if (!mUpdatedNodeIds.isEmpty()) {
     foreach (int id, mUpdatedNodeIds) {
@@ -1392,7 +1393,10 @@ void WbSupervisorUtilities::writeAnswer(QDataStream &stream) {
     mNodeGetPosition = NULL;
   }
   if (mNodeGetOrientation) {
-    const WbMatrix4 &m = mNodeGetOrientation->matrix();
+    WbMatrix4 m(mNodeGetOrientation->matrix());
+    // remove scale from matrix
+    const WbVector3 &s = m.scale();
+    m.scale(1.0 / s.x(), 1.0 / s.y(), 1.0 / s.z());
     stream << (short unsigned int)0;
     stream << (unsigned char)C_SUPERVISOR_NODE_GET_ORIENTATION;
     stream << (double)m(0, 0) << (double)m(0, 1) << (double)m(0, 2);

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1309,7 +1309,6 @@ void WbSupervisorUtilities::writeNode(QDataStream &stream, const WbBaseNode *bas
     connect(baseNode, &WbNode::defUseNameChanged, this, &WbSupervisorUtilities::notifyNodeUpdate, Qt::UniqueConnection);
 }
 
-#include <QtCore/QDebug>
 void WbSupervisorUtilities::writeAnswer(QDataStream &stream) {
   if (!mUpdatedNodeIds.isEmpty()) {
     foreach (int id, mUpdatedNodeIds) {

--- a/tests/api/controllers/supervisor_get_position_orientation/supervisor_get_position_orientation.c
+++ b/tests/api/controllers/supervisor_get_position_orientation/supervisor_get_position_orientation.c
@@ -30,6 +30,16 @@ int main(int argc, char **argv) {
   ts_assert_doubles_in_delta(9, orientation, ROTATION, 0.0001,
                              "wb_supervisor_node_get_orientation() did not return the expected values.");
 
+  // change node scale and check that `wb_supervisor_node_get_orientation` still returns the unscaled matrix
+  WbFieldRef scale_field = wb_supervisor_node_get_field(node, "scale");
+  const double new_scale[] = {2.0, 3.0, 4.0};
+  wb_supervisor_field_set_sf_vec3f(scale_field, new_scale);
+
+  wb_robot_step(TIME_STEP);
+
+  orientation = wb_supervisor_node_get_orientation(node);
+  ts_assert_doubles_in_delta(9, orientation, ROTATION, 0.0001,
+                             "wb_supervisor_node_get_orientation() did not return the expected values for scaled node.");
   ts_send_success();
   return EXIT_SUCCESS;
 }

--- a/tests/api/worlds/supervisor_get_position_orientation.wbt
+++ b/tests/api/worlds/supervisor_get_position_orientation.wbt
@@ -21,6 +21,7 @@ Robot {
     TestSuiteEmitter {
     }
   ]
+  name "supervisor"
   controller "supervisor_get_position_orientation"
   supervisor TRUE
 }


### PR DESCRIPTION
Fix #1993 and #1986: remove scaling factor from matrix returned by `wb_supervisor_node_get_orientation` and fix conversion from identity matrix to quaternion in `ros` default controller.

* [x] Fix returned matrix in `WbSupervisorUtilities.cpp`
* [x] Fix conversion from identity matrix to quaternion in `RosMathUtils.cpp`
* [x] Add entry in Change Log
* [x] Add test in test_suite
* [x] Check ROS API
* [x] Cleanup WbMatrix4 class and remove unused methods