### PR TITLE
Fixed selection of robots with closed loop

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -7,6 +7,7 @@ Released on XXX YYth, 2020.
     - Improved the `inverse_kinematics` controller to use the URDF definition instead of hard-coding the robot model ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - macOS: Add support for Python 3.7 and 3.8 installed with [Homebrew](https://brew.sh) ([#2079](https://github.com/cyberbotics/webots/pull/2079)).
   - Bug fixes
+    - Fixed crash occurring when selecting a [Robot](robot.md) with mechanical closed-loop ([#2117](https://github.com/cyberbotics/webots/pull/2117)).
     - Fixed crash occurring with some PROTO nodes when modifying fields from the scene tree that trigger the PROTO model regeneration ([#2100](https://github.com/cyberbotics/webots/pull/2100)).
     - Fixed bugs in streaming server protocol and added support for X3D/MJPEG mode selection in simulation server ([#2077](https://github.com/cyberbotics/webots/pull/2077)).
     - Fixed the `roadBorderWidth` field of the [HelicoidalRoadSegment](../guide/object-road.md#helicoidalroadsegment) PROTO node ([#2099](https://github.com/cyberbotics/webots/pull/2099)).

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -477,6 +477,8 @@ void WbBasicJoint::write(WbVrmlWriter &writer) const {
 }
 
 WbBoundingSphere *WbBasicJoint::boundingSphere() const {
+  if (solidReference())
+    return NULL;
   const WbSolid *const solid = solidEndPoint();
   if (solid)
     return solid->boundingSphere();

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -137,11 +137,10 @@ void WbBasicJoint::createOdeObjects() {
 }
 
 bool WbBasicJoint::setJoint() {
-  WbSolidReference *const r = solidReference();
-  if (r)
-    r->updateName();
+  WbSolidReference *const sr = solidReference();
+  if (sr)
+    sr->updateName();
   const WbSolid *const s = solidEndPoint();
-  const WbSolidReference *const sr = solidReference();
   const bool invalidEndPoint = s == NULL && (sr == NULL || !sr->pointsToStaticEnvironment());
   if (invalidEndPoint || upperSolid() == NULL || (s && s->physics() == NULL) || (s && s->solidMerger().isNull())) {
     if (mJoint) {

--- a/src/webots/plugins/WbPhysicsPlugin.cpp
+++ b/src/webots/plugins/WbPhysicsPlugin.cpp
@@ -246,9 +246,6 @@ const WbNode *WbPhysicsPlugin::findNodeByDef(const WbNode *node, const QString &
   const WbBasicJoint *const joint = dynamic_cast<const WbBasicJoint *>(node);
   if (joint) {
     const WbSolid *endPoint = joint->solidEndPoint();
-    if (!endPoint && joint->solidReference())
-      endPoint = joint->solidReference()->solid();
-
     if (endPoint) {
       const WbNode *const result = findNodeByDef(endPoint, def);
       if (result)


### PR DESCRIPTION
**Description**
Fix #1411: ignore solid references when computing the bounding sphere.
For the graphical functionalities it is fine if the bounding sphere doesn't include the referenced solid and for ray tracing is not a problem because the solid instance is included in a bounding sphere.
