### PR TITLE
Add minimum python version for test_worlds_warnings.py

### DIFF
--- a/tests/manual_tests/test_worlds_warnings.py
+++ b/tests/manual_tests/test_worlds_warnings.py
@@ -23,9 +23,7 @@ from threading import Timer
 from subprocess import Popen, PIPE
 
 if sys.version_info[0] != 3 or sys.version_info[1] < 7:
-    print("This script requires Python version 3.7")
-    sys.exit(1)
-
+    sys.exit('This script requires Python version 3.7')
 
 class TestWorldsWarnings(unittest.TestCase):
     """Unit test of the worlds."""

--- a/tests/manual_tests/test_worlds_warnings.py
+++ b/tests/manual_tests/test_worlds_warnings.py
@@ -25,6 +25,7 @@ from subprocess import Popen, PIPE
 if sys.version_info[0] != 3 or sys.version_info[1] < 7:
     sys.exit('This script requires Python version 3.7')
 
+
 class TestWorldsWarnings(unittest.TestCase):
     """Unit test of the worlds."""
 

--- a/tests/manual_tests/test_worlds_warnings.py
+++ b/tests/manual_tests/test_worlds_warnings.py
@@ -26,6 +26,7 @@ if sys.version_info[0] != 3 or sys.version_info[1] < 7:
     print("This script requires Python version 3.7")
     sys.exit(1)
 
+
 class TestWorldsWarnings(unittest.TestCase):
     """Unit test of the worlds."""
 

--- a/tests/manual_tests/test_worlds_warnings.py
+++ b/tests/manual_tests/test_worlds_warnings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 1996-2020 Cyberbotics Ltd.
 #
@@ -22,6 +22,9 @@ import sys
 from threading import Timer
 from subprocess import Popen, PIPE
 
+if sys.version_info[0] != 3 or sys.version_info[1] < 7:
+    print("This script requires Python version 3.7")
+    sys.exit(1)
 
 class TestWorldsWarnings(unittest.TestCase):
     """Unit test of the worlds."""


### PR DESCRIPTION
The current version of `test_worlds_warnings.py` only works with python >= 3.7.
There is no need to make it compatible with previous versions, but it is better to have a nice message explaining why it doesn't work.