### PR TITLE
Add comments to setup_viewer.js

### DIFF
--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -36,7 +36,7 @@ function connect() {
   // https://www.cyberbotics.com/doc/guide/web-simulation#how-to-embed-a-web-scene-in-your-website
   let playerDiv = document.getElementById('playerDiv');
   view = new webots.View(playerDiv, mobileDevice);
-  view.broadcast = true; // disable global changes to the simulation
+  view.broadcast = true; // disable controlling the simulation
   view.setTimeout(-1); // disable timeout that stops the simulation after a given time
   view.broadcast = true;
   let modeSelect = document.getElementById('mode');

--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -31,8 +31,13 @@ function init() {
 }
 
 function connect() {
+  // This `streaming viewer` setups a broadcast streaming where the simulation is shown but it is not possible to control it.
+  // For any other use, please refer to the documentation:
+  // https://www.cyberbotics.com/doc/guide/web-simulation#how-to-embed-a-web-scene-in-your-website
   let playerDiv = document.getElementById('playerDiv');
   view = new webots.View(playerDiv, mobileDevice);
+  view.broadcast = true; // disable global changes to the simulation
+  view.setTimeout(-1); // disable timeout that stops the simulation after a given time
   view.broadcast = true;
   let modeSelect = document.getElementById('mode');
   let streamingMode = modeSelect.options[modeSelect.selectedIndex].value;


### PR DESCRIPTION
Improve documentation of `setup_viewer.js` and explicitly unset the timeout so that the simulation is not automatically stopped when changing the broadcast value to false.