### PR TITLE
Fixed indentation of the URDF export.

### DIFF
--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -340,7 +340,6 @@ void WbSliderJoint::writeExport(WbVrmlWriter &writer) const {
                     .arg(m->maxVelocity());
       else
         writer << QString("<limit effort=\"%1\" velocity=\"%2\"/>\n").arg(m->maxForceOrTorque()).arg(m->maxVelocity());
-      writer.indent();
     }
     writer.decreaseIndent();
 


### PR DESCRIPTION
**Description**
Before:
```
  <joint name="left gripper sensor" type="prismatic">
    <parent link="solid_3865"/>
    <child link="left gripper"/>
    <axis xyz="0 1 0"/>
    <origin xyz="-0.042639 -0.007087 -0.00119" rpy="0 0 0"/>
    <limit effort="57.5" lower="-0.01" upper="0.012" velocity="0.2"/>
      </joint>
```
After:
```
  <joint name="left gripper sensor" type="prismatic">
    <parent link="solid_3865"/>
    <child link="left gripper"/>
    <axis xyz="0 1 0"/>
    <origin xyz="-0.042639 -0.007087 -0.00119" rpy="0 0 0"/>
    <limit effort="57.5" lower="-0.01" upper="0.012" velocity="0.2"/>
  </joint>
```