### PR TITLE
Fix robot-window not up to date.

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -13,6 +13,7 @@ Released on XXX YYth, 2020.
     - Fixed removing nodes from [Supervisor](supervisor.md) API's internal list after deleting the parent node ([#2123](https://github.com/cyberbotics/webots/pull/2123)).
     - Fixed various crashes and rendering issues occurring when opening an external rendering device window ([#2119](https://github.com/cyberbotics/webots/pull/2119)).
     - Fixed crash occurring when selecting a [Robot](robot.md) with mechanical closed-loop ([#2117](https://github.com/cyberbotics/webots/pull/2117)).
+    - Fixed various issues when an extern [Robot](robot.md) controller exits and then a new one connects to the same [Robot](robot.md) ([#2152](https://github.com/cyberbotics/webots/pull/2152)).
     - Remove scaling factor in matrix returned by [`wb_supervisor_node_get_orientation`](supervisor.md#wb_supervisor_node_get_orientation) ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed conversion of identity matrix to quaternion in ROS API ([#2112](https://github.com/cyberbotics/webots/pull/2112)).
     - Fixed header stamps of the topics published by the ros controller ([#2127](https://github.com/cyberbotics/webots/pull/2127)).

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -888,7 +888,7 @@ QString WbController::commandLine() const {  // returns the command line with do
 void WbController::handleControllerExit() {
   if (mRobot->controllerName() == "<extern>") {
     processFinished(0, QProcess::NormalExit);
-    mRobot->setControllerStarted(false);
+    mRobot->restartController();
   }
 }
 

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -888,7 +888,7 @@ QString WbController::commandLine() const {  // returns the command line with do
 void WbController::handleControllerExit() {
   if (mRobot->controllerName() == "<extern>") {
     processFinished(0, QProcess::NormalExit);
-    mRobot->restartController();
+    mRobot->setControllerNeedRestart();
   }
 }
 

--- a/tests/api/controllers/extern/extern.c
+++ b/tests/api/controllers/extern/extern.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <webots/robot.h>
+#include <webots/supervisor.h>
 #include "../../../lib/ts_assertion.h"
 #include "../../../lib/ts_utils.h"
 
@@ -40,6 +41,7 @@ int main(int argc, char **argv) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
 #endif
+    wb_robot_step(TIME_STEP);
     wb_robot_cleanup();
     return EXIT_SUCCESS;
   }
@@ -47,6 +49,10 @@ int main(int argc, char **argv) {
   ts_assert_int_equal(argc, 2, "Wrong number of arguments on the command line for starting extern controller.");
   ts_assert_string_equal(argv[1], "2", "Wrong argument for the extern controller: got \"%s\" instead of \"2\".");
   ts_assert_string_equal(wb_robot_get_name(), "extern1", "Extern controller connected to wrong robot.");
+  wb_robot_step(TIME_STEP);
+  // we need to disable synchronization otherwise this controller will block the simulation when exiting
+  WbFieldRef synchronization_field = wb_supervisor_node_get_field(wb_supervisor_node_get_self(), "synchronization");
+  wb_supervisor_field_set_sf_bool(synchronization_field, false);
   wb_robot_step(TIME_STEP);
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/worlds/extern.wbt
+++ b/tests/api/worlds/extern.wbt
@@ -32,6 +32,7 @@ Robot {
   ]
   name "extern1"
   controller "<extern>"
+  supervisor TRUE
 }
 Robot {
   name "launcher"


### PR DESCRIPTION
**Description**
When a extern controller is stopped and restarted the robot-window was not linked to the new controller.

**Related Issues**
This pull-request fixes issue #2080