### PR TITLE
Hide Indicator Motor in Vehicle Robot-Window

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -25,6 +25,7 @@ Released on XXX YYth, 2020.
     - Fixed the [`camera/recognition_objects`](camera.md#wb_camera_recognition_get_objects) ros topic not published when the [`camera/image`](camera.md#wb_camera_recognition_get_objects) topic has no subscriber ([#2115](https://github.com/cyberbotics/webots/pull/2115)).
     - Fixed the `near` field of the `Robotino3Webcam` [Camera](camera.md) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
     - Fixed orientation of the [Lights](light.md) in the [`robotino3` world](../guide/robotino3.md#robotino3-wbt) ([#2051](https://github.com/cyberbotics/webots/pull/2051)).
+    - Removed unwanted `indicator_lever_motor` motor displayed in the `automobile_window` robot-window ([#2162](https://github.com/cyberbotics/webots/pull/2162)).
     - Fixed missing `limit` element when exporting joints with the [`wb_robot_get_urdf`](robot.md#wb_robot_get_urdf) function ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - Fixed the `axis` element when exporting joints with the [`wb_robot_get_urdf`](robot.md#wb_robot_get_urdf) function ([#2062](https://github.com/cyberbotics/webots/pull/2062)).
     - Fixed wrong color of the first log in the console ([#2088](https://github.com/cyberbotics/webots/pull/2088)).

--- a/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.cpp
+++ b/projects/vehicles/plugins/robot_windows/automobile_window/Viewer.cpp
@@ -51,6 +51,7 @@ QStringList hiddenDevices = (QStringList() << "left_steer"
                                            << "rear_pitch_mirror_frame_motor"
                                            << "steering_wheel_motor"
                                            << "speed_needle_motor"
+                                           << "indicator_lever_motor"
                                            << "rpm_needle_motor");
 
 Viewer::Viewer() : GenericWindow(hiddenDevices) {


### PR DESCRIPTION
**Description**
This motor is an internal motor and should not be displayed in the robot-window.
