### PR TITLE
Fix ros controller Makefile

### DIFF
--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -62,13 +62,13 @@ $(GENERATED_HEADERS): $(SERVICE_HEADERS) $(MESSAGE_HEADERS)
 
 include/messages/%.h: include/msg/%.msg include/templateHeader.h include/templateRequest.h include/templateResponse.h headersFromMSG.py headersGenerator.py
 	@echo "# generating message header" $(notdir $<)
-	$(SILENT)python headersFromMSG.py $<
+	$(SILENT)$(PYTHON_COMMAND) headersFromMSG.py $<
 	$(SILENT)mkdir -p include/messages
 	$(SILENT)cp include/webots_ros/$(basename $(notdir $<)).h include/messages/$(basename $(notdir $<)).h
 
 include/services/%.h: include/srv/%.srv include/templateHeader.h include/templateRequest.h include/templateResponse.h headersFromSRV.py headersGenerator.py
 	@echo "# generating service header" $(notdir $<)
-	$(SILENT)python headersFromSRV.py $<
+	$(SILENT)$(PYTHON_COMMAND) headersFromSRV.py $<
 	$(SILENT)mkdir -p include/services
 	$(SILENT)cp include/webots_ros/$(basename $(notdir $<)).h include/services/$(basename $(notdir $<)).h
 


### PR DESCRIPTION
Fix python command in `ros` controller Makefile in case `PYTHON_COMMAND` was set.
