### PR TITLE
Enforce check of ros controller in package

### DIFF
--- a/scripts/packaging/exist_in_projects_linux.txt
+++ b/scripts/packaging/exist_in_projects_linux.txt
@@ -1,0 +1,1 @@
+projects/default/controllers/ros/ros


### PR DESCRIPTION
**Description**
Currently the ros controller is missing from the snap package because ROS is not installed in the snap environment, this PR does not fix the issue, but makes sure that the ros controller is available in all the Linux packages.