### PR TITLE
Run Test in the Github Action Nightlies

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -62,7 +62,7 @@ jobs:
           distribution/*.deb
   test-suite:
     needs: build
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || github.event_name == 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
@@ -90,7 +90,7 @@ jobs:
         xvfb-run --auto-servernum python tests/test_suite.py
   world-update:
     needs: build
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test world update') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test world update') || github.event_name == 'schedule' }}
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It is good to make sure that these tests are run at least once per day (unlike on Travis, the nightly build will be released even if the test fails like on AppVeyor).