### PR TITLE
Fix date in About box

### DIFF
--- a/src/webots/gui/WbAboutBox.cpp
+++ b/src/webots/gui/WbAboutBox.cpp
@@ -44,7 +44,7 @@ WbAboutBox::WbAboutBox(QWidget *parent) : QDialog(parent) {
                                "href='https://www.apache.org/licenses/LICENSE-2.0'>Apache License, Version 2.0</a></p>"
                                "<p>© Cyberbotics 1998-%3</p>")
                          .arg(WbApplicationInfo::version().toString())
-                         .arg(releaseTimestamp.date().toString(Qt::SystemLocaleShortDate))
+                         .arg(releaseTimestamp.date().toString("MMMM dd, yyyy"))
                          .arg(QDate::currentDate().year()));
   firstRowLayout->addWidget(versionInfo, 0, 1, 1, 2, Qt::AlignCenter);
 


### PR DESCRIPTION
**Description**
With some locale settings, the date is not displayed correctly (see https://github.com/cyberbotics/webots/pull/2223#issuecomment-693992002).
To avoid this kind of issues, the format is now hard coded in the format `MMMM dd, yyyy` (i.e. `September 17, 2020`).

![date](https://user-images.githubusercontent.com/5910449/93437197-fb83f480-f8cb-11ea-9465-d36b8aeaf4cc.png)
