### PR TITLE
Improve streaming viewer and add web simulation quick start

### DIFF
--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -79,6 +79,7 @@ cd $WEBOTS_HOME/resources/web/server
 ```
 
 Further in the document, you will find more details on how to start multiple simulation servers, how to monitor servers, how to rewrite the ports, and more.
+
 #### Protocol
 
 When a web client needs to know whether it may start a simulation, it will open a WebSocket connection to the session server to monitor the availability of simulation servers.

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -41,7 +41,7 @@ Note that Webots have to be installed on all the machines where a simulation ser
 
 
 #### Quick Start
-This section gives a simple step by step guide on how to start a streaming server with one session and one simulation server.
+This section gives a simple step-by-step guide on how to start a streaming server with one session and one simulation server.
 We assume you use Ubuntu 18.04 or newer.
 
 First, you need to install dependencies:

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -57,14 +57,7 @@ cd $WEBOTS_HOME/resources/web/server
 The session server keeps a track of the available simulation servers and assigns a connection to the most suitable simulation server (similar to a load balancer). 
 A task of the simulation server is to start a Webots instance with the correct world.
 
-To run the user interface you need a web server:
-```bash
-cd $WEBOTS_HOME/resources/web
-python3 -m http.server 8080
-```
-
-Now, you can access the simulation at [http://localhost:8080/streaming\_viewer/](http://localhost:8080/streaming\_viewer/).
-
+To show the user interface simply open the `$WEBOTS_HOME/resources/web/streaming_viewer/index.html` file in your browser.
 In the user interface, find a `Connect to` field, and type for example:
 ```
 ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -63,7 +63,7 @@ cd $WEBOTS_HOME/resources/web
 python3 -m http.server 8080
 ```
 
-Now, you can access the simulation at [http://localhost:8080/streaming_viewer/](http://localhost:8080/streaming\_viewer/).
+Now, you can access the simulation at [http://localhost:8080/streaming\_viewer/](http://localhost:8080/streaming\_viewer/).
 
 In the user interface, find a `Connect to` field, and type for example:
 ```

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -45,7 +45,7 @@ This section gives a simple step by step guide on how to start streaming server 
 
 First, you need to install dependencies:
 ```bash
-sudo apt install subversion firejail
+sudo apt install subversion firejail python3-tornado python3-pynvml
 ```
 
 Then, start a session and simulation servers:
@@ -53,7 +53,8 @@ Then, start a session and simulation servers:
 cd $WEBOTS_HOME/resources/web/server
 ./server.sh start default
 ```
-The session server keeps a track of the available simulation servers and assigns a connection to the most suitable simulation server (similar to a load balancer). A task of the simulation server is to start a Webots instance with a correct world.
+The session server keeps a track of the available simulation servers and assigns a connection to the most suitable simulation server (similar to a load balancer). 
+A task of the simulation server is to start a Webots instance with a correct world.
 
 To run the user interface you need a web server:
 ```bash
@@ -61,7 +62,7 @@ cd $WEBOTS_HOME/resources/web
 python3 -m http.server 8080
 ```
 
-Now, you can access the simulation at: [http://localhost:8080/](http://localhost:8080/)
+Now, you can access the simulation at [http://localhost:8080/streaming_viewer/](http://localhost:8080/streaming_viewer/).
 
 In `Connect to` field type for example:
 ```

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -41,7 +41,8 @@ Note that Webots have to be installed on all the machines where a simulation ser
 
 
 #### Quick Start
-This section gives a simple step by step guide on how to start streaming server with one session and one simulation server. We assume you use Ubuntu 18.04 or newer.
+This section gives a simple step by step guide on how to start a streaming server with one session and one simulation server.
+We assume you use Ubuntu 18.04 or newer.
 
 First, you need to install dependencies:
 ```bash
@@ -54,7 +55,7 @@ cd $WEBOTS_HOME/resources/web/server
 ./server.sh start default
 ```
 The session server keeps a track of the available simulation servers and assigns a connection to the most suitable simulation server (similar to a load balancer). 
-A task of the simulation server is to start a Webots instance with a correct world.
+A task of the simulation server is to start a Webots instance with the correct world.
 
 To run the user interface you need a web server:
 ```bash
@@ -64,7 +65,7 @@ python3 -m http.server 8080
 
 Now, you can access the simulation at [http://localhost:8080/streaming_viewer/](http://localhost:8080/streaming_viewer/).
 
-In `Connect to` field type for example:
+In the user interface, find a `Connect to` field, type for example:
 ```
 ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt
 ```
@@ -77,8 +78,7 @@ cd $WEBOTS_HOME/resources/web/server
 ./server.sh stop
 ```
 
-Further in the document, you will find more details on how to start multiple simulation servers, how to monitor servers, how to rewrite the ports and more.
-
+Further in the document, you will find more details on how to start multiple simulation servers, how to monitor servers, how to rewrite the ports, and more.
 #### Protocol
 
 When a web client needs to know whether it may start a simulation, it will open a WebSocket connection to the session server to monitor the availability of simulation servers.

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -39,6 +39,45 @@ Note that Webots have to be installed on all the machines where a simulation ser
 
 %end
 
+
+#### Quick Start
+This section gives a simple step by step guide on how to start streaming server with one session and one simulation server. We assume you use Ubuntu 18.04 or newer.
+
+First, you need to install dependencies:
+```bash
+sudo apt install subversion firejail
+```
+
+Then, start a session and simulation servers:
+```bash
+cd $WEBOTS_HOME/resources/web/server
+./server.sh start default
+```
+The session server keeps a track of the available simulation servers and assigns a connection to the most suitable simulation server (similar to a load balancer). A task of the simulation server is to start a Webots instance with a correct world.
+
+To run the user interface you need a web server:
+```bash
+cd $WEBOTS_HOME/resources/web
+python3 -m http.server 8080
+```
+
+Now, you can access the simulation at: [http://localhost:8080/](http://localhost:8080/)
+
+In `Connect to` field type for example:
+```
+ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt
+```
+and click `Connect`.
+Webots will clone the `example.wbt` simulation from GitHub and start it.
+
+If you want to stop the session and simulation servers run:
+```
+cd $WEBOTS_HOME/resources/web/server
+./server.sh stop
+```
+
+Further in the document, you will find more details on how to start multiple simulation servers, how to monitor servers, how to rewrite the ports and more.
+
 #### Protocol
 
 When a web client needs to know whether it may start a simulation, it will open a WebSocket connection to the session server to monitor the availability of simulation servers.

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -63,13 +63,13 @@ cd $WEBOTS_HOME/resources/web
 python3 -m http.server 8080
 ```
 
-Now, you can access the simulation at [http://localhost:8080/streaming_viewer/](http://localhost:8080/streaming_viewer/).
+Now, you can access the simulation at [http://localhost:8080/streaming_viewer/](http://localhost:8080/streaming\_viewer/).
 
-In the user interface, find a `Connect to` field, type for example:
+In the user interface, find a `Connect to` field, and type for example:
 ```
 ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt
 ```
-and click `Connect`.
+Click the `Connect` button to initiate the streaming.
 Webots will clone the `example.wbt` simulation from GitHub and start it.
 
 If you want to stop the session and simulation servers run:

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -14,7 +14,7 @@
     <header>
       <h1>Webots streaming viewer</h1>
 
-      <p> Connect to: <input id="IPInput" type="text" size="60" value="ws://localhost:1234/" />
+      <p> Connect to: <input id="IPInput" type="text" size="60" value="ws://localhost:1234" />
         mode:
         <select id="mode">
           <option value="x3d">X3D</option>

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -11,7 +11,7 @@
   </head>
 
   <body>
-    <div style="padding-left:10px;height:100px">
+    <header>
       <h1>Webots streaming viewer</h1>
 
       <p> Connect to: <input id="IPInput" type="text" size="60" value="ws://localhost:1234/" />
@@ -36,9 +36,8 @@
           </li>
         </ul>
       </details>
-    </div>
-    <div id="playerDiv" style="height:calc(100% - 120px)">
-    </div>
+    </header>
+    <div id="playerDiv"></div>
     <script src='https://code.jquery.com/jquery-3.1.1.min.js' integrity='sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=' crossorigin='anonymous'></script>
     <script src='https://code.jquery.com/ui/1.12.1/jquery-ui.min.js' integrity='sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=' crossorigin='anonymous'></script>
     <script src='https://cyberbotics.com/jquery-dialogextend/2.0.4/jquery.dialogextend.min.js'></script>

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -13,13 +13,29 @@
   <body>
     <div style="padding-left:10px;height:100px">
       <h1>Webots streaming viewer</h1>
-      <p> Connect to: <input id="IPInput" type="text" value="localhost" /> : <input id="PortInput" type="text" value="1234" maxlength="5" size="5" /> mode:
+
+      <p> Connect to: <input id="IPInput" type="text" size="60" value="ws://localhost:1234/" />
+        mode:
         <select id="mode">
           <option value="x3d">X3D</option>
           <option value="mjpeg">MJPEG</option>
         </select> broadcast: <input id="broadcast" type="checkbox" />
         <input id="ConnectButton" type="button" value="Connect" onclick="connect()" />
       </p>
+
+      <details>
+        <summary>URL formats</summary>
+        <ul>
+          <li>
+            Load world from GitHub (requires session server, <a href="https://cyberbotics.com/doc/guide/web-simulation#start-simulation-data-download-experimental" target="_blank">more</a>):<br />
+            <small>ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt</small>
+          </li>
+          <li>
+            Connect to already running Webots instance:<br />
+            <small>ws://localhost:1234/</small>
+          </li>
+        </ul>
+      </details>
     </div>
     <div id="playerDiv" style="height:calc(100% - 120px)">
     </div>

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -32,7 +32,7 @@
           </li>
           <li>
             Connect to already running Webots instance:<br />
-            <small>ws://localhost:1234/</small>
+            <small>ws://localhost:1234</small>
           </li>
         </ul>
       </details>

--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -24,7 +24,6 @@ if (mobileDevice) {
 
 function init() {
   ipInput = document.getElementById('IPInput');
-  portInput = document.getElementById('PortInput');
   connectButton = document.getElementById('ConnectButton');
   modeSelect = document.getElementById('mode');
   broadcast = document.getElementById('broadcast')
@@ -39,12 +38,11 @@ function connect() {
   view.broadcast = broadcast.checked;
   view.setTimeout(-1); // disable timeout that stops the simulation after a given time
   const streamingMode = modeSelect.options[modeSelect.selectedIndex].value;
-  view.open('ws://' + ipInput.value + ':' + portInput.value, streamingMode);
+  view.open(ipInput.value, streamingMode);
   view.onquit = disconnect;
   connectButton.value = 'Disconnect';
   connectButton.onclick = disconnect;
   ipInput.disabled = true;
-  portInput.disabled = true;
   modeSelect.disabled = true;
   broadcast.disabled = true;
 }
@@ -57,7 +55,6 @@ function disconnect() {
   connectButton.value = 'Connect';
   connectButton.onclick = connect;
   ipInput.disabled = false;
-  portInput.disabled = false;
   modeSelect.disabled = false;
   broadcast.disabled = false;
 }

--- a/resources/web/streaming_viewer/style.css
+++ b/resources/web/streaming_viewer/style.css
@@ -6,8 +6,13 @@ html, body {
   padding:0;
   height: 100%;
   overflow-y: hidden;
+  display: flex; 
+  flex-flow: column;
 }
+header {
+  padding: 0 10px 10px 10px;
+}
+
 #playerDiv {
-  height: calc(100% - 150px);
-  width: 100%;
+  flex: 1;
 }


### PR DESCRIPTION
**Description**
Documentation for web simulation is well written, but it is missing a good quick start guide. Also, the streaming viewer does not support URLs in the format: `ws://localhost:1999/session?url=webots://github.com/cyberbotics/webots/branch/develop/projects/languages/python/worlds/example.wbt`

**Tasks**
  - [x] Add quicks start to web simulation
  - [x] Allow the streaming viewer to accept URL that incorporate GitHub URLs
  - [x] Verify if something is broken

**Documentation**
https://cyberbotics.com/doc/guide/web-simulation?version=documentation-web-simulation-quick-start
