### PR TITLE
Fixed startup of extern controllers with WEBOTS_PID set

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,6 +4,7 @@
 Released on XXX YYY, 2020.
 
   - Bug fixes
+    - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).
     - Fixed re-initialization of external camera window if recognition is enabled ([#2196](https://github.com/cyberbotics/webots/pull/2196)).

--- a/src/Controller/api/system.c
+++ b/src/Controller/api/system.c
@@ -177,6 +177,7 @@ const char *wbu_system_webots_tmp_path() {
       struct dirent *entry;
       char folder_start[32];
       sprintf(folder_start, "webots-%d", webots_pid);
+      webots_pid = 0;
       while ((entry = readdir(dir))) {
         if (strncmp(entry->d_name, folder_start, strlen(folder_start)) == 0) {
           struct stat s;
@@ -185,7 +186,7 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (!S_ISDIR(s.st_mode))
             continue;
-          if (strlen(entry->d_name) > 64)
+          if (strlen(entry->d_name) > 70)
             continue;
           sscanf(entry->d_name, "webots-%d%63s", &webots_pid, random_part);
           break;

--- a/src/Controller/api/system.c
+++ b/src/Controller/api/system.c
@@ -162,7 +162,7 @@ const char *wbu_system_webots_tmp_path() {
             continue;
           if (s.st_mtime < most_recent)
             continue;
-          if (strlen(entry->d_name) > 64)
+          if (strlen(entry->d_name) > 70)
             continue;
           sscanf(entry->d_name, "webots-%d%63s", &webots_pid, random_part);
           most_recent = s.st_mtime;

--- a/src/Controller/api/system.c
+++ b/src/Controller/api/system.c
@@ -177,7 +177,7 @@ const char *wbu_system_webots_tmp_path() {
       struct dirent *entry;
       char folder_start[32];
       sprintf(folder_start, "webots-%d", webots_pid);
-      // reset webots_pid containing the webots script process id before retrieving the webots binary id
+      // reset webots_pid containing the webots script process id to be able to test if the corresponding directory was actually found
       webots_pid = 0;
       while ((entry = readdir(dir))) {
         if (strncmp(entry->d_name, folder_start, strlen(folder_start)) == 0) {

--- a/src/Controller/api/system.c
+++ b/src/Controller/api/system.c
@@ -177,6 +177,7 @@ const char *wbu_system_webots_tmp_path() {
       struct dirent *entry;
       char folder_start[32];
       sprintf(folder_start, "webots-%d", webots_pid);
+      // reset webots_pid containing the webots script process id before retrieving the webots binary id
       webots_pid = 0;
       while ((entry = readdir(dir))) {
         if (strncmp(entry->d_name, folder_start, strlen(folder_start)) == 0) {

--- a/src/Controller/api/system.c
+++ b/src/Controller/api/system.c
@@ -177,7 +177,8 @@ const char *wbu_system_webots_tmp_path() {
       struct dirent *entry;
       char folder_start[32];
       sprintf(folder_start, "webots-%d", webots_pid);
-      // reset webots_pid containing the webots script process id to be able to test if the corresponding directory was actually found
+      // reset webots_pid containing the webots script process id to be able to test if the corresponding directory was actually
+      // found
       webots_pid = 0;
       while ((entry = readdir(dir))) {
         if (strncmp(entry->d_name, folder_start, strlen(folder_start)) == 0) {


### PR DESCRIPTION
Fixed synchronization bug when starting an extern controller while specifying the `WEBOTS_PID` environment variable.