### PR TITLE
Fixed Ctrl key keyboard interface on macOS

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,6 +4,7 @@
 Released on XXX YYY, 2020.
 
   - Bug fixes
+    - Fixed handling of <kbd>Ctrl</kbd> key on mac OS from the keyboard API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,7 +4,7 @@
 Released on XXX YYY, 2020.
 
   - Bug fixes
-    - Fixed handling of <kbd>Ctrl</kbd> key on mac OS from the keyboard API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
+    - Fixed handling of <kbd>Ctrl</kbd> key on macOS from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -2174,7 +2174,7 @@ void WbView3D::keyPressEvent(QKeyEvent *event) {
   const int key = event->key();
   if (key != Qt::Key_Control && key != Qt::Key_Meta && key != Qt::Key_Shift && key != Qt::Key_Alt) {
     foreach (WbRobot *robot, robotList)
-      robot->keyPressed(event->text(), key, modifiers);
+      robot->keyPressed(key, modifiers);
   }
   handleModifierKey(event, true);
   QWindow::keyPressEvent(event);
@@ -2193,8 +2193,11 @@ void WbView3D::keyReleaseEvent(QKeyEvent *event) {
     else
       robotList = mWorld->robots();
 
-    foreach (WbRobot *const robot, robotList)
-      robot->keyReleased(event->text(), event->key());
+    const int key = event->key();
+    if (key != Qt::Key_Control && key != Qt::Key_Meta && key != Qt::Key_Shift && key != Qt::Key_Alt) {
+      foreach (WbRobot *const robot, robotList)
+        robot->keyReleased(key);
+    }
   }
   handleModifierKey(event, false);
   QWindow::keyReleaseEvent(event);

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -2157,7 +2157,11 @@ void WbView3D::keyPressEvent(QKeyEvent *event) {
 
   // pass key event to robots if appropriate
   const int modifiers = (((event->modifiers() & Qt::SHIFT) == 0) ? 0 : WbRobot::mapSpecialKey(Qt::SHIFT)) +
+#ifdef __APPLE__
+                        (((event->modifiers() & Qt::META) == 0) ? 0 : WbRobot::mapSpecialKey(Qt::CTRL)) +
+#else
                         (((event->modifiers() & Qt::CTRL) == 0) ? 0 : WbRobot::mapSpecialKey(Qt::CTRL)) +
+#endif
                         (((event->modifiers() & Qt::ALT) == 0) ? 0 : WbRobot::mapSpecialKey(Qt::ALT));
 
   WbRobot *const currentRobot = getCurrentRobot();
@@ -2167,8 +2171,11 @@ void WbView3D::keyPressEvent(QKeyEvent *event) {
   else
     robotList = mWorld->robots();
 
-  foreach (WbRobot *robot, robotList)
-    robot->keyPressed(event->text(), event->key(), modifiers);
+  const int key = event->key();
+  if (key != Qt::Key_Control && key != Qt::Key_Meta && key != Qt::Key_Shift && key != Qt::Key_Alt) {
+    foreach (WbRobot *robot, robotList)
+      robot->keyPressed(event->text(), key, modifiers);
+  }
   handleModifierKey(event, true);
   QWindow::keyPressEvent(event);
 }

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -682,7 +682,7 @@ void WbRobot::powerOn(bool e) {
     device->powerOn(e);
 }
 
-void WbRobot::keyPressed(const QString &text, int key, int modifiers) {
+void WbRobot::keyPressed(int key, int modifiers) {
   const int pressedKeys = modifiers + (gSpecialKeys.contains(key) ? gSpecialKeys.value(key) : key & WB_KEYBOARD_KEY);
 
   if (pressedKeys && !mPressedKeys.contains(pressedKeys)) {
@@ -692,7 +692,7 @@ void WbRobot::keyPressed(const QString &text, int key, int modifiers) {
   }
 }
 
-void WbRobot::keyReleased(const QString &text, int key) {
+void WbRobot::keyReleased(int key) {
   bool reset = true;
   QMutableListIterator<int> it(mPressedKeys);
   while (it.hasNext()) {
@@ -701,12 +701,10 @@ void WbRobot::keyReleased(const QString &text, int key) {
       // remove all sequences containing the released special key
       it.remove();
       reset = false;
-    } else if (!text.isEmpty()) {
-      if ((i & 0xffff) == (key & 0xffff)) {
-        // remove all sequences containing the released key
-        it.remove();
-        reset = false;
-      }
+    } else if ((i & 0xffff) == (key & 0xffff)) {
+      // remove all sequences containing the released key
+      it.remove();
+      reset = false;
     }
   }
 

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -683,11 +683,7 @@ void WbRobot::powerOn(bool e) {
 }
 
 void WbRobot::keyPressed(const QString &text, int key, int modifiers) {
-  int pressedKeys = modifiers;
-
-  if (gSpecialKeys.contains(key))  // special key
-    pressedKeys += gSpecialKeys.value(key);
-  pressedKeys += key & WB_KEYBOARD_KEY;
+  const int pressedKeys = modifiers + (gSpecialKeys.contains(key) ? gSpecialKeys.value(key) : key & WB_KEYBOARD_KEY);
 
   if (pressedKeys && !mPressedKeys.contains(pressedKeys)) {
     mPressedKeys.prepend(pressedKeys);
@@ -1132,6 +1128,7 @@ void WbRobot::writeAnswer(QDataStream &stream) {
     stream << (short unsigned int)0;
     stream << (unsigned char)C_ROBOT_KEYBOARD_VALUE;
     stream << (unsigned char)mKeyboardLastValue.size();
+
     foreach (int key, mKeyboardLastValue)
       stream << (int)key;
 

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -685,18 +685,12 @@ void WbRobot::powerOn(bool e) {
 void WbRobot::keyPressed(const QString &text, int key, int modifiers) {
   int pressedKeys = modifiers;
 
-  if (gSpecialKeys.contains(key))
-    // special key
+  if (gSpecialKeys.contains(key))  // special key
     pressedKeys += gSpecialKeys.value(key);
-  else if (!text.isEmpty())
-    // normal key
-    pressedKeys += key & WB_KEYBOARD_KEY;
-  else
-    // unknown key
-    return;
+  pressedKeys += key & WB_KEYBOARD_KEY;
 
   if (pressedKeys && !mPressedKeys.contains(pressedKeys)) {
-    mPressedKeys.append(pressedKeys);
+    mPressedKeys.prepend(pressedKeys);
     mKeyboardHasChanged = true;
     emit keyboardChanged();
   }
@@ -1138,7 +1132,6 @@ void WbRobot::writeAnswer(QDataStream &stream) {
     stream << (short unsigned int)0;
     stream << (unsigned char)C_ROBOT_KEYBOARD_VALUE;
     stream << (unsigned char)mKeyboardLastValue.size();
-
     foreach (int key, mKeyboardLastValue)
       stream << (int)key;
 

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -117,8 +117,8 @@ public:
   double energyUploadSpeed() const;
 
   // handle key events
-  void keyPressed(const QString &text, int key, int modifiers);
-  void keyReleased(const QString &text, int key);
+  void keyPressed(int key, int modifiers);
+  void keyReleased(int key);
 
   // map qt special key to webots special key, return 0 if not found
   static int mapSpecialKey(int qtKey);


### PR DESCRIPTION
A user reported a bug on macOS: when pressing the <kbd>Ctrl</kbd> key in the 3D view together with another key, it was not taken into account by the keyboard API. This PR fixes that bug.