### PR TITLE
Compute Animation step update after Solid coordinates have been updated

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -9,6 +9,8 @@ Released on XXX YYY, 2020.
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).
     - Fixed re-initialization of external camera window if recognition is enabled ([#2196](https://github.com/cyberbotics/webots/pull/2196)).
+    - Fixed precision of devices using rays ([Camera](camera.md), [DistanceSensor](distancesensor.md), [Radar](radar.md), and [Receiver](receiver.md)) located on articulated robots' parts ([#2266](https://github.com/cyberbotics/webots/pull/2266)).
+    - Fixed position lags of articulated robots' parts in recorded [animations](../guide/web-animation.md) ([#2266](https://github.com/cyberbotics/webots/pull/2266)).
     - Fixed the `inverse_kinematics` controller ([#2211](https://github.com/cyberbotics/webots/pull/2211)).
     - Fixed exported URDF axis when the [Joint](joint.md) anchor is not equal to the [Solid](solid.md) endpoint translation ([#2212](https://github.com/cyberbotics/webots/pull/2212)).
 

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -229,11 +229,11 @@ void WbSimulationWorld::step() {
   if (mPhysicsPlugin)
     mPhysicsPlugin->stepEnd();
 
-  emit physicsStepEnded();
-
   // call postPhysicsStep on all Solids to assign new coordinates
   foreach (WbSolid *const solid, l)
     solid->postPhysicsStep();
+
+  emit physicsStepEnded();
 
   WbSimulationState::instance()->increaseTime(timeStep);
   viewpoint()->updateFollowUp();

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -417,7 +417,7 @@ void WbCamera::reset() {
 }
 
 void WbCamera::updateRaysSetupIfNeeded() {
-  updateTransformAfterPhysicsStep();
+  updateTransformForPhysicsStep();
 
   // compute the camera position and rotation
   const WbVector3 cameraPosition = matrix().translation();
@@ -428,7 +428,7 @@ void WbCamera::updateRaysSetupIfNeeded() {
   WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(cameraPosition, cameraRotation, verticalFieldOfView,
                                                                          horizontalFieldOfView, recognition()->maxRange());
   foreach (WbRecognizedObject *recognizedObject, mRecognizedObjects) {
-    recognizedObject->object()->updateTransformAfterPhysicsStep();
+    recognizedObject->object()->updateTransformForPhysicsStep();
     bool valid =
       recognizedObject->recomputeRayDirection(this, cameraPosition, cameraRotation, cameraInverseRotation, frustumPlanes);
     if (valid)

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -451,7 +451,7 @@ void WbDistanceSensor::setSensorRays() {
 }
 
 void WbDistanceSensor::updateRaysSetupIfNeeded() {
-  updateTransformAfterPhysicsStep();
+  updateTransformForPhysicsStep();
   setSensorRays();
 }
 

--- a/src/webots/nodes/WbLightSensor.cpp
+++ b/src/webots/nodes/WbLightSensor.cpp
@@ -252,7 +252,7 @@ void WbLightSensor::prePhysicsStep(double ms) {
 }
 
 void WbLightSensor::updateRaysSetupIfNeeded() {
-  updateTransformAfterPhysicsStep();
+  updateTransformForPhysicsStep();
   foreach (LightRay *ray, mRayList)
     ray->recomputeRayDirection();
 }

--- a/src/webots/nodes/WbRadar.cpp
+++ b/src/webots/nodes/WbRadar.cpp
@@ -302,7 +302,7 @@ void WbRadar::postPhysicsStep() {
 }
 
 void WbRadar::updateRaysSetupIfNeeded() {
-  updateTransformAfterPhysicsStep();
+  updateTransformForPhysicsStep();
 
   // compute the radar position, rotation, axis and plane
   const WbVector3 radarPosition = matrix().translation();
@@ -313,7 +313,7 @@ void WbRadar::updateRaysSetupIfNeeded() {
   WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(radarPosition, radarRotation, verticalFieldOfView(),
                                                                          horizontalFieldOfView(), maxRange());
   foreach (WbRadarTarget *target, mRadarTargets) {
-    target->object()->updateTransformAfterPhysicsStep();
+    target->object()->updateTransformForPhysicsStep();
     bool valid = target->recomputeRayDirection(this, radarPosition, radarRotation, radarInverseRotation, frustumPlanes);
     if (valid)
       valid =

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -71,7 +71,7 @@ public:
   void recomputeRayDirection(const WbVector3 &receiverTranslation) {
     // compute ray direction and length
     WbEmitter *e = mPacket->emitter();
-    e->updateTransformAfterPhysicsStep();
+    e->updateTransformForPhysicsStep();
     const WbVector3 &te = e->matrix().translation();
     WbVector3 dir = receiverTranslation - te;
     dGeomRaySetLength(mGeom, dir.length());
@@ -242,7 +242,7 @@ void WbReceiver::prePhysicsStep(double ms) {
 }
 
 void WbReceiver::updateRaysSetupIfNeeded() {
-  updateTransformAfterPhysicsStep();
+  updateTransformForPhysicsStep();
   const WbVector3 position = matrix().translation();
   // update receiver position in pending packets
   foreach (Transmission *t, mTransmissionList)

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1948,17 +1948,27 @@ void WbSolid::updateTransformAfterPhysicsStep() {
 
   applyPhysicsTransform();
 
+  QList<WbSolid *> reversedList;
+  reversedList << this;
   WbSolid *s = NULL;
   WbNode *p = parentNode();
   while (p != NULL && !p->isWorldRoot()) {
     s = dynamic_cast<WbSolid *>(p);
     if (s != NULL) {
-      s->applyPhysicsTransform();
-      s->mUpdatedAfterStep = true;
+      if (s->mUpdatedAfterStep)
+        break;  // ancestor nodes already updated
+      reversedList.prepend(s);
     }
     p = p->parentNode();
   }
-  mUpdatedAfterStep = true;
+
+  // update transform from root to current node as applyPhysicsTransform uses the upper transform matrix
+  QListIterator<WbSolid *> it(reversedList);
+  while (it.hasNext()) {
+    WbSolid *s = it.next();
+    s->applyPhysicsTransform();
+    s->mUpdatedAfterStep = true;
+  }
 }
 
 void WbSolid::applyPhysicsTransform() {

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -104,7 +104,7 @@ void WbSolid::init() {
   mUseInertiaMatrix = false;
   mIsPermanentlyKinematic = false;
   mIsKinematic = false;
-  mUpdatedAfterStep = false;
+  mUpdatedInStep = false;
   mKinematicWarningPrinted = false;
   mHasDynamicSolidDescendant = false;
 
@@ -1942,8 +1942,8 @@ void WbSolid::applyToOdeScale() {
   resetJoints();
 }
 
-void WbSolid::updateTransformAfterPhysicsStep() {
-  if (mUpdatedAfterStep)
+void WbSolid::updateTransformForPhysicsStep() {
+  if (mUpdatedInStep)
     return;
 
   applyPhysicsTransform();
@@ -1955,7 +1955,7 @@ void WbSolid::updateTransformAfterPhysicsStep() {
   while (p != NULL && !p->isWorldRoot()) {
     s = dynamic_cast<WbSolid *>(p);
     if (s != NULL) {
-      if (s->mUpdatedAfterStep)
+      if (s->mUpdatedInStep)
         break;  // ancestor nodes already updated
       reversedList.prepend(s);
     }
@@ -1967,7 +1967,7 @@ void WbSolid::updateTransformAfterPhysicsStep() {
   while (it.hasNext()) {
     WbSolid *s = it.next();
     s->applyPhysicsTransform();
-    s->mUpdatedAfterStep = true;
+    s->mUpdatedInStep = true;
   }
 }
 
@@ -2090,7 +2090,7 @@ void WbSolid::prePhysicsStep(double ms) {
   for (i = 0; i < mPropellerChildren.size(); ++i)
     mPropellerChildren.at(i)->prePhysicsStep(ms);
 
-  mUpdatedAfterStep = false;
+  mUpdatedInStep = false;
 }
 
 ////////////

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1965,7 +1965,7 @@ void WbSolid::updateTransformForPhysicsStep() {
   // update transform from root to current node as applyPhysicsTransform uses the upper transform matrix
   QListIterator<WbSolid *> it(reversedList);
   while (it.hasNext()) {
-    WbSolid *s = it.next();
+    s = it.next();
     s->applyPhysicsTransform();
     s->mUpdatedInStep = true;
   }

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -198,9 +198,9 @@ public:
   // ODE positioning
   void resetJointsToLinkedSolids();  // reset joint to any linked solid to this one
 
-  // update the node tranform matrix based on the newly computed ODE transform matrix
+  // update the node transform matrix based on the newly computed ODE transform matrix
   // it loops through all the ancestor Solid nodes with a body and updates them
-  void updateTransformAfterPhysicsStep();
+  void updateTransformForPhysicsStep();
 
   // Density
   double volume() const;
@@ -338,7 +338,7 @@ private:
 
   // ODE
   dJointID mJoint;
-  bool mUpdatedAfterStep;
+  bool mUpdatedInStep;  // used to update Transform coordinated to setup ray collisions (based on pre-physics step values)
   void setGeomAndBodyPositions();
   void applyPhysicsTransform();
   void computePlaneParams(WbTransform *transform, WbVector3 &n, double &d) const;

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -77,7 +77,7 @@ void WbObjectDetection::setCollided(double depth) {
 bool WbObjectDetection::recomputeRayDirection(WbSolid *device, const WbVector3 &devicePosition, const WbMatrix3 &deviceRotation,
                                               const WbMatrix3 &deviceInverseRotation, const WbAffinePlane *frustumPlanes) {
   assert(mGeom);
-  mObject->updateTransformAfterPhysicsStep();
+  mObject->updateTransformForPhysicsStep();
   // recompute ray properties
   if (!computeObject(devicePosition, deviceRotation, deviceInverseRotation, frustumPlanes))
     return false;


### PR DESCRIPTION
**Description**
Fixes #2234: the animation recording system publishes the changes too early, before the Solid nodes translation and rotation field values are correctly updated.

This issue alone won't create so big position/rotation mismatches if it was not for the `WbSimulationCluster::step` that updates the Solid coordinates earlier (in the middle of the physics step) in order to update the DistanceSensor rays.
This should also be inspected, because the translation values computed when updating the rays are different from the ones at the end of the step and could lead to wrong detection.
Note that these intermediate coordinate values are not simply "one step old" values.

**Tasks**
* [x] store Animation step update after the Solid coordinates have been updated
* [x] check that all the other methods related to the `physicsStepEnd` signal still work even if called after updating the coordinates
* [x] check Solid coordinates values when updating of ODE rays
