### PR TITLE
Fixed movie recording when WorldInfo.basicTimeStep was greater than 40

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,7 +4,7 @@
 Released on XXX YYY, 2020.
 
   - Bug fixes
-    - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40.
+    - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40 ([#2268](https://github.com/cyberbotics/webots/pull/2268)).
     - Fixed handling of <kbd>Ctrl</kbd> key on macOS from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -4,6 +4,7 @@
 Released on XXX YYY, 2020.
 
   - Bug fixes
+    - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40.
     - Fixed handling of <kbd>Ctrl</kbd> key on macOS from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -131,7 +131,7 @@ WbVideoRecorder::~WbVideoRecorder() {
 bool WbVideoRecorder::initRecording(WbSimulationView *view, double basicTimeStep) {
   // show dialog to select parameters
   // compute maximum slow down with the current basicTimeStep
-  WbVideoRecorderDialog dialog(NULL, view->view3D()->size(), 1.0 / floor(EXPECTED_FRAME_STEP / basicTimeStep));
+  WbVideoRecorderDialog dialog(NULL, view->view3D()->size(), 1.0 / ceil(EXPECTED_FRAME_STEP / basicTimeStep));
   bool accept = dialog.exec();
   if (!accept) {
     // cancel button - reject
@@ -168,12 +168,12 @@ bool WbVideoRecorder::setMainWindowFullScreen(bool fullScreen) {
 }
 
 void WbVideoRecorder::estimateMovieInfo(double basicTimeStep) {
-  const int roundedBasicTimeStep = round(basicTimeStep);
-  const double refresh = mVideoAcceleration * EXPECTED_FRAME_STEP / (double)roundedBasicTimeStep;
+  const int ceilBasicTimeStep = ceil(basicTimeStep);
+  const double refresh = mVideoAcceleration * EXPECTED_FRAME_STEP / (double)ceilBasicTimeStep;
   const int floorRefresh = floor(refresh);
   const int ceilRefresh = ceil(refresh);
-  const int frameStep0 = floorRefresh * roundedBasicTimeStep;
-  const int frameStep1 = ceilRefresh * roundedBasicTimeStep;
+  const int frameStep0 = floorRefresh * ceilBasicTimeStep;
+  const int frameStep1 = ceilRefresh * ceilBasicTimeStep;
 
   if (frameStep0 == 0 || abs(frameStep0 - EXPECTED_FRAME_STEP) > abs(frameStep1 - EXPECTED_FRAME_STEP)) {
     mMovieFPS = mVideoAcceleration * 1000.0 / frameStep1;


### PR DESCRIPTION
This bug was reported by a Discord user:

> I'm trying to record video and I'm having  an issue. The video acceleration won't let me change it from inf. I then get an error when it tries to save. Unable to parse option value "inf" as video rate.

This actually happens if the `WorldInfo.basicTimeStep` value is greater than 40.