### PR TITLE
Fix optional rendering on reset

### DIFF
--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -480,7 +480,7 @@ bool WbDistanceSensor::refreshSensorIfNeeded() {
 
 void WbDistanceSensor::reset() {
   WbSolidDevice::reset();
-  wr_node_set_visible(WR_NODE(mTransform), false);
+  updateOptionalRendering(WbWrenRenderingContext::VF_DISTANCE_SENSORS_RAYS);
 }
 
 void WbDistanceSensor::computeValue() {


### PR DESCRIPTION
**Description**
DistanceSensor rays used to disappear after the simulation reset.

**Related Issues**
Fixes #2221