### PR TITLE
Fix missing function Anchor in doc

### DIFF
--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -599,6 +599,7 @@ If the specified device is not found, the function returns `NULL` in C++, `null`
 ---
 
 #### `wb_robot_get_device_by_index`
+#### `wb_robot_get_number_of_devices`
 
 %tab-component "language"
 


### PR DESCRIPTION
**Description**
Before: https://cyberbotics.com/doc/reference/robot?tab-language=c#wb_robot_get_device_by_index
After: https://cyberbotics.com/doc/reference/robot?tab-language=c&version=DavidMansolino-patch-2#wb_robot_get_device_by_index