### PR TITLE
Fix Motor Target Position when Changing Joint Parameter Position

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -18,6 +18,7 @@ Released on XXX YYY, 2020.
     - Fixed cylinder-to-cylinder collision detection in certain cases ([#2282](https://github.com/cyberbotics/webots/pull/2282)).
     - Fixed [Battery](robot.md#wb_robot_battery_sensor_enable) sensor when the [Robot](robot.md) contains a [Propeller](propeller.md) device ([#1801](https://github.com/cyberbotics/webots/pull/1801)).
     - Fixed [Motor](motor.md) target position not updated when changing the `position` field of a [JointParameters](jointparameters.md) node ([#2326](https://github.com/cyberbotics/webots/pull/2326)).
+    - Fixed [`wb_motor_get_target_position`](motor.md#wb_motor_get_target_position) function if the joint initial position is not 0 ([#2326](https://github.com/cyberbotics/webots/pull/2326)).
   - Dependency Updates
     - Upgraded to Qt 5.15.1 on Windows ([#2312](https://github.com/cyberbotics/webots/pull/2312)).
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -17,6 +17,7 @@ Released on XXX YYY, 2020.
     - Fixed disappearing [DistanceSensor](distancesensor.md) rays [optional rendering](https://cyberbotics.com/doc/guide/the-user-interface#view-menu) after simulation reset ([#2276](https://github.com/cyberbotics/webots/pull/2276)).
     - Fixed cylinder-to-cylinder collision detection in certain cases ([#2282](https://github.com/cyberbotics/webots/pull/2282)).
     - Fixed [Battery](robot.md#wb_robot_battery_sensor_enable) sensor when the [Robot](robot.md) contains a [Propeller](propeller.md) device ([#1801](https://github.com/cyberbotics/webots/pull/1801)).
+    - Fixed [Motor](motor.md) target position not updated when changing the `position` field of a [JointParameters](jointparameters.md) node ([#2326](https://github.com/cyberbotics/webots/pull/2326)).
   - Dependency Updates
     - Upgraded to Qt 5.15.1 on Windows ([#2312](https://github.com/cyberbotics/webots/pull/2312)).
 

--- a/src/Controller/api/motor.c
+++ b/src/Controller/api/motor.c
@@ -173,6 +173,7 @@ static void motor_read_answer(WbDevice *d, WbRequest *r) {
       m->control_p = m->previous_control_p;
       m->control_i = m->previous_control_i;
       m->control_d = m->previous_control_d;
+      m->position = request_read_double(r);
       m->configured = true;
       break;
     case C_MOTOR_FEEDBACK:

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -235,14 +235,12 @@ void WbBallJoint::updatePositions(double position, double position2, double posi
   mPosition = position;
   mPosition2 = position2;
   mPosition3 = position3;
-  if (!motor()->isConfigureDone()) {
-    if (motor())
-      motor()->setTargetPosition(position);
-    if (motor2())
-      motor2()->setTargetPosition(position2);
-    if (motor3())
-      motor3()->setTargetPosition(position3);
-  }
+  if (motor() && !motor()->isConfigureDone())
+    motor()->setTargetPosition(position);
+  if (motor2() && !motor2()->isConfigureDone())
+    motor2()->setTargetPosition(position2);
+  if (motor3() && !motor3()->isConfigureDone())
+    motor3()->setTargetPosition(position3);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -233,8 +233,14 @@ void WbBallJoint::updatePositions(double position, double position2, double posi
   assert(s);
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
+  if (motor())
+    motor()->setTargetPosition(position);
   mPosition2 = position2;
+  if (motor2())
+    motor2()->setTargetPosition(position2);
   mPosition3 = position3;
+  if (motor3())
+    motor3()->setTargetPosition(position3);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -233,14 +233,16 @@ void WbBallJoint::updatePositions(double position, double position2, double posi
   assert(s);
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
-  if (motor())
-    motor()->setTargetPosition(position);
   mPosition2 = position2;
-  if (motor2())
-    motor2()->setTargetPosition(position2);
   mPosition3 = position3;
-  if (motor3())
-    motor3()->setTargetPosition(position3);
+  if (!motor()->isConfigureDone()) {
+    if (motor())
+      motor()->setTargetPosition(position);
+    if (motor2())
+      motor2()->setTargetPosition(position2);
+    if (motor3())
+      motor3()->setTargetPosition(position3);
+  }
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -548,7 +548,11 @@ void WbHinge2Joint::updatePositions(double position, double position2) {
   assert(s);
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
+  if (motor())
+    motor()->setTargetPosition(position);
   mPosition2 = position2;
+  if (motor2())
+    motor2()->setTargetPosition(position2);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -548,11 +548,13 @@ void WbHinge2Joint::updatePositions(double position, double position2) {
   assert(s);
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
-  if (motor())
-    motor()->setTargetPosition(position);
   mPosition2 = position2;
-  if (motor2())
-    motor2()->setTargetPosition(position2);
+  if (!motor()->isConfigureDone()) {
+    if (motor())
+      motor()->setTargetPosition(position);
+    if (motor2())
+      motor2()->setTargetPosition(position2);
+  }
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -549,12 +549,10 @@ void WbHinge2Joint::updatePositions(double position, double position2) {
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
   mPosition2 = position2;
-  if (!motor()->isConfigureDone()) {
-    if (motor())
-      motor()->setTargetPosition(position);
-    if (motor2())
-      motor2()->setTargetPosition(position2);
-  }
+  if (motor() && !motor()->isConfigureDone())
+    motor()->setTargetPosition(position);
+  if (motor2() && !motor2()->isConfigureDone())
+    motor2()->setTargetPosition(position2);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHingeJoint.cpp
+++ b/src/webots/nodes/WbHingeJoint.cpp
@@ -360,6 +360,8 @@ void WbHingeJoint::updatePosition(double position) {
   assert(s);
   // called after an artificial move
   mPosition = position;
+  if (motor())
+    motor()->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHingeJoint.cpp
+++ b/src/webots/nodes/WbHingeJoint.cpp
@@ -360,7 +360,7 @@ void WbHingeJoint::updatePosition(double position) {
   assert(s);
   // called after an artificial move
   mPosition = position;
-  if (motor())
+  if (motor() && !motor()->isConfigureDone())
     motor()->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -358,6 +358,7 @@ void WbMotor::addConfigureToStream(QDataStream &stream) {
   stream << (double)mControlPID->value().x();
   stream << (double)mControlPID->value().y();
   stream << (double)mControlPID->value().z();
+  stream << (double)mTargetPosition;
   mNeedToConfigure = false;
 }
 

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -338,6 +338,10 @@ void WbMotor::powerOn(bool e) {  // called when running out of energy with e=fal
     mMotorForceOrTorque = mMaxForceOrTorque->value();
 }
 
+bool WbMotor::isConfigureDone() const {
+  return robot()->isConfigureDone();
+}
+
 /////////////
 // Control //
 /////////////

--- a/src/webots/nodes/WbMotor.hpp
+++ b/src/webots/nodes/WbMotor.hpp
@@ -58,6 +58,7 @@ public:
   void powerOn(bool) override;
 
   bool isPIDPositionControl() const { return (!mUserControl && mMotorForceOrTorque != 0.0 && !std::isinf(mTargetPosition)); }
+  bool isConfigureDone() const;
 
   bool hasMuscles() const { return !mMuscles->isEmpty(); }
 

--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -123,6 +123,8 @@ void WbSliderJoint::updatePosition(double position) {
   assert(s);
   // called after a special artificial move, i.e. a statically based robot was moved
   mPosition = position;
+  if (motor())
+    motor()->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -123,7 +123,7 @@ void WbSliderJoint::updatePosition(double position) {
   assert(s);
   // called after a special artificial move, i.e. a statically based robot was moved
   mPosition = position;
-  if (motor())
+  if (motor() && !motor()->isConfigureDone())
     motor()->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;

--- a/tests/api/controllers/motor/motor.c
+++ b/tests/api/controllers/motor/motor.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
 
   const double target_position = wb_motor_get_target_position(motor);
   ts_assert_double_equal(target_position, max_position,
-                         "The target position value measured by the motor should be %g and not %g", M_PI_2, target_position);
+                         "The target position value measured by the motor should be %g and not %g", max_position, target_position);
   int i;
   for (i = 0; i < NUMBER_OF_STEPS; ++i)
     wb_robot_step(TIME_STEP);

--- a/tests/api/controllers/motor/motor.c
+++ b/tests/api/controllers/motor/motor.c
@@ -75,13 +75,13 @@ int main(int argc, char **argv) {
   wb_motor_enable_torque_feedback(motor, TIME_STEP);
   wb_motor_set_control_pid(motor, CONTROL_P, CONTROL_I, CONTROL_D);
   wb_motor_set_available_torque(motor, TORQUE);
-  wb_motor_set_position(motor, M_PI_2);
+  wb_motor_set_position(motor, 100);
 
   wb_robot_step(TIME_STEP);
 
   const double target_position = wb_motor_get_target_position(motor);
-  ts_assert_double_equal(target_position, M_PI_2, "The target position value measured by the motor should be %g and not %g",
-                         M_PI_2, target_position);
+  ts_assert_double_equal(target_position, max_position,
+                         "The target position value measured by the motor should be %g and not %g", M_PI_2, target_position);
   int i;
   for (i = 0; i < NUMBER_OF_STEPS; ++i)
     wb_robot_step(TIME_STEP);

--- a/tests/api/controllers/motor/motor.c
+++ b/tests/api/controllers/motor/motor.c
@@ -81,7 +81,8 @@ int main(int argc, char **argv) {
 
   const double target_position = wb_motor_get_target_position(motor);
   ts_assert_double_equal(target_position, max_position,
-                         "The target position value measured by the motor should be %g and not %g", max_position, target_position);
+                         "The target position value measured by the motor should be %g and not %g", max_position,
+                         target_position);
   int i;
   for (i = 0; i < NUMBER_OF_STEPS; ++i)
     wb_robot_step(TIME_STEP);


### PR DESCRIPTION
**Description**
Previously, when changing the 'position' field of a joint parameter, a save and revert was required to update the motor target position, otherwise when starting the simulation the motor was pushing the joint to the 0 position again.