### PR TITLE
Fix enabling Help item in context menu for Recognition node

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -17,6 +17,7 @@ Released on XXX YYY, 2020.
     - Fixed disappearing [DistanceSensor](distancesensor.md) rays [optional rendering](https://cyberbotics.com/doc/guide/the-user-interface#view-menu) after simulation reset ([#2276](https://github.com/cyberbotics/webots/pull/2276)).
     - Fixed cylinder-to-cylinder collision detection in certain cases ([#2282](https://github.com/cyberbotics/webots/pull/2282)).
     - Fixed [Battery](robot.md#wb_robot_battery_sensor_enable) sensor when the [Robot](robot.md) contains a [Propeller](propeller.md) device ([#1801](https://github.com/cyberbotics/webots/pull/1801)).
+    - Fixed disabled `Help..` item in context menu for some nodes ([#2327](https://github.com/cyberbotics/webots/pull/2327)).
   - Dependency Updates
     - Upgraded to Qt 5.15.1 on Windows ([#2312](https://github.com/cyberbotics/webots/pull/2312)).
 

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -20,7 +20,7 @@ Released on XXX YYY, 2020.
     - Fixed [Battery](robot.md#wb_robot_battery_sensor_enable) sensor when the [Robot](robot.md) contains a [Propeller](propeller.md) device ([#1801](https://github.com/cyberbotics/webots/pull/1801)).
     - Fixed [Motor](motor.md) target position not updated when changing the `position` field of a [JointParameters](jointparameters.md) node ([#2326](https://github.com/cyberbotics/webots/pull/2326)).
     - Fixed [`wb_motor_get_target_position`](motor.md#wb_motor_get_target_position) function if the joint initial position is not 0 ([#2326](https://github.com/cyberbotics/webots/pull/2326)).
-    - Fixed disabled `Help..` item in context menu for some nodes ([#2327](https://github.com/cyberbotics/webots/pull/2327)).
+    - Fixed the disabled `Help...` item in the context menu for some nodes ([#2327](https://github.com/cyberbotics/webots/pull/2327)).
   - Dependency Updates
     - Upgraded to Qt 5.15.1 on Windows ([#2312](https://github.com/cyberbotics/webots/pull/2312)).
 

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1119,8 +1119,9 @@ void WbSceneTree::updateSelection() {
       // baseNode = NULL if none or multiple instances exists
       baseNode = baseNode->getSingleFinalizedProtoInstance();
 
-    if (baseNode && !baseNode->areWrenObjectsInitialized())
+    if (baseNode && !(baseNode->areWrenObjectsInitialized() || baseNode->isPostFinalizedCalled()))
       // ignore not initialized nodes
+      // for nodes without WREN objects (e.g. Recognition) check if finalization is completed
       baseNode = NULL;
 
     // enable move viewpoint to object if the item has a corresponding bounding sphere

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1119,9 +1119,8 @@ void WbSceneTree::updateSelection() {
       // baseNode = NULL if none or multiple instances exists
       baseNode = baseNode->getSingleFinalizedProtoInstance();
 
-    if (baseNode && !(baseNode->areWrenObjectsInitialized() || baseNode->isPostFinalizedCalled()))
+    if (baseNode && !baseNode->isPostFinalizedCalled())
       // ignore not initialized nodes
-      // for nodes without WREN objects (e.g. Recognition) check if finalization is completed
       baseNode = NULL;
 
     // enable move viewpoint to object if the item has a corresponding bounding sphere


### PR DESCRIPTION
Currently the `Help..` item is disabled in the context menu when a Recognition node is selected.

All the other nodes without WREN objects have the same issue: ContactProperties, Focus, Zoom, etc.