### PR TITLE
Fixed Webots Windows launcher to escape properly spaces in arguments

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -16,6 +16,7 @@ Released on XXX YYY, 2020.
     - Fixed exported URDF axis when the [Joint](joint.md) anchor is not equal to the [Solid](solid.md) endpoint translation ([#2212](https://github.com/cyberbotics/webots/pull/2212)).
     - Fixed disappearing [DistanceSensor](distancesensor.md) rays [optional rendering](https://cyberbotics.com/doc/guide/the-user-interface#view-menu) after simulation reset ([#2276](https://github.com/cyberbotics/webots/pull/2276)).
     - Fixed cylinder-to-cylinder collision detection in certain cases ([#2282](https://github.com/cyberbotics/webots/pull/2282)).
+    - Windows: Fixed parsing of arguments with spaces when starting Webots from a DOS console ([#2330](https://github.com/cyberbotics/webots/pull/2330)).
   - Dependency Updates
     - Upgraded to Qt 5.15.1 on Windows ([#2312](https://github.com/cyberbotics/webots/pull/2312)).
 

--- a/src/webots/launcher/launcher.c
+++ b/src/webots/launcher/launcher.c
@@ -64,15 +64,18 @@ int main(int argc, char *argv[]) {
 #endif
   l = l0;
   for (int i = 1; i < argc; i++)
-    l += 1 + strlen(argv[i]);          // spaces between arguments
-  char *command_line = malloc(l + 5);  // room for the extra "-bin" string and final '\0'
-  command_line[0] = '\0';              // initially empty string
+    l += 3 + strlen(argv[i]);          // spaces and double quotes between arguments
+  char *command_line = malloc(l + 7);  // room for double quotes, the extra "-bin" string and final '\0'
+  command_line[0] = '\"';
+  command_line[1] = '\0';
   strcat(command_line, module_path);
-  command_line[l0 - 4] = '\0';  // cut out ".exe" after "webots" or "webotsw"
+  command_line[l0 - 3] = '\0';  // cut out ".exe" after "webots" or "webotsw"
   strcat(command_line, "-bin.exe");
+  strcat(command_line, "\"");
   for (int i = 1; i < argc; i++) {
-    strcat(command_line, " ");
+    strcat(command_line, " \"");
     strcat(command_line, argv[i]);
+    strcat(command_line, "\"");
   }
 
   // add "WEBOTS_HOME/msys64/mingw64/bin", "WEBOTS_HOME/msys64/mingw64/bin/cpp" and "WEBOTS_HOME/msys64/usr/bin" to the PATH


### PR DESCRIPTION
A user reported on Discord that he was unable to open a world file that includes spaces in the path when starting Webots from a Windows DOS console. He tried several things, including adding double quotes around the world path, but that didn't work. I found that adding 3 double quotes around the world path worked, but is quite odd:
```dos
C:\Users\Olivier>"C:\Program Files\Webots\msys64\mingw64\bin\webots.exe" """C:\Program Files\Webots\projects\samples\devices\worlds\camera.wbt"""
```
 This PR fixes the problem and makes that adding a single double quote around the path is sufficient, as it should be:
```dos
C:\Users\Olivier>"C:\Program Files\Webots\msys64\mingw64\bin\webots.exe" "C:\Program Files\Webots\projects\samples\devices\worlds\camera.wbt"
```