### PR TITLE
Update tests_sources.yml

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -3,6 +3,8 @@ name: Test Sources
 on: 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:


### PR DESCRIPTION
This will avoid starting the test source action when we modify only the documentation in a PR.