### PR TITLE
Attempt to fix new cppcheck issues.

### DIFF
--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -235,15 +235,15 @@ void WbBallJoint::updatePositions(double position, double position2, double posi
   mPosition = position;
   mPosition2 = position2;
   mPosition3 = position3;
-  WbMotor *motor1 = motor();
-  WbMotor *motor2 = motor2();
-  WbMotor *motor3 = motor3();
-  if (motor1 && !motor1->isConfigureDone())
-    motor1->setTargetPosition(position);
-  if (motor2 && !motor2->isConfigureDone())
-    motor2->setTargetPosition(position2);
-  if (motor3 && !motor3->isConfigureDone())
-    motor3->setTargetPosition(position3);
+  WbMotor *m1 = motor();
+  WbMotor *m2 = motor2();
+  WbMotor *m3 = motor3();
+  if (m1 && !m1->isConfigureDone())
+    m1->setTargetPosition(position);
+  if (m2 && !m2->isConfigureDone())
+    m2->setTargetPosition(position2);
+  if (m3 && !m3->isConfigureDone())
+    m3->setTargetPosition(position3);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -235,12 +235,15 @@ void WbBallJoint::updatePositions(double position, double position2, double posi
   mPosition = position;
   mPosition2 = position2;
   mPosition3 = position3;
-  if (motor() && !motor()->isConfigureDone())
-    motor()->setTargetPosition(position);
-  if (motor2() && !motor2()->isConfigureDone())
-    motor2()->setTargetPosition(position2);
-  if (motor3() && !motor3()->isConfigureDone())
-    motor3()->setTargetPosition(position3);
+  WbMotor *motor1 = motor();
+  WbMotor *motor2 = motor2();
+  WbMotor *motor3 = motor3();
+  if (motor1 && !motor1->isConfigureDone())
+    motor1->setTargetPosition(position);
+  if (motor2 && !motor2->isConfigureDone())
+    motor2->setTargetPosition(position2);
+  if (motor3 && !motor3->isConfigureDone())
+    motor3->setTargetPosition(position3);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -549,12 +549,12 @@ void WbHinge2Joint::updatePositions(double position, double position2) {
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
   mPosition2 = position2;
-  WbMotor *motor1 = motor();
-  WbMotor *motor2 = motor2();
-  if (motor1 && !motor1->isConfigureDone())
-    motor1->setTargetPosition(position);
-  if (motor2 && !motor2->isConfigureDone())
-    motor2->setTargetPosition(position2);
+  WbMotor *m1 = motor();
+  WbMotor *m2 = motor2();
+  if (m1 && !m1->isConfigureDone())
+    m1->setTargetPosition(position);
+  if (m2 && !m2->isConfigureDone())
+    m2->setTargetPosition(position2);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHinge2Joint.cpp
+++ b/src/webots/nodes/WbHinge2Joint.cpp
@@ -549,10 +549,12 @@ void WbHinge2Joint::updatePositions(double position, double position2) {
   // called after an artificial move (user or Supervisor move) or in kinematic mode
   mPosition = position;
   mPosition2 = position2;
-  if (motor() && !motor()->isConfigureDone())
-    motor()->setTargetPosition(position);
-  if (motor2() && !motor2()->isConfigureDone())
-    motor2()->setTargetPosition(position2);
+  WbMotor *motor1 = motor();
+  WbMotor *motor2 = motor2();
+  if (motor1 && !motor1->isConfigureDone())
+    motor1->setTargetPosition(position);
+  if (motor2 && !motor2->isConfigureDone())
+    motor2->setTargetPosition(position2);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbHingeJoint.cpp
+++ b/src/webots/nodes/WbHingeJoint.cpp
@@ -360,8 +360,9 @@ void WbHingeJoint::updatePosition(double position) {
   assert(s);
   // called after an artificial move
   mPosition = position;
-  if (motor() && !motor()->isConfigureDone())
-    motor()->setTargetPosition(position);
+  WbMotor *m = motor();
+  if (m && !m->isConfigureDone())
+    m->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);

--- a/src/webots/nodes/WbSliderJoint.cpp
+++ b/src/webots/nodes/WbSliderJoint.cpp
@@ -123,8 +123,9 @@ void WbSliderJoint::updatePosition(double position) {
   assert(s);
   // called after a special artificial move, i.e. a statically based robot was moved
   mPosition = position;
-  if (motor() && !motor()->isConfigureDone())
-    motor()->setTargetPosition(position);
+  WbMotor *m = motor();
+  if (m && !m->isConfigureDone())
+    m->setTargetPosition(position);
   WbVector3 translation;
   WbRotation rotation;
   computeEndPointSolidPositionFromParameters(translation, rotation);


### PR DESCRIPTION
**Description**
New cppcheck issues raised after merging #2326:
```
AssertionError: Cppcheck detected some errors:

src/webots/nodes/WbBallJoint.cpp:240:26: warning: Possible null pointer dereference: motor2() [nullPointer]
  if (motor2() && !motor2()->isConfigureDone())
                         ^
src/webots/nodes/WbBallJoint.cpp:241:11: warning: Possible null pointer dereference: motor2() [nullPointer]
    motor2()->setTargetPosition(position2);
          ^
src/webots/nodes/WbBallJoint.cpp:242:26: warning: Possible null pointer dereference: motor3() [nullPointer]
  if (motor3() && !motor3()->isConfigureDone())
                         ^
src/webots/nodes/WbBallJoint.cpp:243:11: warning: Possible null pointer dereference: motor3() [nullPointer]
    motor3()->setTargetPosition(position3);
          ^
src/webots/nodes/WbHinge2Joint.cpp:554:26: warning: Possible null pointer dereference: motor2() [nullPointer]
  if (motor2() && !motor2()->isConfigureDone())
                         ^
src/webots/nodes/WbHinge2Joint.cpp:555:11: warning: Possible null pointer dereference: motor2() [nullPointer]
    motor2()->setTargetPosition(position2);
          ^
```