### PR TITLE
Replace ros test

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -21,7 +21,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:
     needs: cleanup-runs
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test world update') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test world update') }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
@@ -88,6 +88,46 @@ jobs:
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
         export WEBOTS_HOME=$PWD/artifact/webots
         xvfb-run --auto-servernum python tests/test_suite.py
+  test-ros:
+    needs: build
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test ros') || github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+        include:
+          - os: ubuntu-18.04
+            ROS_DISTRO: melodic
+            python: 2.7
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+         submodules: true
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: build-${{ matrix.os }}
+        path: artifact
+    - name: Extract Webots
+      run: tar xjf artifact/webots-*-x86-64.tar.bz2 -C artifact
+    - name: Install Webots Dependencies
+      run: sudo scripts/install/linux_runtime_dependencies.sh
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Setup ROS ${{ matrix.ROS_DISTRO }} environment
+      uses: ros-tooling/setup-ros@0.0.25
+      with:
+        required-ros-distributions: ${{ matrix.ROS_DISTRO }}
+    - name: Run Test
+      run: |
+        export WEBOTS_HOME=$PWD/artifact/webots
+        export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+        python -m pip install rospkg catkin_pkg empy defusedxml netifaces
+        Xvfb :99 &
+        export DISPLAY=:99
+        ./tests/ros.sh
   world-update:
     needs: build
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test world update') || github.event_name == 'schedule' }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,6 @@ jobs:
         - make release -j2
         - make release -j2 -C tests
         - python tests/test_suite.py --no-ansi-escape --nomake
-        - ./tests/ros.sh
     - <<: *unit_tests_staging
       name: Ubuntu 18.04 / Python 3.8 / openjdk 11 / ROS melodic
       dist: bionic

--- a/tests/ros.sh
+++ b/tests/ros.sh
@@ -2,6 +2,7 @@
 
 echo @@@ Compile ros webots_ros package
 source /opt/ros/$ROS_DISTRO/setup.bash
+# BASEDIR might differ from WEBOTS_HOME if we are not using Webots compiled from this repository directory (e.g. in CI).
 BASEDIR=$(dirname $(realpath $0))/..
 [ -d $BASEDIR/webots_catkin_ws ] && rm -r $BASEDIR/webots_catkin_ws
 mkdir -p $BASEDIR/webots_catkin_ws/src

--- a/tests/ros.sh
+++ b/tests/ros.sh
@@ -2,13 +2,14 @@
 
 echo @@@ Compile ros webots_ros package
 source /opt/ros/$ROS_DISTRO/setup.bash
-[ -d $WEBOTS_HOME/webots_catkin_ws ] && rm -r $WEBOTS_HOME/webots_catkin_ws
-mkdir -p $WEBOTS_HOME/webots_catkin_ws/src
-cd $WEBOTS_HOME/webots_catkin_ws/src
+BASEDIR=$(dirname $(realpath $0))/..
+[ -d $BASEDIR/webots_catkin_ws ] && rm -r $BASEDIR/webots_catkin_ws
+mkdir -p $BASEDIR/webots_catkin_ws/src
+cd $BASEDIR/webots_catkin_ws/src
 catkin_init_workspace 2>&1 >> /dev/null
-cp -r $WEBOTS_HOME/resources/webots_ros webots_ros
-cp -r $WEBOTS_HOME/projects/robots/universal_robots/resources/ros_package/ur_e_webots ur_e_webots
-cd $WEBOTS_HOME/webots_catkin_ws
+cp -r $BASEDIR/resources/webots_ros webots_ros
+cp -r $BASEDIR/projects/robots/universal_robots/resources/ros_package/ur_e_webots ur_e_webots
+cd $BASEDIR/webots_catkin_ws
 echo @@@ Installing dependencies
 sudo rosdep init
 rosdep update
@@ -22,12 +23,12 @@ if grep -q 'Error' ros_compilation.log; then
   exit -1
 fi
 
-source $WEBOTS_HOME/webots_catkin_ws/devel/setup.bash
+source $BASEDIR/webots_catkin_ws/devel/setup.bash
 
 # run the complete test
 export ROSCONSOLE_FORMAT='${severity}: ${message}   Line: ${line}'
-export ROSCONSOLE_CONFIG_FILE=$WEBOTS_HOME/tests/rosconsole.config
-cd $WEBOTS_HOME/tests
+export ROSCONSOLE_CONFIG_FILE=$BASEDIR/tests/rosconsole.config
+cd $BASEDIR/tests
 echo @@@ Run ros complete test
 roslaunch webots_ros complete_test.launch auto_close:=true no_gui:=true 2> stderr.log
 if grep 'ERROR' stderr.log | grep -q -v 'ERROR: Cannot initialize the sound engine'; then
@@ -37,7 +38,7 @@ if grep 'ERROR' stderr.log | grep -q -v 'ERROR: Cannot initialize the sound engi
 fi
 
 # checks that all the service messages specific to webots_ros are available
-cd $WEBOTS_HOME/webots_catkin_ws
+cd $BASEDIR/webots_catkin_ws
 source devel/setup.bash
 rossrv list >> available_services.log
 echo @@@ Checking that all webots_ros services are available
@@ -45,7 +46,7 @@ echo @@@ Checking that all webots_ros services are available
 FILES=src/webots_ros/srv/*.srv
 if [ ${#FILES[@]} -gt 1 ]; then
   echo @@@ Error: no service file found
-  rm -rf $WEBOTS_HOME/webots_catkin_ws
+  rm -rf $BASEDIR/webots_catkin_ws
   exit -1
 fi
 # check that each associated service is found
@@ -59,7 +60,7 @@ do
   fi
 done
 if $missing_service_file ; then
-  rm -rf $WEBOTS_HOME/webots_catkin_ws
+  rm -rf $BASEDIR/webots_catkin_ws
   exit -1
 else
   echo "OK: all service files found"


### PR DESCRIPTION
**Description**

This PR removes the ros test on travis (as it is often making the nightly fail) and add it to Github Actions (which doesn't block the nightly if failed and use a more recent version of ROS1).

It also introduced a new tag `test ros` which allows to trigger the ros test only (or in addition to other tests).