### PR TITLE
Fixed Python 3.9 support on Windows

### DIFF
--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -68,7 +68,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
 #ifdef __linux__
                 "x"  // we support 3.6 on ubuntu 18.04 and 3.5 and 3.6 on ubuntu 16.04
 #else
-                "8, 3.7"
+                "9, 3.8, 3.7"
 #endif
                 " or 2.7 (64 bit) from python.org in your current PATH.\n"
                 "To fix the problem, you should:\n"
@@ -88,7 +88,8 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   const QString output = process.readAll();
   // "3.6.3 (v3.6.3:2c5fed8, Oct  3 2017, 18:11:49) [MSC v.1900 64 bit (AMD64)]\nTrue\n" or the like
   const QStringList version = output.split("\n");
-  if (!version[0].startsWith("3.8.") && !version[0].startsWith("3.7.") && !version[0].startsWith("2.7.")) {
+  if (!version[0].startsWith("3.9.") && !version[0].startsWith("3.8.") && !version[0].startsWith("3.7.") &&
+      !version[0].startsWith("2.7.")) {
     WbLog::warning(QObject::tr("\"%1\" was not found.\n").arg(pythonCommand) + advice);
     pythonCommand = "!";
   } else if (version.size() > 1 && version[1].startsWith("False")) {


### PR DESCRIPTION
It was not possible to launch a python controller with Python 3.9.
This PR fixes the problem.