### PR TITLE
Fix active loop waiting for extern controllers

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -12,7 +12,7 @@ Released on XXX YYY, 2020.
     - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40 ([#2268](https://github.com/cyberbotics/webots/pull/2268)).
     - Fixed handling of <kbd>Ctrl</kbd> key on macOS from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
-    - Fixed large amount of resources consumed by Webots in run mode when waiting for extern controllers([#2377](https://github.com/cyberbotics/webots/pull/2377)).
+    - Fixed large amount of CPU resources consumed by Webots in run mode when waiting for extern controllers ([#2377](https://github.com/cyberbotics/webots/pull/2377)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).
     - Fixed re-initialization of external camera window if recognition is enabled ([#2196](https://github.com/cyberbotics/webots/pull/2196)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -12,6 +12,7 @@ Released on XXX YYY, 2020.
     - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40 ([#2268](https://github.com/cyberbotics/webots/pull/2268)).
     - Fixed handling of <kbd>Ctrl</kbd> key on macOS from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
+    - Fixed large amount of resources consumed by Webots in run mode when waiting for extern controllers([#2377](https://github.com/cyberbotics/webots/pull/2377)).
     - Fixed [Lidar](lidar.md) and [RangeFinder](rangefinder.md) memory leak when the robot-window is opened ([#2210](https://github.com/cyberbotics/webots/pull/2210)).
     - Fixed noise generation for [Camera](camera.md), [Lidar](lidar.md) and [RangeFinder](rangefinder.md) producing fixed patterns on some GPUs (like the NVIDIA GeForce RTX series)([#2215](https://github.com/cyberbotics/webots/pull/2215)).
     - Fixed re-initialization of external camera window if recognition is enabled ([#2196](https://github.com/cyberbotics/webots/pull/2196)).

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -308,7 +308,7 @@ void WbControlledWorld::step() {
   }
 
   if (waitForController) {
-    if (needToWaitForExternControllerStart)
+    if (waitForExternControllerStart)
       // stop timer and restore it when extern controller is connected
       pauseStepTimer();
     else if (simulationState->isStep() || simulationState->isPaused())
@@ -362,11 +362,11 @@ void WbControlledWorld::step() {
 }
 
 bool WbControlledWorld::needToWait(bool *waitForExternControllerStart) {
-  waitForExternControllerStart = false;
+  *waitForExternControllerStart = false;
   foreach (WbRobot *const robot, mRobotsWaitingExternController) {
     if (robot->synchronization()) {
       if (waitForExternControllerStart)
-        waitForExternControllerStart = true;
+        *waitForExternControllerStart = true;
       return true;
     }
   }

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -169,7 +169,7 @@ void WbControlledWorld::startControllerFromSocket(WbRobot *robot, QLocalSocket *
     controller->setSocket(socket);
     robot->setControllerStarted(true);
     // restart simulation if waiting for extern controller
-    restoreStepTimer();
+    restartStepTimer();
     return;
   }
   controller->start();

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -362,7 +362,8 @@ void WbControlledWorld::step() {
 }
 
 bool WbControlledWorld::needToWait(bool *waitForExternControllerStart) {
-  *waitForExternControllerStart = false;
+  if (waitForExternControllerStart)
+    *waitForExternControllerStart = false;
   foreach (WbRobot *const robot, mRobotsWaitingExternController) {
     if (robot->synchronization()) {
       if (waitForExternControllerStart)

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -37,7 +37,7 @@ public:
   void startController(WbRobot *robot);
 
   QStringList activeControllersNames() const;
-  bool needToWait();
+  bool needToWait(bool *waitForExternControllerStart = NULL);
   void writePendingImmediateAnswer();
   bool isExecutingStep() const { return mIsExecutingStep; }
 

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -255,8 +255,18 @@ void WbSimulationWorld::step() {
   }
 }
 
+void WbSimulationWorld::pauseStepTimer() {
+  mTimer->stop();
+}
+
+void WbSimulationWorld::restoreStepTimer() {
+  const WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
+  if (!mTimer->isActive() && (mode == WbSimulationState::REALTIME || mode == WbSimulationState::RUN || mode == WbSimulationState::FAST))
+    mTimer->start();
+}
+
 void WbSimulationWorld::modeChanged() {
-  WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
+  const WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
   switch (mode) {
     case WbSimulationState::PAUSE:
       mTimer->stop();

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -259,7 +259,7 @@ void WbSimulationWorld::pauseStepTimer() {
   mTimer->stop();
 }
 
-void WbSimulationWorld::restoreStepTimer() {
+void WbSimulationWorld::restartStepTimer() {
   const WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
   if (!mTimer->isActive() &&
       (mode == WbSimulationState::REALTIME || mode == WbSimulationState::RUN || mode == WbSimulationState::FAST))

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -261,7 +261,8 @@ void WbSimulationWorld::pauseStepTimer() {
 
 void WbSimulationWorld::restoreStepTimer() {
   const WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
-  if (!mTimer->isActive() && (mode == WbSimulationState::REALTIME || mode == WbSimulationState::RUN || mode == WbSimulationState::FAST))
+  if (!mTimer->isActive() &&
+      (mode == WbSimulationState::REALTIME || mode == WbSimulationState::RUN || mode == WbSimulationState::FAST))
     mTimer->start();
 }
 

--- a/src/webots/engine/WbSimulationWorld.hpp
+++ b/src/webots/engine/WbSimulationWorld.hpp
@@ -50,6 +50,9 @@ public:
   bool saveAs(const QString &fileName) override;
   void reset(bool restartControllers) override;
 
+  void pauseStepTimer();
+  void restoreStepTimer();
+
   virtual void step();
 
 public slots:

--- a/src/webots/engine/WbSimulationWorld.hpp
+++ b/src/webots/engine/WbSimulationWorld.hpp
@@ -51,7 +51,7 @@ public:
   void reset(bool restartControllers) override;
 
   void pauseStepTimer();
-  void restoreStepTimer();
+  void restartStepTimer();
 
   virtual void step();
 


### PR DESCRIPTION
Fix #2253: Webots uses too many computer resources when waiting for extern controllers (especially in run/fast mode).

This fix consists in pausing the timer that triggers the ``WbControlledWorld::step()`` if Webots is waiting for an extern controller and restart the timer when an extern controller connects.
This way the step function is not continuously called and aborted.

Another change of this PR is that a user clicks on the step button while waiting for an extern controller first connection, the step request is ignored and the step button is not grayed out (see  #2284).
This could be more intuitive and we could even print a warning in the console explaining that Webots is waiting for an extern controller.

