### PR TITLE
change scene_render to correspond to prototype

### DIFF
--- a/src/wren/demo/default.cpp
+++ b/src/wren/demo/default.cpp
@@ -99,7 +99,7 @@ static void create_wren_scene() {
 
 // Render function.
 static void render() {
-  wr_scene_render(wr_scene_get_instance(), NULL);
+  wr_scene_render(wr_scene_get_instance(), NULL, true);
   glutSwapBuffers();
 }
 


### PR DESCRIPTION
**Description**
default.cpp (a demo program using wren) was not compiling because it misses one argument (the culling)

I added this last argument
