### PR TITLE
add headers for emscripten and ifdef to make wren compilable with emcc

### DIFF
--- a/src/wren/Config.cpp
+++ b/src/wren/Config.cpp
@@ -26,7 +26,12 @@
 
 #include <wren/config.h>
 
-#include <glad.h>
+#ifdef __EMSCRIPTEN__
+#include <GL/gl.h>
+#include <GLES3/gl3.h>
+#else
+#include <glad/glad.h>
+#endif
 
 namespace wren {
   namespace config {

--- a/src/wren/Constants.cpp
+++ b/src/wren/Constants.cpp
@@ -16,7 +16,11 @@
 
 #include "Primitive.hpp"
 
-#include <glad.h>
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
+#include <glad/glad.h>
+#endif
 
 namespace wren {
   const primitive::Aabb gAabbInf(glm::vec3(-std::numeric_limits<float>::max()), glm::vec3(std::numeric_limits<float>::max()));

--- a/src/wren/CustomUniform.cpp
+++ b/src/wren/CustomUniform.cpp
@@ -14,7 +14,11 @@
 
 #include "CustomUniform.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/DrawableTexture.cpp
+++ b/src/wren/DrawableTexture.cpp
@@ -17,7 +17,11 @@
 
 #include <wren/drawable_texture.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 
@@ -99,7 +103,11 @@ namespace wren {
       // Replace old texture if texture setup was already made
       if (mGlName) {
         Texture::bind(DEFAULT_USAGE_PARAMS);
+#ifdef __EMSCRIPTEN__
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, newData);
+#else
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_BGRA, GL_UNSIGNED_BYTE, newData);
+#endif
         mHaveMipMapsBeenGenerated = false;
       }
     } else {
@@ -224,8 +232,12 @@ namespace wren {
 
     Texture::bind(Texture::DEFAULT_USAGE_PARAMS);
 
-    // Some texture parameters (format, internal format & data type) are fixed since the class behaviour relies on them
+// Some texture parameters (format, internal format & data type) are fixed since the class behaviour relies on them
+#ifdef __EMSCRIPTEN__
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mWidth, mHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, mData);
+#else
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mWidth, mHeight, 0, GL_BGRA, GL_UNSIGNED_BYTE, mData);
+#endif
 
     mDirty = false;
     resetDirtyRect();
@@ -246,7 +258,12 @@ namespace wren {
         memcpy(&data[index1], &mData[index2], width * sizeof(int));
       }
 
+#ifdef __EMSCRIPTEN__
+      glTexSubImage2D(GL_TEXTURE_2D, 0, mDirtyMinX, mDirtyMinY, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+#else
       glTexSubImage2D(GL_TEXTURE_2D, 0, mDirtyMinX, mDirtyMinY, width, height, GL_BGRA, GL_UNSIGNED_BYTE, data);
+#endif
+
       if (params.mAreMipMapsEnabled)
         generateMipMaps(true);
 

--- a/src/wren/DynamicMesh.cpp
+++ b/src/wren/DynamicMesh.cpp
@@ -21,7 +21,11 @@
 
 #include <wren/dynamic_mesh.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <unordered_map>
 

--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -21,7 +21,11 @@
 
 #include <wren/frame_buffer.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 #include <numeric>
@@ -173,7 +177,10 @@ namespace wren {
 
     const Texture::GlFormatParams &params = drawBufferFormat(index);
     const int rowIndex = flipY ? (mHeight - 1 - y) : y;
+#ifdef __EMSCRIPTEN__
+#else
     glGetBufferSubData(GL_PIXEL_PACK_BUFFER, params.mPixelSize * (rowIndex * mWidth + x), params.mPixelSize, data);
+#endif
 
     glstate::bindPixelPackBuffer(currentPixelPackBuffer);
   }

--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -176,9 +176,9 @@ namespace wren {
     glstate::bindPixelPackBuffer(mOutputDrawBuffers[index].mGlNamePbo);
 
     const Texture::GlFormatParams &params = drawBufferFormat(index);
-    const int rowIndex = flipY ? (mHeight - 1 - y) : y;
 #ifdef __EMSCRIPTEN__
 #else
+    const int rowIndex = flipY ? (mHeight - 1 - y) : y;
     glGetBufferSubData(GL_PIXEL_PACK_BUFFER, params.mPixelSize * (rowIndex * mWidth + x), params.mPixelSize, data);
 #endif
 

--- a/src/wren/GlState.cpp
+++ b/src/wren/GlState.cpp
@@ -343,14 +343,15 @@ namespace wren {
     }
 
     void setPolygonMode(unsigned int polygonMode) {
+#ifdef __EMSCRIPTEN__
+      cPolygonMode = polygonMode;
+#else
       if (cPolygonMode != polygonMode) {
         cPolygonMode = polygonMode;
-#ifdef __EMSCRIPTEN__
-#else
         glPolygonMode(GL_FRONT_AND_BACK, polygonMode);
-#endif
       }
-    }
+#endif
+    }  // namespace glstate
 
     void setPolygonOffset(bool enable, float factor, float units) {
       if (cPolygonOffset != enable) {

--- a/src/wren/Material.cpp
+++ b/src/wren/Material.cpp
@@ -22,7 +22,11 @@
 #include "TextureTransform.hpp"
 #include "UniformBuffer.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/Overlay.cpp
+++ b/src/wren/Overlay.cpp
@@ -26,7 +26,11 @@
 
 #include <wren/overlay.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 

--- a/src/wren/PbrMaterial.cpp
+++ b/src/wren/PbrMaterial.cpp
@@ -25,7 +25,11 @@
 
 #include <wren/material.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/PhongMaterial.cpp
+++ b/src/wren/PhongMaterial.cpp
@@ -25,7 +25,11 @@
 
 #include <wren/material.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/PostProcessingEffect.cpp
+++ b/src/wren/PostProcessingEffect.cpp
@@ -25,7 +25,11 @@
 
 #include <wren/post_processing_effect.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 

--- a/src/wren/Renderable.cpp
+++ b/src/wren/Renderable.cpp
@@ -31,7 +31,11 @@
 
 #include <wren/renderable.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -41,7 +41,11 @@
 #include <wren/renderable.h>
 #include <wren/scene.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 #include <memory>
@@ -116,7 +120,13 @@ namespace wren {
 
   void Scene::bindPixelBuffer(int buffer) { glBindBuffer(GL_PIXEL_PACK_BUFFER, buffer); }
 
-  void *Scene::mapPixelBuffer(unsigned int accessMode) { return glMapBuffer(GL_PIXEL_PACK_BUFFER, accessMode); }
+  void *Scene::mapPixelBuffer(unsigned int accessMode) {
+#ifdef __EMSCRIPTEN__
+    return NULL;
+#else
+    return glMapBuffer(GL_PIXEL_PACK_BUFFER, accessMode);
+#endif
+  }
 
   void Scene::unMapPixelBuffer() { glUnmapBuffer(GL_PIXEL_PACK_BUFFER); }
 

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -21,7 +21,11 @@
 
 #include <wren/shader_program.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 #include <cstdlib>

--- a/src/wren/ShadowVolumeCaster.cpp
+++ b/src/wren/ShadowVolumeCaster.cpp
@@ -26,7 +26,11 @@
 #include "Scene.hpp"
 #include "ShaderProgram.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <vector>
 

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -21,7 +21,11 @@
 
 #include <wren/static_mesh.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <unordered_map>
 #include <vector>
@@ -1938,7 +1942,10 @@ namespace wren {
 
   static void copyFromBuffer(unsigned int target, unsigned int buffer, size_t size, void *dest) {
     glBindBuffer(target, buffer);
+#ifdef __EMSCRIPTEN__
+#else
     glGetBufferSubData(target, 0, size, dest);
+#endif
   }
 
   /*

--- a/src/wren/Texture.cpp
+++ b/src/wren/Texture.cpp
@@ -19,7 +19,11 @@
 #include "GlState.hpp"
 #include "Material.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 
@@ -29,8 +33,13 @@ namespace wren {
   const Texture::GlFormatParams Texture::GL_FORMAT_PARAMS[WR_TEXTURE_INTERNAL_FORMAT_COUNT] = {
     GlFormatParams(GL_R8, GL_RED, GL_UNSIGNED_BYTE, 1, 1),
     GlFormatParams(GL_RG8, GL_RG, GL_UNSIGNED_BYTE, 2, 2),
+#ifdef __EMSCRIPTEN__
+    GlFormatParams(GL_RGB8, GL_RGB, GL_UNSIGNED_BYTE, 3, 3),
+    GlFormatParams(GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, 4, 4),
+#else
     GlFormatParams(GL_RGB8, GL_BGR, GL_UNSIGNED_BYTE, 3, 3),
     GlFormatParams(GL_RGBA8, GL_BGRA, GL_UNSIGNED_BYTE, 4, 4),
+#endif
     GlFormatParams(GL_R16F, GL_RED, GL_UNSIGNED_BYTE, 2, 1),
     GlFormatParams(GL_RGB16F, GL_RGB, GL_UNSIGNED_BYTE, 6, 3),
     GlFormatParams(GL_RGBA16F, GL_RGBA, GL_UNSIGNED_BYTE, 8, 4),

--- a/src/wren/Texture2d.cpp
+++ b/src/wren/Texture2d.cpp
@@ -19,7 +19,11 @@
 
 #include <wren/texture_2d.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <cstring>
 

--- a/src/wren/TextureCubeMap.cpp
+++ b/src/wren/TextureCubeMap.cpp
@@ -20,7 +20,12 @@
 #include <wren/gl_state.h>
 #include <wren/texture_cubemap.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GL/gl.h>
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/TextureCubeMapBaker.cpp
+++ b/src/wren/TextureCubeMapBaker.cpp
@@ -22,7 +22,12 @@
 #include "TextureCubeMap.hpp"
 #include "TextureRtt.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
+
 #include <wren/shader_program.h>
 #include <wren/texture_cubemap.h>
 #include <wren/texture_cubemap_baker.h>

--- a/src/wren/TextureRtt.cpp
+++ b/src/wren/TextureRtt.cpp
@@ -18,7 +18,11 @@
 
 #include <wren/texture_rtt.h>
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/UniformBuffer.cpp
+++ b/src/wren/UniformBuffer.cpp
@@ -16,7 +16,11 @@
 
 #include "GlState.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 namespace wren {
 

--- a/src/wren/Viewport.cpp
+++ b/src/wren/Viewport.cpp
@@ -22,7 +22,12 @@
 #include "PostProcessingEffect.hpp"
 #include "TextureRtt.hpp"
 
+#ifdef __EMSCRIPTEN__
+#include <GL/gl.h>
+#include <GLES3/gl3.h>
+#else
 #include <glad/glad.h>
+#endif
 
 #include <algorithm>
 


### PR DESCRIPTION
**Description**
To prepare wren to be used in the stream viewer, I changed the headers of the files that include glad.h in order to use gles3 if the file is compiled with emscripten.

I also introduced some ifdef because some functions/enumerations that are used in wren do not exist in gles 3/ webgl 2
Modifying these ifdef to find a common solution to opengl 3.3 and webgl2 will be the object of another PR.

In the current state, wren can be compiled with both gcc and emcc even so the result can be different as wren with opengl will sometimes use BGR(A) whereas wren with webgl will always use RGB(A)