### PR TITLE
Fix movie recording behavior on simulation reset from Supervisor controller

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -13,7 +13,7 @@ Released on XXX YYY, 2020.
     - Fixed values returned by the [Supervisor](supervisor.md) [get field value](supervisor.md#wb_supervisor_field_get_sf_bool) functions after [setting](supervisor.md#wb_supervisor_field_set_sf_bool) the field value in the same controller step ([#2375](https://github.com/cyberbotics/webots/pull/2375)).
     - Fixed supervisor label color change which was not working if the text remained unchanged ([#2357](https://github.com/cyberbotics/webots/pull/2357)).
     - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40 ([#2268](https://github.com/cyberbotics/webots/pull/2268)).
-    - Fixed recording of movie canceled on simulation revert if recording is started from a [Supervisor](supervisor.md#wb_supervisor_movie_start_recording) controller ([#2406](https://github.com/cyberbotics/webots/pull/2406)).
+    - Fixed recording of movie canceled on simulation reset if recording is started from a [Supervisor](supervisor.md#wb_supervisor_movie_start_recording) controller ([#2406](https://github.com/cyberbotics/webots/pull/2406)).
     - macOS: Fixed handling of <kbd>Ctrl</kbd> key from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed large amount of CPU resources consumed by Webots in run mode when waiting for extern controllers ([#2377](https://github.com/cyberbotics/webots/pull/2377)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -13,6 +13,7 @@ Released on XXX YYY, 2020.
     - Fixed values returned by the [Supervisor](supervisor.md) [get field value](supervisor.md#wb_supervisor_field_get_sf_bool) functions after [setting](supervisor.md#wb_supervisor_field_set_sf_bool) the field value in the same controller step ([#2375](https://github.com/cyberbotics/webots/pull/2375)).
     - Fixed supervisor label color change which was not working if the text remained unchanged ([#2357](https://github.com/cyberbotics/webots/pull/2357)).
     - Fixed recording of movies which was broken when the [WorldInfo](worldinfo.md).`basicTimeStep` was greater than 40 ([#2268](https://github.com/cyberbotics/webots/pull/2268)).
+    - Fixed recording of movie canceled on simulation revert if recording is started from a [Supervisor](supervisor.md#wb_supervisor_movie_start_recording) controller ([#2406](https://github.com/cyberbotics/webots/pull/2406)).
     - macOS: Fixed handling of <kbd>Ctrl</kbd> key from the [Keyboard](keyboard.md) API ([#2265](https://github.com/cyberbotics/webots/pull/2265)).
     - Fixed synchronization bug in the start up of extern controllers when the `WEBOTS_PID` environment variable was defined ([#2260](https://github.com/cyberbotics/webots/pull/2260)).
     - Fixed large amount of CPU resources consumed by Webots in run mode when waiting for extern controllers ([#2377](https://github.com/cyberbotics/webots/pull/2377)).

--- a/src/Controller/api/supervisor.c
+++ b/src/Controller/api/supervisor.c
@@ -1235,6 +1235,11 @@ void wb_supervisor_movie_start_recording(const char *filename, int width, int he
   if (!robot_check_supervisor(__FUNCTION__))
     return;
 
+  if (!wb_supervisor_movie_is_ready()) {
+    fprintf(stderr, "Error: %s(): movie recording has already been started.\n", __FUNCTION__);
+    return;
+  }
+
   if (!filename || !filename[0]) {
     fprintf(stderr, "Error: %s() called with NULL or empty 'filename' argument.\n", __FUNCTION__);
     return;

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1533,7 +1533,8 @@ void WbMainWindow::resetWorld(bool restartControllers) {
   if (!WbWorld::instance())
     newWorld();
   else {
-    mSimulationView->cancelSupervisorMovieRecording();
+    if (restartControllers)
+      mSimulationView->cancelSupervisorMovieRecording();
     WbWorld::instance()->reset(restartControllers);
   }
   mSimulationView->view3D()->renderLater();

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -828,6 +828,10 @@ void WbSimulationView::setWorld(WbSimulationWorld *w) {
   connect(WbActionManager::instance()->action(WbAction::BOTTOM_VIEW), &QAction::triggered,
           WbSimulationWorld::instance()->viewpoint(), &WbViewpoint::bottomView);
 
+  connect(WbVideoRecorder::instance(), &WbVideoRecorder::videoCreationStatusChanged, w, &WbWorld::updateVideoRecordingStatus);
+  w->updateVideoRecordingStatus(WbVideoRecorder::instance()->isRecording() ? WB_SUPERVISOR_MOVIE_RECORDING :
+                                                                             WB_SUPERVISOR_MOVIE_READY);
+
   mSceneTree->updateSelection();
   disableStepButton(false);
 }

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1698,6 +1698,14 @@ void WbSupervisorUtilities::writeConfigure(QDataStream &stream) {
   stream.writeRawData(s.constData(), s.size() + 1);
   const QByteArray &ba = selfNode->defName().toUtf8();
   stream.writeRawData(ba.constData(), ba.size() + 1);
+
+  if (WbWorld::instance()->isVideoRecording()) {
+    stream << (short unsigned int)0;
+    stream << (unsigned char)C_SUPERVISOR_MOVIE_STATUS;
+    stream << (unsigned char)WB_SUPERVISOR_MOVIE_RECORDING;
+    delete mMovieStatus;
+    mMovieStatus = NULL;
+  }
 }
 
 void WbSupervisorUtilities::movieStatusChanged(int status) {

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -87,7 +87,8 @@ WbWorld::WbWorld(WbProtoList *protos, WbTokenizer *tokenizer) :
   mProtos(protos ? protos : new WbProtoList()),
   mLastAwakeningTime(0.0),
   mIsLoading(false),
-  mIsCleaning(false) {
+  mIsCleaning(false),
+  mIsVideoRecording(false) {
   gInstance = this;
   WbNode::setInstantiateMode(true);
   WbNode::setGlobalParentNode(NULL);

--- a/src/webots/nodes/utils/WbWorld.hpp
+++ b/src/webots/nodes/utils/WbWorld.hpp
@@ -69,6 +69,8 @@ public:
   void setIsCleaning(bool cleaning) { mIsCleaning = cleaning; }
   bool wasWorldLoadingCanceled() { return mWorldLoadingCanceled; }
 
+  bool isVideoRecording() const { return mIsVideoRecording; }
+
   static QString defaultX3dFrustumCullingParameter() { return "true"; }
   static void enableX3DMetaFileExport() { cX3DMetaFileExport = true; }
   static bool isX3DStreaming() { return cX3DStreaming; }
@@ -149,6 +151,9 @@ signals:
 
 public slots:
   void awake();
+  void updateVideoRecordingStatus(int status) {
+    mIsVideoRecording = (status == WB_SUPERVISOR_MOVIE_RECORDING || status == WB_SUPERVISOR_MOVIE_SAVING);
+  }
 
 protected:
   // collecting contact and immersion geometries
@@ -184,6 +189,7 @@ private:
   double mLastAwakeningTime;
   bool mIsLoading;
   bool mIsCleaning;
+  bool mIsVideoRecording;
 
   void checkPresenceOfMandatoryNodes();
   WbNode *findTopLevelNode(const QString &modelName, int preferredPosition) const;


### PR DESCRIPTION
Address #2386: cancel supervisor movie recording on reset only if controllers are restarted (i.e. reset from the UI).

