### PR TITLE
Fixed clang-format 11.0.0 issues

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -27,11 +27,11 @@ jobs:
         python: [2.7, 3.9]
         include:
           - os: ubuntu-16.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10"
           - os: ubuntu-18.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10"
           - os: ubuntu-20.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10"
           - os: macos-10.15
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -27,7 +27,7 @@ jobs:
         python: [2.7, 3.9]
         include:
           - os: ubuntu-16.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
           - os: ubuntu-18.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10"
           - os: ubuntu-20.04

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -31,7 +31,7 @@ jobs:
           - os: ubuntu-18.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
           - os: ubuntu-20.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
           - os: macos-10.15
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -27,9 +27,9 @@ jobs:
         python: [2.7, 3.9]
         include:
           - os: ubuntu-16.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
           - os: ubuntu-18.04
-            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-9"
+            DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
           - os: ubuntu-20.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-11"
           - os: macos-10.15

--- a/projects/robots/k-team/khepera1/controllers/pipe/pipe.c
+++ b/projects/robots/k-team/khepera1/controllers/pipe/pipe.c
@@ -38,12 +38,15 @@ int main() {
   return 0;
 }
 #else
-#include <fcntl.h>    /* definition of O_RDONLY and O_WRONLY */
-#include <stdio.h>    /* definition of sprintf, fprintf, sscanf and stderr */
-#include <stdlib.h>   /* definition of exit() */
-#include <string.h>   /* definition of strcpy() and strlen() */
-#include <sys/stat.h> /* definition of mknod() and S_IFIFO */
-#include <unistd.h>   /* definition of close() */
+// clang-format off
+// clang-format 11.0.0 has problems with AlignTrailingComments when the line starts with a hash (#).
+#include <fcntl.h>     // definition of O_RDONLY and O_WRONLY
+#include <stdio.h>     // definition of sprintf, fprintf, sscanf and stderr
+#include <stdlib.h>    // definition of exit()
+#include <string.h>    // definition of strcpy() and strlen()
+#include <sys/stat.h>  // definition of mknod() and S_IFIFO
+#include <unistd.h>    // definition of close()
+// clang-format on
 #include <webots/distance_sensor.h>
 #include <webots/light_sensor.h>
 #include <webots/motor.h>

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
@@ -125,7 +125,8 @@ Serial::Serial(const string &port) : mName(port) {
     throwFatalException("Error getting the tty attributes");
   }
 
-#else  // __linux__
+#else
+  // __linux__
   mFd = open(mName.c_str(), O_RDWR | O_NOCTTY);
   if (mFd > 0) {
     tcflush(mFd, TCIOFLUSH);  // flush old data

--- a/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
+++ b/projects/robots/nex/plugins/remote_controls/fire_bird_6_remote_control/Serial.cpp
@@ -125,7 +125,7 @@ Serial::Serial(const string &port) : mName(port) {
     throwFatalException("Error getting the tty attributes");
   }
 
-#else   // __linux__
+#else  // __linux__
   mFd = open(mName.c_str(), O_RDWR | O_NOCTTY);
   if (mFd > 0) {
     tcflush(mFd, TCIOFLUSH);  // flush old data

--- a/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/nao_soccer_supervisor.c
+++ b/projects/robots/softbank/nao/controllers/nao_soccer_supervisor/nao_soccer_supervisor.c
@@ -65,6 +65,8 @@ enum { X, Y, Z };
 #define MAX_NUM_ROBOTS (2 * MAX_NUM_PLAYERS)
 
 // field dimensions (in meters) according to the SPL Nao Rule Book
+// clang-format off
+// clang-format 11.0.0 has problems with AlignTrailingComments when the line starts with a hash (#).
 #define FIELD_SIZE_X 9.050        // official size of the field
 #define FIELD_SIZE_Z 6.050        // for the 2014 competition
 #define CIRCLE_DIAMETER 1.550     // soccer field's central circle
@@ -76,6 +78,7 @@ enum { X, Y, Z };
 #define THROW_IN_LINE_OFFSET 0.400  // offset from side line
 #define LINE_WIDTH 0.050            // white lines
 #define BALL_RADIUS 0.0325
+// clang-format on
 
 // throw-in lines
 const double THROW_IN_LINE_X_END = THROW_IN_LINE_LENGTH / 2;

--- a/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
+++ b/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     ANSI_CLEAR_CONSOLE();
     for (i = 0; i < 3; i++)
       // clang-format off
-      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+      // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
       printf("last %s blob seen at (%d,%d) with an angle of %f\n",
              (i == GREEN) ? "Green" :
              (i == RED)   ? "Red" :

--- a/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
+++ b/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
@@ -125,12 +125,15 @@ int main(int argc, char **argv) {
     // print results
     ANSI_CLEAR_CONSOLE();
     for (i = 0; i < 3; i++)
+      // clang-format off
+      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
       printf("last %s blob seen at (%d,%d) with an angle of %f\n",
              (i == GREEN) ? "Green" :
              (i == RED)   ? "Red" :
                             "Blue",
              color_index[i][X], color_index[i][Y],
              coord2D_to_angle((double)(color_index[i][X] + width / 2), (double)(color_index[i][Y] + height / 2)));
+    // clang-format on
 
     // set actuators
     wb_motor_set_velocity(left_motor, 3.0 + speed[LEFT]);

--- a/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
+++ b/projects/samples/devices/controllers/spherical_camera/spherical_camera.c
@@ -125,7 +125,10 @@ int main(int argc, char **argv) {
     // print results
     ANSI_CLEAR_CONSOLE();
     for (i = 0; i < 3; i++)
-      printf("last %s blob seen at (%d,%d) with an angle of %f\n", (i == GREEN) ? "Green" : (i == RED) ? "Red" : "Blue",
+      printf("last %s blob seen at (%d,%d) with an angle of %f\n",
+             (i == GREEN) ? "Green" :
+             (i == RED)   ? "Red" :
+                            "Blue",
              color_index[i][X], color_index[i][Y],
              coord2D_to_angle((double)(color_index[i][X] + width / 2), (double)(color_index[i][Y] + height / 2)));
 

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -751,7 +751,7 @@ void WbViewpoint::updateFollowUp() {
     } else if (type == FOLLOW_TRACKING) {
       mEquilibriumVector += delta;
       // clang-format off
-      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+      // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
       const double mass = ((mFollowSmoothness->value() < 0.05) ? 0.0 :
                            (mFollowSmoothness->value() > 1.0)  ? 1.0 :
                                                                  mFollowSmoothness->value());

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -750,10 +750,12 @@ void WbViewpoint::updateFollowUp() {
       mPosition->setValue(mFollowedSolid->position() + solidRotation * mReferenceOffset);
     } else if (type == FOLLOW_TRACKING) {
       mEquilibriumVector += delta;
-
+      // clang-format off
+      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
       const double mass = ((mFollowSmoothness->value() < 0.05) ? 0.0 :
                            (mFollowSmoothness->value() > 1.0)  ? 1.0 :
                                                                  mFollowSmoothness->value());
+      // clang-format on
       // If mass is 0, we instantly move the viewpoint to its equilibrium position.
       if (mass == 0.0) {
         // Moves the rotation point if a drag rotating the viewpoint is active

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -751,8 +751,9 @@ void WbViewpoint::updateFollowUp() {
     } else if (type == FOLLOW_TRACKING) {
       mEquilibriumVector += delta;
 
-      const double mass =
-        ((mFollowSmoothness->value() < 0.05) ? 0.0 : (mFollowSmoothness->value() > 1.0) ? 1.0 : mFollowSmoothness->value());
+      const double mass = ((mFollowSmoothness->value() < 0.05) ? 0.0 :
+                           (mFollowSmoothness->value() > 1.0)  ? 1.0 :
+                                                                 mFollowSmoothness->value());
       // If mass is 0, we instantly move the viewpoint to its equilibrium position.
       if (mass == 0.0) {
         // Moves the rotation point if a drag rotating the viewpoint is active

--- a/tests/api/controllers/gps/gps.c
+++ b/tests/api/controllers/gps/gps.c
@@ -17,23 +17,29 @@ int main(int argc, char **argv) {
 
   r = wb_gps_get_values(gps);
   for (i = 0; i < 3; i++)
+    // clang-format off
+    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
     ts_assert_double_equal(r[i], NAN, "The %c value measured by the GPS should be NaN and not %g before the device is enabled",
                            i == 0 ? 'X' :
                            i == 1 ? 'Y' :
                                     'Z',
                            r[i]);
+  // clang-format on
 
   wb_gps_enable(gps, TIME_STEP);
 
   r = wb_gps_get_values(gps);
 
   for (i = 0; i < 3; i++)
+    // clang-format off
+    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
     ts_assert_double_equal(r[i], NAN,
                            "The %c value measured by the GPS should be NaN and not %g before a wb_robot_step is performed",
                            i == 0 ? 'X' :
                            i == 1 ? 'Y' :
                                     'Z',
                            r[i]);
+  // clang-format on
 
   int coordinate_system = wb_gps_get_coordinate_system(gps);
   ts_assert_int_equal(coordinate_system, WB_GPS_LOCAL_COORDINATE, "Wrong coordinate system returned");
@@ -42,12 +48,15 @@ int main(int argc, char **argv) {
     wb_robot_step(TIME_STEP);
     r = wb_gps_get_values(gps);
     for (i = 0; i < 3; i++)
+      // clang-format off
+      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
       ts_assert_double_in_delta(r[i], e[i], 0.000001,
                                 "The %c value measured by the GPS should be %g and not %g after %d wb_robot_step(s)",
                                 i == 0 ? 'X' :
                                 i == 1 ? 'Y' :
                                          'Z',
                                 e[i], r[i], j);
+    // clang-format on
   }
 
   ts_send_success();

--- a/tests/api/controllers/gps/gps.c
+++ b/tests/api/controllers/gps/gps.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
   r = wb_gps_get_values(gps);
   for (i = 0; i < 3; i++)
     // clang-format off
-    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+    // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
     ts_assert_double_equal(r[i], NAN, "The %c value measured by the GPS should be NaN and not %g before the device is enabled",
                            i == 0 ? 'X' :
                            i == 1 ? 'Y' :
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
 
   for (i = 0; i < 3; i++)
     // clang-format off
-    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+    // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
     ts_assert_double_equal(r[i], NAN,
                            "The %c value measured by the GPS should be NaN and not %g before a wb_robot_step is performed",
                            i == 0 ? 'X' :
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     r = wb_gps_get_values(gps);
     for (i = 0; i < 3; i++)
       // clang-format off
-      // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+      // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
       ts_assert_double_in_delta(r[i], e[i], 0.000001,
                                 "The %c value measured by the GPS should be %g and not %g after %d wb_robot_step(s)",
                                 i == 0 ? 'X' :

--- a/tests/api/controllers/gps/gps.c
+++ b/tests/api/controllers/gps/gps.c
@@ -18,7 +18,10 @@ int main(int argc, char **argv) {
   r = wb_gps_get_values(gps);
   for (i = 0; i < 3; i++)
     ts_assert_double_equal(r[i], NAN, "The %c value measured by the GPS should be NaN and not %g before the device is enabled",
-                           i == 0 ? 'X' : i == 1 ? 'Y' : 'Z', r[i]);
+                           i == 0 ? 'X' :
+                           i == 1 ? 'Y' :
+                                    'Z',
+                           r[i]);
 
   wb_gps_enable(gps, TIME_STEP);
 
@@ -27,7 +30,10 @@ int main(int argc, char **argv) {
   for (i = 0; i < 3; i++)
     ts_assert_double_equal(r[i], NAN,
                            "The %c value measured by the GPS should be NaN and not %g before a wb_robot_step is performed",
-                           i == 0 ? 'X' : i == 1 ? 'Y' : 'Z', r[i]);
+                           i == 0 ? 'X' :
+                           i == 1 ? 'Y' :
+                                    'Z',
+                           r[i]);
 
   int coordinate_system = wb_gps_get_coordinate_system(gps);
   ts_assert_int_equal(coordinate_system, WB_GPS_LOCAL_COORDINATE, "Wrong coordinate system returned");
@@ -38,7 +44,10 @@ int main(int argc, char **argv) {
     for (i = 0; i < 3; i++)
       ts_assert_double_in_delta(r[i], e[i], 0.000001,
                                 "The %c value measured by the GPS should be %g and not %g after %d wb_robot_step(s)",
-                                i == 0 ? 'X' : i == 1 ? 'Y' : 'Z', e[i], r[i], j);
+                                i == 0 ? 'X' :
+                                i == 1 ? 'Y' :
+                                         'Z',
+                                e[i], r[i], j);
   }
 
   ts_send_success();

--- a/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
+++ b/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
   const double *position = wb_gps_get_values(gps);
   for (int i = 0; i < 3; i++)
     // clang-format off
-    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
+    // clang-format 11.0.0 is not compatible with previous versions with respect to nested conditional operators
     ts_assert_double_in_delta(position[i], expected_position[i], 0.0000001,
                               "The %c value measured by the GPS should be %g and not %g",
                               i == 0 ? 'X' :

--- a/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
+++ b/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
@@ -19,7 +19,10 @@ int main(int argc, char **argv) {
   const double *position = wb_gps_get_values(gps);
   for (int i = 0; i < 3; i++)
     ts_assert_double_in_delta(position[i], expected_position[i], 0.0000001,
-                              "The %c value measured by the GPS should be %g and not %g", i == 0 ? 'X' : i == 1 ? 'Y' : 'Z',
+                              "The %c value measured by the GPS should be %g and not %g",
+                              i == 0 ? 'X' :
+                              i == 1 ? 'Y' :
+                                       'Z',
                               expected_position[i], position[i]);
 
   ts_send_success();

--- a/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
+++ b/tests/api/controllers/gps_coordinates_north_direction/gps_coordinates_north_direction.c
@@ -18,12 +18,15 @@ int main(int argc, char **argv) {
   const double expected_position[] = {0.0451744, 0.0179479, 0};
   const double *position = wb_gps_get_values(gps);
   for (int i = 0; i < 3; i++)
+    // clang-format off
+    // clang-format 11.0.0 is not compatible with previous versions with respect to the conditional operator
     ts_assert_double_in_delta(position[i], expected_position[i], 0.0000001,
                               "The %c value measured by the GPS should be %g and not %g",
                               i == 0 ? 'X' :
                               i == 1 ? 'Y' :
                                        'Z',
                               expected_position[i], position[i]);
+  // clang-format on
 
   ts_send_success();
   return EXIT_SUCCESS;


### PR DESCRIPTION
Since clang-format was updated to version 11 on Windows, the tests on appveyor are not any more passing. This PR attempts at fixing the problem.