### PR TITLE
Modify shaders to have float in the form 1.0 and not just 1

### DIFF
--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -412,6 +412,6 @@ void main() {
       fogFactor = (fogEnd - z) * fogInverseScale;
     fogFactor = clamp(fogFactor, 0.0, 1.0);
 
-    fragColor = vec4(mix(fragColor.xyz, fog.color.xyz, pow(1 - fogFactor, 2.2)), fragColor.w);
+    fragColor = vec4(mix(fragColor.xyz, fog.color.xyz, pow(1.0 - fogFactor, 2.2)), fragColor.w);
   }
 }

--- a/resources/wren/shaders/phong.frag
+++ b/resources/wren/shaders/phong.frag
@@ -196,7 +196,7 @@ void main() {
       if (material.textureFlags.z == 0.0)
         texColor = mainColor;
       else
-        texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0, 1));
+        texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0.0, 1.0));
     }
 
     // Mix with pen texture
@@ -241,6 +241,6 @@ void main() {
       fogFactor = (fogEnd - z) * fogInverseScale;
     fogFactor = clamp(fogFactor, 0.0, 1.0);
 
-    fragColor = vec4(mix(fragColor.xyz, fog.color.xyz, pow(1 - fogFactor, 2.2)), fragColor.w);
+    fragColor = vec4(mix(fragColor.xyz, fog.color.xyz, pow(1.0 - fogFactor, 2.2)), fragColor.w);
   }
 }

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.frag
@@ -81,7 +81,7 @@ void main() {
   // Main texture
   if (material.textureFlags.x > 0.0) {
     vec4 mainColor = SRGBtoLINEAR(texture(inputTextures[mainTextureIndex], texUv));
-    texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0, 1));
+    texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0.0, 1.0));
   }
 
   // Pen texture

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.frag
@@ -189,7 +189,7 @@ void main() {
     // Apply main texture
     if (material.textureFlags.x > 0.0) {
       vec4 mainColor = SRGBtoLINEAR(texture(inputTextures[mainTextureIndex], texUv));
-      texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0, 1));
+      texColor = vec4(mix(texColor.xyz, mainColor.xyz, mainColor.w), clamp(texColor.w + mainColor.w, 0.0, 1.0));
     }
 
     // Mix with pen texture


### PR DESCRIPTION
**Description**
WebGL does not accept shaders where a float has the form 1 or 0 (instead of 1.0 and 0.0). 

I changed the float in some shaders in order for them to be compatible with WebGL