### PR TITLE
Fix padding of vec3 for std140

### DIFF
--- a/src/wren/GlslLayout.hpp
+++ b/src/wren/GlslLayout.hpp
@@ -91,6 +91,7 @@ namespace wren {
       SpotLight mSpotLights[gMaxActiveSpotLights];
       glm::vec4 mAmbientLight;
       glm::ivec3 mLightCount;
+      float pad;  // pad the struct to get the same size as the std140 struct in shaders where vec3 is counted as a vec4
     };
 
     // Used for doing one pass per light


### PR DESCRIPTION
**Description**
Wren uses the size of the struct Lights to initialize the corresponding uniform buffer.
In the shaders, we redeclare this struct with the std140 layer.

However, std140 always rounds up to size of vec4 (16 bytes) but we have a vec3 (12 bytes) in the struct. (https://www.khronos.org/opengl/wiki/Interface_Block_(GLSL)#Memory_layout)

So the sizeof is short of 4 bytes compared to the size expected by GLSL.