### PR TITLE
Improve stability and performance of the IK example

### DIFF
--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths: '["docs/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "pull_request"]'
 
   test-doc:
     needs: job-skipper

--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths: '["docs/**"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "pull_request.opened"]'
+          concurrent_skipping: 'false'
 
   test-doc:
     needs: job-skipper

--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths: '["docs/**"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "pull_request"]'
+          do_not_skip: '{"workflow_dispatch": [], "schedule": [], "pull_request": ["opened"] }'
 
   test-doc:
     needs: job-skipper

--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths: '["docs/**"]'
-          do_not_skip: '{"workflow_dispatch": [], "schedule": [], "pull_request": ["opened"] }'
+          do_not_skip: '["workflow_dispatch", "schedule", "pull_request.opened"]'
 
   test-doc:
     needs: job-skipper

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -17,11 +17,11 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v2.1.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths_ignore: '["docs/**"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "pull_request"]'
+          concurrent_skipping: 'false'
 
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths_ignore: '["docs/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "pull_request"]'
 
   cleanup-runs:
     runs-on: ubuntu-latest

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -106,6 +106,12 @@ while supervisor.step(timeStep) != -1:
     initial_position = [0] + [m.getPositionSensor().getValue() for m in motors] + [0]
     ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
+    # Recalculate he inverse kinematics of the arm if necessary.
+    position = armChain.forward_kinematics(ikResults)
+    squared_distance = (position[0, 3] - x)**2 + (position[1, 3] - y)**2 + (position[2, 3] - z)**2
+    if math.sqrt(squared_distance) > 0.03:
+        ikResults = armChain.inverse_kinematics([x, y, z])
+
     # Actuate the arm motors with the IK results.
     for i in range(len(motors)):
         motors[i].setPosition(ikResults[i + 1])

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -106,7 +106,7 @@ while supervisor.step(timeStep) != -1:
     initial_position = [0] + [m.getPositionSensor().getValue() for m in motors] + [0]
     ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
-    # Recalculate he inverse kinematics of the arm if necessary.
+    # Recalculate the inverse kinematics of the arm if necessary.
     position = armChain.forward_kinematics(ikResults)
     squared_distance = (position[0, 3] - x)**2 + (position[1, 3] - y)**2 + (position[2, 3] - z)**2
     if math.sqrt(squared_distance) > 0.03:

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -43,7 +43,7 @@ with tempfile.NamedTemporaryFile(suffix='.urdf', delete=False) as file:
     filename = file.name
     file.write(supervisor.getUrdf().encode('utf-8'))
 armChain = Chain.from_urdf_file(filename)
-for i in [0, 4, 5, 6]:
+for i in [0, 6]:
     armChain.active_links_mask[0] = False
 
 # Initialize the arm motors and encoders.
@@ -106,6 +106,6 @@ while supervisor.step(timeStep) != -1:
     initial_position = [0] + [motor.getPositionSensor().getValue() for motor in motors] + [0]
     ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
-    # Actuate the 3 first arm motors with the IK results.
+    # Actuate the arm motors with the IK results.
     for i in range(len(motors)):
         motors[i].setPosition(ikResults[i + 1])

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -71,7 +71,7 @@ while supervisor.step(timeStep) != -1:
     z = 0.05
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    initial_position = [0] + [motor.getPositionSensor().getValue() for motor in motors] + [0]
+    initial_position = [0] + [m.getPositionSensor().getValue() for m in motors] + [0]
     ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
     # Actuate the 3 first arm motors with the IK results.
@@ -103,7 +103,7 @@ while supervisor.step(timeStep) != -1:
     z = targetPosition[1] - armPosition[1]
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    initial_position = [0] + [motor.getPositionSensor().getValue() for motor in motors] + [0]
+    initial_position = [0] + [m.getPositionSensor().getValue() for m in motors] + [0]
     ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
     # Actuate the arm motors with the IK results.

--- a/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
+++ b/projects/robots/abb/irb/controllers/inverse_kinematics/inverse_kinematics.py
@@ -30,6 +30,9 @@ if ikpy.__version__[0] < '3':
     sys.exit('The "ikpy" Python module version is too old. '
              'Please upgrade "ikpy" Python module to version "3.0" or newer with this command: "pip install --upgrade ikpy"')
 
+
+IKPY_MAX_ITERATIONS = 4
+
 # Initialize the Webots Supervisor.
 supervisor = Supervisor()
 timeStep = int(4 * supervisor.getBasicTimeStep())
@@ -40,13 +43,17 @@ with tempfile.NamedTemporaryFile(suffix='.urdf', delete=False) as file:
     filename = file.name
     file.write(supervisor.getUrdf().encode('utf-8'))
 armChain = Chain.from_urdf_file(filename)
+for i in [0, 4, 5, 6]:
+    armChain.active_links_mask[0] = False
 
-# Initialize the arm motors.
+# Initialize the arm motors and encoders.
 motors = []
 for link in armChain.links:
     if 'motor' in link.name:
         motor = supervisor.getMotor(link.name)
         motor.setVelocity(1.0)
+        position_sensor = motor.getPositionSensor()
+        position_sensor.enable(timeStep)
         motors.append(motor)
 
 # Get the arm and target nodes.
@@ -64,7 +71,8 @@ while supervisor.step(timeStep) != -1:
     z = 0.05
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    ikResults = armChain.inverse_kinematics([x, y, z])
+    initial_position = [0] + [motor.getPositionSensor().getValue() for motor in motors] + [0]
+    ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
     # Actuate the 3 first arm motors with the IK results.
     for i in range(3):
@@ -95,7 +103,8 @@ while supervisor.step(timeStep) != -1:
     z = targetPosition[1] - armPosition[1]
 
     # Call "ikpy" to compute the inverse kinematics of the arm.
-    ikResults = armChain.inverse_kinematics([x, y, z])
+    initial_position = [0] + [motor.getPositionSensor().getValue() for motor in motors] + [0]
+    ikResults = armChain.inverse_kinematics([x, y, z], max_iter=IKPY_MAX_ITERATIONS, initial_position=initial_position)
 
     # Actuate the 3 first arm motors with the IK results.
     for i in range(len(motors)):


### PR DESCRIPTION
It should be around 6 times faster now. We could run it even faster, but we need to modify the `ikpy` library.

---

The new CI skipping mechanism didn't work properly for the first commit in a PR (the first commit is always skipped). Adding `concurrent_skipping: 'false'` should fix it.