### PR TITLE
Fix Python Display.imageNew and improve documentation

### DIFF
--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -789,8 +789,9 @@ The size in bytes of this memory chunk can be computed as follows:
 byte_size = camera_width * camera_height * 4
 ```
 
-Internal pixel format of the buffer is BGRA (32 bits).
 Attempting to read outside the bounds of this chunk will cause an error.
+Internal pixel format of the buffer is BGRA (32 bits).
+Note that the Java API uses little-endian format and stores the pixel integer value in ARGB format.
 
 The `wb_camera_image_get_red`, `wb_camera_image_get_green` and `wb_camera_image_get_blue` macros can be used for directly accessing the pixel RGB levels from the pixel coordinates.
 The `wb_camera_image_get_gray` macro works in a similar way but returns the gray level of the specified pixel by averaging the three RGB components.
@@ -810,8 +811,9 @@ for (int x = 0; x < image_width; x++)
 
 > **Note** [Java]: The `Camera.getImage` function returns an array of int (`int[]`).
 The length of this array corresponds to the number of pixels in the image, that is the width multiplied by the height of the image.
-Each `int` element of the array represents one pixel coded in BGRA (32 bits).
-For example red is `0x0000ff00`, green is `0x00ff0000`, etc. The `Camera.pixelGetRed`, `Camera.pixelGetGreen` and `Camera.pixelGetBlue` functions can be used to decode a pixel value for the red, green and blue components.
+Each `int` element of the array represents one pixel coded in ARGB (32 bits).
+For example red is `0x00ff0000`, green is `0x0000ff00`, etc.
+The `Camera.pixelGetRed`, `Camera.pixelGetGreen` and `Camera.pixelGetBlue` functions can be used to decode a pixel value for the red, green and blue components.
 The `Camera.pixelGetGray` function works in a similar way, but returns the gray level of the pixel by averaging the three RGB components.
 Each of these four functions take an `int` pixel argument and return an `int` color/gray component in the range [0..255].
 Here is an example:
@@ -841,7 +843,7 @@ This `string` is closely related to the `const char *` of the C API.
 > gray = Camera.imageGetGray(cameraData, camera.getWidth(), 5, 10)
 > ```
 
-> Another way to use the camera in Python is to get the image by the `getImageArray` function which returns a `list<list<list<int>>>`.
+> Another way to use the camera in Python is to get the image by the `getImageArray` function which returns the RGB image data in the `list<list<list<int>>>` format.
 This three dimensional list can be directly used for accessing to the pixels.
 Here is an example:
 

--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -182,6 +182,7 @@ Similarly, let `vFov` be the vertical field of view (defined just above), and `p
 The camera image is shown by default on top of the 3D window with a magenta border, see [this figure](#camera-overlay-image).
 The user can move this camera image at the desired position using the mouse drag and drop and resize it by clicking on the icon at the bottom right corner.
 Additionally a close button is available on the top right corner to hide the image.
+If the mouse cursor is over the overlay image and the simulation is paused, the RGB value of the selected pixel is displayed in the status bar at the Webots window bottom.
 Once the robot is selected, it is also possible to show or hide the overlay images from the `Camera Devices` item in `Robot` menu.
 
 It is also possible to show the camera image in an external window by double-clicking on it.

--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -182,7 +182,7 @@ Similarly, let `vFov` be the vertical field of view (defined just above), and `p
 The camera image is shown by default on top of the 3D window with a magenta border, see [this figure](#camera-overlay-image).
 The user can move this camera image at the desired position using the mouse drag and drop and resize it by clicking on the icon at the bottom right corner.
 Additionally a close button is available on the top right corner to hide the image.
-If the mouse cursor is over the overlay image and the simulation is paused, the RGB value of the selected pixel is displayed in the status bar at the Webots window bottom.
+If the mouse cursor is over the overlay image and the simulation is paused, the RGB value of the selected pixel is displayed in the status bar at the bottom of the Webots window.
 Once the robot is selected, it is also possible to show or hide the overlay images from the `Camera Devices` item in `Robot` menu.
 
 It is also possible to show the camera image in an external window by double-clicking on it.

--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -843,8 +843,8 @@ This `string` is closely related to the `const char *` of the C API.
 > gray = Camera.imageGetGray(cameraData, camera.getWidth(), 5, 10)
 > ```
 
-> Another way to use the camera in Python is to get the image by the `getImageArray` function which returns the RGB image data in the `list<list<list<int>>>` format.
-This three dimensional list can be directly used for accessing to the pixels.
+> Another way to use the camera in Python is to get the image by the `getImageArray` function which returns a `list<list<list<int>>>`.
+This three dimensional list can be directly used for accessing the RGB pixels value.
 Here is an example:
 
 > ```python

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -6,6 +6,7 @@ Released on XXX YYY, 2020.
   - Enhancements
     - Added support for Python 3.9 ([#2318](https://github.com/cyberbotics/webots/pull/2079)).
     - Improved [Solid](solid.md).`recognitionColors` value for the [BiscuitBox](../guide/object-kitchen.md#biscuitbox) PROTO model ([#2401](https://github.com/cyberbotics/webots/pull/2401)).
+    - Improved documentation of [Camera](camera.md) image format and how to show the image retrieved through the [Camera](camera.md) API in a [Display](display.md) device ([#2443](https://github.com/cyberbotics/webots/pull/2443)).
   - Bug fixes
     - **Fixed cube, compact and flat texture mappings of [TexturedParallelepiped](../guide/object-geometries.md#texturedparallelepiped) proto** ([#2364](https://github.com/cyberbotics/webots/pull/2364)).
     - macOS: Fixed ability to inverse the distance sensor condition in BotStudio with the e-puck robot ([#2391](https://github.com/cyberbotics/webots/pull/2391)).

--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -10,6 +10,7 @@ Released on XXX YYY, 2020.
   - Bug fixes
     - **Fixed cube, compact and flat texture mappings of [TexturedParallelepiped](../guide/object-geometries.md#texturedparallelepiped) proto** ([#2364](https://github.com/cyberbotics/webots/pull/2364)).
     - macOS: Fixed ability to inverse the distance sensor condition in BotStudio with the e-puck robot ([#2391](https://github.com/cyberbotics/webots/pull/2391)).
+    - Fixed crash in the Python [Display.imageNew](display.md#wb_display_image_new) function when passing the image data in string/bytes format ([#2443](https://github.com/cyberbotics/webots/pull/2443)).
     - Fixed crash in the [Supervisor](supervisor.md) API occurring when [setting](supervisor.md#wb_supervisor_field_set_mf_bool) an item of a multiple field just before [inserting](supervisor.md#wb_supervisor_field_insert_mf_bool) or [removing](supervisor.md#wb_supervisor_field_remove_mf) an item in the same field during the same controller step ([#2366](https://github.com/cyberbotics/webots/pull/2366)).
     - Fixed values returned by the [Supervisor](supervisor.md) [get field value](supervisor.md#wb_supervisor_field_get_sf_bool) functions after [setting](supervisor.md#wb_supervisor_field_set_sf_bool) the field value in the same controller step ([#2375](https://github.com/cyberbotics/webots/pull/2375)).
     - Fixed supervisor label color change which was not working if the text remained unchanged ([#2357](https://github.com/cyberbotics/webots/pull/2357)).

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -748,7 +748,7 @@ int main() {
 
   int time_step = wb_robot_get_basic_time_step();
   WbDeviceTag camera = wb_robot_get_device("camera");
-  wb_camera_enable(time_step);
+  wb_camera_enable(camera, time_step);
   const int width = wb_camera_get_width(camera);
   const int height = wb_camera_get_height(camera);
   WbDeviceTag display = wb_robot_get_device("display");
@@ -787,7 +787,7 @@ int main() {
   Display *display = robot->getDisplay("display");
 
   while (robot->step(timeStep) != -1) {
-    const unsinged char *data = camera->getImage();
+    const unsigned char *data = camera->getImage();
     if (data) {
       ImageRef *ir = display->imageNew(width, height, data, Display::ARGB);
       display->imagePaste(ir, 0, 0, false);
@@ -845,7 +845,7 @@ public class ShowCameraInDisplay {
 
     while (robot.step(32) != -1) {
       int[] data = camera.getImage();
-      if (data) {
+      if (data != null) {
         ImageRef ir = display.imageNew(width, height, data, Display.ARGB);
         display.imagePaste(ir, 0, 0, false);
         display.imageDelete(ir);
@@ -877,4 +877,4 @@ end
 %tab-end
 %end
 
-> **Note** [Java]: The `Display.imageNew` function can display the image returned by the `Camera.getImage` function directly if the pixel format argument is set to ARGB.
+> **Note**: The `wb_display_image_new` function can display the image returned by the [`wb_camera_get_image`](camera.md#wb_camera_get_image) function directly if the pixel format argument is set to ARGB.

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -815,9 +815,9 @@ height = camera.getHeight()
 display = robot.getDisplay('display');
 
 while robot.step(32) != -1:
-    data = camera.getImageArray()
+    data = camera.getImage()
     if data:
-        ir = display.imageNew(data, Display.RGB, width, height)
+        ir = display.imageNew(data, Display.ARGB, width, height)
         display.imagePaste(ir, 0, 0, False)
         display.imageDelete(ir)
 ```

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -733,4 +733,148 @@ The `wb_display_image_delete` function releases the memory used by a clipboard i
 After this call the value of `ir` becomes invalid and should not be used any more.
 Using this function is recommended after a clipboard image is not needed any more.
 
+The following controller snippet shows how to copy a [Camera](camera.md) image to the main display image.
+This is particularly useful if you need to process the [Camera](camera.md) image before copying it to the main display image, otherwise please use the [`wb_display_attach_camera`](#wb_display_attach_camera) function that provides better performance.
+
+%tab-component "language"
+%tab "C"
+```c
+#include <webots/robot.h>
+#include <webots/camera.h>
+#include <webots/display.h>
+
+int main() {
+  wb_robot_init();
+
+  int time_step = wb_robot_get_basic_time_step();
+  WbDeviceTag camera = wb_robot_get_device("camera");
+  wb_camera_enable(time_step);
+  const int width = wb_camera_get_width(camera);
+  const int height = wb_camera_get_height(camera);
+  WbDeviceTag display = wb_robot_get_device("display");
+
+  while(wb_robot_step(time_step) != -1) {
+    const unsigned char *data = wb_camera_get_image(camera);
+    if (data) {
+      WbImageRef ir = wb_display_image_new(display, width, height, data, WB_IMAGE_ARGB);
+      wb_display_image_paste(display, ir, 0, 0, false);
+      wb_display_image_delete(display, ir);
+    }
+  }
+
+  wb_robot_cleanup();
+  return 0;
+}
+```
+%tab-end
+
+%tab "C++"
+```cpp
+#include <webots/Robot.hpp>
+#include <webots/Camera.hpp>
+#include <webots/Display.hpp>
+
+using namespace webots;
+
+int main() {
+  Robot *robot = new Robot();
+  int timeStep = robot->getBasicTimeStep();
+
+  Camera *camera = robot->getCamera("camera");
+  camera->enable(timeStep);
+  const int width = camera->getWidth();
+  const int height = camera->getHeight();
+  Display *display = robot->getDisplay("display");
+
+  while (robot->step(timeStep) != -1) {
+    const unsinged char *data = camera->getImage();
+    if (data) {
+      ImageRef *ir = display->imageNew(width, height, data, Display::ARGB);
+      display->imagePaste(ir, 0, 0, false);
+      display->imageDelete(ir);
+    }
+  }
+
+  delete robot;
+  return 0;
+}
+```
+%tab-end
+
+%tab "Python"
+```python
+from controller import Robot, Camera, Display
+
+robot = Robot()
+timestep = int(robot.getBasicTimeStep())
+
+camera = robot.getCamera('camera')
+camera.enable(timestep)
+width = camera.getWidth()
+height = camera.getHeight()
+display = robot.getDisplay('display');
+
+while robot.step(32) != -1:
+    data = camera.getImageArray()
+    if data:
+        ir = display.imageNew(data, Display.RGB, width, height)
+        display.imagePaste(ir, 0, 0, False)
+        display.imageDelete(ir)
+```
+%tab-end
+
+%tab "Java"
+```java
+import com.cyberbotics.webots.controller.Robot;
+import com.cyberbotics.webots.controller.Camera;
+import com.cyberbotics.webots.controller.Display;
+import com.cyberbotics.webots.controller.ImageRef;
+
+public class ShowCameraInDisplay {
+
+  public static void main(String[] args) {
+
+    final Robot robot = new Robot();
+    int timeStep = (int) Math.round(robot.getBasicTimeStep());
+
+    Camera camera = robot.getCamera("camera");
+    camera.enable(timeStep);
+    int width = camera.getWidth();
+    int height = camera.getHeight();
+    Display display = robot.getDisplay("display");
+
+    while (robot.step(32) != -1) {
+      int[] data = camera.getImage();
+      if (data) {
+        ImageRef ir = display.imageNew(width, height, data, Display.ARGB);
+        display.imagePaste(ir, 0, 0, false);
+        display.imageDelete(ir);
+      }
+    }
+  }
+}
+```
+%tab-end
+
+%tab "MATLAB"
+```MATLAB
+time_step = wb_robot_get_basic_time_step();
+camera = wb_robot_get_device("camera");
+wb_camera_enable(camera, time_step);
+width = wb_camera_get_width(camera);
+height = wb_camera_get_height(camera);
+display = wb_robot_get_device("display");
+
+while wb_robot_step(time_step) ~= -1
+  data = wb_camera_get_image(camera);
+  if data
+    ir = wb_display_image_new(display, width, height, data, ARGB);
+    wb_display_image_paste(display, ir, 0, 0, false);
+    wb_display_image_delete(display, ir);
+  end
+end
+```
+%tab-end
+%end
+
 > **Note** [Java]: The `Display.imageNew` function can display the image returned by the `Camera.getImage` function directly if the pixel format argument is set to ARGB.

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -55,6 +55,7 @@ For example, in order to draw two red lines, the `wb_display_set_color` contextu
 The display image is shown by default on top of the 3D window with a cyan border, see [this figure](#display-overlay-image).
 The user can move this display image at the desired position using the mouse drag and drop and resize it by clicking on the icon at the bottom right corner.
 Additionally a close button is available on the top right corner to hide the image.
+If the mouse cursor is over the overlay image and the simulation is paused, the RGBA value of the selected pixel is displayed in the status bar at the Webots window bottom.
 Once the robot is selected, it is also possible to show or hide the overlay image from the `Display Devices` item in `Robot` menu.
 
 It is also possible to show the display image in an external window by double-clicking on it.

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -55,7 +55,7 @@ For example, in order to draw two red lines, the `wb_display_set_color` contextu
 The display image is shown by default on top of the 3D window with a cyan border, see [this figure](#display-overlay-image).
 The user can move this display image at the desired position using the mouse drag and drop and resize it by clicking on the icon at the bottom right corner.
 Additionally a close button is available on the top right corner to hide the image.
-If the mouse cursor is over the overlay image and the simulation is paused, the RGBA value of the selected pixel is displayed in the status bar at the Webots window bottom.
+If the mouse cursor is over the overlay image and the simulation is paused, the RGBA value of the selected pixel is displayed in the status bar at the bottom of the Webots window.
 Once the robot is selected, it is also possible to show or hide the overlay image from the `Display Devices` item in `Robot` menu.
 
 It is also possible to show the display image in an external window by double-clicking on it.

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -747,7 +747,7 @@ This is particularly useful if you need to process the [Camera](camera.md) image
 int main() {
   wb_robot_init();
 
-  int time_step = wb_robot_get_basic_time_step();
+  const int time_step = wb_robot_get_basic_time_step();
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, time_step);
   const int width = wb_camera_get_width(camera);

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -735,7 +735,7 @@ After this call the value of `ir` becomes invalid and should not be used any mor
 Using this function is recommended after a clipboard image is not needed any more.
 
 The following controller snippet shows how to copy a [Camera](camera.md) image to the main display image.
-This is particularly useful if you need to process the [Camera](camera.md) image before copying it to the main display image, otherwise please use the [`wb_display_attach_camera`](#wb_display_attach_camera) function that provides better performance.
+This is particularly useful if you need to modify the [Camera](camera.md) image before copying it to the main display image, otherwise you should use the [`wb_display_attach_camera`](#wb_display_attach_camera) function that provides a better performance.
 
 %tab-component "language"
 %tab "C"

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -779,7 +779,7 @@ using namespace webots;
 
 int main() {
   Robot *robot = new Robot();
-  int timeStep = robot->getBasicTimeStep();
+  const int timeStep = robot->getBasicTimeStep();
 
   Camera *camera = robot->getCamera("camera");
   camera->enable(timeStep);

--- a/resources/languages/python/controller.i
+++ b/resources/languages/python/controller.i
@@ -385,20 +385,20 @@ class AnsiCodes(object):
 
 %typemap(in) const void * {
   if (!PyList_Check($input) && !PyString_Check($input)) {
-    PyErr_SetString(PyExc_TypeError, "in method '$name', expected 'PyList' or 'PyString'\n");
+    PyErr_SetString(PyExc_TypeError, "expected 'PyList' or 'PyString'\n");
     return NULL;
   }
   if (PyList_Check($input)) {
     int len1 = PyList_Size($input);
     PyObject *l2 = PyList_GetItem($input, 0);
     if (!PyList_Check(l2)) {
-      PyErr_SetString(PyExc_TypeError, "in method '$name', expected 'PyList' of 'PyList'\n");
+      PyErr_SetString(PyExc_TypeError, "expected 'PyList' of 'PyList'\n");
       return NULL;
     }
     int len2 = PyList_Size(l2);
     PyObject *l3 = PyList_GetItem(l2, 0);
     if (!PyList_Check(l3)) {
-      PyErr_SetString(PyExc_TypeError, "in method '$name', expected 'PyList' of 'PyList' of 'PyList'\n");
+      PyErr_SetString(PyExc_TypeError, "expected 'PyList' of 'PyList' of 'PyList'\n");
       return NULL;
     }
     int len3 = PyList_Size(l3);
@@ -407,8 +407,13 @@ class AnsiCodes(object):
       for (int j = 0; j < len2; ++j)
         for (int k = 0; k < len3; ++k)
           ((unsigned char *)$1)[(j * len1 * len3) + (i * len3) + k] = (unsigned char) PyInt_AsLong(PyList_GetItem(PyList_GetItem(PyList_GetItem($input, i), j), k));
-  } else // PyString case
-    $1 = PyString_AsString($input);
+  } else { // PyString case
+    const char* s = PyString_AsString($input);
+    // allocate the string in a new variable so that the free defined in the typemap(freearg) applies to a valid pointer
+    char* p = (char *)malloc(PyString_Size($input) * sizeof(unsigned char));
+    strcpy(p, s);
+    $1 = (void *)p;
+  }
 }
 
 %typemap(freearg) const void * {


### PR DESCRIPTION
Address #2441: improve documentation of the image format returned by the Camera API and how to display a Camera image in a Display.

Tasks:
* [x] specify image format in Camera section
* [x] add examples in Display section
* [x] ~add a warning in the Python API if the passed image has string format~
    _edit:_ fix free of invalid pointer in the Python API if the passed image has string format