### PR TITLE
modify shaders to have float in the form x.0

### DIFF
--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -164,7 +164,7 @@ vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection) {
     // A single irradiance map is used for the diffuse and specular reflections:
     // Thanks to the following fact: the diffuse map is close to the specular map at the 6th LOD.
     // invert z components of sample vectors due to VRML default camera orientation looking towards -z
-    diffuseLight = textureLod(cubeTextures[0], vec3(n.xy, -n.z), 6).rgb;
+    diffuseLight = textureLod(cubeTextures[0], vec3(n.xy, -n.z), 6.0).rgb;
     specularLight = textureLod(cubeTextures[0], vec3(reflection.xy, -reflection.z), lod).rgb;
   } else {
     diffuseLight = material.backgroundColorAndIblStrength.rgb;

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -81,7 +81,7 @@ vec3 getIBLContribution(IBLInfo iblInputs, vec3 n, vec3 reflection) {
     // A single irradiance map is used for the diffuse and specular reflections:
     // Thanks to the following fact: the diffuse map is close to the specular map at the 6th LOD.
     // invert z components of sample vectors due to VRML default camera orientation looking towards -z
-    diffuseLight = textureLod(cubeTextures[0], vec3(n.xy, -n.z), 6).rgb;
+    diffuseLight = textureLod(cubeTextures[0], vec3(n.xy, -n.z), 6.0).rgb;
     specularLight = textureLod(cubeTextures[0], vec3(reflection.xy, -reflection.z), lod).rgb;
   } else {
     diffuseLight = material.backgroundColorAndIblStrength.rgb;


### PR DESCRIPTION
WebGL does not accept shaders where a float has the form 6 instead of 6.0

I changed the floats in some shaders in order for them to be compatible with WebGL