### PR TITLE
Improve macOS installation instructions

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -283,6 +283,11 @@ open ~/Applications/Webots.app    # to launch Webots using the open command
 ~/Applications/Webots.app/webots  # to launch Webots directly
 ```
 
+Finally, you can launch Webots typing any of these instructions:
+    ```bash  
+    open ~/Applications/Webots.app    # to launch Webots using the open command
+    ~/Applications/Webots.app/webots  # to launch Webots directly
+    ```
 Alternatively, you can double-click on the Webots icon to launch it.
 
 To install Webots for any user, copy the Webots app to the system `/Applications` folder (administrator privileges required).

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -279,8 +279,6 @@ To install Webots only for the current user, without administrator privileges, p
 ```bash
 mkdir ~/Applications
 cp -r /Volumes/Webots/Webots.app ~/Applications
-open ~/Applications/Webots.app    # to launch Webots using the open command
-~/Applications/Webots.app/webots  # to launch Webots directly
 ```
 To install Webots for any user, copy the Webots app to the system `/Applications` folder instead (administrator privileges required).
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -271,8 +271,8 @@ It is better to download Webots using `curl` so that it doesn't get tagged as "d
 
 1. Open a Terminal app.
 2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
-3. From the finder, locate the downloaded dmg file, double-click on it. This will mount on the desktop a volume named "Webots" containing the "Webots" application.
-4. Move this application to your home ~/Applications folder or to your system "/Application" folder (administrator priviliges required).
+3. From the finder, locate the downloaded dmg file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
+4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator priviliges required).
 
 #### From the Homebrew Package
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -288,7 +288,7 @@ Webots can then be installed with:
 brew cask install webots
 ```
 
-### Working Around macOS Gatekeeper
+### Working around macOS Gatekeeper
 
 If Webots was downloaded from a web browser (e.g., not from a Terminal with `curl` or `wget`) macOS Gatekeeper may refuse to run Webots because it is from an unidentified developer (see [this figure](#unidentified-developer-dialog)).
 You will need administrator privileges to be able to install Webots.

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -290,7 +290,6 @@ Finally, you can launch Webots typing any of these instructions:
     ```
 Alternatively, you can double-click on the Webots icon to launch it.
 
-To install Webots for any user, copy the Webots app to the system `/Applications` folder (administrator privileges required).
 
 #### From the Homebrew Package
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -267,12 +267,25 @@ You can pass this warning and install Webots by clicking on the "More info" link
 
 #### From the Installation File
 
-It is better to download Webots using `curl` so that it doesn't get tagged as "downloaded from the Internet" and won't be blocked by macOS Gatekeeper:
+It is better to download Webots using `curl` so that it doesn't get tagged as "downloaded from the Internet" and won't be blocked by macOS Gatekeeper.
+To proceed, open a Terminal app and type the following:
 
-1. Open a Terminal app.
-2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
-3. From the Finder, locate the downloaded DMG file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
-4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator privileges required).
+```bash
+curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg
+open webots-{{ webots.version.package }}.dmg
+```
+
+To install Webots only for the current user, without administrator privileges, proceed with:
+```bash
+mkdir ~/Applications
+cp -r /Volumes/Webots/Webots.app ~/Applications
+open ~/Applications/Webots.app    # to launch Webots using the open command
+~/Applications/Webots.app/webots  # to launch Webots directly
+```
+
+Alternatively, you can double-click on the Webots icon to launch it.
+
+To install Webots for any user, copy the Webots app to the system `/Applications` folder (administrator privileges required).
 
 #### From the Homebrew Package
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -269,7 +269,6 @@ You can pass this warning and install Webots by clicking on the "More info" link
 
 It is better to download Webots using `curl` so that it doesn't get tagged as "downloaded from the Internet" and won't be blocked by macOS Gatekeeper.
 To proceed, open the Terminal and type the following instructions to download and mount the Webots disk image:
-
 ```bash
 curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg
 open webots-{{ webots.version.package }}.dmg
@@ -280,13 +279,15 @@ To install Webots only for the current user, without administrator privileges, p
 mkdir ~/Applications
 cp -r /Volumes/Webots/Webots.app ~/Applications
 ```
+
 To install Webots for any user, copy the Webots app to the system `/Applications` folder instead (administrator privileges required).
 
 Finally, you can launch Webots typing any of these instructions:
-    ```bash  
-    open ~/Applications/Webots.app    # to launch Webots using the open command
-    ~/Applications/Webots.app/webots  # to launch Webots directly
-    ```
+```bash
+open ~/Applications/Webots.app    # to launch Webots using the open command
+~/Applications/Webots.app/webots  # to launch Webots directly
+```
+
 Alternatively, you can double-click on the Webots icon to launch it.
 
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -268,7 +268,7 @@ You can pass this warning and install Webots by clicking on the "More info" link
 #### From the Installation File
 
 It is better to download Webots using `curl` so that it doesn't get tagged as "downloaded from the Internet" and won't be blocked by macOS Gatekeeper.
-To proceed, open a Terminal app and type the following:
+To proceed, open the Terminal and type the following instructions to download and mount the Webots disk image:
 
 ```bash
 curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -271,7 +271,7 @@ It is better to download Webots using `curl` so that it doesn't get tagged as "d
 
 1. Open a Terminal app.
 2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
-3. From the finder, locate the downloaded dmg file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
+3. From the finder, locate the downloaded `dmg` file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
 4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator priviliges required).
 
 #### From the Homebrew Package

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -272,7 +272,7 @@ It is better to download Webots using `curl` so that it doesn't get tagged as "d
 1. Open a Terminal app.
 2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
 3. From the Finder, locate the downloaded DMG file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
-4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator priviliges required).
+4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator privileges required).
 
 #### From the Homebrew Package
 

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -282,6 +282,7 @@ cp -r /Volumes/Webots/Webots.app ~/Applications
 open ~/Applications/Webots.app    # to launch Webots using the open command
 ~/Applications/Webots.app/webots  # to launch Webots directly
 ```
+To install Webots for any user, copy the Webots app to the system `/Applications` folder instead (administrator privileges required).
 
 Finally, you can launch Webots typing any of these instructions:
     ```bash  

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -271,7 +271,7 @@ It is better to download Webots using `curl` so that it doesn't get tagged as "d
 
 1. Open a Terminal app.
 2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
-3. From the finder, locate the downloaded `dmg` file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
+3. From the Finder, locate the downloaded DMG file, double-click on it. This will mount on the desktop a volume named `Webots` containing the `Webots` application.
 4. Move this application to your home `~/Applications` folder or to your system `/Application` folder (administrator priviliges required).
 
 #### From the Homebrew Package

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -267,10 +267,12 @@ You can pass this warning and install Webots by clicking on the "More info" link
 
 #### From the Installation File
 
-1. Download the `webots-{{ webots.version.package }}.dmg` installation file from our [website](https://cyberbotics.com).
-2. Double click on this file.
-This will mount on the desktop a volume named "Webots" containing the "Webots" folder.
-3. Move this folder to your "/Applications" folder or wherever you would like to install Webots.
+It is better to download Webots using `curl` so that it doesn't get tagged as "downloaded from the Internet" and won't be blocked by macOS Gatekeeper:
+
+1. Open a Terminal app.
+2. Type `curl -L -O https://github.com/cyberbotics/webots/releases/download/{{ webots.version.package }}/webots-{{ webots.version.package }}.dmg`.
+3. From the finder, locate the downloaded dmg file, double-click on it. This will mount on the desktop a volume named "Webots" containing the "Webots" application.
+4. Move this application to your home ~/Applications folder or to your system "/Application" folder (administrator priviliges required).
 
 #### From the Homebrew Package
 
@@ -286,9 +288,10 @@ Webots can then be installed with:
 brew cask install webots
 ```
 
-### macOS Security
+### Working Around macOS Gatekeeper
 
-During the first Webots launch, macOS may complain about opening Webots because it is from an unidentified developer (see [this figure](#unidentified-developer-dialog)).
+If Webots was downloaded from a web browser (e.g., not from a Terminal with `curl` or `wget`) macOS Gatekeeper may refuse to run Webots because it is from an unidentified developer (see [this figure](#unidentified-developer-dialog)).
+You will need administrator privileges to be able to install Webots.
 
 %figure "Unidentified developer dialog"
 
@@ -296,8 +299,8 @@ During the first Webots launch, macOS may complain about opening Webots because 
 
 %end
 
-In this case, `Ctrl + click` (or right-click) on the Webots icon, and select the `Open` menu item.
-`macOS` should propose to open the application anyway (see [this figure](#unidentified-developer-dialog)).
+You should <kbd>Ctrl</kbd> + click (or right-click) on the Webots icon, and select the `Open` menu item.
+Then, macOS should propose to open the application anyway (see [this figure](#unidentified-developer-dialog)).
 
 %figure "Open Webots anyway"
 
@@ -305,5 +308,5 @@ In this case, `Ctrl + click` (or right-click) on the Webots icon, and select the
 
 %end
 
-In earlier versions of macOS, this last operation may not work.
-In this case, refer to your macOS security settings to open Webots anyway (`System Preferences / Security & Privacy / General / Allow apps downloaded from:`).
+More information about disabling macOS Gatekeeper is available [here](https://disable-gatekeeper.github.io/).
+You may also change your macOS security settings to open Webots anyway (`System Preferences / Security & Privacy / General / Allow apps downloaded from:`).


### PR DESCRIPTION
These instructions allow you to install Webots on macOS without administrator privileges (thanks to @brettle).
See https://cyberbotics.com/doc/guide/installation-procedure?version=doc-improve-mac-os-installation-instructions#installation-on-macos
