### PR TITLE
Enhancement Linux installation scripts

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -6,15 +6,13 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget
+apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev
 
 UBUNTU_VERSION=$(lsb_release -rs)
-if [[ $UBUNTU_VERSION == "16.04" ]]; then
-       apt install --yes libssl-dev python-pip
-elif [[ $UBUNTU_VERSION == "18.04" ]]; then
-       apt install --yes libssl1.0-dev python-pip
+if [[ $UBUNTU_VERSION == "16.04"  || $UBUNTU_VERSION == "18.04" ]]; then
+       apt install --yes python-pip
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
-       apt install --yes libssl-dev libzip5 python-pip-whl
+       apt install --yes libzip5 python-pip-whl
 else
        echo "Unsupported Linux version."
 fi

--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -6,7 +6,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev
+apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev zip unzip
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "16.04"  || $UBUNTU_VERSION == "18.04" ]]; then

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -10,8 +10,8 @@ apt install --yes software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt update
 apt install --yes lsb-release curl python3.6-dev python3.7-dev python3.8-dev python3.9-dev dirmngr
-curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
-sudo apt-get install -y nodejs
+curl -sL https://deb.nodesource.com/setup_15.x | bash -
+apt-get install --yes nodejs
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "16.04" ]]; then

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -9,13 +9,13 @@ fi
 apt install --yes software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt update
-apt install --yes lsb-release curl python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev
+apt install --yes lsb-release curl python3.6-dev python3.7-dev python3.8-dev python3.9-dev dirmngr
 curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "16.04" ]]; then
-       apt install --yes openjdk-8-jdk
+       apt install --yes openjdk-8-jdk python3.5-dev
        export ROS_DISTRO=kinetic
 elif [[ $UBUNTU_VERSION == "18.04" ]]; then
        apt install --yes openjdk-11-jdk

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -9,21 +9,19 @@ fi
 apt install --yes software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt update
-apt install --yes lsb-release wget python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev
+apt install --yes lsb-release curl python3.5-dev python3.6-dev python3.7-dev python3.8-dev python3.9-dev
+curl -sL https://deb.nodesource.com/setup_15.x | sudo -E bash -
+sudo apt-get install -y nodejs
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "16.04" ]]; then
        apt install --yes openjdk-8-jdk
-       wget --quiet -O nodesource_setup.sh https://deb.nodesource.com/setup_12.x
-       bash nodesource_setup.sh
-       apt install --yes nodejs
-       rm nodesource_setup.sh
        export ROS_DISTRO=kinetic
 elif [[ $UBUNTU_VERSION == "18.04" ]]; then
-       apt install --yes openjdk-11-jdk npm
+       apt install --yes openjdk-11-jdk
        export ROS_DISTRO=melodic
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
-       apt install --yes openjdk-14-jdk npm
+       apt install --yes openjdk-14-jdk
        export ROS_DISTRO=noetic
 else
        echo "Unsupported Linux version."


### PR DESCRIPTION
Address issues with `npm` installation mentioned at https://github.com/cyberbotics/webots-snap/pull/22
  - [x] install latest `Node.js` version directly from the [nodesource repo](https://github.com/nodesource/distributions#installation-instructions):
    default version available through apt is still depending on libssl1.0 that it is not compatible with ROS
  - [x] move installation of Python 3.5. that is only used on Ubuntu 16.04
  - [x] add missing dependencies:
      - `zip` and `unzip` for compiling robotbenchmark and e-puck xc16
      - `dirmngr` to to add the key associated with the ROS install.
