### PR TITLE
330core to 300es

### DIFF
--- a/resources/wren/shaders/bake_brdf.frag
+++ b/resources/wren/shaders/bake_brdf.frag
@@ -1,4 +1,6 @@
-#version 330 core
+#version 300 es
+
+precision highp float;
 
 out vec3 fragColor;
 in vec2 texUv;

--- a/resources/wren/shaders/bake_brdf.vert
+++ b/resources/wren/shaders/bake_brdf.vert
@@ -1,4 +1,4 @@
-#version 330 core
+#version 300 es
 layout(location = 0) in vec3 aPos;
 layout(location = 1) in vec2 aTexCoords;
 

--- a/resources/wren/shaders/bake_cubemap.vert
+++ b/resources/wren/shaders/bake_cubemap.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 layout(location = 0) in vec3 aPos;
 
 out vec3 worldPosition;

--- a/resources/wren/shaders/bake_diffuse_cubemap.frag
+++ b/resources/wren/shaders/bake_diffuse_cubemap.frag
@@ -1,4 +1,7 @@
-#version 330
+#version 300 es
+
+precision highp float;
+
 out vec3 fragColor;
 in vec3 worldPosition;
 

--- a/resources/wren/shaders/bake_specular_cubemap.frag
+++ b/resources/wren/shaders/bake_specular_cubemap.frag
@@ -1,4 +1,7 @@
-#version 330 core
+#version 300 es
+
+precision highp float;
+
 out vec4 fragColor;
 in vec3 worldPosition;
 

--- a/resources/wren/shaders/blend_bloom.frag
+++ b/resources/wren/shaders/blend_bloom.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 uniform sampler2D inputTextures[7];
 

--- a/resources/wren/shaders/blend_lens_flare.frag
+++ b/resources/wren/shaders/blend_lens_flare.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/bounding_volume.frag
+++ b/resources/wren/shaders/bounding_volume.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 out vec4 fragColor;
 

--- a/resources/wren/shaders/bounding_volume.vert
+++ b/resources/wren/shaders/bounding_volume.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/bright_pass.frag
+++ b/resources/wren/shaders/bright_pass.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 uniform sampler2D inputTextures[1];
 
@@ -13,7 +15,7 @@ float luma(vec3 color) {
 
 void main() {
   vec4 color = texture(inputTextures[0], texUv);
-  vec2 textureSize = textureSize(inputTextures[0], 0);
+  vec2 textureSize = vec2(textureSize(inputTextures[0], 0));
 
   float totalLuma = luma(color.rgb);
 
@@ -27,7 +29,7 @@ void main() {
   totalLuma += luma(texture(inputTextures[0], texUv + vec2(-1, 1) / textureSize).rgb);
   totalLuma += luma(texture(inputTextures[0], texUv + vec2(-1, -1) / textureSize).rgb);
 
-  totalLuma /= 9;
+  totalLuma /= 9.0;
 
   if (isnan(totalLuma) || totalLuma < threshold)
     fragColor = vec4(vec3(0.0), 1.0);

--- a/resources/wren/shaders/color_noise.frag
+++ b/resources/wren/shaders/color_noise.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 in vec2 seed1;

--- a/resources/wren/shaders/color_noise.vert
+++ b/resources/wren/shaders/color_noise.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/coordinate_system.frag
+++ b/resources/wren/shaders/coordinate_system.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 in float depth;

--- a/resources/wren/shaders/coordinate_system.vert
+++ b/resources/wren/shaders/coordinate_system.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/default.frag
+++ b/resources/wren/shaders/default.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int mainTextureIndex = 0;
 const int penTextureIndex = 1;

--- a/resources/wren/shaders/default.vert
+++ b/resources/wren/shaders/default.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/depth_of_field.frag
+++ b/resources/wren/shaders/depth_of_field.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sceneTextureIndex = 0;  // full resolution scene texture
 const int depthTextureIndex = 1;  // full resolution depth buffer texture

--- a/resources/wren/shaders/depth_only.frag
+++ b/resources/wren/shaders/depth_only.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 fragmentPosition;
 

--- a/resources/wren/shaders/depth_only.vert
+++ b/resources/wren/shaders/depth_only.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/depth_resolution.frag
+++ b/resources/wren/shaders/depth_resolution.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sceneTextureIndex = 0;
 

--- a/resources/wren/shaders/encode_depth.frag
+++ b/resources/wren/shaders/encode_depth.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 layout(location = 0) out float floatDepth;
 layout(location = 1) out float outputDepth;

--- a/resources/wren/shaders/encode_depth.vert
+++ b/resources/wren/shaders/encode_depth.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/fog.frag
+++ b/resources/wren/shaders/fog.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 fragmentPosition;
 

--- a/resources/wren/shaders/fog.vert
+++ b/resources/wren/shaders/fog.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/gaussian_blur.frag
+++ b/resources/wren/shaders/gaussian_blur.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sourceTextureIndex = 0;
 const int blurTextureIndex = 1;

--- a/resources/wren/shaders/gaussian_blur_13_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_13_tap.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sourceTextureIndex = 0;
 const int blurTextureIndex = 1;
@@ -65,8 +67,8 @@ vec4 convolveVertically(vec2 textureSizeBlur) {
 }
 
 void main() {
-  vec2 textureSizeSource = textureSize(inputTextures[sourceTextureIndex], 0);
-  vec2 textureSizeBlur = textureSize(inputTextures[blurTextureIndex], 0);
+  vec2 textureSizeSource = vec2(textureSize(inputTextures[sourceTextureIndex], 0));
+  vec2 textureSizeBlur = vec2(textureSize(inputTextures[blurTextureIndex], 0));
   if (iterationNumber % 2 == 0)
     result = convolveHorizontally(textureSizeSource, textureSizeBlur);
   else

--- a/resources/wren/shaders/gaussian_blur_5_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_5_tap.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sourceTextureIndex = 0;
 const int blurTextureIndex = 1;

--- a/resources/wren/shaders/gaussian_blur_9_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_9_tap.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sourceTextureIndex = 0;
 const int blurTextureIndex = 1;

--- a/resources/wren/shaders/gtao.frag
+++ b/resources/wren/shaders/gtao.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // This shader does the heavy lifting for GTAO based on
 // https://github.com/asylum2010/Asylum_Tutorials/blob/master/ShaderTutors/media/shadersGL/gtao.frag
@@ -37,7 +39,7 @@ float GTAOFastSqrt(float x) {
 float GTAOFastAcos(float x) {
   float res = -0.156583 * abs(x) + PI_HALF;
   res *= GTAOFastSqrt(1.0 - abs(x));
-  return x >= 0 ? res : PI - res;
+  return x >= 0.0 ? res : PI - res;
 }
 
 vec4 getViewSpacePosition(vec2 pixelLocation, mat4 inverseProjectionMatrix) {
@@ -46,8 +48,8 @@ vec4 getViewSpacePosition(vec2 pixelLocation, mat4 inverseProjectionMatrix) {
   if (z == 1.0)
     return vec4(0.0);
   // Get x/w and y/w from the viewport position
-  float x = pixelLocation.x * 2 - 1;
-  float y = pixelLocation.y * 2 - 1;
+  float x = pixelLocation.x * 2.0 - 1.0;
+  float y = pixelLocation.y * 2.0 - 1.0;
   vec4 projectedPosition = vec4(x, y, z, 1.0f);
   // Transform by the inverse projection matrix
   vec4 vPositionVS = inverseProjectionMatrix * projectedPosition;
@@ -85,7 +87,7 @@ void searchForHorizons(inout vec2 horizons, vec2 offset, vec3 viewVector, vec4 v
   if (sampleViewspacePosition != vec4(0.0)) {
     sliceSampleToOrigin = sampleViewspacePosition.xyz - viewSpacePosition.xyz;
 
-    squaredSampleDistance = pow(length(sliceSampleToOrigin), 2);
+    squaredSampleDistance = pow(length(sliceSampleToOrigin), 2.0);
     inverseSquaredSampleDistance = inversesqrt(squaredSampleDistance);
     horizonCosine = inverseSquaredSampleDistance * dot(sliceSampleToOrigin, viewVector);
 
@@ -100,13 +102,13 @@ float integrateArc(vec2 horizons, float cosN, float sinN2, float projectedNormal
 }
 
 void main() {
-  vec3 viewSpaceNormal = textureLod(inputTextures[1], texUv, 0).rgb;
+  vec3 viewSpaceNormal = textureLod(inputTextures[1], texUv, 0.0).rgb;
 
   mat4 inverseProjectionMatrix = inverse(cameraTransforms.projection);
 
   // first, retrieve view-space position and normals
   vec4 viewSpacePosition = getViewSpacePosition(texUv, inverseProjectionMatrix);
-  if (viewSpaceNormal == vec3(0.0) || viewSpacePosition.z > 200) {
+  if (viewSpaceNormal == vec3(0.0) || viewSpacePosition.z > 200.0) {
     // discard any fragments from the background or those which don't have a normal
     fragColor = 1.0;
     return;
@@ -135,7 +137,7 @@ void main() {
   vec2 horizons = vec2(-1.0, -1.0);
 
   vec2 offset;
-  for (int j = 0; j < params.z; ++j) {
+  for (int j = 0; j < int(params.z); ++j) {
     offset = round(searchDirection.xy * currentStep);
     currentStep += stepsize;
 
@@ -161,7 +163,7 @@ void main() {
   horizons.y = n + min(horizons.y - n, PI_HALF);
 
   // distance filter - accept all values until 100m, then ramp down to 0 contrib at 200m
-  float distanceFalloff = (max(min(0.01 * (200 - viewSpacePosition.z), 1.0), 0.0));
+  float distanceFalloff = (max(min(0.01 * (200.0 - viewSpacePosition.z), 1.0), 0.0));
 
   fragColor = 1.0 - ((1.0 - integrateArc(horizons, cosN, sinN2, projectedNormalLength, n)) * distanceFalloff);
 }

--- a/resources/wren/shaders/gtao_combine.frag
+++ b/resources/wren/shaders/gtao_combine.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // This shader does the final blend for GTAO based on
 // https://github.com/asylum2010/Asylum_Tutorials/blob/master/ShaderTutors/media/shadersGL/gtaocombine.frag

--- a/resources/wren/shaders/gtao_spatial_denoise.frag
+++ b/resources/wren/shaders/gtao_spatial_denoise.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // This shader does the spatial filtering for GTAO based on
 // https://github.com/asylum2010/Asylum_Tutorials/blob/master/ShaderTutors/media/shadersGL/gtaospatialdenoise.frag

--- a/resources/wren/shaders/gtao_temporal_denoise.frag
+++ b/resources/wren/shaders/gtao_temporal_denoise.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // This shader does the inter-frame filtering for GTAO based on
 // https://github.com/asylum2010/Asylum_Tutorials/blob/master/ShaderTutors/media/shadersGL/gtaotemporaldenoise.frag

--- a/resources/wren/shaders/handles.frag
+++ b/resources/wren/shaders/handles.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 fragmentPosition;
 in vec3 normalTransformed;

--- a/resources/wren/shaders/handles.vert
+++ b/resources/wren/shaders/handles.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/hdr_clear.frag
+++ b/resources/wren/shaders/hdr_clear.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/hdr_resolve.frag
+++ b/resources/wren/shaders/hdr_resolve.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/lens_flare.frag
+++ b/resources/wren/shaders/lens_flare.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int lastResultTextureIndex = 0;
 

--- a/resources/wren/shaders/lens_flare.vert
+++ b/resources/wren/shaders/lens_flare.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/light_representation.frag
+++ b/resources/wren/shaders/light_representation.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/light_representation.vert
+++ b/resources/wren/shaders/light_representation.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/line_set.frag
+++ b/resources/wren/shaders/line_set.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 color;
 

--- a/resources/wren/shaders/line_set.vert
+++ b/resources/wren/shaders/line_set.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 3) in vec3 vColor;

--- a/resources/wren/shaders/merge_spherical.frag
+++ b/resources/wren/shaders/merge_spherical.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 #define pi_2 1.570796327
 

--- a/resources/wren/shaders/motion_blur.frag
+++ b/resources/wren/shaders/motion_blur.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int sceneTextureIndex = 0;
 const int lastResultTextureIndex = 1;

--- a/resources/wren/shaders/noise_mask.frag
+++ b/resources/wren/shaders/noise_mask.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int lastResultTextureIndex = 0;
 const int noiseTextureIndex = 1;

--- a/resources/wren/shaders/overlay.frag
+++ b/resources/wren/shaders/overlay.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 const int bgTextureIndex = 0;
 const int mainTextureIndex = 1;

--- a/resources/wren/shaders/overlay.vert
+++ b/resources/wren/shaders/overlay.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/pass_through.frag
+++ b/resources/wren/shaders/pass_through.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/pass_through.vert
+++ b/resources/wren/shaders/pass_through.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
 const int maxDirectionalLights = 256;

--- a/resources/wren/shaders/pbr.vert
+++ b/resources/wren/shaders/pbr.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 fragmentPosition;
 in vec3 fragmentNormal;

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.vert
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
 const int maxDirectionalLights = 256;

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.vert
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/phong.frag
+++ b/resources/wren/shaders/phong.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
 const int maxDirectionalLights = 256;

--- a/resources/wren/shaders/phong.vert
+++ b/resources/wren/shaders/phong.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
 const int maxDirectionalLights = 256;

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.vert
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
 const int maxDirectionalLights = 256;

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.vert
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/picking.frag
+++ b/resources/wren/shaders/picking.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 out vec4 fragColor;
 

--- a/resources/wren/shaders/picking.vert
+++ b/resources/wren/shaders/picking.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/point_set.frag
+++ b/resources/wren/shaders/point_set.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec3 color;
 

--- a/resources/wren/shaders/point_set.vert
+++ b/resources/wren/shaders/point_set.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 3) in vec3 vColor;

--- a/resources/wren/shaders/range_noise.frag
+++ b/resources/wren/shaders/range_noise.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 in vec2 seed;

--- a/resources/wren/shaders/range_noise.vert
+++ b/resources/wren/shaders/range_noise.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/segmentation.frag
+++ b/resources/wren/shaders/segmentation.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 out vec4 fragColor;
 

--- a/resources/wren/shaders/segmentation.vert
+++ b/resources/wren/shaders/segmentation.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/shadow_volume.frag
+++ b/resources/wren/shaders/shadow_volume.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 layout(location = 0) out vec4 result;
 

--- a/resources/wren/shaders/shadow_volume.vert
+++ b/resources/wren/shaders/shadow_volume.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/simple.frag
+++ b/resources/wren/shaders/simple.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 in vec2 texUv;
 

--- a/resources/wren/shaders/simple.vert
+++ b/resources/wren/shaders/simple.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/skybox.frag
+++ b/resources/wren/shaders/skybox.frag
@@ -1,4 +1,6 @@
-#version 330 core
+#version 300 es
+
+precision highp float;
 #define GAMMA 2.0
 
 layout(location = 0) out vec4 fragColor;
@@ -11,6 +13,6 @@ uniform samplerCube cubeTextures[1];
 void main() {
   // invert z components of sample vector due to VRML default camera orientation looking towards -z
   fragNormal = vec3(0.0);
-  fragColor = textureLod(cubeTextures[0], vec3(texUv.xy, -texUv.z), 0);
+  fragColor = textureLod(cubeTextures[0], vec3(texUv.xy, -texUv.z), 0.0);
   fragColor.rgb = pow(fragColor.rgb, vec3(GAMMA));
 }

--- a/resources/wren/shaders/skybox.vert
+++ b/resources/wren/shaders/skybox.vert
@@ -1,4 +1,4 @@
-#version 330 core
+#version 300 es
 layout(location = 0) in vec3 vCoord;
 
 out vec3 texUv;

--- a/resources/wren/shaders/smaa_blending_weights.frag
+++ b/resources/wren/shaders/smaa_blending_weights.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 #define SMAASampleLevelZeroOffset(tex, coord, offset) texture(tex, coord + float(offset) * RESOLUTION)
 #define SMAASampleLevelZero(tex, coord) textureLod(tex, coord, 0.0)

--- a/resources/wren/shaders/smaa_blending_weights.vert
+++ b/resources/wren/shaders/smaa_blending_weights.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 #define SMAA_MAX_SEARCH_STEPS 16
 #define RESOLUTION (1.0 / viewportSize)

--- a/resources/wren/shaders/smaa_edge_detect.frag
+++ b/resources/wren/shaders/smaa_edge_detect.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 #define SMAA_THRESHOLD 0.1
 

--- a/resources/wren/shaders/smaa_edge_detect.vert
+++ b/resources/wren/shaders/smaa_edge_detect.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/smaa_final_blend.frag
+++ b/resources/wren/shaders/smaa_final_blend.frag
@@ -1,4 +1,6 @@
-#version 330
+#version 300 es
+
+precision highp float;
 
 uniform sampler2D inputTextures[2];
 uniform vec2 viewportSize;

--- a/resources/wren/shaders/smaa_final_blend.vert
+++ b/resources/wren/shaders/smaa_final_blend.vert
@@ -1,4 +1,4 @@
-#version 330
+#version 300 es
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;


### PR DESCRIPTION
**Description**
Change the headers of some shaders to make them compatible with webgl2
For vertex shaders:
Changed : #330 core 
To : #300 es

For fragment shaders:
Changed: #330 core
To: #300 es
      precision highp float;

I also added some .0 to some floats (in skybox.frag and gtao.frag)
