### PR TITLE
Fixed a warning displayed by Visual C++

### DIFF
--- a/resources/languages/cpp/Robot.cpp
+++ b/resources/languages/cpp/Robot.cpp
@@ -439,7 +439,7 @@ Device *Robot::getDevice(int tag) {
   if (tag == 0)
     return NULL;
 
-  int size = deviceList.size();
+  int size = (int)deviceList.size();
   if (size == 0 || size <= tag)
     return NULL;
   return deviceList[tag];
@@ -449,7 +449,7 @@ Device *Robot::getOrCreateDevice(int tag) {
   if (tag == 0)
     return NULL;
 
-  int size = deviceList.size();
+  int size = (int)deviceList.size();
   if (size > 0) {
     if (size <= tag)
       return NULL;


### PR DESCRIPTION
While compiling a C++ controller from Visual C++ 2019, the following warning was displayed:
```
1>C:\Users\Olivier\AppData\Local\Programs\Webots\resources\languages\cpp\Robot.cpp(411,31): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
1>C:\Users\Olivier\AppData\Local\Programs\Webots\resources\languages\cpp\Robot.cpp(421,31): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
```
This PR fixes it.