### PR TITLE
replace rgb16f by rgba16f in order to be compatible with webgl

### DIFF
--- a/src/wren/TextureCubeMapBaker.cpp
+++ b/src/wren/TextureCubeMapBaker.cpp
@@ -248,7 +248,7 @@ namespace wren {
       glBindTexture(GL_TEXTURE_CUBE_MAP, prefilteredCubeGlName);
 
       for (unsigned int i = 0; i < 6; ++i)
-        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB16F, size, size, 0, GL_RGB, GL_FLOAT, nullptr);
+        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGBA16F, size, size, 0, GL_RGBA, GL_FLOAT, nullptr);
 
       glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
@@ -334,7 +334,7 @@ namespace wren {
 
       // pre-allocate enough memory for the LUT texture.
       glBindTexture(GL_TEXTURE_2D, brdfTextureGlName);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, size, size, 0, GL_RGB, GL_FLOAT, 0);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, size, size, 0, GL_RGBA, GL_FLOAT, 0);
       // be sure to set wrapping mode to GL_CLAMP_TO_EDGE
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
**Description**
In WebGL2, the RGB16F format is not color-renderable whereas the RGBA16F format is (https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/). I propose to replace RGB16F by RGBA16F is these two functions that I need in WebGl.


