### PR TITLE
Fix updating device list after importing a joint descendant node

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -21,3 +21,4 @@ Released on December XXth, 2020.
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.
+    - Fixed updating the robot's device list after importing a device node at run time in a field descending from a joint ([#2482](https://github.com/cyberbotics/webots/pull/2482)).

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -113,6 +113,9 @@ void WbBasicJoint::postFinalize() {
     e->postFinalize();
 
   connect(mEndPoint, &WbSFNode::changed, this, &WbBasicJoint::updateEndPoint);
+  const WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
+  assert(pg);
+  connect(this, &WbBasicJoint::endPointChanged, pg, &WbGroup::insertChildFromSlotOrJoint);
   connect(mParameters, &WbSFNode::changed, this, &WbBasicJoint::updateParameters);
 
   WbSolid *const s = solidEndPoint();

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -240,13 +240,10 @@ void WbGroup::descendantNodeInserted(WbBaseNode *decendant) {
     pg->descendantNodeInserted(decendant);
     return;
   }
-  WbBasicJoint *pj = dynamic_cast<WbBasicJoint *>(parentNode());
-  if (pj) {
+
+  if (dynamic_cast<WbBasicJoint *>(parentNode()))
     emit notifyParentJoint(decendant);
-    return;
-  }
-  WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
-  if (ps)
+  else if (dynamic_cast<WbSlot *>(parentNode()))
     emit notifyParentSlot(decendant);
 }
 

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -14,6 +14,7 @@
 
 #include "WbGroup.hpp"
 
+#include "WbBasicJoint.hpp"
 #include "WbBoundingSphere.hpp"
 #include "WbGeometry.hpp"
 #include "WbOdeContext.hpp"
@@ -88,6 +89,10 @@ void WbGroup::postFinalize() {
   WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
   if (ps)
     connect(this, &WbGroup::notifyParentSlot, ps, &WbSlot::endPointInserted);
+  // if parent is a joint, it needs to be notified when a new node is inserted
+  const WbBasicJoint *pj = dynamic_cast<WbBasicJoint *>(parentNode());
+  if (pj)
+    connect(this, &WbGroup::notifyParentJoint, pj, &WbBasicJoint::endPointChanged);
 
   const WbGroup *const parent = dynamic_cast<const WbGroup *const>(parentNode());
   if (parent && parent->mHasNoSolidAncestor) {
@@ -227,17 +232,25 @@ bool WbGroup::isAValidBoundingObject(bool checkOde, bool warning) const {
 }
 
 void WbGroup::descendantNodeInserted(WbBaseNode *decendant) {
-  if (parentNode()) {
-    WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
-    WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
-    if (pg)
-      pg->descendantNodeInserted(decendant);
-    if (ps)
-      emit notifyParentSlot(decendant);
+  if (!parentNode())
+    return;
+
+  WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
+  if (pg) {
+    pg->descendantNodeInserted(decendant);
+    return;
   }
+  WbBasicJoint *pj = dynamic_cast<WbBasicJoint *>(parentNode());
+  if (pj) {
+    emit notifyParentJoint(decendant);
+    return;
+  }
+  WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
+  if (ps)
+    emit notifyParentSlot(decendant);
 }
 
-void WbGroup::insertChildFromSlot(WbBaseNode *decendant) {
+void WbGroup::insertChildFromSlotOrJoint(WbBaseNode *decendant) {
   descendantNodeInserted(decendant);
   emit childAdded(decendant);
 }

--- a/src/webots/nodes/WbGroup.hpp
+++ b/src/webots/nodes/WbGroup.hpp
@@ -108,6 +108,7 @@ signals:
   void childAdded(WbBaseNode *child);
   void finalizedChildAdded(WbBaseNode *child);  // emit signal when inserting child after current node is finalized
   void notifyParentSlot(WbBaseNode *child);
+  void notifyParentJoint(WbBaseNode *child);
   void childFinalizationHasProgressed(const int progress);  // 0: beginning, 100: end
 
 protected:
@@ -137,7 +138,7 @@ private:
 
 public slots:
   void cancelFinalization();
-  void insertChildFromSlot(WbBaseNode *decendant);
+  void insertChildFromSlotOrJoint(WbBaseNode *decendant);
 
 private slots:
   void insertChildPrivate(int index);

--- a/src/webots/nodes/WbSlot.cpp
+++ b/src/webots/nodes/WbSlot.cpp
@@ -58,7 +58,7 @@ void WbSlot::preFinalize() {
   connect(mEndPoint, &WbSFString::changed, this, &WbSlot::endPointChanged);
   WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
   if (pg)  // parent is a group
-    connect(this, &WbSlot::endPointInserted, pg, &WbGroup::insertChildFromSlot);
+    connect(this, &WbSlot::endPointInserted, pg, &WbGroup::insertChildFromSlotOrJoint);
   WbSlot *ps = dynamic_cast<WbSlot *>(parentNode());
   if (ps)  // parent is another slot
     connect(this, &WbSlot::endPointInserted, ps, &WbSlot::endPointInserted);


### PR DESCRIPTION
Fix #2476: import even in joint is not propagated to the top robot node and the list of devices is not updated.