### PR TITLE
extends the exported fields for the stream viewer

### DIFF
--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -432,6 +432,7 @@ void WbImageTexture::exportNodeFields(WbVrmlWriter &writer) const {
   urlFieldCopy.write(writer);
   findField("repeatS", true)->write(writer);
   findField("repeatT", true)->write(writer);
+  findField("filtering", true)->write(writer);
 
   if (writer.isX3d()) {
     writer << " containerField=\'" << mContainerField << "\' origChannelCount=\'3\' isTransparent=\'"

--- a/src/webots/nodes/WbLight.cpp
+++ b/src/webots/nodes/WbLight.cpp
@@ -233,6 +233,7 @@ void WbLight::exportNodeFields(WbVrmlWriter &writer) const {
   findField("on", true)->write(writer);
   findField("color", true)->write(writer);
   findField("intensity", true)->write(writer);
+  findField("ambientIntensity", true)->write(writer);
   findField("castShadows", true)->write(writer);
   if (writer.isX3d() && castShadows()) {
     QMap<QString, QString> x3dExportParameters = WbWorld::instance()->perspective()->x3dExportParameters();

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -1527,7 +1527,9 @@ void WbViewpoint::exportNodeFields(WbVrmlWriter &writer) const {
     writer << " exposure=\'" << mExposure->value() << "\'";
     writer << " bloomThreshold=\'" << mBloomThreshold->value() << "\'";
     writer << " zNear=\'" << mNear->value() << "\'";
+    writer << " far=\'" << mFar->value() << "\'";
     writer << " followSmoothness=\'" << mFollowSmoothness->value() << "\'";
+    writer << " ambientOcclusionRadius=\'" << mAmbientOcclusionRadius->value() << "\'";
     if (mFollowedSolid)
       writer << " followedId=\'n" << QString::number(mFollowedSolid->uniqueId()) << "\'";
   }


### PR DESCRIPTION
**Description**
Added export for the ambientIntensity variable of Ligth, filtering of ImageTexture, far and ambientOcclusionRadius of Viewpoint.

The far field is called "far" and not "zFar" because the zFar field is already utilized by the current streaming viewer and it expects another default value (2000 instead of 0)