### PR TITLE
Call the physics plugin callback `webots_physics_collide` on Group node

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -19,6 +19,7 @@ Released on December XXth, 2020.
     - Added a `data_type` parameter to a Python method [`getPointCloud`](lidar.md#wb_lidar_get_point_cloud) that retrieves a `bytearray` representation of points a few times faster than the previous version.
   - Bug fixes
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
+    - The [webots_physics_collide(dGeomID, dGeomID)](callback-functions.md#int-webots_physics_collidedgeomid-dgeomid) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -19,7 +19,7 @@ Released on December XXth, 2020.
     - Added a `data_type` parameter to a Python method [`getPointCloud`](lidar.md#wb_lidar_get_point_cloud) that retrieves a `bytearray` representation of points a few times faster than the previous version.
   - Bug fixes
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
-    - The [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
+    - Fixed the [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function so that it gets called even if the [`boundingObject`](solid.md#solid-fields) is a [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -19,7 +19,7 @@ Released on December XXth, 2020.
     - Added a `data_type` parameter to a Python method [`getPointCloud`](lidar.md#wb_lidar_get_point_cloud) that retrieves a `bytearray` representation of points a few times faster than the previous version.
   - Bug fixes
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
-    - The [webots_physics_collide(dGeomID, dGeomID)](callback-functions.md#int-webots_physics_collidedgeomid-dgeomid) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
+    - The [webots_physics_collide(dGeomID, dGeomID)](callback-functions.md) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -19,7 +19,7 @@ Released on December XXth, 2020.
     - Added a `data_type` parameter to a Python method [`getPointCloud`](lidar.md#wb_lidar_get_point_cloud) that retrieves a `bytearray` representation of points a few times faster than the previous version.
   - Bug fixes
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
-    - The [webots_physics_collide(dGeomID, dGeomID)](callback-functions.md) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
+    - The [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function is called even if the [`boundingObject`](solid.md#solid-fields) value is set to be the [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -474,6 +474,9 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       return;
   }
 
+  if (dGeomIsSpace(o1) || dGeomIsSpace(o2))
+    return;
+
   // yvan: we are never interested in the collision between 2 ray geoms
   // (rays geoms can be either distance sensor, emitter-receiver or light sensor rays)
   const bool isRayGeom1 = dGeomGetClass(o1) == dRayClass;

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -439,7 +439,6 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       dSpaceCollide((dSpaceID)o1, data, odeNearCallback);
     if (dGeomIsSpace(o2))
       dSpaceCollide((dSpaceID)o2, data, odeNearCallback);
-    return;
   }
 
   // retrieve data


### PR DESCRIPTION
**Description**
Callback function `webots_physics_collide` used not to be called if `boundingObject` is a `Group` node. This PR fixes the behavior.

**Related Issues**
Fixes #2420
It also seems to be fixing #2455 (it is not crashing anymore)

**Tasks**
  - [x] Fix
  - [x] Check regressions
  - [x] Add changelog
