### PR TITLE
Proto splitter script fix

### DIFF
--- a/scripts/proto_splitter/proto2multi.py
+++ b/scripts/proto_splitter/proto2multi.py
@@ -142,7 +142,7 @@ class proto2multi:
                     if "{" in ln or "[" in ln:
                         shapeLevel += 1
                 replaceString = self.createProto(newProtoString)
-                self.pf.write(indent * level + defString + "geometry " + replaceString)
+                self.pf.write(indent * level +  "geometry " + defString + replaceString)
                 self.pf.write(indent * level + "}\n")
             else:
                 if "}" in ln or "]" in ln:

--- a/scripts/proto_splitter/proto2multi.py
+++ b/scripts/proto_splitter/proto2multi.py
@@ -80,7 +80,7 @@ class proto2multi:
         path = os.path.dirname(inFile)
         self.robotName = os.path.splitext(os.path.basename(inFile))[0]
         if outFile is None:
-            newPath = "{}/multifile_{}".format(path, self.robotName)
+            newPath = "{}/{}_multifile".format(path, self.robotName)
             outFile = "{}/{}.proto".format(newPath, self.robotName)
         else:
             newPath = os.path.dirname(outFile)
@@ -124,7 +124,7 @@ class proto2multi:
                 if eof > 10:
                     self.f.close()
                     self.pf.close()
-                    self.cleanup(inFile)                    
+                    self.cleanup(inFile)
                     return
             if "IndexedFaceSet" in ln:
                 shapeLevel = 1
@@ -142,7 +142,7 @@ class proto2multi:
                     if "{" in ln or "[" in ln:
                         shapeLevel += 1
                 replaceString = self.createProto(newProtoString)
-                self.pf.write(indent * level +  "geometry " + defString + replaceString)
+                self.pf.write(indent * level + "geometry " + defString + replaceString)
                 self.pf.write(indent * level + "}\n")
             else:
                 if "}" in ln or "]" in ln:


### PR DESCRIPTION
**Description**
Fixed a naming bug for the generated meshes protos. It generated the names as 
`<robotName>Mesh<number>Mesh.proto`
instead of
`<robotName>Mesh<number>.proto`

Change:
Instead of creating a backup of the directory to convert, it leaves the original directory as is, and generates a new directory with the changes. For example:
```bash
python .\proto2multi.py --input=../../projects/robots
```
will convert the entire robot directory, but leave the original untouched. The converted one will be in webots/projects, next to the robot directory