### PR TITLE
Fix propagating import information to joint with slot parent

### DIFF
--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -102,6 +102,7 @@ void WbBasicJoint::setMatrixNeedUpdate() {
     s->setMatrixNeedUpdate();
 }
 
+#include <QtCore/QDebug>
 void WbBasicJoint::postFinalize() {
   WbBaseNode::postFinalize();
 
@@ -114,8 +115,13 @@ void WbBasicJoint::postFinalize() {
 
   connect(mEndPoint, &WbSFNode::changed, this, &WbBasicJoint::updateEndPoint);
   const WbGroup *pg = dynamic_cast<WbGroup *>(parentNode());
-  assert(pg);
-  connect(this, &WbBasicJoint::endPointChanged, pg, &WbGroup::insertChildFromSlotOrJoint);
+  if (pg)
+    connect(this, &WbBasicJoint::endPointChanged, pg, &WbGroup::insertChildFromSlotOrJoint);
+  else {
+    const WbSlot *slot = dynamic_cast<WbSlot *>(parentNode());
+    if (slot)
+      connect(this, &WbBasicJoint::endPointChanged, slot, &WbSlot::endPointInserted);
+  }
   connect(mParameters, &WbSFNode::changed, this, &WbBasicJoint::updateParameters);
 
   WbSolid *const s = solidEndPoint();

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -102,7 +102,6 @@ void WbBasicJoint::setMatrixNeedUpdate() {
     s->setMatrixNeedUpdate();
 }
 
-#include <QtCore/QDebug>
 void WbBasicJoint::postFinalize() {
   WbBaseNode::postFinalize();
 


### PR DESCRIPTION
Fix check for joint's parent node introduced in #2482.
Previously the test_suite was failing if Webots was compiled in debug mode.