### PR TITLE
Fix lens flare shader compilation failure

### DIFF
--- a/resources/wren/shaders/lens_flare.frag
+++ b/resources/wren/shaders/lens_flare.frag
@@ -4,7 +4,7 @@ precision highp float;
 
 const int lastResultTextureIndex = 0;
 
-noperspective in vec2 texUv;
+in vec2 texUv;
 
 layout(location = 0) out vec4 fragColor;
 

--- a/resources/wren/shaders/lens_flare.vert
+++ b/resources/wren/shaders/lens_flare.vert
@@ -3,7 +3,7 @@
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;
 
-noperspective out vec2 texUv;
+out vec2 texUv;
 
 void main() {
   texUv = vTexCoord;


### PR DESCRIPTION
Fixes #2528.

This is an emergency patch that fixes the compilation error of the shader. However, with this patch, the lens flare effect doesn't show up any more. The lens flare effect is anyhow broken (see #939). Therefore, I would suggest to fix it there as soon as possible.
