### PR TITLE
Fixed the WREN demos to run on Windows as well

### DIFF
--- a/src/wren/demo/Makefile
+++ b/src/wren/demo/Makefile
@@ -19,11 +19,13 @@ include ../../../resources/Makefile.os.include
 ifeq ($(OSTYPE),linux)
 GLAD=libglad.a
 GLU=GLU
+GLUT=glut
 OPENGL=GL
 WREN=libwren.a
 else ifeq ($(OSTYPE),windows)
 GLAD=glad.a
 GLU=glu32
+GLUT=freeglut
 OPENGL=opengl32
 WREN=wren.a
 else
@@ -33,10 +35,10 @@ endif
 all: default phong
 
 default: default.cpp
-	g++ -I../../../include default.cpp ../wren.a ../../glad/$(GLAD) -lfreeglut -l$(OPENGL) -l$(GLU) -o default
+	g++ -I../../../include default.cpp ../$(WREN) ../../glad/$(GLAD) -l$(GLUT) -l$(OPENGL) -l$(GLU) -ldl -o default
 
 phong: phong.cpp
-	g++ -g -I../../../include phong.cpp ../wren.a ../../glad/$(GLAD) -lfreeglut -l$(OPENGL) -l$(GLU) -o phong
+	g++ -g -I../../../include phong.cpp ../$(WREN) ../../glad/$(GLAD) -l$(GLUT) -l$(OPENGL) -l$(GLU) -ldl -o phong
 
 clean:
 	rm default phong

--- a/src/wren/demo/Makefile
+++ b/src/wren/demo/Makefile
@@ -12,15 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For now, it can only works on linux.
+# For now, it works only on linux and Windows
+
+include ../../../resources/Makefile.os.include
+
+ifeq ($(OSTYPE),linux)
+GLAD=libglad.a
+GLU=GLU
+OPENGL=GL
+WREN=libwren.a
+else ifeq ($(OSTYPE),windows)
+GLAD=glad.a
+GLU=glu32
+OPENGL=opengl32
+WREN=wren.a
+else
+$(error $(OSTYPE) is not supported)
+endif
 
 all: default phong
 
 default: default.cpp
-	g++ -I../../../include default.cpp ../libwren.a ../../glad/libglad.a -lglut -lGL -lGLU -ldl -o default
+	g++ -I../../../include default.cpp ../wren.a ../../glad/$(GLAD) -lfreeglut -l$(OPENGL) -l$(GLU) -o default
 
 phong: phong.cpp
-	g++ -g -I../../../include phong.cpp ../libwren.a ../../glad/libglad.a -lglut -lGL -lGLU -ldl -o phong
+	g++ -g -I../../../include phong.cpp ../wren.a ../../glad/$(GLAD) -lfreeglut -l$(OPENGL) -l$(GLU) -o phong
 
 clean:
 	rm default phong

--- a/src/wren/demo/Makefile
+++ b/src/wren/demo/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# For now, it works only on linux and Windows
+# For now, it works only on Linux and Windows
 
 include ../../../resources/Makefile.os.include
 

--- a/src/wren/demo/phong.cpp
+++ b/src/wren/demo/phong.cpp
@@ -113,26 +113,9 @@ static void initMaterialToPhong(WrMaterial *material) {
   if (!wr_shader_program_get_gl_name(phongStencilDiffuseSpecularProgram))
     printf("Compilation failed: %s\n", wr_shader_program_get_compilation_log(phongStencilDiffuseSpecularProgram));
 
-  WrShaderProgram *phongStencilClampProgram = wr_shader_program_new();
-  wr_shader_program_use_uniform(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_TEXTURE0);  // main texture
-  wr_shader_program_use_uniform(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_TEXTURE1);  // pen texture
-  wr_shader_program_use_uniform(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_TEXTURE2);  // background texture
-  wr_shader_program_use_uniform(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_MODEL_TRANSFORM);
-  wr_shader_program_use_uniform(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_TEXTURE_TRANSFORM);
-  wr_shader_program_use_uniform_buffer(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_BUFFER_MATERIAL_PHONG);
-  wr_shader_program_use_uniform_buffer(phongStencilClampProgram, WR_GLSL_LAYOUT_UNIFORM_BUFFER_CAMERA_TRANSFORMS);
-  wr_shader_program_set_vertex_shader_path(phongStencilClampProgram,
-                                           "../../../resources/wren/shaders/phong_stencil_clamp.vert");
-  wr_shader_program_set_fragment_shader_path(phongStencilClampProgram,
-                                             "../../../resources/wren/shaders/phong_stencil_clamp.frag");
-  wr_shader_program_setup(phongStencilClampProgram);
-  if (!wr_shader_program_get_gl_name(phongStencilClampProgram))
-    printf("Compilation failed: %s\n", wr_shader_program_get_compilation_log(phongStencilClampProgram));
-
   wr_material_set_default_program(material, phongProgram);
   wr_material_set_stencil_ambient_emissive_program(material, phongStencilAmbientEmissiveProgram);
   wr_material_set_stencil_diffuse_specular_program(material, phongStencilDiffuseSpecularProgram);
-  wr_material_set_stencil_clamp_program(material, phongStencilClampProgram);
 }
 
 // Create the WREN scene.
@@ -155,9 +138,9 @@ static void create_wren_scene() {
 
   WrTransform *root = wr_scene_get_root(wr_scene_get_instance());
 
-  printf("Loading:\n");
   for (int i = 0; i < 100; ++i) {
-    printf("  %d%%\n", i);
+    printf("\33[2K\rLoading: %d%%", i);
+    fflush(stdout);
 
     WrRenderable *sphereRenderable = wr_renderable_new();
     WrStaticMesh *sphereMesh = wr_static_mesh_unit_sphere_new(2, true, false);
@@ -175,12 +158,15 @@ static void create_wren_scene() {
     wr_transform_set_position(sphereTransform, sphere_position);
     wr_transform_attach_child(root, WR_NODE(sphereTransform));
   }
+  printf("\n");
 }
 
 // Render function.
 static void render() {
-  printf("render\n");
-  wr_scene_render(wr_scene_get_instance(), NULL);
+  static int i = 0;
+  printf("\33[2K\rrendering iteration %d", i++);
+  fflush(stdout);
+  wr_scene_render(wr_scene_get_instance(), NULL, true);
   glutSwapBuffers();
 }
 


### PR DESCRIPTION
The WREN demos are useful to debug WREN and to better understand it.
It's nice to have them working on Windows as well.
This PR adds support for Windows in the Makefile.
It also fixes the phong demo which was broken due to a missing shader and missing function parameter.