### PR TITLE
Improve highway grass shape

### DIFF
--- a/projects/samples/robotbenchmark/highway_driving/worlds/highway_driving.wbt
+++ b/projects/samples/robotbenchmark/highway_driving/worlds/highway_driving.wbt
@@ -677,6 +677,7 @@ Solid {
         ccw FALSE
         creaseAngle 1.1
       }
+      castShadows FALSE
     }
   ]
   name "solid(2)"
@@ -891,4 +892,13 @@ DEF SUMO_VEHICLE24 CitroenCZeroSimple {
     0.18 0.28 0.64
   ]
   name "vehicle(26)"
+}
+SumoInterface {
+  gui FALSE
+  useNetconvert FALSE
+  enableWheelsRotation TRUE
+  radius 200
+  laneChangeDelay 4
+  port 1472
+  seed 0
 }

--- a/projects/samples/robotbenchmark/highway_driving/worlds/highway_driving.wbt
+++ b/projects/samples/robotbenchmark/highway_driving/worlds/highway_driving.wbt
@@ -893,12 +893,3 @@ DEF SUMO_VEHICLE24 CitroenCZeroSimple {
   ]
   name "vehicle(26)"
 }
-SumoInterface {
-  gui FALSE
-  useNetconvert FALSE
-  enableWheelsRotation TRUE
-  radius 200
-  laneChangeDelay 4
-  port 1472
-  seed 0
-}

--- a/projects/vehicles/worlds/highway_overtake.wbt
+++ b/projects/vehicles/worlds/highway_overtake.wbt
@@ -791,6 +791,7 @@ Solid {
         ccw FALSE
         creaseAngle 1.1
       }
+      castShadows FALSE
     }
   ]
   name "solid(2)"


### PR DESCRIPTION
Disable shadows for the grass that could cause z-fighting issues on some particular camera settings (see #2281).