### PR TITLE
Fix sick example after range finder behavior change (infinity return value)

### DIFF
--- a/projects/samples/devices/controllers/sick/sick.c
+++ b/projects/samples/devices/controllers/sick/sick.c
@@ -117,9 +117,10 @@ int main(int argc, char **argv) {
 
     // apply the braitenberg coefficients on the resulted values of the lms291
     double obstacle = 0.0;
-    for (i = 0; i < lms291_width; i++)
-      obstacle += braitenberg_coefficients[i] * (1.0 - lms291_values[i] / max_range);
-
+    for (i = 0; i < lms291_width; i++) {
+      const float value = isinf(lms291_values[i]) ? max_range : lms291_values[i];
+      obstacle += braitenberg_coefficients[i] * (1.0 - value / max_range);
+    }
     // compute the speed and the direction according to the information about
     // a front obstacle
     double speed = MAX_SPEED * (0.99 - obstacle);


### PR DESCRIPTION
The example was displaying many warnings in red in the console.
This was due to the return value of the lidar which can now return infinity and was not properly handled.
This PR fixes it.