### PR TITLE
Reduce timestep in the `ure` world to avoid warnings

### DIFF
--- a/projects/robots/universal_robots/worlds/ure.wbt
+++ b/projects/robots/universal_robots/worlds/ure.wbt
@@ -4,7 +4,7 @@ WorldInfo {
     "Unviversal Robot UR3e, UR5e and UR10e grasping cans using Robotiq 3F grippers."
   ]
   title "Universal Robot"
-  basicTimeStep 16
+  basicTimeStep 8
   physicsDisableAngularThreshold 0.1
   coordinateSystem "NUE"
   contactProperties [


### PR DESCRIPTION
Running the `ure.wbt` shows the following error:
```
WARNING: The current physics step could not be computed correctly. Your world may be too complex. If this problem persists, try simplifying your bounding object(s), reducing the number of joints, or reducing WorldInfo.basicTimeStep.
```
