### PR TITLE
Include missing images needed by streaming viewer

### DIFF
--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -341,6 +341,8 @@ resources/web/wwi/
 resources/web/wwi/request_methods.js
 resources/web/wwi/webots.min.js
 resources/web/wwi/wwi.css
+resources/web/wwi/images/
+resources/web/wwi/images/documentation/
 resources/wren/
 resources/wren/meshes/
 resources/wren/meshes/*.obj


### PR DESCRIPTION
Fixes #2548. Some images are not distributed with the packages.