### PR TITLE
Fixed detection of Visual Studio on Windows

### DIFF
--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -351,7 +351,9 @@ endif
 ifeq ($(OSTYPE),windows)
  ifdef BUILD_SHARED_LIBRARY
   ifndef USE_CXX
-   VISUAL_STUDIO_PATH?=/C/Program Files (x86)/Microsoft Visual Studio 10.0
+    ifneq ($(wildcard /C/Program\ Files\ */Microsoft\ Visual\ Studio\ 10.0),)
+      VISUAL_STUDIO_PATH?=/C/Program Files (x86)/Microsoft Visual Studio 10.0
+    endif
    VS_DEF_NAME = $(NAME).def
   endif
  endif


### PR DESCRIPTION
There was a problem with the detection of Visual Studio 10 on Windows.
If it was not installed, the Makefile was setting its path to a non-existing folder instead of ignoring it.
This was breaking the compilation process in case Visual Studio 10 is not installed.
This PR fixes the problem.