### PR TITLE
reverts the headers to 330 core for compatibility with Mac

### DIFF
--- a/resources/wren/shaders/bake_brdf.frag
+++ b/resources/wren/shaders/bake_brdf.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/bake_brdf.vert
+++ b/resources/wren/shaders/bake_brdf.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 layout(location = 0) in vec3 aPos;
 layout(location = 1) in vec2 aTexCoords;
 

--- a/resources/wren/shaders/bake_cubemap.vert
+++ b/resources/wren/shaders/bake_cubemap.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 layout(location = 0) in vec3 aPos;
 
 out vec3 worldPosition;

--- a/resources/wren/shaders/bake_diffuse_cubemap.frag
+++ b/resources/wren/shaders/bake_diffuse_cubemap.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/bake_specular_cubemap.frag
+++ b/resources/wren/shaders/bake_specular_cubemap.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/blend_bloom.frag
+++ b/resources/wren/shaders/blend_bloom.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/blend_lens_flare.frag
+++ b/resources/wren/shaders/blend_lens_flare.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/bounding_volume.frag
+++ b/resources/wren/shaders/bounding_volume.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/bounding_volume.vert
+++ b/resources/wren/shaders/bounding_volume.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/bright_pass.frag
+++ b/resources/wren/shaders/bright_pass.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/color_noise.frag
+++ b/resources/wren/shaders/color_noise.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/color_noise.vert
+++ b/resources/wren/shaders/color_noise.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/coordinate_system.frag
+++ b/resources/wren/shaders/coordinate_system.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/coordinate_system.vert
+++ b/resources/wren/shaders/coordinate_system.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/default.frag
+++ b/resources/wren/shaders/default.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/default.vert
+++ b/resources/wren/shaders/default.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/depth_of_field.frag
+++ b/resources/wren/shaders/depth_of_field.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/depth_only.frag
+++ b/resources/wren/shaders/depth_only.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/depth_only.vert
+++ b/resources/wren/shaders/depth_only.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/depth_resolution.frag
+++ b/resources/wren/shaders/depth_resolution.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/encode_depth.frag
+++ b/resources/wren/shaders/encode_depth.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/encode_depth.vert
+++ b/resources/wren/shaders/encode_depth.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/fog.frag
+++ b/resources/wren/shaders/fog.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/fog.vert
+++ b/resources/wren/shaders/fog.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/gaussian_blur.frag
+++ b/resources/wren/shaders/gaussian_blur.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gaussian_blur_13_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_13_tap.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gaussian_blur_5_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_5_tap.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gaussian_blur_9_tap.frag
+++ b/resources/wren/shaders/gaussian_blur_9_tap.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gtao.frag
+++ b/resources/wren/shaders/gtao.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gtao_combine.frag
+++ b/resources/wren/shaders/gtao_combine.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gtao_spatial_denoise.frag
+++ b/resources/wren/shaders/gtao_spatial_denoise.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/gtao_temporal_denoise.frag
+++ b/resources/wren/shaders/gtao_temporal_denoise.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/handles.frag
+++ b/resources/wren/shaders/handles.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/handles.vert
+++ b/resources/wren/shaders/handles.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/hdr_clear.frag
+++ b/resources/wren/shaders/hdr_clear.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/hdr_resolve.frag
+++ b/resources/wren/shaders/hdr_resolve.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/lens_flare.frag
+++ b/resources/wren/shaders/lens_flare.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/lens_flare.vert
+++ b/resources/wren/shaders/lens_flare.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/light_representation.frag
+++ b/resources/wren/shaders/light_representation.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/light_representation.vert
+++ b/resources/wren/shaders/light_representation.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/line_set.frag
+++ b/resources/wren/shaders/line_set.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/line_set.vert
+++ b/resources/wren/shaders/line_set.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 3) in vec3 vColor;

--- a/resources/wren/shaders/merge_spherical.frag
+++ b/resources/wren/shaders/merge_spherical.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/motion_blur.frag
+++ b/resources/wren/shaders/motion_blur.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/noise_mask.frag
+++ b/resources/wren/shaders/noise_mask.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/overlay.frag
+++ b/resources/wren/shaders/overlay.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/overlay.vert
+++ b/resources/wren/shaders/overlay.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/pass_through.frag
+++ b/resources/wren/shaders/pass_through.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/pass_through.vert
+++ b/resources/wren/shaders/pass_through.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/pbr.vert
+++ b/resources/wren/shaders/pbr.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.vert
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.vert
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/phong.frag
+++ b/resources/wren/shaders/phong.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/phong.vert
+++ b/resources/wren/shaders/phong.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 1) in vec3 vNormal;

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.vert
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.vert
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/picking.frag
+++ b/resources/wren/shaders/picking.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/picking.vert
+++ b/resources/wren/shaders/picking.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/point_set.frag
+++ b/resources/wren/shaders/point_set.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/point_set.vert
+++ b/resources/wren/shaders/point_set.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 3) in vec3 vColor;

--- a/resources/wren/shaders/range_noise.frag
+++ b/resources/wren/shaders/range_noise.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/range_noise.vert
+++ b/resources/wren/shaders/range_noise.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/segmentation.frag
+++ b/resources/wren/shaders/segmentation.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/segmentation.vert
+++ b/resources/wren/shaders/segmentation.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 

--- a/resources/wren/shaders/shadow_volume.frag
+++ b/resources/wren/shaders/shadow_volume.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/shadow_volume.vert
+++ b/resources/wren/shaders/shadow_volume.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 

--- a/resources/wren/shaders/simple.frag
+++ b/resources/wren/shaders/simple.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/simple.vert
+++ b/resources/wren/shaders/simple.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/skybox.frag
+++ b/resources/wren/shaders/skybox.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 #define GAMMA 2.0

--- a/resources/wren/shaders/skybox.vert
+++ b/resources/wren/shaders/skybox.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 layout(location = 0) in vec3 vCoord;
 
 out vec3 texUv;

--- a/resources/wren/shaders/smaa_blending_weights.frag
+++ b/resources/wren/shaders/smaa_blending_weights.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/smaa_blending_weights.vert
+++ b/resources/wren/shaders/smaa_blending_weights.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 #define SMAA_MAX_SEARCH_STEPS 16
 #define RESOLUTION (1.0 / viewportSize)

--- a/resources/wren/shaders/smaa_edge_detect.frag
+++ b/resources/wren/shaders/smaa_edge_detect.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/smaa_edge_detect.vert
+++ b/resources/wren/shaders/smaa_edge_detect.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;

--- a/resources/wren/shaders/smaa_final_blend.frag
+++ b/resources/wren/shaders/smaa_final_blend.frag
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 precision highp float;
 

--- a/resources/wren/shaders/smaa_final_blend.vert
+++ b/resources/wren/shaders/smaa_final_blend.vert
@@ -1,4 +1,4 @@
-#version 300 es
+#version 330 core
 
 layout(location = 0) in vec3 vCoord;
 layout(location = 2) in vec2 vTexCoord;


### PR DESCRIPTION
**Description**
It seems that Mac OS doesn't support the "300 ES" headers for the shaders. We will revert the headers to the previous core version

**Related Issues**
This pull-request fixes issue #2553 

