### PR TITLE
Fix Webots freeze on NaN value in hokuyo.wbt

### DIFF
--- a/projects/samples/devices/controllers/hokuyo/hokuyo.c
+++ b/projects/samples/devices/controllers/hokuyo/hokuyo.c
@@ -66,7 +66,7 @@ static void display(WbDeviceTag d,   // display
   int i;
   for (i = 0; i < ns; i++) {
     const float f = v[i];
-    if (f != INFINITY) {
+    if (f != INFINITY && !isnan(f)) {
       const float alpha = -fov2 + fov * i / ns - M_PI_2;
       wb_display_draw_line(d, dw2, dh2, dw2 + f * cos(alpha) * dw2 / RADIUS, dh2 + f * sin(alpha) * dh2 / RADIUS);
     }


### PR DESCRIPTION
Fix #2563: in the VM some lidar values are NaN causing Webots to freeze when handling the `wb_display_draw_line` function.
However, on my native Ubuntu 18.04, it never occurs that lidar values are NaN.