### PR TITLE
Fixes movie creation on Windows

### DIFF
--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -16,6 +16,7 @@ declare -a BASE_PACKAGES=(
   "mingw-w64-x86_64-libgd"    # Webots
   "liblzma"                   # Webots
   "mingw-w64-x86_64-ffmpeg"   # Webots movies
+  "mingw-w64-x86_64-dlfcn"    # dependency of ffmpeg
 )
 
 declare -a OPTIONAL_PACKAGES=(


### PR DESCRIPTION
The current version of MSYS2 is somehow broken as a dependency of ffmpeg doesn't get automatically installed.
This PR fixes the problem.
I will upload a patched version of Webots R2021a for Windows on the release page to fix the problem.