### PR TITLE
Fix Windows nightly builds

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -45,7 +45,7 @@ jobs:
         echo 'export PYTHON27_HOME=/C/hostedtoolcache/windows/Python/2.7.18/x64' >> ~/.bash_profile
         echo 'export PYTHON37_HOME=/C/hostedtoolcache/windows/Python/3.7.9/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME=/C/hostedtoolcache/windows/Python/3.8.6/x64' >> ~/.bash_profile
-        echo 'export PYTHON39_HOME=/C/hostedtoolcache/windows/Python/3.9.0/x64' >> ~/.bash_profile
+        echo 'export PYTHON39_HOME=/C/hostedtoolcache/windows/Python/3.9.1/x64' >> ~/.bash_profile
         echo 'export VISUAL_STUDIO_PATH="/C/Program Files (x86)/Microsoft Visual Studio 10.0"' >> ~/.bash_profile
         echo 'export INNO_SETUP_HOME="/C/Program Files (x86)/Inno Setup 6"' >> ~/.bash_profile
         echo 'export PATH=$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$GITHUB_WORKSPACE/msys64/mingw64/bin:$GITHUB_WORKSPACE/bin/node:/mingw64/bin:/usr/bin:$JAVA_HOME/bin:$PATH' >> ~/.bash_profile

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -41,7 +41,7 @@ jobs:
         echo 'export PYTHON27_HOME=/C/hostedtoolcache/windows/Python/2.7.18/x64' >> ~/.bash_profile
         echo 'export PYTHON37_HOME=/C/hostedtoolcache/windows/Python/3.7.9/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME=/C/hostedtoolcache/windows/Python/3.8.6/x64' >> ~/.bash_profile
-        echo 'export PYTHON39_HOME=/C/hostedtoolcache/windows/Python/3.9.0/x64' >> ~/.bash_profile
+        echo 'export PYTHON39_HOME=/C/hostedtoolcache/windows/Python/3.9.1/x64' >> ~/.bash_profile
         echo 'export VISUAL_STUDIO_PATH="/C/Program Files (x86)/Microsoft Visual Studio 10.0"' >> ~/.bash_profile
         echo 'export INNO_SETUP_HOME="/C/Program Files (x86)/Inno Setup 6"' >> ~/.bash_profile
         echo 'export PATH=$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$GITHUB_WORKSPACE/msys64/mingw64/bin:$GITHUB_WORKSPACE/bin/node:/mingw64/bin:/usr/bin:$JAVA_HOME/bin:$PATH' >> ~/.bash_profile


### PR DESCRIPTION
The full versions of Python (e.g., 3.9.0 or 3.9.1) is hard-coded in the workflow file, which may not be a good idea as it will break the nightly build at each Python minor version. This patch fixes the problem until Python 3.9.2, but I will investigate for a better solution.