### PR TITLE
Fix Display external window update

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -1,5 +1,11 @@
 # Webots R2021 Change Log
 
+## Webots R2021a Revision 1
+Released on XX Xth, 2021.
+
+  - Bug fixes
+    - Fix Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).
+
 ## Webots R2021a
 Released on December 15th, 2020.
 

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -15,6 +15,8 @@
 #include "WbRenderingDeviceWindow.hpp"
 
 #include "WbAbstractCamera.hpp"
+#include "WbCamera.hpp"
+#include "WbDisplay.hpp"
 #include "WbNodeUtilities.hpp"
 #include "WbPerformanceLog.hpp"
 #include "WbRenderingDevice.hpp"
@@ -120,6 +122,11 @@ WbRenderingDeviceWindow::WbRenderingDeviceWindow(WbRenderingDevice *device) :
   connect(mDevice, &WbRenderingDevice::closeWindow, this, &WbRenderingDeviceWindow::closeFromMainWindow);
   connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::mainRenderingEnded, this,
           &WbRenderingDeviceWindow::renderNow);
+  const WbDisplay *display = dynamic_cast<WbDisplay *>(mDevice);
+  if (display) {
+    connect(display, &WbDisplay::attachedCameraChanged, this, &WbRenderingDeviceWindow::listenToBackgroundImageChanges);
+    listenToBackgroundImageChanges(NULL, display->attachedCamera());
+  }
 
   // set initial size
   double pixelSize = mDevice->pixelSize();
@@ -376,6 +383,16 @@ void WbRenderingDeviceWindow::updateTextureGLId(int id, WbRenderingDevice::Textu
   }
   mUpdateRequested = true;
   mInitialized = false;
+}
+
+void WbRenderingDeviceWindow::listenToBackgroundImageChanges(const WbRenderingDevice *previousAttachedDevice,
+                                                             const WbRenderingDevice *newAttachedDevice) {
+  const WbDisplay *display = dynamic_cast<WbDisplay *>(mDevice);
+  assert(display);
+  if (previousAttachedDevice)
+    disconnect(previousAttachedDevice, &WbRenderingDevice::textureUpdated, this, &WbRenderingDeviceWindow::requestUpdate);
+  if (newAttachedDevice)
+    connect(newAttachedDevice, &WbRenderingDevice::textureUpdated, this, &WbRenderingDeviceWindow::requestUpdate);
 }
 
 QStringList WbRenderingDeviceWindow::perspective() const {

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -387,8 +387,6 @@ void WbRenderingDeviceWindow::updateTextureGLId(int id, WbRenderingDevice::Textu
 
 void WbRenderingDeviceWindow::listenToBackgroundImageChanges(const WbRenderingDevice *previousAttachedDevice,
                                                              const WbRenderingDevice *newAttachedDevice) {
-  const WbDisplay *display = dynamic_cast<WbDisplay *>(mDevice);
-  assert(display);
   if (previousAttachedDevice)
     disconnect(previousAttachedDevice, &WbRenderingDevice::textureUpdated, this, &WbRenderingDeviceWindow::requestUpdate);
   if (newAttachedDevice)

--- a/src/webots/gui/WbRenderingDeviceWindow.hpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.hpp
@@ -80,6 +80,8 @@ private slots:
   void renderNow();
   void requestUpdate();
   void updateTextureGLId(int id, WbRenderingDevice::TextureRole);
+  void listenToBackgroundImageChanges(const WbRenderingDevice *previousAttachedDevice,
+                                      const WbRenderingDevice *newAttachedDevice);
   void closeFromMainWindow();
 };
 

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -466,7 +466,7 @@ void WbAbstractCamera::createWrenCamera() {
   applyNoiseToWren();
 
   if (mExternalWindowEnabled)
-    updateTextureUpdateNotifications();
+    updateTextureUpdateNotifications(mExternalWindowEnabled);
 }
 
 void WbAbstractCamera::updateBackground() {
@@ -848,18 +848,24 @@ void WbAbstractCamera::updateFrustumDisplay() {
   wr_node_set_visible(WR_NODE(mFrustumDisplayTransform), true);
 }
 
-void WbAbstractCamera::updateTextureUpdateNotifications() {
+void WbAbstractCamera::updateTextureUpdateNotifications(bool enabled) {
   assert(mWrenCamera);
-  if (mExternalWindowEnabled)
+  if (enabled)
     connect(mWrenCamera, &WbWrenCamera::textureUpdated, this, &WbRenderingDevice::textureUpdated, Qt::UniqueConnection);
   else
     disconnect(mWrenCamera, &WbWrenCamera::textureUpdated, this, &WbRenderingDevice::textureUpdated);
-  mWrenCamera->enableTextureUpdateNotifications(mExternalWindowEnabled);
+  mWrenCamera->enableTextureUpdateNotifications(enabled);
+}
+
+void WbAbstractCamera::enableExternalWindowForAttachedCamera(bool enabled) {
+  if (mExternalWindowEnabled)
+    return;
+  updateTextureUpdateNotifications(enabled);
 }
 
 void WbAbstractCamera::enableExternalWindow(bool enabled) {
   WbRenderingDevice::enableExternalWindow(enabled);
   mExternalWindowEnabled = enabled;
   if (mWrenCamera)
-    updateTextureUpdateNotifications();
+    updateTextureUpdateNotifications(mExternalWindowEnabled);
 }

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -56,6 +56,8 @@ public:
 
   virtual void updateCameraTexture();
 
+  void enableExternalWindowForAttachedCamera(bool enabled);
+
   void setNodeVisibility(WbBaseNode *node, bool visible);
 
   virtual bool isEnabled() const { return mSensor ? mSensor->isEnabled() : false; }
@@ -157,7 +159,7 @@ protected:
 
   bool mExternalWindowEnabled;
   void updateFrustumDisplay();
-  virtual void updateTextureUpdateNotifications();
+  virtual void updateTextureUpdateNotifications(bool enabled);
 
 public slots:
   void updateAntiAliasing();

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -887,11 +887,11 @@ void WbCamera::updateOverlayMaskTexture() {
   emit textureIdUpdated(mOverlay->maskTextureGLId(), MASK_TEXTURE);
 }
 
-void WbCamera::updateTextureUpdateNotifications() {
-  WbAbstractCamera::updateTextureUpdateNotifications();
+void WbCamera::updateTextureUpdateNotifications(bool enabled) {
+  WbAbstractCamera::updateTextureUpdateNotifications(enabled);
   if (!mWrenCamera || !mSegmentationCamera)
     return;
-  if (mExternalWindowEnabled)
+  if (enabled && mExternalWindowEnabled)
     connect(mSegmentationCamera, &WbWrenCamera::textureUpdated, this, &WbRenderingDevice::textureUpdated, Qt::UniqueConnection);
   else
     disconnect(mSegmentationCamera, &WbWrenCamera::textureUpdated, this, &WbRenderingDevice::textureUpdated);
@@ -995,7 +995,7 @@ void WbCamera::createSegmentationCamera() {
   }
   updateOverlayMaskTexture();
   if (mExternalWindowEnabled)
-    updateTextureUpdateNotifications();
+    updateTextureUpdateNotifications(mExternalWindowEnabled);
 }
 
 void WbCamera::updateLensFlare() {

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -49,7 +49,7 @@ public:
   void reset() override;
   void resetSharedMemory() override;
   bool isEnabled() const override;
-  void updateTextureUpdateNotifications() override;
+  void updateTextureUpdateNotifications(bool enabled) override;
 
   // specific functions
   void rayCollisionCallback(dGeomID geom, WbSolid *collidingSolid, double depth);

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -1109,6 +1109,12 @@ void WbDisplay::attachCamera(WbDeviceTag cameraTag) {
   assert(camera);
   WrTexture *texture = camera->getWrenTexture();
   if (texture != NULL && mAttachedCamera != camera) {
+    if (isWindowActive()) {
+      if (mAttachedCamera)
+        mAttachedCamera->enableExternalWindowForAttachedCamera(false);
+      camera->enableExternalWindowForAttachedCamera(true);
+    }
+    emit attachedCameraChanged(mAttachedCamera, camera);
     mAttachedCamera = camera;
     connect(mAttachedCamera, &WbCamera::destroyed, this, &WbDisplay::detachCamera);
     mOverlay->setBackgroundTexture(texture);
@@ -1135,9 +1141,19 @@ void WbDisplay::detachCamera() {
     foreach (WbImageTexture *imageTexture, mImageTextures)
       imageTexture->unsetBackgroundTexture();
 
-    mAttachedCamera = NULL;
+    if (isWindowActive()) {
+      mAttachedCamera->enableExternalWindowForAttachedCamera(false);
+      emit attachedCameraChanged(mAttachedCamera, NULL);
+    }
     emit textureIdUpdated(0, BACKGROUND_TEXTURE);
+    mAttachedCamera = NULL;
   }
+}
+
+void WbDisplay::enableExternalWindow(bool enabled) {
+  if (mAttachedCamera)
+    mAttachedCamera->enableExternalWindowForAttachedCamera(enabled);
+  WbRenderingDevice::enableExternalWindow(enabled);
 }
 
 int WbDisplay::shiftedChannel(int x, int y, int shift) const {

--- a/src/webots/nodes/WbDisplay.hpp
+++ b/src/webots/nodes/WbDisplay.hpp
@@ -43,6 +43,12 @@ public:
   void createWrenObjects() override;
   void postPhysicsStep() override;
   void reset() override;
+  void enableExternalWindow(bool enabled) override;
+
+  WbCamera *const attachedCamera() const { return mAttachedCamera; }
+
+signals:
+  void attachedCameraChanged(const WbRenderingDevice *previousAttachedDevice, const WbRenderingDevice *newAttachedDevice);
 
 protected:
   void setup() override;


### PR DESCRIPTION
Fix #2585:
add methods to listen to changes in the attached camera image and request the rendering of the Display external window.