### PR TITLE
removal of the forced reset for solids with ballJoint parents that causes incorrect reset

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -5,6 +5,7 @@ Released on XX Xth, 2021.
 
   - Bug fixes
     - Fix Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).
+    - Fix reset of simulations including [BallJoint](balljoint.md) nodes like the [Stewart Platform](https://github.com/cyberbotics/webots/blob/master/projects/samples/demos/worlds/stewart_platform.wbt) ([#2593](https://github.com/cyberbotics/webots/pull/2593)).
 
 ## Webots R2021a
 Released on December 15th, 2020.

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2216,16 +2216,7 @@ void WbSolid::reset() {
   if (p)
     p->reset();
 
-  int parentJointNumber = mJointParents.size();
-  bool hasBallJoint = false;
-  for (int i = 0; i < parentJointNumber; ++i) {
-    if (mJointParents.at(i)->nodeType() == WB_NODE_BALL_JOINT) {
-      hasBallJoint = true;
-      break;
-    }
-  }
-  if (parentJointNumber == 0 || hasBallJoint) {
-    // if the Solid is connected to the parent with a joint (other than ballJoint), the joint will restore the position
+  if (mJointParents.size() == 0) {
     setTranslation(mTranslationLoadedFromFile);
     setRotation(mRotationLoadedFromFile);
   }


### PR DESCRIPTION
**Description**
The reset function of WbSolid explicitly treats solids having a ballJoint parent differently from all other types of joint, suggesting that in this particular case the parent doesn't take care of it, hence it forces a manual reset of these types of Solid to their initial values.

In practice, that doesn't appear to be the case, as the reset propagates through the chain just fine:

> BallJoint::reset() ---> WbHinge2Joint::reset() ---> WbJoint::reset() ---> WbBasicJoint::reset() ---> endpoint reset (in this case, the _upper_surface_ solid)

It also explains why in issue #2539 resetting twice the steward_platform.wbt works:

- **first reset:** _upper_surface_ solid forced to its initial position, then when the rest of the chain updates it messes up (the pistons reset fine, only _upper_surface_ isn't where it should be).
- **second reset:** since the rest of chain is now in the correct position, the second forced reset of the _upper_surface_ solid puts it where it should be

**Fix**
By removing this forced manual update for the specific case of a Solid having a BallJoint parent, the simulation reverts to the initial position correctly.

PS: the manual reset itself shouldn't be removed. It takes care of resetting free-floating objects (in this case the flying boxes) and resetting the root of the robot, from which the rest propagates.

**Tests**
visual validation of the fix in the following worlds:
- all files in samples/demos

The addition of a world having a highly jointed robot to use as testbench for the reset mechanism might be warranted

**Related Issues**
This pull-request fixes issue #2539

**Screenshots**
Before reset:
![messed_up](https://user-images.githubusercontent.com/44834743/102839089-033dc280-4400-11eb-8d1d-c48b04c6e261.png)
After reset:
![after_reset](https://user-images.githubusercontent.com/44834743/102839086-020c9580-4400-11eb-8cbc-1e158c5a617a.png)



**Additional context**
Add any other context about the pull-request here.
