### PR TITLE
Remode deprecated run mode from instructions

### DIFF
--- a/docs/guide/starting-webots.md
+++ b/docs/guide/starting-webots.md
@@ -42,7 +42,7 @@ Options:
 
   --mode=<mode>
     Choose the startup mode, overriding application preferences. The <mode>
-    argument must be either pause, realtime, run or fast.
+    argument must be either pause, realtime or fast.
 
   --fullscreen
     Start Webots in fullscreen.

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -62,7 +62,7 @@ void WbSingleTaskApplication::showHelp() const {
   cout << tr("    Display information about the system and exit.").toUtf8().constData() << endl << endl;
   cout << "  --mode=<mode>" << endl;
   cout << tr("    Choose the startup mode, overriding application preferences. The <mode>").toUtf8().constData() << endl;
-  cout << tr("    argument must be either pause, realtime, run or fast.").toUtf8().constData() << endl << endl;
+  cout << tr("    argument must be either pause, realtime or fast.").toUtf8().constData() << endl << endl;
   cout << "  --fullscreen" << endl;
   cout << tr("    Start Webots in fullscreen.").toUtf8().constData() << endl << endl;
   cout << "  --minimize" << endl;


### PR DESCRIPTION
Remove remaining "run" mode from the documented starting mode.