### PR TITLE
use closest contact for ray collision

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -6,6 +6,7 @@ Released on XX Xth, 2021.
   - Bug fixes
     - Fix Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).
     - Fix reset of simulations including [BallJoint](balljoint.md) nodes like the [Stewart Platform](https://github.com/cyberbotics/webots/blob/master/projects/samples/demos/worlds/stewart_platform.wbt) ([#2593](https://github.com/cyberbotics/webots/pull/2593)).
+    - Fix in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
 
 ## Webots R2021a
 Released on December 15th, 2020.

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -625,9 +625,9 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   if (isRayGeom1) {
     WbDistanceSensor *const ds = dynamic_cast<WbDistanceSensor *>(s1);
     if (ds) {
-      int ix = 0; // index of the closest contact
+      int ix = 0;  // index of the closest contact
       for (int i = 1; i < n; ++i)
-        if(contact[i].geom.depth < contact[ix].geom.depth)
+        if (contact[i].geom.depth < contact[ix].geom.depth)
           ix = i;
       // Luc : contact[0].geom.g1 and contact[0].geom.g2 may not coincide with o1 and o2 in an oddly defined dCollide call-back
       // function of ODE. Should we be worried?

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -625,10 +625,14 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   if (isRayGeom1) {
     WbDistanceSensor *const ds = dynamic_cast<WbDistanceSensor *>(s1);
     if (ds) {
+      int ix = 0; // index of the closest contact
+      for (int i = 1; i < n; ++i)
+        if(contact[i].geom.depth < contact[ix].geom.depth)
+          ix = i;
       // Luc : contact[0].geom.g1 and contact[0].geom.g2 may not coincide with o1 and o2 in an oddly defined dCollide call-back
       // function of ODE. Should we be worried?
-      assert(o1 == contact[0].geom.g1 && o2 == contact[0].geom.g2);
-      ds->rayCollisionCallback(odeGeomData2->geometry(), o1, &contact[0].geom);
+      assert(o1 == contact[ix].geom.g1 && o2 == contact[ix].geom.g2);
+      ds->rayCollisionCallback(odeGeomData2->geometry(), o1, &contact[ix].geom);
       return;
     }
 


### PR DESCRIPTION
**Related Issues**
This pull-request addresses issue #2605

**Description**
The root of the problem appears to be that IndexedFaceSets are different to classic Solids with regards to ray collision. With solids like boxes and spheres there appears to be always only one point of contact (n = 1 [here](https://github.com/cyberbotics/webots/blob/3766a52ca250cc6ba41a777182a4aeb61d2d3642/src/webots/engine/WbSimulationCluster.cpp#L582-L585)) which might explain why the collision callback:

> ds->rayCollisionCallback(odeGeomData2->geometry(), o1, &contact[0].geom);

is always called with `contact[0]`. With IndexedFaceSets however there can be more, I'm not sure if more than 2 but at least 2 for a box-like shape built using IndexedFaceSets, as shown in this video. 

https://user-images.githubusercontent.com/44834743/103298156-089b9e00-49fa-11eb-8510-e8fd0fe9934a.mp4

As can be seen the problem then arises from the fact that it isn't guaranteed that contact[0] is the closest, in fact it appears to never be. Since `dCollide()` returned the contact point on the opposite face as first element, the angle computed [here](https://github.com/cyberbotics/webots/blob/3766a52ca250cc6ba41a777182a4aeb61d2d3642/src/webots/nodes/WbDistanceSensor.cpp#L545-L548) when the contact is handled evaluates in this case to 180° ( `angle = direction.angle(-normal)` ) and the ray is therefore ignored because outside the 45° cone which explains why it always returns max value as mentioned in issue #2605.

The suggested fix then is to use the closest contact among the `n` returned by `dCollide()`;

Here's the same video after the fix:

https://user-images.githubusercontent.com/44834743/103298149-05081700-49fa-11eb-8bbf-4225e258a602.mp4

**Test world used**
[distance_sensor_bug.zip](https://github.com/cyberbotics/webots/files/5751497/distance_sensor_bug.zip)


**Related (possible) pitfalls**
It doesn't appear to be at the origin of the problem here, but the `TexturedBox.proto` (technically `TexturedParallelepiped.proto`) primitive uses a IndexedFaceSet to define the parallelepiped, and the faces are defined as squares (4 vertices) whereas according to the IndexedFaceSet documentation 

> When used for collision detection (boundingObject), each face of the IndexedFaceSet must contain exactly three vertices, hence defining a triangle mesh (or trimesh).

Considering more often than not TexturedBoxes will use their own shape as boundingObject, it might be better to re-define them as such. It doesn't appear to create any issue as is, despite being defined as 4-vertices faces there appears to be a mechanism somewhere that splits them into triangles the correct way (or just out of luck) so the issue mentioned here might return if the automatic splitting is altered at some point and the normals of some of the triangles aren't in the correct direction (rays being ignored again because the angle is outside the 45° cone). Unless of course the splitting isn't random at all, in which case it will be fine.
