### PR TITLE
Fix GPU tests

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,6 +4,7 @@
 Released on XX Xth, 2021.
 
   - Enhancements
+    - Don't display warnings for recent Intel and AMD graphics cards ([#2623](https://github.com/cyberbotics/webots/pull/2623)).
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
   - Bug fixes
     - Fix Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -16,6 +16,7 @@
 
 #include "WbMacAddress.hpp"
 
+#include <QtCore/QRegularExpression>
 #include <QtCore/QStringList>
 #include <QtGui/QOpenGLFunctions>
 
@@ -511,15 +512,10 @@ bool WbSysInfo::isLowEndGpu() {
           renderer.contains("Ironlake"))
         lowEndGpu = 1;
       else {
-        const int modelIndex = renderer.indexOf(" HD Graphics ") + 13;
-        QString model = renderer.mid(modelIndex, renderer.indexOf(" ", modelIndex));
-        if (model.startsWith("P"))
-          model = model.mid(1);
-        else if (model.startsWith("("))
-          model = "-1";
-        if (model.contains("/"))
-          model = model.left(model.indexOf("/"));
-        const int number = model.toInt();
+        const QRegularExpression re(" HD Graphics P{0,1}([\\d]{3,4})");
+        const QRegularExpressionMatch match = re.match(renderer);
+        const int number = match.hasMatch() ? match.captured(1).toInt() : 0;
+        qDebug() << number;
         if ((number >= 2000 && number <= 6000) || (number >= 100 && number < 500))
           lowEndGpu = 1;
       }

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -507,11 +507,11 @@ bool WbSysInfo::isLowEndGpu() {
     const QString &renderer = openGLRenderer();
     if (renderer.contains("Intel") && renderer.contains(" HD Graphics ")) {
       // we support only recent Intel GPUs from about 2015
-      const int modelIndex = renderer.indexOf(" HD Graphics ") + 13;
       if (renderer.contains("Ivybridge") || renderer.contains("Sandybridge") || renderer.contains("Haswell") ||
           renderer.contains("Ironlake"))
         lowEndGpu = 1;
       else {
+        const int modelIndex = renderer.indexOf(" HD Graphics ") + 13;
         QString model = renderer.mid(modelIndex, renderer.indexOf(" ", modelIndex));
         if (model.startsWith("P"))
           model = model.mid(1);

--- a/src/webots/core/WbSysInfo.hpp
+++ b/src/webots/core/WbSysInfo.hpp
@@ -49,6 +49,8 @@ namespace WbSysInfo {
   quint32 gpuVendorId(QOpenGLFunctions *gl);
   int intelGPUGeneration(QOpenGLFunctions *gl);
   bool isAmdLowEndGpu(QOpenGLFunctions *gl);
+#else
+  bool isLowEndGpu();
 #endif
   const void initializeOpenGlInfo();
   const QString &openGLRenderer();

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1231,30 +1231,28 @@ void WbView3D::checkRendererCapabilities() {
     reduceTextureQuality = 1;
   }
 
-  if (mWrenRenderingContext->isIntelRenderer()) {
 #ifdef _WIN32
+  if (mWrenRenderingContext->isIntelRenderer()) {
     int gpuGeneration = WbSysInfo::intelGPUGeneration(WbWrenOpenGlContext::instance()->functions());
     if (gpuGeneration < 5) {
-      message += tr("Webots has detected that your system features an old Intel GPU. "
+      message += tr("Webots has detected that your system features an old unsupported Intel GPU. "
                     "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
       message += '\n';
       disableShadows = true;
       disableAntiAliasing = true;
     }
-#else
-    message += tr("Webots has detected that your system features an Intel GPU. "
-                  "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
-    message += '\n';
-#endif
-
-  }
-#ifdef _WIN32
-  else if (WbSysInfo::isAmdLowEndGpu(WbWrenOpenGlContext::instance()->functions())) {
-    message += tr("Webots has detected that you are using an old AMD GPU. "
+  } else if (WbSysInfo::isAmdLowEndGpu(WbWrenOpenGlContext::instance()->functions())) {
+    message += tr("Webots has detected that you are using an old unsupported AMD GPU. "
                   "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
     disableAntiAliasing = true;
     disableGTAO = true;
     reduceTextureQuality = 1;
+  }
+#else
+  if (WbSysInfo::isLowEndGpu()) {
+    message += tr("Webots has detected that your system features an old unsupported GPU. "
+                  "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
+    message += '\n';
   }
 #endif
 

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1232,17 +1232,21 @@ void WbView3D::checkRendererCapabilities() {
   }
 
   if (mWrenRenderingContext->isIntelRenderer()) {
-    message += tr("Webots has detected that your system features an Intel GPU. "
-                  "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
-    message += '\n';
-
 #ifdef _WIN32
     int gpuGeneration = WbSysInfo::intelGPUGeneration(WbWrenOpenGlContext::instance()->functions());
     if (gpuGeneration < 5) {
+      message += tr("Webots has detected that your system features an old Intel GPU. "
+                    "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
+      message += '\n';
       disableShadows = true;
       disableAntiAliasing = true;
     }
+#else
+    message += tr("Webots has detected that your system features an Intel GPU. "
+                  "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
+    message += '\n';
 #endif
+
   }
 #ifdef _WIN32
   else if (WbSysInfo::isAmdLowEndGpu(WbWrenOpenGlContext::instance()->functions())) {
@@ -1260,17 +1264,19 @@ void WbView3D::checkRendererCapabilities() {
   while (maxHardwareAfLevel >>= 1)
     ++maxTextureFiltering;
 
-  // check GPU memory (not for Intel GPU, because the texture size has no impact on the rendring speed)
-  if (mWrenRenderingContext->isNvidiaRenderer() || mWrenRenderingContext->isAmdRenderer()) {
+  // check GPU memory on NVIDIA GPU
+  // (not for Intel GPU, because the texture size has no impact on the rendring speed)
+  // (not for AMD GPU, because the GPU memory cannot be retrieved accurately)
+  if (mWrenRenderingContext->isNvidiaRenderer()) {
     if (wr_gl_state_get_gpu_memory() == 2097152)
       WbPreferences::instance()->setValue("OpenGL/limitBakingResolution", true);
-    else if (wr_gl_state_get_gpu_memory() < 2097152) {  // Less than 2Gb of GPU memory
+    else if (wr_gl_state_get_gpu_memory() < 2097152) {  // Less than 2 GB of GPU memory
       if (message.isEmpty()) {
-        message += tr("Webots has detected that your GPU has less than 2Gb of memory. "
-                      "A minimum of 2Gb of memory is recommended to use high-resolution textures. ");
+        message += tr("Webots has detected that your GPU has less than 2 GB of memory. "
+                      "A minimum of 2 GB of memory is recommended to use high-resolution textures. ");
         message += '\n';
       }
-      if (wr_gl_state_get_gpu_memory() < 1048576)  // Less than 1Gb of GPU memory
+      if (wr_gl_state_get_gpu_memory() < 1048576)  // Less than 1 GB of GPU memory
         reduceTextureQuality = 2;
       else
         reduceTextureQuality = 1;

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1255,6 +1255,7 @@ void WbView3D::checkRendererCapabilities() {
     message += '\n';
     disableAntiAliasing = true;
     disableGTAO = true;
+    disableShadows = true;
     reduceTextureQuality = 1;
   }
 #endif

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1253,6 +1253,9 @@ void WbView3D::checkRendererCapabilities() {
     message += tr("Webots has detected that your system features an old unsupported GPU. "
                   "A recent NVIDIA or AMD graphics adapter is highly recommended to run Webots smoothly. ");
     message += '\n';
+    disableAntiAliasing = true;
+    disableGTAO = true;
+    reduceTextureQuality = 1;
   }
 #endif
 


### PR DESCRIPTION
Fixes #2588.

In addition to fixing #2588, this PR also removes some annoying warnings with recent Intel or AMD graphics cards which support OpenGL very well and should not cause such warnings.

Our [telemetry](https://cyberbotics.com/telemetry) reports the following GPU usage: [gpu.txt](https://github.com/cyberbotics/webots/files/5769060/gpu.txt)