### PR TITLE
Fix MATLAB path

### DIFF
--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -129,10 +129,8 @@ const QString &WbLanguageTools::matlabCommand() {
     // and with the termination of the QProcess.
     QString PATH = qgetenv("PATH");
     QStringList dirs = PATH.split(';', Qt::SkipEmptyParts);
-    bool matlabFound = false;
     foreach (QString dir, dirs) {
-      if (dir.contains("matlab", Qt::CaseInsensitive)) {
-        matlabFound = QDir(dir).exists();
+      if (QDir(dir).exists()) {
         QString file = dir + "\\win64\\MATLAB.exe";
         if (QFile::exists(file)) {
           gMatlabCommand = file;
@@ -141,10 +139,7 @@ const QString &WbLanguageTools::matlabCommand() {
       }
     }
     if (gMatlabCommand.isEmpty()) {
-      if (matlabFound)
-        WbLog::warning(QObject::tr("To run Matlab controllers, you need to install a 64-bit version of Matlab."));
-      else
-        WbLog::warning(QObject::tr("To run Matlab controllers, you need to install Matlab 64-bit and ensure it is available "
+      WbLog::warning(QObject::tr("To run Matlab controllers, you need to install Matlab 64-bit and ensure it is available "
                                    "from the DOS CMD.EXE console."));
       gMatlabCommand = "!";
     }


### PR DESCRIPTION
Fixes #2608. We assumed MATLAB is installed in the path that contains `matlab`, this simple fix avoids it.