### PR TITLE
Fix Cylinder unwrapped texture mapping

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -7,10 +7,11 @@ Released on XX Xth, 2021.
     - Don't display warnings for recent Intel and AMD graphics cards ([#2623](https://github.com/cyberbotics/webots/pull/2623)).
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
   - Bug fixes
-    - Fix Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).
-    - Fix reset of simulations including [BallJoint](balljoint.md) nodes like the [Stewart Platform](https://github.com/cyberbotics/webots/blob/master/projects/samples/demos/worlds/stewart_platform.wbt) ([#2593](https://github.com/cyberbotics/webots/pull/2593)).
-    - Fix in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
-    - Fix a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).
+    - Fixed painting with the [Pen](pen.md) device on the bottom face of a [Cylinder](cylinder.md) geometry ([#2629](https://github.com/cyberbotics/webots/pull/2629)).
+    - Fixed Display external window not updated when the attached camera image changes ([#2589](https://github.com/cyberbotics/webots/pull/2589)).
+    - Fixed reset of simulations including [BallJoint](balljoint.md) nodes like the [Stewart Platform](https://github.com/cyberbotics/webots/blob/master/projects/samples/demos/worlds/stewart_platform.wbt) ([#2593](https://github.com/cyberbotics/webots/pull/2593)).
+    - Fixed in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
+    - Fixed a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).
 
 ## Webots R2021a
 Released on December 15th, 2020.

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -503,7 +503,7 @@ namespace wren {
           mesh->addCoord(glm::vec3(x, -h, y));
           mesh->addNormal(glm::vec3(0.0f, -1.0f, 0.0f));
           mesh->addTexCoord(glm::vec2(0.5f * x + 0.5f, -0.5f * y + 0.5f));
-          mesh->addUnwrappedTexCoord(glm::vec2(0.25f * x + 0.75f, -0.25f * y + 0.25));
+          mesh->addUnwrappedTexCoord(glm::vec2(0.25f * x + 0.25f, -0.25f * y + 0.75));
         }
 
         // connect bottom circle points

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -503,7 +503,7 @@ namespace wren {
           mesh->addCoord(glm::vec3(x, -h, y));
           mesh->addNormal(glm::vec3(0.0f, -1.0f, 0.0f));
           mesh->addTexCoord(glm::vec2(0.5f * x + 0.5f, -0.5f * y + 0.5f));
-          mesh->addUnwrappedTexCoord(glm::vec2(0.25f * x + 0.25f, -0.25f * y + 0.75));
+          mesh->addUnwrappedTexCoord(glm::vec2(0.25f * x + 0.25f, -0.25f * y + 0.75f));
         }
 
         // connect bottom circle points

--- a/tests/api/worlds/pen_cylinder_scaled.wbt
+++ b/tests/api/worlds/pen_cylinder_scaled.wbt
@@ -20,22 +20,27 @@ DEF BOARD Solid {
   rotation 0.5578327925294718 0.8064497000632672 0.19611592706008768 7.19948
   scale 1.44 1.44 1.44
   children [
-    Shape {
-      appearance Appearance {
-        material Material {
-          ambientIntensity 1
-          diffuseColor 1 1 1
+    Transform {
+      rotation 0 0 1 3.1415
+      children [
+        Shape {
+          appearance Appearance {
+            material Material {
+              ambientIntensity 1
+              diffuseColor 1 1 1
+            }
+            texture ImageTexture {
+              url [
+                "textures/white256.png"
+              ]
+            }
+          }
+          geometry Cylinder {
+            height 0.1
+            radius 0.05
+          }
         }
-        texture ImageTexture {
-          url [
-            "textures/white256.png"
-          ]
-        }
-      }
-      geometry Cylinder {
-        height 0.1
-        radius 0.05
-      }
+      ]
     }
   ]
   locked TRUE


### PR DESCRIPTION
Fix #2628: texture coordinates for the bottom face of Cylinder where wrong.


Note: in the changelog I changed "Fix" to "Fixed" (form that we always used in the change log) for the existing entries.