### PR TITLE
Backporting minor doc fixes from the master branch

### DIFF
--- a/docs/reference/contactproperties.md
+++ b/docs/reference/contactproperties.md
@@ -12,8 +12,8 @@ ContactProperties {
   SFFloat  softERP            0.2                  # [0, 1]
   SFFloat  softCFM            0.001                # (0, inf)
   SFString bumpSound          "sounds/bump.wav"    # any string
-  SFString rollSound          "sounds/roll.waw"    # any string
-  SFString SlideSound         "sounds/slide.wav"   # any string
+  SFString rollSound          "sounds/roll.wav"    # any string
+  SFString slideSound         "sounds/slide.wav"   # any string
 }
 ```
 


### PR DESCRIPTION
Such typos should go to the released branch, so that they appear now in the online documentation.