### PR TITLE
Rework of external force/torque logic

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Fixed reset of simulations including [BallJoint](balljoint.md) nodes like the [Stewart Platform](https://github.com/cyberbotics/webots/blob/master/projects/samples/demos/worlds/stewart_platform.wbt) ([#2593](https://github.com/cyberbotics/webots/pull/2593)).
     - Fixed in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
     - Fixed a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).
+    - Fixed external force/torque logic such that the closest dynamic Solid ancestor is picked if the selected one lacks it ([#2635](https://github.com/cyberbotics/webots/pull/2635)).
 
 ## Webots R2021a
 Released on December 15th, 2020.

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1945,8 +1945,10 @@ void WbView3D::mouseMoveEvent(QMouseEvent *event) {
       return;
 
     WbNode *node = dynamic_cast<WbNode *>(mPickedMatter);
-    WbSolid *selectedSolid = NULL;
-    while (node) {
+    if (!node)
+      return;
+    WbSolid *selectedSolid;
+    while (1) {
       selectedSolid = dynamic_cast<WbSolid *>(node);
       if (selectedSolid && selectedSolid->bodyMerger() != NULL)
         break;
@@ -1955,8 +1957,6 @@ void WbView3D::mouseMoveEvent(QMouseEvent *event) {
       if (!node || node->level() < 1)  // abort the search at the top of this node chain
         return;
     }
-    if (!selectedSolid)
-      return;
 
     Qt::MouseButtons buttons = event->buttons();
     bool forceButtonPressed = buttons == Qt::LeftButton;

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1943,9 +1943,21 @@ void WbView3D::mouseMoveEvent(QMouseEvent *event) {
     if (mDisabledUserInteractionsMap.value(WbAction::DISABLE_FORCE_AND_TORQUE, false))
       // user interaction disabled
       return;
-    WbSolid *const selectedSolid = dynamic_cast<WbSolid *>(mPickedMatter);
-    if (!selectedSolid || selectedSolid->bodyMerger() == NULL)
+
+    WbNode *node = dynamic_cast<WbNode *>(mPickedMatter);
+    WbSolid *selectedSolid = NULL;
+    while (node) {
+      selectedSolid = dynamic_cast<WbSolid *>(node);
+      if (selectedSolid && selectedSolid->bodyMerger() != NULL)
+        break;
+
+      node = node->parentNode();
+      if (!node || node->level() < 1)  // abort the search at the top of this node chain
+        return;
+    }
+    if (!selectedSolid)
       return;
+
     Qt::MouseButtons buttons = event->buttons();
     bool forceButtonPressed = buttons == Qt::LeftButton;
 #ifdef __APPLE__


### PR DESCRIPTION
**Related Issues**
This pull-request relates to issue #358

**Description**
As suggested in issue #358, if an external force is applied to a node without physics (typically a sensor which by default don't), and a node ancestor with physics exists, then it should be possible to apply the external force anyway.

The proposed solution goes up the chain until it finds a dynamic solid and does fix issue #358.

Currently, **it searches upwards, not sideways,** so if there's a Transform or a Group with multiple children (some with and some without physics), applying a force on a children wouldn't actually move the entire Group. (Like the stacked box/cylinder on the video)

The search can be extended sideways too, but in practice I don't really know if it's desirable because:
- If the Group/Transform is part of a Robot, then by the Physics rules (i.e _if any of the children nodes have physics, then the topmost node (the Robot) also needs to_), so searching upwards will always lead to a solid with physics to be found.
- If it's not part of a Robot, it means it's part of the environment and likely was _intended_ to have parts with physics and parts without, would it make sense for everything to be affected by the force? (assuming there's an ancestor with physics, otherwise can't be moved anyway)

Which begs the question if it's even necessary to search at all since we can go straight to the Robot node and test that one. 
The only reason for actually climbing the hierarchy that I can imagine is if it's desirable to apply the force as close to the cursor as possible. In which case an even more deep search should be done, in all directions, and shouldn't just involve node vicinity (with transforms it could very well not be physically near, despite being close node-wise). In short, reverting to the Robot node might be the more 'reasonable' option.

Basically, I don't know if the proposed solution is sufficient, or even overkill.

**Test world**
[force_logic.zip](https://github.com/cyberbotics/webots/files/5780206/force_logic.zip)

**Video**

https://user-images.githubusercontent.com/44834743/103865457-87609d00-50c4-11eb-82cb-9e3aa13fed37.mp4

Red have physics, green don't. The Stack behind is a Transform composed by a Box + Cylinder

https://user-images.githubusercontent.com/44834743/103865488-92b3c880-50c4-11eb-83e9-ffab10ea300b.mp4


