### PR TITLE
Mac keys - Update the-3d-window.md

### DIFF
--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -32,8 +32,7 @@ If you click on the background, the camera will rotate around its own position.
 Dragging the mouse horizontally will rotate the camera around the viewing axis.
 Alternatively, the mouse wheel alone can also be used for zooming.
 
-> **Note**: If you are a Mac user with a single button mouse, hold the Alt key and press the mouse button to translate the camera according to the mouse motion.
-Hold the control key (Ctrl) down and press the mouse button to zoom / rotate the camera.
+> **Note**: If you are a Mac user with a single button mouse, hold the control key and press the mouse button to translate the camera according to the mouse motion.
 
 ### Moving a Solid Object
 


### PR DESCRIPTION
There is no "Alt" key on a Mac. Pressing the control key allows to change from rotating the scene to translating the camera. This is not really necessary, as translation can also be achieved by pressing the pad with two fingers.

I'm able to zoom by pinching, but I'm not able to zoom out. None of the other Mac keys (option, command) help with this...