### PR TITLE
Fixes documentation with respect to 3D mouse controls on Mac

### DIFF
--- a/docs/css/webots-doc.css
+++ b/docs/css/webots-doc.css
@@ -264,6 +264,20 @@ body {
 .webots-doc hr {
   margin: 40px 0px;
 }
+.webots-doc kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font: 11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+  line-height: normal;
+  line-height: 10px;
+  color: #777;
+  vertical-align: middle;
+  background-color: #eee;
+  border-bottom-color: #333;
+  border: 1px solid #333;
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 #333;
+}
 .webots-doc h1,
 .webots-doc h2,
 .webots-doc h3,

--- a/docs/css/webots-doc.css
+++ b/docs/css/webots-doc.css
@@ -270,13 +270,13 @@ body {
   font: 11px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
   line-height: normal;
   line-height: 10px;
-  color: #777;
+  color: #444d56;
   vertical-align: middle;
-  background-color: #eee;
-  border-bottom-color: #333;
-  border: 1px solid #333;
+  background-color: #fafbfc;
+  border-bottom-color: #d1d5da;
+  border: 1px solid #d1d5da;
   border-radius: 6px;
-  box-shadow: inset 0 -1px 0 #333;
+  box-shadow: inset 0 -1px 0 #d1d5da;
 }
 .webots-doc h1,
 .webots-doc h2,

--- a/docs/guide/bioloid.md
+++ b/docs/guide/bioloid.md
@@ -51,13 +51,13 @@ You will find the following sample in this folder: "WEBOTS\_HOME/projects/robots
 
 ![bioloid.wbt.png](images/robots/bioloid/bioloid.wbt.thumbnail.jpg) In this example, the dog-like robot model walks on a flat floor.
 
-Using the keyboard, the user can control the quadruped robot by setting the walking direction (forward or backwards) and also the heading direction (right or left).
+Using the keyboard, the user can control the quadruped robot by setting the walking direction (<kbd>▲</kbd> forward or <kbd>▼</kbd> backwards) and also the heading direction (<kbd>▶</kbd> right or <kbd>◀</kbd> left).
 Keyboard actions include:
 
-- `Right Arrow`: Turn right.
-- `Left Arrow`: Turn left.
-- `B`: Walk backwards.
-- `F`: Walk forward.
+- <kbd>▶</kbd>: Turn right.
+- <kbd>◀</kbd>: Turn left.
+- <kbd>B</kbd>: Walk backwards.
+- <kbd>F</kbd>: Walk forward.
 
 The walking gait used in the controller relies on an inverse kinematics model.
 Further details are available from [BIRG website](http://birg.epfl.ch/page66584.html).
@@ -68,7 +68,7 @@ During the walk, the extremity of each leg is describing an ellipsoid, the diame
 
 Other keyboard actions are also provided to fine-tune the frequency and the stride length factor:
 
-- `Q`: Increase frequency.
-- `W`: Decrease frequency.
-- `S`: Increase stride length factor.
-- `A`: Decrease stride length factor.
+- <kbd>Q</kbd>: Increase frequency.
+- <kbd>W</kbd>: Decrease frequency.
+- <kbd>S</kbd>: Increase stride length factor.
+- <kbd>A</kbd>: Decrease stride length factor.

--- a/docs/guide/debugging-c-cpp-controllers.md
+++ b/docs/guide/debugging-c-cpp-controllers.md
@@ -68,7 +68,7 @@ Once the break point is reached, you will be able to query variables, setup new 
 Then, the `cont` command will instruct the debugger to resume the execution of the process.
 You may also use the `step` function to proceed step-by-step.
 
-The controller's execution can be interrupted at any time (Ctrl-C), in order to query variables, set up break points, etc.
+The controller's execution can be interrupted at any time (<kbd>ctrl<kbd>-<kbd>C</kbd>), in order to query variables, set up break points, etc.
 When a crash occurs, `gdb` prints a diagnostic message similar to this:
 
 ```

--- a/docs/guide/debugging-c-cpp-controllers.md
+++ b/docs/guide/debugging-c-cpp-controllers.md
@@ -68,7 +68,7 @@ Once the break point is reached, you will be able to query variables, setup new 
 Then, the `cont` command will instruct the debugger to resume the execution of the process.
 You may also use the `step` function to proceed step-by-step.
 
-The controller's execution can be interrupted at any time (<kbd>ctrl<kbd>-<kbd>C</kbd>), in order to query variables, set up break points, etc.
+The controller's execution can be interrupted at any time (<kbd>ctrl</kbd>-<kbd>C</kbd>), in order to query variables, set up break points, etc.
 When a crash occurs, `gdb` prints a diagnostic message similar to this:
 
 ```

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -316,7 +316,7 @@ You will need administrator privileges to be able to install Webots.
 
 %end
 
-You should <kbd>Ctrl</kbd> + click (or right-click) on the Webots icon, and select the `Open` menu item.
+You should <kbd>ctrl</kbd> + click (or right-click) on the Webots icon, and select the `Open` menu item.
 Then, macOS should propose to open the application anyway (see [this figure](#unidentified-developer-dialog)).
 
 %figure "Open Webots anyway"

--- a/docs/guide/matlab.md
+++ b/docs/guide/matlab.md
@@ -53,7 +53,7 @@ Then MATLAB opens your controller m-file in its editor and indicates that the ex
 After that, the controller m-file can be debugged interactively, i.e., it is possible to continue the execution step-by-step, set break points, watch variable, etc.
 While debugging, the current values of the controller variables are shown in the MATLAB workspace.
 It is possible to *continue* the execution of the controller by typing `return` at the `K>>` prompt.
-Finally the execution of the controller can be terminated with `Ctrl-C` key combination.
+Finally the execution of the controller can be terminated with <kbd>ctrl<kbd>-<kbd>C<kbd> key combination.
 
 Once the controller is terminated, the connection with Webots remains active.
 Therefore it becomes possible to issue Webots commands directly on the MATLAB prompt, for example you can interactively issue commands to query the sensors, etc.:

--- a/docs/guide/matlab.md
+++ b/docs/guide/matlab.md
@@ -53,7 +53,7 @@ Then MATLAB opens your controller m-file in its editor and indicates that the ex
 After that, the controller m-file can be debugged interactively, i.e., it is possible to continue the execution step-by-step, set break points, watch variable, etc.
 While debugging, the current values of the controller variables are shown in the MATLAB workspace.
 It is possible to *continue* the execution of the controller by typing `return` at the `K>>` prompt.
-Finally the execution of the controller can be terminated with <kbd>ctrl<kbd>-<kbd>C<kbd> key combination.
+Finally the execution of the controller can be terminated with <kbd>ctrl</kbd>-<kbd>C</kbd> key combination.
 
 Once the controller is terminated, the connection with Webots remains active.
 Therefore it becomes possible to issue Webots commands directly on the MATLAB prompt, for example you can interactively issue commands to query the sensors, etc.:

--- a/docs/guide/samples-devices.md
+++ b/docs/guide/samples-devices.md
@@ -180,8 +180,8 @@ The first technique consists in using an on-board [GPS](../reference/gps.md) dev
 The second method uses a [Supervisor](../reference/supervisor.md) controller that reads and transmits the position info to the robot.
 Note that a [Supervisor](../reference/supervisor.md) controller can read (or change) the position of any object in the simulation at any time.
 This example implements both techniques, and you can choose either one or the other with the keyboard.
-The `G` key prints the robot's [GPS](../reference/gps.md) device position.
-The `S` key prints the position read by the [Supervisor](../reference/supervisor.md) controller.
+The <kbd>G</kbd> key prints the robot's [GPS](../reference/gps.md) device position.
+The <kbd>S</kbd> key prints the position read by the [Supervisor](../reference/supervisor.md) controller.
 
 ### [gps\_lat\_long.wbt](https://github.com/cyberbotics/webots/tree/released/projects/samples/devices/worlds/gps_lat_long.wbt)
 

--- a/docs/guide/samples-howto.md
+++ b/docs/guide/samples-howto.md
@@ -119,7 +119,7 @@ It goes down the slope with a smooth motion simply because of its shape and its 
 **Keywords**: Pedal racer, apply a force, mechanical loop, [SolidReference](../reference/solidreference.md)
 
 ![pedal_racer.png](images/samples/pedal_racer.thumbnail.jpg) This example shows the mouse interaction with a complex model.
-You can apply a force to the pedals using `Alt + mouse left click.`.
+You can apply a force to the pedals using <kbd>alt</kbd> + mouse left click.
 
 ### [physics.wbt](https://github.com/cyberbotics/webots/tree/released/projects/samples/howto/worlds/physics.wbt)
 
@@ -154,7 +154,7 @@ A [Supervisor](../reference/supervisor.md) controller applies the scan depth out
 **Keywords**: Spinner, chessboard, chess pieces, apply a torque
 
 ![spinning_top.png](images/samples/spinning_top.thumbnail.jpg) This example shows rotating objects, in order to play with the torque application feature.
-To apply a torque on the spinner, use the `Alt + mouse right click` sequence.
+To apply a torque on the spinner, use the <kbd>alt</kbd> + mouse right click sequence.
 
 ### [supervisor\_draw\_trail.wbt](https://github.com/cyberbotics/webots/tree/released/projects/samples/howto/worlds/supervisor_draw_trail.wbt)
 

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -8,7 +8,7 @@ These lines turn pink if the solid is colliding with another one and blue when t
 Double-clicking on a [Robot](../reference/robot.md) opens the Robot Window.
 
 If an object has a solid subpart, then it is also possible to select only this subpart by clicking on it once the whole object is already selected, or by clicking on it while holding down the Alt key.
-Linux users should also hold down the Control key (Ctrl) together with the Alt key.
+Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key.
 
 #### Context Menu
 

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -36,7 +36,8 @@ Alternatively, the mouse wheel alone can also be used for zooming.
 - **Camera rotation**: click with one finger and drag.
 - **Camera translation**: click with two fingers and drag.
 - **Camera zoom**: slide two fingers (without clicking) downwards to zoom in and upwards to zoom out.
-If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
+
+> **Note**: If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
 Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
 
 ### Moving a Solid Object

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -34,6 +34,10 @@ Alternatively, the mouse wheel alone can also be used for zooming.
 
 > **Note**: If you are a Mac user with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
 Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
+If you are you are on a MacBook, you can use trackpad to navigate in scene:
+- **Camera rotation**: click with one finger and drag.
+- **Camera translation**: click with two fingers and drag.
+- **Camera zoom**: slide two fingers (without clicking) downwards to zoom in and upwards to zoom out.
 
 ### Moving a Solid Object
 
@@ -74,7 +78,7 @@ Hold the <kbd>⇧ shift</kbd> key and the <kbd>⌘ command</kbd> key down and pr
 ### Applying a Force to a Solid Object with Physics
 
 To apply a force to an object, place the mouse pointer where the force will apply, hold down the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards) and left mouse button together while dragging the mouse.
-Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Mac keyboards).
+Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards).
 This way your are drawing a 3D-vector whose end is located on the plane parallel to the view which passes through the point of application.
 The intensity of the applied force is directly proportional to the cube of the length of this vector.
 

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -32,12 +32,12 @@ If you click on the background, the camera will rotate around its own position.
 Dragging the mouse horizontally will rotate the camera around the viewing axis.
 Alternatively, the mouse wheel alone can also be used for zooming.
 
-> **Note**: If you are a Mac user with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
-Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
-If you are you are on a MacBook, you can use trackpad to navigate in scene:
+> **Note**: If you are on a MacBook, you can use trackpad to navigate in scene:
 - **Camera rotation**: click with one finger and drag.
 - **Camera translation**: click with two fingers and drag.
 - **Camera zoom**: slide two fingers (without clicking) downwards to zoom in and upwards to zoom out.
+If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
+Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
 
 ### Moving a Solid Object
 

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -37,7 +37,7 @@ Alternatively, the mouse wheel alone can also be used for zooming.
 - **Camera translation**: click with two fingers and drag.
 - **Camera zoom**: slide two fingers (without clicking) downwards to zoom in and upwards to zoom out.
 
-> **Note**: If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
+> If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
 Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
 
 ### Moving a Solid Object

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -7,7 +7,7 @@ The bounding object of a selected solid is represented by white lines.
 These lines turn pink if the solid is colliding with another one and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
 Double-clicking on a [Robot](../reference/robot.md) opens the Robot Window.
 
-If an object has a solid subpart, then it is also possible to select only this subpart by clicking on it once the whole object is already selected, or by clicking on it while holding down the Alt key.
+If an object has a solid subpart, then it is also possible to select only this subpart by clicking on it once the whole object is already selected, or by clicking on it while holding down the <kbd>alt</kbd> key.
 Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key.
 
 #### Context Menu
@@ -32,8 +32,8 @@ If you click on the background, the camera will rotate around its own position.
 Dragging the mouse horizontally will rotate the camera around the viewing axis.
 Alternatively, the mouse wheel alone can also be used for zooming.
 
-> **Note**: If you are a Mac user with a single button mouse, hold the Alt key and press the mouse button to translate the camera according to the mouse motion.
-Hold the control key (Ctrl) down and press the mouse button to zoom / rotate the camera.
+> **Note**: If you are a Mac user with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
+Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
 
 ### Moving a Solid Object
 
@@ -46,7 +46,7 @@ These handles can be used to translate and rotate the object along the correspon
 For moving the object you can simply click on the handle and drag it to the desired position.
 A label will show the currect relative translation or rotation during the movement, as shown in [this figure](#labels-displaying-relative-translation-and-rotation-when-moving-objects-with-handles).
 
-If the Control key (Ctrl) is pressed, the handles for resizing the solid object will be displayed instead of translation and rotation handles.
+If the <kbd>ctrl</kbd> key is pressed, the handles for resizing the solid object will be displayed instead of translation and rotation handles.
 These resize handles can also be enabled from the Field Editor.
 
 %figure "Axis-aligned handles to move solid objects"
@@ -63,26 +63,26 @@ These resize handles can also be enabled from the Field Editor.
 
 #### Translation Using Keyboard Shortcuts
 
-- **Translation**: To move an object parallel to the ground: hold down the Shift key, press the left mouse button and drag.
-- **Rotation**: To rotate an object around the world's vertical axis: hold down the Shift key, press the right mouse button and drag.
-- **Lift**: To raise or lower an object: hold down the Shift key, press both left and right mouse buttons (or the middle button) and drag.
-Alternatively, the mouse wheel combined with the Shift key can also be used.
+- **Translation**: To move an object parallel to the ground: hold down the <kbd>⇧ shift</kbd> key, press the left mouse button and drag.
+- **Rotation**: To rotate an object around the world's vertical axis: hold down the <kbd>⇧ shift</kbd> key, press the right mouse button and drag.
+- **Lift**: To raise or lower an object: hold down the <kbd>⇧ shift</kbd> key, press both left and right mouse buttons (or the middle button) and drag.
+Alternatively, the mouse wheel combined with the <kbd>⇧ shift</kbd> key can also be used.
 
-> **Note**: If you are a Mac user with a single button mouse, hold the Shift key and the Control key (Ctrl) down and press the mouse button to rotate the selected object according to mouse motion.
-Hold the Shift key and the Command key (key with Apple symbol) down and press the mouse button to lift the selected object according to mouse motion.
+> **Note**: If you are a Mac user with a single button mouse, hold the <kbd>⇧ shift</kbd> key and the <kbd>ctrl</kbd> key down and press the mouse button to rotate the selected object according to mouse motion.
+Hold the <kbd>⇧ shift</kbd> key and the <kbd>⌘ command</kbd> key down and press the mouse button to lift the selected object according to mouse motion.
 
 ### Applying a Force to a Solid Object with Physics
 
-To apply a force to an object, place the mouse pointer where the force will apply, hold down the Alt key and left mouse button together while dragging the mouse.
-Linux users should also hold down the Control key (Ctrl) together with the Alt key.
+To apply a force to an object, place the mouse pointer where the force will apply, hold down the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards) and left mouse button together while dragging the mouse.
+Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Mac keyboards).
 This way your are drawing a 3D-vector whose end is located on the plane parallel to the view which passes through the point of application.
 The intensity of the applied force is directly proportional to the cube of the length of this vector.
 
 ### Applying a Torque to a Solid Object with Physics
 
-To apply a torque to an object, place the mouse pointer on it, hold down the Alt key and right mouse button together while dragging the mouse.
-Linux users should also hold down the Control key (Ctrl) together with the Alt key.
-Also, macOS users with a one-button mouse should hold down the Control key (Ctrl) to emulate the right mouse button.
+To apply a torque to an object, place the mouse pointer on it, hold down the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards) and right mouse button together while dragging the mouse.
+Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards).
+Also, macOS users with a one-button mouse should hold down the <kbd>ctrl</kbd> key to emulate the right mouse button.
 This way your are drawing a 3D-vector with origin the center of mass and whose end is located on the plane parallel to the view which passes through this center.
 The object is prompted to turn around the vector direction, the intensity of the applied torque is directly proportional to the product of the mass by the length of the 3D-vector.
 

--- a/docs/guide/the-scene-tree.md
+++ b/docs/guide/the-scene-tree.md
@@ -22,9 +22,9 @@ Additionally, if the current selection is a [Robot](../reference/robot.md) node 
 
 Nodes can be expanded with a double-click.
 When a field is selected, its value can be edited at the bottom of the Scene Tree.
-Double-clicking or pressing the `Enter` key on a field selects the first editable item of the field editor panel.
+Double-clicking or pressing the <kbd>enter</kbd> key on a field selects the first editable item of the field editor panel.
 Keyboard focus can be returned to the Scene Tree by tabbing through all of the items in the field editor panel.
-For text fields, changes are applied by pressing the `Enter` key.
+For text fields, changes are applied by pressing the <kbd>Enter</kbd> key.
 This is the same for numeric fields, but the up and down arrow keys can also be used to adjust values up and down, with changes immediately applied.
 For checkboxes, values are changed using the `Space` bar.
 Applied changes are immediately reflected in the 3D window.

--- a/docs/guide/the-scene-tree.md
+++ b/docs/guide/the-scene-tree.md
@@ -24,7 +24,7 @@ Nodes can be expanded with a double-click.
 When a field is selected, its value can be edited at the bottom of the Scene Tree.
 Double-clicking or pressing the <kbd>enter</kbd> key on a field selects the first editable item of the field editor panel.
 Keyboard focus can be returned to the Scene Tree by tabbing through all of the items in the field editor panel.
-For text fields, changes are applied by pressing the <kbd>Enter</kbd> key.
+For text fields, changes are applied by pressing the <kbd>enter</kbd> key.
 This is the same for numeric fields, but the up and down arrow keys can also be used to adjust values up and down, with changes immediately applied.
 For checkboxes, values are changed using the `Space` bar.
 Applied changes are immediately reflected in the 3D window.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -77,7 +77,7 @@ Double-click on it in the scene tree to open its fields.
 2. Change its `translation` to `0 0.05 0` instead of `0 0.3 0`.
 Alternatively, you may use the green arrow that appears in the 3D view to adjust its `translation.y` field.
 3. Now shift-click and drag the box in the 3D view and move it in some corner of the arena.
-4. Select the box and press Ctrl-C, Ctrl-V (Windows, Linux) or Cmd-C, Cmd-V (macOS) to copy and paste it.
+4. Select the box and press <kbd>ctrl</kbd>-<kbd>C</kbd>, <kbd>ctrl</kbd>-<kbd>V</kbd> (Windows, Linux) or <kbd>⌘ command</kbd>-<kbd>C</kbd>, <kbd>⌘ command</kbd>-<kbd>V</kbd> (macOS) to copy and paste it.
 Shift-click and drag the new box to move it at some different location.
 Create a third box this way.
 5. Move the boxes, so that no box is at the center of the arena.

--- a/docs/guide/tutorial-1-your-first-simulation-in-webots.md
+++ b/docs/guide/tutorial-1-your-first-simulation-in-webots.md
@@ -125,8 +125,8 @@ Because we won't need it, you can actually close it.
 
 Now, while the simulation is running, let's play with the physics:
 
-> **Hands-on #6**: [Apply a force](the-3d-window.md#applying-a-force-to-a-solid-object-with-physics) to the robot by pressing *Alt + left-click + drag*.
-On Linux, you should also press the *Ctrl* key in addition to *Alt + left-click + drag*.
+> **Hands-on #6**: [Apply a force](the-3d-window.md#applying-a-force-to-a-solid-object-with-physics) to the robot by pressing <kbd>alt</kbd> *+ left-click + drag*.
+On Linux, you should also press the <kbd>ctrl</kbd> key in addition to <kbd>alt</kbd> *+ left-click + drag*.
 It is not possible to apply a force to a `WoodenBox` node, because by default, they have no mass and are considered as glued on the floor.
 To enable physics on the `WoodenBox` nodes, you should set their `mass` field to a certain value (for example 0.2 kg).
 Once this is done, should be able to apply a force on them as well.

--- a/docs/guide/tutorial-2-modification-of-the-environment.md
+++ b/docs/guide/tutorial-2-modification-of-the-environment.md
@@ -22,7 +22,7 @@ The default `RectangleArena` PROTO defines a simple floor pinned on the static e
 Other pre-built floors are available in the Webots objects library.
 We will now delete the `RectangleArena` node and add a simple floor that we will manually surround with walls later in this tutorial.
 
-> **Hands-on #2**: To remove the `RectangleArena`, select it either in the 3D view or in the scene tree view with a left click and press the `Delete` key on your keyboard.
+> **Hands-on #2**: To remove the `RectangleArena`, select it either in the 3D view or in the scene tree view with a left click and press the <kbd>del</kbd> key on your keyboard.
 Alternatively, you can right click on it in the 3D view and select `Delete` in the context menu (you can also use the context menu directly in the scene tree view).
 Select the `TexturedBackgroundLight` node and click on the `Add` button.
 In the open dialog box, and choose `PROTO nodes (Webots Projects) / objects / floors / Floor (Solid)`.

--- a/docs/guide/tutorial-2-modification-of-the-environment.md
+++ b/docs/guide/tutorial-2-modification-of-the-environment.md
@@ -96,7 +96,7 @@ Select the `appearance` field of the [Shape](../reference/shape.md) node and use
 %end
 
 When the simulation is started, the ball hits the floor.
-You can move the ball by [applying a force](the-3d-window.md#applying-a-force-to-a-solid-object-with-physics) to it (Ctrl + Alt + left-click + drag).
+You can move the ball by [applying a force](the-3d-window.md#applying-a-force-to-a-solid-object-with-physics) to it (<kbd>ctrl</kbd> + <kbd>alt</kbd> + left-click + drag).
 The contact points between the ball and the floor can be displayed as cyan lines by enabling the `View / Optional Rendering / Show Contact Points` menu item.
 
 ### Geometries

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -87,8 +87,8 @@ Webots offers several rendering modes available in the `View` menu.
 Then restore the plain rendering mode: `View / Plain Rendering`.
 
 Others rendering features can be helpful:
-- View Coordinates systems: `View / Optional Rendering / Show Coordinates System (Ctrl + F1)`.
-- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays (Ctrl + F10)`.
+- View Coordinates systems: `View / Optional Rendering / Show Coordinates System (<kbd>ctrl</kbd>-<kbd>F1</kbd>)`.
+- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays (<kbd>ctrl</kbd>-<kbd>F10</kbd>)`.
 
 ### Solution: World File
 

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -87,8 +87,8 @@ Webots offers several rendering modes available in the `View` menu.
 Then restore the plain rendering mode: `View / Plain Rendering`.
 
 Others rendering features can be helpful:
-- View Coordinates systems: `View / Optional Rendering / Show Coordinates System (<kbd>ctrl</kbd>-<kbd>F1</kbd>)`.
-- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays (<kbd>ctrl</kbd>-<kbd>F10</kbd>)`.
+- View Coordinates systems: `View / Optional Rendering / Show Coordinates System` <kbd>ctrl</kbd>-<kbd>F1</kbd>
+- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays` <kbd>ctrl</kbd>-<kbd>F10</kbd>)
 
 ### Solution: World File
 

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -88,7 +88,7 @@ Then restore the plain rendering mode: `View / Plain Rendering`.
 
 Others rendering features can be helpful:
 - View Coordinates systems: `View / Optional Rendering / Show Coordinates System` <kbd>ctrl</kbd>-<kbd>F1</kbd>
-- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays` <kbd>ctrl</kbd>-<kbd>F10</kbd>)
+- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays` <kbd>ctrl</kbd>-<kbd>F10</kbd>
 
 ### Solution: World File
 

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -159,7 +159,7 @@ So, it is necessary to rotate the distance sensor to point their x-axis outside 
 
 %spoiler "**Reminder**: How to know the orientation of the distance sensor?"
 
-As already says in [Tutorial 3](tutorial-3-appearance.md), the distance sensor rays can be viewed using the shortcut <kbd>ctrl</kbd>-<kbd>F10</kbd>)` or `View / Optional Rendering / Show DistanceSensor Rays`.
+As already says in [Tutorial 3](tutorial-3-appearance.md), the distance sensor rays can be viewed using the shortcut <kbd>ctrl</kbd>-<kbd>F10</kbd> or `View / Optional Rendering / Show DistanceSensor Rays`.
 
 %end
 

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -159,7 +159,7 @@ So, it is necessary to rotate the distance sensor to point their x-axis outside 
 
 %spoiler "**Reminder**: How to know the orientation of the distance sensor?"
 
-As already says in [Tutorial 3](tutorial-3-appearance.md), the distance sensor rays can be viewed using the shortcut `(Ctrl + F10)` or `View / Optional Rendering / Show DistanceSensor Rays`.
+As already says in [Tutorial 3](tutorial-3-appearance.md), the distance sensor rays can be viewed using the shortcut <kbd>ctrl</kbd>-<kbd>F10</kbd>)` or `View / Optional Rendering / Show DistanceSensor Rays`.
 
 %end
 

--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -189,7 +189,7 @@ If you want to use the C++ API follow these instructions:
     In the file dialog, go to the "C:\Program Files\Webots\resources\languages\cpp" directory, then select all the .cpp files (but no other file) in that directory and hit the `Add` button.
     This should add the "Accelerometer.cpp, Camera.cpp, Compass.cpp", etc. source files to your project.
 
-6. Now you should be able to build your controller with the `Build / Build MyController` menu item (or the F7 key).
+6. Now you should be able to build your controller with the `Build / Build MyController` menu item (or the <kbd>F7</kbd> key).
 This should generate the "MyProject\controllers\MyController\MyController.exe" file.
 
 7. Now we can switch to Webots in order to test the .exe controller.

--- a/docs/reference/keyboard.md
+++ b/docs/reference/keyboard.md
@@ -161,7 +161,7 @@ The function can be called up to 7 times to detect up to 7 simultaneous keys pre
 The `wb_keyboard_disable` function should be used to stop the keyboard readings.
 
 > **Note** [C++]: The keyboard predefined values are located into a (static) enumeration of the Keyboard class.
-For example, `Keyboard.CONTROL` corresponds to the <kbd>Ctrl</kbd> key stroke.
+For example, `Keyboard.CONTROL` corresponds to the <kbd>ctrl</kbd> key stroke.
 
 <!-- -->
 

--- a/docs/reference/keyboard.md
+++ b/docs/reference/keyboard.md
@@ -161,12 +161,12 @@ The function can be called up to 7 times to detect up to 7 simultaneous keys pre
 The `wb_keyboard_disable` function should be used to stop the keyboard readings.
 
 > **Note** [C++]: The keyboard predefined values are located into a (static) enumeration of the Keyboard class.
-For example, `Keyboard.CONTROL` corresponds to the *Control* key stroke.
+For example, `Keyboard.CONTROL` corresponds to the <kbd>Ctrl</kbd> key stroke.
 
 <!-- -->
 
 > **Note** [Java]: The keyboard predefined values are final integers located in the Keyboard class.
-For example, *Ctrl+B* can be tested like this:
+For example, <kbd>ctrl</kbd>-<kbd>B</kbd> can be tested like this:
 
 > ```java
 > int key=keyboard.getKey()
@@ -177,7 +177,7 @@ For example, *Ctrl+B* can be tested like this:
 <!-- -->
 
 > **Note** [Python]: The keyboard predefined values are integers located into the Keyboard class.
-For example, *Ctrl+B* can be tested like this:
+For example, <kbd>ctrl</kbd>-<kbd>B</kbd> can be tested like this:
 
 > ```python
 > key=keyboard.getKey()


### PR DESCRIPTION
Fixes #2640.

See the result at https://cyberbotics.com/doc/guide/the-3d-window?version=fix-documentation-keyboard-shortcuts

I also took the opportunity of this PR to fix the appearance (CSS) of the `kbd` tag (keyboard keys).