### PR TITLE
Update pen.wbt

### DIFF
--- a/projects/samples/devices/worlds/pen.wbt
+++ b/projects/samples/devices/worlds/pen.wbt
@@ -135,7 +135,7 @@ Robot {
     HingeJoint {
       jointParameters HingeJointParameters {
         axis -1 0 0
-        anchor 0 0.025 0
+        anchor -0.045 0.025 0
       }
       device [
         RotationalMotor {
@@ -179,7 +179,7 @@ Robot {
     HingeJoint {
       jointParameters HingeJointParameters {
         axis -1 0 0
-        anchor 0 0.025 0
+        anchor 0.045 0.025 0
       }
       device [
         RotationalMotor {


### PR DESCRIPTION
Changed the value of the anchor field in the HingeJointParameters Node to match the values of the translation field of their respective Solid nodes

**Description**
Describe the bug you are fixing, the new feature your are introducing or the enhancement you are proposing.

**Related Issues**
This pull-request fixes issue #

**Tasks**
Add the list of tasks of this PR.
  - [ ] Task 1
  - [ ] Task 2

**Documentation**
If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
https://cyberbotics.com/doc/guide/getting-started-with-webots?version=develop

**Screenshots**
If this pull-request includes any new robots/simulations/etc. add one or more screenshots of the result.

**Additional context**
Add any other context about the pull-request here.
