### PR TITLE
Fixed use of deprecated API method

### DIFF
--- a/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
+++ b/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
@@ -236,7 +236,7 @@ class TestSuite (Supervisor):
                 self.loadNextWorld()
                 return
         else:
-            receiver = self.getReceiver("ts_receiver")
+            receiver = self.getDevice("ts_receiver")
             receiver.enable(basicTimeStep)
 
         # 30 seconds before executing the next world


### PR DESCRIPTION
This was causing many warnings in the log of the test suite.