### PR TITLE
Expose new API for accessing RangeFinder's raw float buffer in Python

### DIFF
--- a/docs/reference/rangefinder.md
+++ b/docs/reference/rangefinder.md
@@ -483,7 +483,7 @@ namespace webots {
 from controller import RangeFinder
 
 class RangeFinder (Device):
-    def getRangeImage(self):
+    def getRangeImage(self, data_type='list'):
     def getRangeImageArray(self):
     @staticmethod
     def rangeImageGetDepth(image, width, x, y):
@@ -550,8 +550,17 @@ The `range_finder_width` parameter can be obtained from the `wb_range_finder_get
 The `x` and `y` parameters are the coordinates of the pixel in the image.
 
 > **Note** [Python]: The RangeFinder class has two methods for getting the range-finder image.
-The `getRangeImage` function returns a one-dimensional list of floats, while the `getRangeImageArray` function returns a two-dimensional list of floats.
+The `getRangeImage` function, by default, returns a one-dimensional list of floats, while the `getRangeImageArray` function returns a two-dimensional list of floats.
 Their content are identical but their handling is of course different.
+
+> `getRangeImage` takes a `data_type` keyword parameter, supporting either `list` (default) or `buffer`.
+> If `buffer`, the function will return a `bytes` object containing the native machine encoding for a buffer of `float` values, closely resembling the C API.
+> `buffer` is significantly faster than `list`, and can easily be wrapped using external libraries such as NumPy:
+
+> ```python
+> image_bytes = range_finder.getRangeImage(data_type="buffer")
+> image_np = np.frombuffer(image_bytes, dtype=np.float32)
+> ```
 
 ---
 

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -753,19 +753,29 @@ class AnsiCodes(object):
 //  RangeFinder
 //----------------------------------------------------------------------------------------------
 
-%typemap(out) float * {
-  int width = arg1->getWidth();
-  int height = arg1->getHeight();
-  int len = width * height;
-  if ($1) {
-    $result = PyList_New(len);
-    for (int x = 0; x < len; ++x)
-      PyList_SetItem($result, x, PyFloat_FromDouble($1[x]));
-  } else
-    $result = Py_None;
-}
-
 %extend webots::RangeFinder {
+
+  PyObject *__getRangeImageList() {
+    const float *im = $self->getRangeImage();
+    int width = $self->getWidth();
+    int height = $self->getHeight();
+    int len = width * height;
+    if (im) {
+      PyObject *ret = PyList_New(len);
+      for (int x = 0; x < len; ++x)
+        PyList_SetItem(ret, x, PyFloat_FromDouble(im[x]));
+      return ret;
+    } else {
+      return Py_None;
+    }
+  }
+
+  PyObject *__getRangeImageBuffer() {
+    const float *im = $self->getRangeImage();
+    const char *im_bytes = (const char *)im;
+    const int size = $self->getWidth() * $self->getHeight() * sizeof(float);
+    return PyBytes_FromStringAndSize(im_bytes, size);
+  }
 
   PyObject *getRangeImageArray() {
     const float *im = $self->getRangeImage();
@@ -785,6 +795,17 @@ class AnsiCodes(object):
     }
     return ret;
   }
+
+  %pythoncode %{
+    def getRangeImage(self, data_type='list'):
+      if data_type == 'list':
+        return self.__getRangeImageList()
+      elif data_type == 'buffer':
+        return self.__getRangeImageBuffer()
+      else:
+        print("Error: `data_type` cannot be `{}`! Supported values are 'list' and 'buffer'.".format(data_type), file=sys.stderr)
+        return None
+  %}
 
   static PyObject *rangeImageGetValue(PyObject *im, double minRange, double maxRange, int width, int x, int y) {
     if (!PyList_Check(im)) {

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -757,9 +757,9 @@ class AnsiCodes(object):
 
   PyObject *__getRangeImageList() {
     const float *im = $self->getRangeImage();
-    int width = $self->getWidth();
-    int height = $self->getHeight();
-    int len = width * height;
+    const int width = $self->getWidth();
+    const int height = $self->getHeight();
+    const int len = width * height;
     if (im) {
       PyObject *ret = PyList_New(len);
       for (int x = 0; x < len; ++x)


### PR DESCRIPTION
**Description**

This PR introduces a new `data_type` keyword parameter on the `getRangeImage` method. The default value, `list`, preserves its existing behavior. The new alternative, `buffer`, returns a `bytes` object with a copy of the machine-dependent `float` buffer.

The behavior of `getRangeImageArray` is unchanged. I opted to add the new functionality to `getRangeImage` rather than `getRangeImageArray` because a byte buffer more closely resembles a 1D list than 2D. 🤷 

**Related Issues**

Fixes issue #2661. There's a full description in that issue.

API is modelled after #2321.

**Tasks**

I don't know what tasks I'm supposed to put here, but... I added the option and updated the documentation.

I have _not_ introduced a changelog entry.

**Documentation**

This MR is sourced from my fork for politeness; I believe I could push the branch to the upstream repo and change the source if that's what is preferred.

**Additional context**

<details>
<summary>Not-very-scientific test controller</summary>

```python
from controller import Robot

import time
import numpy as np
import cv2

robot = Robot()

timestep = int(robot.getBasicTimeStep())

rf = robot.getDevice("range-finder")
rf.enable(int(robot.getBasicTimeStep()))

i = 0
while robot.step(timestep) != -1:
    if i % 2 == 0:
        start = time.time()
        image = rf.getRangeImage(data_type="list")
        image_np = np.array(image).reshape(rf.getHeight(), rf.getWidth())
        end = time.time()
        #cv2.imwrite("list.png", np.array(image_np * 100, dtype=np.uint8))
        print(f"List time: {(end-start)*1000:.2f} ms")
    else:
        start = time.time()
        image = rf.getRangeImage(data_type="buffer")
        image_np = np.frombuffer(image, dtype=np.float32).reshape(rf.getHeight(), rf.getWidth())
        end = time.time()
        #cv2.imwrite("buffer.png", np.array(image_np * 100, dtype=np.uint8))
        print(f"Buffer time: {(end-start)*1000:.2f} ms")
    i += 1

```
</details>

On my machine, with a 640x480 image (formatted as `median` / `mean`):

-|list|buffer
---|---|---
function call only | 8ms / 8.7ms | 5ms / 5.5ms
function call plus numpy array | 22ms / 24.5ms | 7ms / 7.6ms

I'm not 100% satisfied with this performance (7ms is still rather high for what should, ideally, do effectively zero work) but I figure it's worth opening the PR for discussion.
