### PR TITLE
Fix lidar point cloud visualisation issue

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -441,6 +441,8 @@ void WbLidar::displayPointCloud() {
       }
       for (int l = 0; l < resolution; ++l) {
         const float *vertex = &pointArray()[k * resolution + l].x;
+        if (isinf(vertex[0]) || isinf(vertex[1]) || isinf(vertex[2]))
+          continue;
 
         wr_dynamic_mesh_add_vertex(mLidarPointsMesh, vertex);
         wr_dynamic_mesh_add_color(mLidarPointsMesh, color);


### PR DESCRIPTION
**Related Issues**
This pull-request addresses issue #2660

**Description**
After changing lidar out-of-range behavior in PR #2509, vertexes can have INF components, in which case they shouldn't be added to the mesh for rendering, as it wouldn't make much sense.

PS: As to why having a single vertex that contains an INF component in an otherwise valid cloud of points prevents all others from being drawn wasn't investigated in this PR. It's normal or should be addressed in a different issue? 

**Video**

https://user-images.githubusercontent.com/44834743/105103983-bfe37c00-5ab1-11eb-92db-fadde156c4b5.mp4

https://user-images.githubusercontent.com/44834743/105103998-c5d95d00-5ab1-11eb-840a-39a798e0f7f6.mp4

**Test**
Validated only on ubuntu 20.04.
