### PR TITLE
Fix lidar point cloud visualisation issue

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -15,6 +15,7 @@ Released on XX Xth, 2021.
     - Fixed a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).
     - Fixed external force/torque logic such that the closest dynamic Solid ancestor is picked if the selected one lacks it ([#2635](https://github.com/cyberbotics/webots/pull/2635)).
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
+    - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree  }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
 

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -441,6 +441,8 @@ void WbLidar::displayPointCloud() {
       }
       for (int l = 0; l < resolution; ++l) {
         const float *vertex = &pointArray()[k * resolution + l].x;
+        if (isinf(vertex[0]) || isinf(vertex[1]) || isinf(vertex[2]))
+          continue;
 
         wr_dynamic_mesh_add_vertex(mLidarPointsMesh, vertex);
         wr_dynamic_mesh_add_color(mLidarPointsMesh, color);

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -440,11 +440,14 @@ void WbLidar::displayPointCloud() {
         color[2] = 1.0f - color[0];
       }
       for (int l = 0; l < resolution; ++l) {
-        const float *vertex = &pointArray()[k * resolution + l].x;
-        if (isinf(vertex[0]) || isinf(vertex[1]) || isinf(vertex[2]))
+        const float *vertex_x = &pointArray()[k * resolution + l].x;
+        const float *vertex_y = &pointArray()[k * resolution + l].y;
+        const float *vertex_z = &pointArray()[k * resolution + l].z;
+
+        if (isinf(*vertex_x) || isinf(*vertex_y) || isinf(*vertex_z))
           continue;
 
-        wr_dynamic_mesh_add_vertex(mLidarPointsMesh, vertex);
+        wr_dynamic_mesh_add_vertex(mLidarPointsMesh, vertex_x);
         wr_dynamic_mesh_add_color(mLidarPointsMesh, color);
         wr_dynamic_mesh_add_index(mLidarPointsMesh, pointsIndex++);
         // Ray
@@ -453,7 +456,7 @@ void WbLidar::displayPointCloud() {
           wr_dynamic_mesh_add_color(mLidarRaysMesh, color);
           wr_dynamic_mesh_add_index(mLidarRaysMesh, raysIndex++);
 
-          wr_dynamic_mesh_add_vertex(mLidarRaysMesh, vertex);
+          wr_dynamic_mesh_add_vertex(mLidarRaysMesh, vertex_x);
           wr_dynamic_mesh_add_color(mLidarRaysMesh, color);
           wr_dynamic_mesh_add_index(mLidarRaysMesh, raysIndex++);
         }


### PR DESCRIPTION
**Related Issues**
This pull-request addresses issue #2660

**Description**
After changing lidar out-of-range behavior in PR #2509, vertexes can have INF components, in which case they shouldn't be added to the mesh for rendering, as it wouldn't make much sense.

PS: As to why having a single vertex that contains an INF component in an otherwise valid cloud of points prevents all others from being drawn wasn't investigated in this PR. It's normal or should be addressed in a different issue? 

**Video**

https://user-images.githubusercontent.com/44834743/105106992-58c8c600-5ab7-11eb-813b-91c1baff1497.mp4

https://user-images.githubusercontent.com/44834743/105107008-5ebea700-5ab7-11eb-8c50-511c2afb3fbb.mp4

**Test**
Validated only on ubuntu 20.04.