### PR TITLE
Add description of the boundingObject color in solid.md

### DIFF
--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -113,8 +113,7 @@ The center of mass is specified by the `centerOfMass` field of the [Physics](phy
 
 The `boundingObject` of the selected object is displayed in the 3D view by depicting the outline of the `boundingObject` shapes.
 Additionally, if the `View|Optional Rendering|Show ALl Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
-The color of the `boundingObject` outline indicates the status of the object:
-usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
+The color of the `boundingObject` outline indicates the status of the object: usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
 
 ### Unique Solid Name
 

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -111,6 +111,11 @@ Such a computation assumes a uniform mass distribution in the primitives composi
 Note that the center of mass of the [Solid](#solid) does not depend on its `boundingObject`.
 The center of mass is specified by the `centerOfMass` field of the [Physics](physics.md) node (in coordinates relative to the center of the [Solid](#solid)).
 
+The outline `boundingObject` of the selected object is displayed in the 3D view.
+Otherwise, if the `View|Optional Rendering|Show ALl Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
+The color of the `boundingObject` outline indicates if the object is colliding:
+usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
+
 ### Unique Solid Name
 
 The capability of identifying uniquely each [Solid](#solid) node is a base requirement for other advanced features, for example to let the viewpoint follow a solid object or to store the preferences for the rendering devices overlays.

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -111,9 +111,9 @@ Such a computation assumes a uniform mass distribution in the primitives composi
 Note that the center of mass of the [Solid](#solid) does not depend on its `boundingObject`.
 The center of mass is specified by the `centerOfMass` field of the [Physics](physics.md) node (in coordinates relative to the center of the [Solid](#solid)).
 
-The outline `boundingObject` of the selected object is displayed in the 3D view.
-Otherwise, if the `View|Optional Rendering|Show ALl Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
-The color of the `boundingObject` outline indicates if the object is colliding:
+The `boundingObject` of the selected object is displayed in the 3D view by depicting the outline of the `boundingObject` shapes.
+Additionally, if the `View|Optional Rendering|Show ALl Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
+The color of the `boundingObject` outline indicates the status of the object:
 usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
 
 ### Unique Solid Name

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -112,7 +112,7 @@ Note that the center of mass of the [Solid](#solid) does not depend on its `boun
 The center of mass is specified by the `centerOfMass` field of the [Physics](physics.md) node (in coordinates relative to the center of the [Solid](#solid)).
 
 The `boundingObject` of the selected object is displayed in the 3D view by depicting the outline of the `boundingObject` shapes.
-Additionally, if the `View|Optional Rendering|Show ALl Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
+Additionally, if the `View|Optional Rendering|Show All Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
 The color of the `boundingObject` outline indicates the status of the object: usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
 
 ### Unique Solid Name


### PR DESCRIPTION
Currently the documentation of the meaning of the `boundingObject` outline color is contained here:
https://www.cyberbotics.com/doc/guide/the-3d-window#selecting-an-object
but it is not easy to find.
I also added in the `Solid.boundingObject` section.