### PR TITLE
Merge released into master

### DIFF
--- a/docs/automobile/cpp-java-and-python-wrappers-of-the-automobile-libraries.md
+++ b/docs/automobile/cpp-java-and-python-wrappers-of-the-automobile-libraries.md
@@ -26,7 +26,7 @@ The `init` and `cleanup` functions are called automatically from the constructor
 > ```
 >
 > You have to define the `CLASSPATH` environment variable and point it to `${WEBOTS_HOME}/lib/controller/java/vehicle.jar`.
-> There is an example on how to add the `CLASSPATH` environment variable to `Makefile` and `runtime.ini` in [WEBOTS\_HOME/projects/vehicles/controllers/VehicleDriver]({{ url.github_tree  }}/projects/vehicles/controllers/VehicleDriver).
+> There is an example on how to add the `CLASSPATH` environment variable to `Makefile` and `runtime.ini` in [WEBOTS\_HOME/projects/vehicles/controllers/VehicleDriver]({{ url.github_tree }}/projects/vehicles/controllers/VehicleDriver).
 
 > **Note** [Python]: The following program shows how to set the cruising speed and the steering angle in Python:
 

--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -1775,7 +1775,7 @@ ShinyLeather {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto]({{ url.github_tree  }}/projects/appearances/protos/ShinyLeather.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto](https://github.com/cyberbotics/webots/tree/master/projects/appearances/protos/ShinyLeather.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1949,7 +1949,7 @@ VarnishedPine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto]({{ url.github_tree  }}/projects/appearances/protos/VarnishedPine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto](https://github.com/cyberbotics/webots/tree/master/projects/appearances/protos/VarnishedPine.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -1775,7 +1775,7 @@ ShinyLeather {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto](https://github.com/cyberbotics/webots/tree/master/projects/appearances/protos/ShinyLeather.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto]({{ url.github_tree  }}/projects/appearances/protos/ShinyLeather.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1949,7 +1949,7 @@ VarnishedPine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto](https://github.com/cyberbotics/webots/tree/master/projects/appearances/protos/VarnishedPine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto]({{ url.github_tree  }}/projects/appearances/protos/VarnishedPine.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1994,4 +1994,3 @@ WireFence {
 - `textureTransform`: Defines an optional 2d texture transform.
 
 - `IBLStrength`: Defines the strength of ambient lighting from the [Background](../reference/background.md) node.
-

--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -21,7 +21,7 @@ Asphalt {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Asphalt.proto]({{ url.github_tree  }}/projects/appearances/protos/Asphalt.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Asphalt.proto]({{ url.github_tree }}/projects/appearances/protos/Asphalt.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -56,7 +56,7 @@ BakelitePlastic {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BakelitePlastic.proto]({{ url.github_tree  }}/projects/appearances/protos/BakelitePlastic.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BakelitePlastic.proto]({{ url.github_tree }}/projects/appearances/protos/BakelitePlastic.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -89,7 +89,7 @@ BlanketFabric {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BlanketFabric.proto]({{ url.github_tree  }}/projects/appearances/protos/BlanketFabric.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BlanketFabric.proto]({{ url.github_tree }}/projects/appearances/protos/BlanketFabric.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -122,7 +122,7 @@ BrushedAluminium {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BrushedAluminium.proto]({{ url.github_tree  }}/projects/appearances/protos/BrushedAluminium.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BrushedAluminium.proto]({{ url.github_tree }}/projects/appearances/protos/BrushedAluminium.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -155,7 +155,7 @@ BrushedSteel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BrushedSteel.proto]({{ url.github_tree  }}/projects/appearances/protos/BrushedSteel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/BrushedSteel.proto]({{ url.github_tree }}/projects/appearances/protos/BrushedSteel.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -192,7 +192,7 @@ CarpetFibers {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CarpetFibers.proto]({{ url.github_tree  }}/projects/appearances/protos/CarpetFibers.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CarpetFibers.proto]({{ url.github_tree }}/projects/appearances/protos/CarpetFibers.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -227,7 +227,7 @@ CementTiles {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CementTiles.proto]({{ url.github_tree  }}/projects/appearances/protos/CementTiles.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CementTiles.proto]({{ url.github_tree }}/projects/appearances/protos/CementTiles.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -259,7 +259,7 @@ Copper {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Copper.proto]({{ url.github_tree  }}/projects/appearances/protos/Copper.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Copper.proto]({{ url.github_tree }}/projects/appearances/protos/Copper.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -290,7 +290,7 @@ CorrodedMetal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrodedMetal.proto]({{ url.github_tree  }}/projects/appearances/protos/CorrodedMetal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrodedMetal.proto]({{ url.github_tree }}/projects/appearances/protos/CorrodedMetal.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -323,7 +323,7 @@ CorrugatedMetal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedMetal.proto]({{ url.github_tree  }}/projects/appearances/protos/CorrugatedMetal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedMetal.proto]({{ url.github_tree }}/projects/appearances/protos/CorrugatedMetal.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -356,7 +356,7 @@ CorrugatedPlates {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedPlates.proto]({{ url.github_tree  }}/projects/appearances/protos/CorrugatedPlates.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedPlates.proto]({{ url.github_tree }}/projects/appearances/protos/CorrugatedPlates.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -389,7 +389,7 @@ CorrugatedPvc {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedPvc.proto]({{ url.github_tree  }}/projects/appearances/protos/CorrugatedPvc.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/CorrugatedPvc.proto]({{ url.github_tree }}/projects/appearances/protos/CorrugatedPvc.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -422,7 +422,7 @@ DamascusSteel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/DamascusSteel.proto]({{ url.github_tree  }}/projects/appearances/protos/DamascusSteel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/DamascusSteel.proto]({{ url.github_tree }}/projects/appearances/protos/DamascusSteel.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -454,7 +454,7 @@ DryMud {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/DryMud.proto]({{ url.github_tree  }}/projects/appearances/protos/DryMud.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/DryMud.proto]({{ url.github_tree }}/projects/appearances/protos/DryMud.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -485,7 +485,7 @@ ElectricConduit {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ElectricConduit.proto]({{ url.github_tree  }}/projects/appearances/protos/ElectricConduit.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ElectricConduit.proto]({{ url.github_tree }}/projects/appearances/protos/ElectricConduit.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -518,7 +518,7 @@ FlexibleAluminiumDuct {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/FlexibleAluminiumDuct.proto]({{ url.github_tree  }}/projects/appearances/protos/FlexibleAluminiumDuct.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/FlexibleAluminiumDuct.proto]({{ url.github_tree }}/projects/appearances/protos/FlexibleAluminiumDuct.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -550,7 +550,7 @@ FormedConcrete {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/FormedConcrete.proto]({{ url.github_tree  }}/projects/appearances/protos/FormedConcrete.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/FormedConcrete.proto]({{ url.github_tree }}/projects/appearances/protos/FormedConcrete.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -581,7 +581,7 @@ GalvanizedMetal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/GalvanizedMetal.proto]({{ url.github_tree  }}/projects/appearances/protos/GalvanizedMetal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/GalvanizedMetal.proto]({{ url.github_tree }}/projects/appearances/protos/GalvanizedMetal.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -614,7 +614,7 @@ GlossyPaint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/GlossyPaint.proto]({{ url.github_tree  }}/projects/appearances/protos/GlossyPaint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/GlossyPaint.proto]({{ url.github_tree }}/projects/appearances/protos/GlossyPaint.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -651,7 +651,7 @@ Grass {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Grass.proto]({{ url.github_tree  }}/projects/appearances/protos/Grass.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Grass.proto]({{ url.github_tree }}/projects/appearances/protos/Grass.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -686,7 +686,7 @@ HammeredCopper {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/HammeredCopper.proto]({{ url.github_tree  }}/projects/appearances/protos/HammeredCopper.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/HammeredCopper.proto]({{ url.github_tree }}/projects/appearances/protos/HammeredCopper.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -724,7 +724,7 @@ Leather {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Leather.proto]({{ url.github_tree  }}/projects/appearances/protos/Leather.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Leather.proto]({{ url.github_tree }}/projects/appearances/protos/Leather.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -762,7 +762,7 @@ LedStrip {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/LedStrip.proto]({{ url.github_tree  }}/projects/appearances/protos/LedStrip.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/LedStrip.proto]({{ url.github_tree }}/projects/appearances/protos/LedStrip.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -797,7 +797,7 @@ Marble {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Marble.proto]({{ url.github_tree  }}/projects/appearances/protos/Marble.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Marble.proto]({{ url.github_tree }}/projects/appearances/protos/Marble.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -830,7 +830,7 @@ MarbleTiles {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MarbleTiles.proto]({{ url.github_tree  }}/projects/appearances/protos/MarbleTiles.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MarbleTiles.proto]({{ url.github_tree }}/projects/appearances/protos/MarbleTiles.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -863,7 +863,7 @@ MattePaint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MattePaint.proto]({{ url.github_tree  }}/projects/appearances/protos/MattePaint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MattePaint.proto]({{ url.github_tree }}/projects/appearances/protos/MattePaint.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -895,7 +895,7 @@ MetalPipePaint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MetalPipePaint.proto]({{ url.github_tree  }}/projects/appearances/protos/MetalPipePaint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MetalPipePaint.proto]({{ url.github_tree }}/projects/appearances/protos/MetalPipePaint.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -925,7 +925,7 @@ MetalStainlessSteelCable {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MetalStainlessSteelCable.proto]({{ url.github_tree  }}/projects/appearances/protos/MetalStainlessSteelCable.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/MetalStainlessSteelCable.proto]({{ url.github_tree }}/projects/appearances/protos/MetalStainlessSteelCable.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -956,7 +956,7 @@ OldPlywood {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OldPlywood.proto]({{ url.github_tree  }}/projects/appearances/protos/OldPlywood.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OldPlywood.proto]({{ url.github_tree }}/projects/appearances/protos/OldPlywood.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -989,7 +989,7 @@ OldSteel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OldSteel.proto]({{ url.github_tree  }}/projects/appearances/protos/OldSteel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OldSteel.proto]({{ url.github_tree }}/projects/appearances/protos/OldSteel.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1022,7 +1022,7 @@ OsbWood {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OsbWood.proto]({{ url.github_tree  }}/projects/appearances/protos/OsbWood.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/OsbWood.proto]({{ url.github_tree }}/projects/appearances/protos/OsbWood.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1055,7 +1055,7 @@ PaintedWood {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PaintedWood.proto]({{ url.github_tree  }}/projects/appearances/protos/PaintedWood.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PaintedWood.proto]({{ url.github_tree }}/projects/appearances/protos/PaintedWood.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1094,7 +1094,7 @@ Parquetry {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Parquetry.proto]({{ url.github_tree  }}/projects/appearances/protos/Parquetry.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Parquetry.proto]({{ url.github_tree }}/projects/appearances/protos/Parquetry.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1136,7 +1136,7 @@ Pavement {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Pavement.proto]({{ url.github_tree  }}/projects/appearances/protos/Pavement.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Pavement.proto]({{ url.github_tree }}/projects/appearances/protos/Pavement.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1170,7 +1170,7 @@ Pcb {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Pcb.proto]({{ url.github_tree  }}/projects/appearances/protos/Pcb.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Pcb.proto]({{ url.github_tree }}/projects/appearances/protos/Pcb.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1201,7 +1201,7 @@ PerforatedMetal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PerforatedMetal.proto]({{ url.github_tree  }}/projects/appearances/protos/PerforatedMetal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PerforatedMetal.proto]({{ url.github_tree }}/projects/appearances/protos/PerforatedMetal.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1234,7 +1234,7 @@ Plaster {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Plaster.proto]({{ url.github_tree  }}/projects/appearances/protos/Plaster.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Plaster.proto]({{ url.github_tree }}/projects/appearances/protos/Plaster.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1270,7 +1270,7 @@ Plastic {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Plastic.proto]({{ url.github_tree  }}/projects/appearances/protos/Plastic.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Plastic.proto]({{ url.github_tree }}/projects/appearances/protos/Plastic.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1305,7 +1305,7 @@ PorcelainChevronTiles {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PorcelainChevronTiles.proto]({{ url.github_tree  }}/projects/appearances/protos/PorcelainChevronTiles.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/PorcelainChevronTiles.proto]({{ url.github_tree }}/projects/appearances/protos/PorcelainChevronTiles.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1337,7 +1337,7 @@ RedBricks {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RedBricks.proto]({{ url.github_tree  }}/projects/appearances/protos/RedBricks.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RedBricks.proto]({{ url.github_tree }}/projects/appearances/protos/RedBricks.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1372,7 +1372,7 @@ ReflectiveSurface {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ReflectiveSurface.proto]({{ url.github_tree  }}/projects/appearances/protos/ReflectiveSurface.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ReflectiveSurface.proto]({{ url.github_tree }}/projects/appearances/protos/ReflectiveSurface.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1405,7 +1405,7 @@ RoughConcrete {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughConcrete.proto]({{ url.github_tree  }}/projects/appearances/protos/RoughConcrete.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughConcrete.proto]({{ url.github_tree }}/projects/appearances/protos/RoughConcrete.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1438,7 +1438,7 @@ RoughOak {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughOak.proto]({{ url.github_tree  }}/projects/appearances/protos/RoughOak.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughOak.proto]({{ url.github_tree }}/projects/appearances/protos/RoughOak.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1471,7 +1471,7 @@ RoughPine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughPine.proto]({{ url.github_tree  }}/projects/appearances/protos/RoughPine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughPine.proto]({{ url.github_tree }}/projects/appearances/protos/RoughPine.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1504,7 +1504,7 @@ RoughPolymer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughPolymer.proto]({{ url.github_tree  }}/projects/appearances/protos/RoughPolymer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RoughPolymer.proto]({{ url.github_tree }}/projects/appearances/protos/RoughPolymer.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1537,7 +1537,7 @@ Roughcast {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Roughcast.proto]({{ url.github_tree  }}/projects/appearances/protos/Roughcast.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Roughcast.proto]({{ url.github_tree }}/projects/appearances/protos/Roughcast.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1573,7 +1573,7 @@ Rubber {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Rubber.proto]({{ url.github_tree  }}/projects/appearances/protos/Rubber.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Rubber.proto]({{ url.github_tree }}/projects/appearances/protos/Rubber.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1608,7 +1608,7 @@ RustyMetal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RustyMetal.proto]({{ url.github_tree  }}/projects/appearances/protos/RustyMetal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/RustyMetal.proto]({{ url.github_tree }}/projects/appearances/protos/RustyMetal.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1642,7 +1642,7 @@ Sand {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Sand.proto]({{ url.github_tree  }}/projects/appearances/protos/Sand.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Sand.proto]({{ url.github_tree }}/projects/appearances/protos/Sand.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1673,7 +1673,7 @@ SandyGround {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/SandyGround.proto]({{ url.github_tree  }}/projects/appearances/protos/SandyGround.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/SandyGround.proto]({{ url.github_tree }}/projects/appearances/protos/SandyGround.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1707,7 +1707,7 @@ ScratchedPaint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ScratchedPaint.proto]({{ url.github_tree  }}/projects/appearances/protos/ScratchedPaint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ScratchedPaint.proto]({{ url.github_tree }}/projects/appearances/protos/ScratchedPaint.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1742,7 +1742,7 @@ ScrewThread {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ScrewThread.proto]({{ url.github_tree  }}/projects/appearances/protos/ScrewThread.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ScrewThread.proto]({{ url.github_tree }}/projects/appearances/protos/ScrewThread.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1775,7 +1775,7 @@ ShinyLeather {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto]({{ url.github_tree  }}/projects/appearances/protos/ShinyLeather.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ShinyLeather.proto]({{ url.github_tree }}/projects/appearances/protos/ShinyLeather.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1811,7 +1811,7 @@ Soil {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Soil.proto]({{ url.github_tree  }}/projects/appearances/protos/Soil.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/Soil.proto]({{ url.github_tree }}/projects/appearances/protos/Soil.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1843,7 +1843,7 @@ SolarCell {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/SolarCell.proto]({{ url.github_tree  }}/projects/appearances/protos/SolarCell.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/SolarCell.proto]({{ url.github_tree }}/projects/appearances/protos/SolarCell.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1878,7 +1878,7 @@ ThreadMetalPlate {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ThreadMetalPlate.proto]({{ url.github_tree  }}/projects/appearances/protos/ThreadMetalPlate.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/ThreadMetalPlate.proto]({{ url.github_tree }}/projects/appearances/protos/ThreadMetalPlate.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1916,7 +1916,7 @@ TireRubber {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/TireRubber.proto]({{ url.github_tree  }}/projects/appearances/protos/TireRubber.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/TireRubber.proto]({{ url.github_tree }}/projects/appearances/protos/TireRubber.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1949,7 +1949,7 @@ VarnishedPine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto]({{ url.github_tree  }}/projects/appearances/protos/VarnishedPine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/VarnishedPine.proto]({{ url.github_tree }}/projects/appearances/protos/VarnishedPine.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -1982,7 +1982,7 @@ WireFence {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/WireFence.proto]({{ url.github_tree  }}/projects/appearances/protos/WireFence.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/appearances/protos/WireFence.proto]({{ url.github_tree }}/projects/appearances/protos/WireFence.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/guide/controller-plugin.md
+++ b/docs/guide/controller-plugin.md
@@ -73,15 +73,15 @@ To create a similar robot window for your project follow these steps:
 1. In your project's root create a file in the following path `plugins/robot_windows/<robot window name>/<robot window name>.html`.
 2. The file is a typical HTML document that can contain JavaScript and CSS.
 However, in addition to the standard JavaScript library, a `webots` object is injected that exposes an interface to allow communication with a robot controller.
-Therefore, you can check usage examples of `webots.window("<robot window name>").receive` and `webots.window("<robot window name>").send` in [`projects/samples/howto/custom_robot_window_simple/plugins/robot_windows/custom_robot_window_simple/custom_robot_window_simple.html`]({{ url.github_tree  }}/projects/samples/howto/custom_robot_window_simple/plugins/robot_windows/custom_robot_window_simple/custom_robot_window_simple.html).
+Therefore, you can check usage examples of `webots.window("<robot window name>").receive` and `webots.window("<robot window name>").send` in [`projects/samples/howto/custom_robot_window_simple/plugins/robot_windows/custom_robot_window_simple/custom_robot_window_simple.html`]({{ url.github_tree }}/projects/samples/howto/custom_robot_window_simple/plugins/robot_windows/custom_robot_window_simple/custom_robot_window_simple.html).
 3. The robot window needs to be registered in the robot's node.
 Find your robot in the scene tree, select a `window` field, click select and choose `<robot window name>`.
 If you double click on the robot, your `<robot window name>` will open.
 4. To send and receive data inside the controller you have to use `wb_robot_wwi_receive_text` and `wb_robot_wwi_send_text`.
-A very simple Python example is given in [`projects/samples/howto/custom_robot_window_simple/controllers/custom_robot_window_simple/custom_robot_window_simple.py`]({{ url.github_tree  }}/projects/samples/howto/custom_robot_window_simple/controllers/custom_robot_window_simple/custom_robot_window_simple.py).
+A very simple Python example is given in [`projects/samples/howto/custom_robot_window_simple/controllers/custom_robot_window_simple/custom_robot_window_simple.py`]({{ url.github_tree }}/projects/samples/howto/custom_robot_window_simple/controllers/custom_robot_window_simple/custom_robot_window_simple.py).
 
 An example of a reusable HTML robot window is given in [`projects/samples/howto/custom_robot_window`](samples-howto.md#custom_robot_window-wbt).
-While in the previous example the HTML robot window interacts directly with the controller, in this example the robot window exchanges data with a controller implemented in [`plugins/robot_windows/custom_robot_window/custom_robot_window.c`]({{ url.github_tree  }}/projects/samples/howto/custom_robot_window/plugins/robot_windows/custom_robot_window/custom_robot_window.c).
+While in the previous example the HTML robot window interacts directly with the controller, in this example the robot window exchanges data with a controller implemented in [`plugins/robot_windows/custom_robot_window/custom_robot_window.c`]({{ url.github_tree }}/projects/samples/howto/custom_robot_window/plugins/robot_windows/custom_robot_window/custom_robot_window.c).
 Therefore, the robot window in this case can be reused in different simulations.
 
 <br />

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -1355,9 +1355,9 @@ Like most terminals, it supports a few basic [ANSI escape codes](https://en.wiki
   - Clear screen (same as issuing `clear` command in your terminal)
   - Reset (colors and styles)
 
-To demonstrate how to use those, there is an example world and a controller file respectively located in "[WEBOTS\_HOME/projects/samples/howto/console/worlds/console.wbt]({{ url.github_tree  }}/projects/samples/howto/console/worlds/console.wbt)" and "[WEBOTS\_HOME/projects/samples/howto/console/controllers/console/console.c]({{ url.github_tree  }}/projects/samples/howto/console/controllers/console/console.c)".
+To demonstrate how to use those, there is an example world and a controller file respectively located in "[WEBOTS\_HOME/projects/samples/howto/console/worlds/console.wbt]({{ url.github_tree }}/projects/samples/howto/console/worlds/console.wbt)" and "[WEBOTS\_HOME/projects/samples/howto/console/controllers/console/console.c]({{ url.github_tree }}/projects/samples/howto/console/controllers/console/console.c)".
 
-The related C header is located at "[WEBOTS\_HOME/include/controller/c/webots/utils/ansi\_codes.h]({{ url.github_tree  }}/include/controller/c/webots/utils/ansi_codes.h)", it contains some useful macros on top of constants, to use it:
+The related C header is located at "[WEBOTS\_HOME/include/controller/c/webots/utils/ansi\_codes.h]({{ url.github_tree }}/include/controller/c/webots/utils/ansi_codes.h)", it contains some useful macros on top of constants, to use it:
 
 %tab-component "language"
 
@@ -1418,9 +1418,9 @@ If the console output is altered because of a previous escape code use without r
 Creating shared libraries can be very useful to share code between controllers and/or plugins.
 There are several ways to do so, but we recommend to place them into a subdirectory of the `libraries` directory of your project.
 Indeed the environment variables of the controllers are modified to include these paths into your [[DY]LD\_LIBRARY\_]PATH environment variable (depending on the OS).
-Moreover the main Makefile ("[WEBOTS\_HOME/resources/Makefile.include]({{ url.github_tree  }}/resources/Makefile.include)") used to compile Webots controllers is able to create shared libraries and to link easily with the Controller libraries, ODE or the Qt framework.
+Moreover the main Makefile ("[WEBOTS\_HOME/resources/Makefile.include]({{ url.github_tree }}/resources/Makefile.include)") used to compile Webots controllers is able to create shared libraries and to link easily with the Controller libraries, ODE or the Qt framework.
 
-A good example of this is the Qt utility library located there: "[WEBOTS\_HOME/resources/projects/libraries/qt\_utils]({{ url.github_tree  }}/resources/projects/libraries/qt_utils)".
+A good example of this is the Qt utility library located there: "[WEBOTS\_HOME/resources/projects/libraries/qt\_utils]({{ url.github_tree }}/resources/projects/libraries/qt_utils)".
 
 If for some reason shared libraries cannot be in the `libraries` directory, the `WEBOTS_LIBRARY_PATH` environment variable will be very helpful.
 The paths it contains will be added at the beginning of the library search path([[DY]LD\_LIBRARY\_]PATH) when starting the controller.

--- a/docs/guide/general-faq.md
+++ b/docs/guide/general-faq.md
@@ -6,7 +6,7 @@ Yes!
 
 Since the [R2019a version](../blog/Webots-2019-a-release.md), Webots is completely free and open-source.
 It remains under active development.
-The source code is available from [GitHub](https://github.com/cyberbotics/webots) and released under the terms of the [Apache 2 license]({{ url.github_tree  }}/LICENSE).
+The source code is available from [GitHub](https://github.com/cyberbotics/webots) and released under the terms of the [Apache 2 license]({{ url.github_tree }}/LICENSE).
 
 Cyberbotics collaborates to several academic and industrial projects, and provides a paid user support, training and consulting for users who need to quickly develop high-quality Webots simulations.
 Please [contact us](mailto:info@cyberbotics.com) for more information about our services.

--- a/docs/guide/general-faq.md
+++ b/docs/guide/general-faq.md
@@ -6,7 +6,7 @@ Yes!
 
 Since the [R2019a version](../blog/Webots-2019-a-release.md), Webots is completely free and open-source.
 It remains under active development.
-The source code is available from [GitHub](https://github.com/cyberbotics/webots) and released under the terms of the [Apache 2 license](https://github.com/cyberbotics/webots/blob/released/LICENSE).
+The source code is available from [GitHub](https://github.com/cyberbotics/webots) and released under the terms of the [Apache 2 license]({{ url.github_tree  }}/LICENSE).
 
 Cyberbotics collaborates to several academic and industrial projects, and provides a paid user support, training and consulting for users who need to quickly develop high-quality Webots simulations.
 Please [contact us](mailto:info@cyberbotics.com) for more information about our services.

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -219,7 +219,7 @@ rm ~/.cache/fontconfig/*
 
 #### Server Edition
 
-Webots requires some graphical features that are usually not available by default on a Linux server edition, [additional packages]({{ url.github_tree  }}/scripts/install/linux_runtime_dependencies.sh) needs to be manually installed to make it work.
+Webots requires some graphical features that are usually not available by default on a Linux server edition, [additional packages]({{ url.github_tree }}/scripts/install/linux_runtime_dependencies.sh) needs to be manually installed to make it work.
 
 Webots can be run without GUI using a virtual framebuffer such as [Xvfb](https://en.wikipedia.org/wiki/Xvfb):
 ```

--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -219,7 +219,7 @@ rm ~/.cache/fontconfig/*
 
 #### Server Edition
 
-Webots requires some graphical features that are usually not available by default on a Linux server edition, [additional packages](https://github.com/cyberbotics/webots/blob/released/scripts/install/linux_runtime_dependencies.sh) needs to be manually installed to make it work.
+Webots requires some graphical features that are usually not available by default on a Linux server edition, [additional packages]({{ url.github_tree  }}/scripts/install/linux_runtime_dependencies.sh) needs to be manually installed to make it work.
 
 Webots can be run without GUI using a virtual framebuffer such as [Xvfb](https://en.wikipedia.org/wiki/Xvfb):
 ```

--- a/docs/guide/interfacing-webots-to-third-party-software-with-tcp-ip.md
+++ b/docs/guide/interfacing-webots-to-third-party-software-with-tcp-ip.md
@@ -7,9 +7,9 @@ It is also possible to interface Webots with other programming languages of soft
 Such an interface can be implemented through a TCP/IP protocol that you can define yourself.
 Webots comes with an example of interfacing a simulated Khepera robot via TCP/IP to any third party program able to read from and write to a TCP/IP connection.
 This example world is called "[khepera\_tcpip.wbt]({{ url.github_tree  }}/projects/robots/k-team/khepera1/worlds/khepera_tcpip.wbt)", and can be found in the "[WEBOTS\_HOME/projects/robots/k-team/khepera1/worlds]({{ url.github_tree  }}/projects/robots/k-team/khepera1/worlds)" directory of Webots.
-The simulated Khepera robot is controlled by the "[tcpip](https://github.com/cyberbotics/webots/blob/master/projects/robots/k-team/khepera1/controllers/tcpip)" controller which is in the "[controllers](https://github.com/cyberbotics/webots/blob/master/projects/robots/k-team/khepera1/controllers)" directory of the same project.
-This small C controller comes with full source code in "[tcpip.c](https://github.com/cyberbotics/webots/blob/master/projects/robots/k-team/khepera1/controllers/tcpip/tcpip.c)", so that you can modify it to suit your needs.
-A client example is provided in "[client.c](https://github.com/cyberbotics/webots/blob/master/projects/robots/k-team/khepera1/controllers/tcpip/client.c)".
+The simulated Khepera robot is controlled by the "[tcpip]({{ url.github_tree  }}/projects/robots/k-team/khepera1/controllers/tcpip)" controller which is in the "[controllers](https://github.com/cyberbotics/webots/blob/master/projects/robots/k-team/khepera1/controllers)" directory of the same project.
+This small C controller comes with full source code in "[tcpip.c]({{ url.github_tree  }}/projects/robots/k-team/khepera1/controllers/tcpip/tcpip.c)", so that you can modify it to suit your needs.
+A client example is provided in "[client.c]({{ url.github_tree  }}/projects/robots/k-team/khepera1/controllers/tcpip/client.c)".
 This client may be used as a model to write a similar client using the programming language of your third party software.
 This has already been implemented in *Lisp*<sup>TM</sup> and MATLAB by some Webots users.
 

--- a/docs/guide/object-advertising-board.md
+++ b/docs/guide/object-advertising-board.md
@@ -35,7 +35,7 @@ AdvertisingBoard {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/advertising\_board/protos/AdvertisingBoard.proto]({{ url.github_tree  }}/projects/objects/advertising_board/protos/AdvertisingBoard.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/advertising\_board/protos/AdvertisingBoard.proto]({{ url.github_tree }}/projects/objects/advertising_board/protos/AdvertisingBoard.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-apartment-structure.md
+++ b/docs/guide/object-apartment-structure.md
@@ -25,7 +25,7 @@ Ceiling {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Ceiling.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/Ceiling.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Ceiling.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/Ceiling.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -73,7 +73,7 @@ Door {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Door.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/Door.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Door.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/Door.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -137,7 +137,7 @@ DoorKnob {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/DoorKnob.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/DoorKnob.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/DoorKnob.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/DoorKnob.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -187,7 +187,7 @@ DoorLever {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/DoorLever.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/DoorLever.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/DoorLever.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/DoorLever.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -232,7 +232,7 @@ GenericDoorAppearance {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/GenericDoorAppearance.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/GenericDoorAppearance.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/GenericDoorAppearance.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/GenericDoorAppearance.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -265,7 +265,7 @@ Radiator {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Radiator.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/Radiator.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Radiator.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/Radiator.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -300,7 +300,7 @@ Wall {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Wall.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/Wall.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Wall.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/Wall.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -334,7 +334,7 @@ WallPlug {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/WallPlug.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/WallPlug.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/WallPlug.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/WallPlug.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -376,7 +376,7 @@ Window {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Window.proto]({{ url.github_tree  }}/projects/objects/apartment_structure/protos/Window.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/apartment\_structure/protos/Window.proto]({{ url.github_tree }}/projects/objects/apartment_structure/protos/Window.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-backgrounds.md
+++ b/docs/guide/object-backgrounds.md
@@ -47,7 +47,7 @@ TexturedBackground {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/backgrounds/protos/TexturedBackground.proto]({{ url.github_tree  }}/projects/objects/backgrounds/protos/TexturedBackground.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/backgrounds/protos/TexturedBackground.proto]({{ url.github_tree }}/projects/objects/backgrounds/protos/TexturedBackground.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -106,7 +106,7 @@ TexturedBackgroundLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto]({{ url.github_tree  }}/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto]({{ url.github_tree }}/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-balls.md
+++ b/docs/guide/object-balls.md
@@ -28,7 +28,7 @@ Ball {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/Ball.proto]({{ url.github_tree  }}/projects/objects/balls/protos/Ball.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/Ball.proto]({{ url.github_tree }}/projects/objects/balls/protos/Ball.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -69,7 +69,7 @@ PingPongBall {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/PingPongBall.proto]({{ url.github_tree  }}/projects/objects/balls/protos/PingPongBall.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/PingPongBall.proto]({{ url.github_tree }}/projects/objects/balls/protos/PingPongBall.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -101,7 +101,7 @@ SoccerBall {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/SoccerBall.proto]({{ url.github_tree  }}/projects/objects/balls/protos/SoccerBall.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/balls/protos/SoccerBall.proto]({{ url.github_tree }}/projects/objects/balls/protos/SoccerBall.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-bathroom.md
+++ b/docs/guide/object-bathroom.md
@@ -22,7 +22,7 @@ BathroomSink {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/BathroomSink.proto]({{ url.github_tree  }}/projects/objects/bathroom/protos/BathroomSink.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/BathroomSink.proto]({{ url.github_tree }}/projects/objects/bathroom/protos/BathroomSink.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -53,7 +53,7 @@ Bathtube {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/Bathtube.proto]({{ url.github_tree  }}/projects/objects/bathroom/protos/Bathtube.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/Bathtube.proto]({{ url.github_tree }}/projects/objects/bathroom/protos/Bathtube.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -79,7 +79,7 @@ Toilet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/Toilet.proto]({{ url.github_tree  }}/projects/objects/bathroom/protos/Toilet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/Toilet.proto]({{ url.github_tree }}/projects/objects/bathroom/protos/Toilet.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -108,7 +108,7 @@ WashingMachine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/WashingMachine.proto]({{ url.github_tree  }}/projects/objects/bathroom/protos/WashingMachine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/bathroom/protos/WashingMachine.proto]({{ url.github_tree }}/projects/objects/bathroom/protos/WashingMachine.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-bedroom.md
+++ b/docs/guide/object-bedroom.md
@@ -24,7 +24,7 @@ Bed {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/bedroom/protos/Bed.proto]({{ url.github_tree  }}/projects/objects/bedroom/protos/Bed.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/bedroom/protos/Bed.proto]({{ url.github_tree }}/projects/objects/bedroom/protos/Bed.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-buildings.md
+++ b/docs/guide/object-buildings.md
@@ -20,7 +20,7 @@ Auditorium {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Auditorium.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Auditorium.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Auditorium.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Auditorium.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -45,7 +45,7 @@ BigGlassTower {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BigGlassTower.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/BigGlassTower.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BigGlassTower.proto]({{ url.github_tree }}/projects/objects/buildings/protos/BigGlassTower.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -85,7 +85,7 @@ Building {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Building.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Building.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Building.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Building.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -140,7 +140,7 @@ BuildingUnderConstruction {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BuildingUnderConstruction.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/BuildingUnderConstruction.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BuildingUnderConstruction.proto]({{ url.github_tree }}/projects/objects/buildings/protos/BuildingUnderConstruction.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -174,7 +174,7 @@ BungalowStyleHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BungalowStyleHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/BungalowStyleHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/BungalowStyleHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/BungalowStyleHouse.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -216,7 +216,7 @@ Carwash {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Carwash.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Carwash.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Carwash.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Carwash.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -246,7 +246,7 @@ Church {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Church.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Church.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Church.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Church.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -275,7 +275,7 @@ CommercialBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/CommercialBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/CommercialBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/CommercialBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/CommercialBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -301,7 +301,7 @@ ComposedHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ComposedHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ComposedHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ComposedHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ComposedHouse.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -330,7 +330,7 @@ CyberboticsTower {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/CyberboticsTower.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/CyberboticsTower.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/CyberboticsTower.proto]({{ url.github_tree }}/projects/objects/buildings/protos/CyberboticsTower.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -360,7 +360,7 @@ FastFoodRestaurant {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/FastFoodRestaurant.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/FastFoodRestaurant.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/FastFoodRestaurant.proto]({{ url.github_tree }}/projects/objects/buildings/protos/FastFoodRestaurant.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -398,7 +398,7 @@ GasStation {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/GasStation.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/GasStation.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/GasStation.proto]({{ url.github_tree }}/projects/objects/buildings/protos/GasStation.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -427,7 +427,7 @@ HollowBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/HollowBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/HollowBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/HollowBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/HollowBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -452,7 +452,7 @@ Hotel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Hotel.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Hotel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Hotel.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Hotel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -478,7 +478,7 @@ HouseWithGarage {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/HouseWithGarage.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/HouseWithGarage.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/HouseWithGarage.proto]({{ url.github_tree }}/projects/objects/buildings/protos/HouseWithGarage.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -510,7 +510,7 @@ LargeResidentialTower {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/LargeResidentialTower.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/LargeResidentialTower.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/LargeResidentialTower.proto]({{ url.github_tree }}/projects/objects/buildings/protos/LargeResidentialTower.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -548,7 +548,7 @@ ModernHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ModernHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ModernHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ModernHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ModernHouse.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -582,7 +582,7 @@ ModernSuburbanHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ModernSuburbanHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ModernSuburbanHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ModernSuburbanHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ModernSuburbanHouse.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -612,7 +612,7 @@ MotelReception {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/MotelReception.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/MotelReception.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/MotelReception.proto]({{ url.github_tree }}/projects/objects/buildings/protos/MotelReception.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -641,7 +641,7 @@ Museum {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Museum.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Museum.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Museum.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Museum.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -668,7 +668,7 @@ OldResidentialBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/OldResidentialBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/OldResidentialBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/OldResidentialBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/OldResidentialBuilding.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -715,7 +715,7 @@ RandomBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/RandomBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/RandomBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/RandomBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/RandomBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -770,7 +770,7 @@ ResidentialBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ResidentialBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ResidentialBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -797,7 +797,7 @@ ResidentialBuildingWithRoundFront {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialBuildingWithRoundFront.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ResidentialBuildingWithRoundFront.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialBuildingWithRoundFront.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ResidentialBuildingWithRoundFront.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -830,7 +830,7 @@ ResidentialTower {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialTower.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/ResidentialTower.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/ResidentialTower.proto]({{ url.github_tree }}/projects/objects/buildings/protos/ResidentialTower.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -878,7 +878,7 @@ SimpleBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SimpleBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SimpleBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SimpleBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SimpleBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -941,7 +941,7 @@ SimpleTwoFloorsHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SimpleTwoFloorsHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SimpleTwoFloorsHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SimpleTwoFloorsHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SimpleTwoFloorsHouse.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -973,7 +973,7 @@ SmallManor {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallManor.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SmallManor.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallManor.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SmallManor.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1004,7 +1004,7 @@ SmallResidentialBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallResidentialBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SmallResidentialBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallResidentialBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SmallResidentialBuilding.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1037,7 +1037,7 @@ SmallResidentialTower {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallResidentialTower.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SmallResidentialTower.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SmallResidentialTower.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SmallResidentialTower.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1071,7 +1071,7 @@ StripBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/StripBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/StripBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/StripBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/StripBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1105,7 +1105,7 @@ SuburbanHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SuburbanHouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/SuburbanHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/SuburbanHouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/SuburbanHouse.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1134,7 +1134,7 @@ TheThreeTowers {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/TheThreeTowers.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/TheThreeTowers.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/TheThreeTowers.proto]({{ url.github_tree }}/projects/objects/buildings/protos/TheThreeTowers.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1159,7 +1159,7 @@ UBuilding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/UBuilding.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/UBuilding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/UBuilding.proto]({{ url.github_tree }}/projects/objects/buildings/protos/UBuilding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1185,7 +1185,7 @@ Warehouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Warehouse.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Warehouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Warehouse.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Warehouse.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1215,7 +1215,7 @@ Windmill {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Windmill.proto]({{ url.github_tree  }}/projects/objects/buildings/protos/Windmill.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/buildings/protos/Windmill.proto]({{ url.github_tree }}/projects/objects/buildings/protos/Windmill.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)

--- a/docs/guide/object-cabinet.md
+++ b/docs/guide/object-cabinet.md
@@ -58,7 +58,7 @@ Cabinet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/cabinet/protos/Cabinet.proto]({{ url.github_tree  }}/projects/objects/cabinet/protos/Cabinet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/cabinet/protos/Cabinet.proto]({{ url.github_tree }}/projects/objects/cabinet/protos/Cabinet.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -107,7 +107,7 @@ CabinetHandle {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/cabinet/protos/CabinetHandle.proto]({{ url.github_tree  }}/projects/objects/cabinet/protos/CabinetHandle.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/cabinet/protos/CabinetHandle.proto]({{ url.github_tree }}/projects/objects/cabinet/protos/CabinetHandle.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-chairs.md
+++ b/docs/guide/object-chairs.md
@@ -22,7 +22,7 @@ Chair {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/Chair.proto]({{ url.github_tree  }}/projects/objects/chairs/protos/Chair.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/Chair.proto]({{ url.github_tree }}/projects/objects/chairs/protos/Chair.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -56,7 +56,7 @@ OfficeChair {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/OfficeChair.proto]({{ url.github_tree  }}/projects/objects/chairs/protos/OfficeChair.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/OfficeChair.proto]({{ url.github_tree }}/projects/objects/chairs/protos/OfficeChair.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -93,7 +93,7 @@ SimpleChair {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/SimpleChair.proto]({{ url.github_tree  }}/projects/objects/chairs/protos/SimpleChair.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/SimpleChair.proto]({{ url.github_tree }}/projects/objects/chairs/protos/SimpleChair.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -128,7 +128,7 @@ WoodenChair {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/WoodenChair.proto]({{ url.github_tree  }}/projects/objects/chairs/protos/WoodenChair.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/chairs/protos/WoodenChair.proto]({{ url.github_tree }}/projects/objects/chairs/protos/WoodenChair.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-computers.md
+++ b/docs/guide/object-computers.md
@@ -23,7 +23,7 @@ ComputerMouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/ComputerMouse.proto]({{ url.github_tree  }}/projects/objects/computers/protos/ComputerMouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/ComputerMouse.proto]({{ url.github_tree }}/projects/objects/computers/protos/ComputerMouse.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -58,7 +58,7 @@ DesktopComputer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/DesktopComputer.proto]({{ url.github_tree  }}/projects/objects/computers/protos/DesktopComputer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/DesktopComputer.proto]({{ url.github_tree }}/projects/objects/computers/protos/DesktopComputer.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -91,7 +91,7 @@ Keyboard {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Keyboard.proto]({{ url.github_tree  }}/projects/objects/computers/protos/Keyboard.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Keyboard.proto]({{ url.github_tree }}/projects/objects/computers/protos/Keyboard.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -124,7 +124,7 @@ Laptop {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Laptop.proto]({{ url.github_tree  }}/projects/objects/computers/protos/Laptop.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Laptop.proto]({{ url.github_tree }}/projects/objects/computers/protos/Laptop.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -155,7 +155,7 @@ Monitor {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Monitor.proto]({{ url.github_tree  }}/projects/objects/computers/protos/Monitor.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/computers/protos/Monitor.proto]({{ url.github_tree }}/projects/objects/computers/protos/Monitor.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-create-wall.md
+++ b/docs/guide/object-create-wall.md
@@ -25,7 +25,7 @@ CreateWall {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/create\_wall/protos/CreateWall.proto]({{ url.github_tree  }}/projects/objects/create_wall/protos/CreateWall.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/create\_wall/protos/CreateWall.proto]({{ url.github_tree }}/projects/objects/create_wall/protos/CreateWall.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-drinks.md
+++ b/docs/guide/object-drinks.md
@@ -21,7 +21,7 @@ BeerBottle {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/BeerBottle.proto]({{ url.github_tree  }}/projects/objects/drinks/protos/BeerBottle.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/BeerBottle.proto]({{ url.github_tree }}/projects/objects/drinks/protos/BeerBottle.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -49,7 +49,7 @@ Can {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/Can.proto]({{ url.github_tree  }}/projects/objects/drinks/protos/Can.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/Can.proto]({{ url.github_tree }}/projects/objects/drinks/protos/Can.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -76,7 +76,7 @@ WaterBottle {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/WaterBottle.proto]({{ url.github_tree  }}/projects/objects/drinks/protos/WaterBottle.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/drinks/protos/WaterBottle.proto]({{ url.github_tree }}/projects/objects/drinks/protos/WaterBottle.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-factory.md
+++ b/docs/guide/object-factory.md
@@ -25,7 +25,7 @@ CardboardBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/CardboardBox.proto]({{ url.github_tree  }}/projects/objects/factory/containers/protos/CardboardBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/CardboardBox.proto]({{ url.github_tree }}/projects/objects/factory/containers/protos/CardboardBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -57,7 +57,7 @@ MetalStorageBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/MetalStorageBox.proto]({{ url.github_tree  }}/projects/objects/factory/containers/protos/MetalStorageBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/MetalStorageBox.proto]({{ url.github_tree }}/projects/objects/factory/containers/protos/MetalStorageBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -85,7 +85,7 @@ PlasticCrate {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/PlasticCrate.proto]({{ url.github_tree  }}/projects/objects/factory/containers/protos/PlasticCrate.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/PlasticCrate.proto]({{ url.github_tree }}/projects/objects/factory/containers/protos/PlasticCrate.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -112,7 +112,7 @@ PlasticFruitBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/PlasticFruitBox.proto]({{ url.github_tree  }}/projects/objects/factory/containers/protos/PlasticFruitBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/PlasticFruitBox.proto]({{ url.github_tree }}/projects/objects/factory/containers/protos/PlasticFruitBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -141,7 +141,7 @@ WoodenBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/WoodenBox.proto]({{ url.github_tree  }}/projects/objects/factory/containers/protos/WoodenBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/containers/protos/WoodenBox.proto]({{ url.github_tree }}/projects/objects/factory/containers/protos/WoodenBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -181,7 +181,7 @@ ConveyorBelt {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/conveyors/protos/ConveyorBelt.proto]({{ url.github_tree  }}/projects/objects/factory/conveyors/protos/ConveyorBelt.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/conveyors/protos/ConveyorBelt.proto]({{ url.github_tree }}/projects/objects/factory/conveyors/protos/ConveyorBelt.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -228,7 +228,7 @@ ConveyorPlatform {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto]({{ url.github_tree  }}/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto]({{ url.github_tree }}/projects/objects/factory/conveyors/protos/ConveyorPlatform.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -266,7 +266,7 @@ FireExtinguisher {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/fire\_extinguisher/protos/FireExtinguisher.proto]({{ url.github_tree  }}/projects/objects/factory/fire_extinguisher/protos/FireExtinguisher.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/fire\_extinguisher/protos/FireExtinguisher.proto]({{ url.github_tree }}/projects/objects/factory/fire_extinguisher/protos/FireExtinguisher.proto)"
 
 > **License**: Attribution-NonCommercial 4.0 International (original model by 3DHaupt)
 [More information.](https://creativecommons.org/licenses/by-nc/4.0)
@@ -299,7 +299,7 @@ SquareManhole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/manhole/protos/SquareManhole.proto]({{ url.github_tree  }}/projects/objects/factory/manhole/protos/SquareManhole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/manhole/protos/SquareManhole.proto]({{ url.github_tree }}/projects/objects/factory/manhole/protos/SquareManhole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -338,7 +338,7 @@ WoodenPallet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pallet/protos/WoodenPallet.proto]({{ url.github_tree  }}/projects/objects/factory/pallet/protos/WoodenPallet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pallet/protos/WoodenPallet.proto]({{ url.github_tree }}/projects/objects/factory/pallet/protos/WoodenPallet.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -384,7 +384,7 @@ WoodenPalletStack {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pallet/protos/WoodenPalletStack.proto]({{ url.github_tree  }}/projects/objects/factory/pallet/protos/WoodenPalletStack.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pallet/protos/WoodenPalletStack.proto]({{ url.github_tree }}/projects/objects/factory/pallet/protos/WoodenPalletStack.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -431,7 +431,7 @@ LJoint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/LJoint.proto]({{ url.github_tree  }}/projects/objects/factory/pipes/protos/LJoint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/LJoint.proto]({{ url.github_tree }}/projects/objects/factory/pipes/protos/LJoint.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -464,7 +464,7 @@ PipeSection {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/PipeSection.proto]({{ url.github_tree  }}/projects/objects/factory/pipes/protos/PipeSection.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/PipeSection.proto]({{ url.github_tree }}/projects/objects/factory/pipes/protos/PipeSection.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -501,7 +501,7 @@ TJoint {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/TJoint.proto]({{ url.github_tree  }}/projects/objects/factory/pipes/protos/TJoint.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/pipes/protos/TJoint.proto]({{ url.github_tree }}/projects/objects/factory/pipes/protos/TJoint.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -536,7 +536,7 @@ Bolt {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Bolt.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Bolt.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Bolt.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Bolt.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -575,7 +575,7 @@ CapScrew {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/CapScrew.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/CapScrew.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/CapScrew.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/CapScrew.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -617,7 +617,7 @@ ElectricalPlug {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/ElectricalPlug.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/ElectricalPlug.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/ElectricalPlug.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/ElectricalPlug.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -653,7 +653,7 @@ EmergencyButton {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/EmergencyButton.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/EmergencyButton.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/EmergencyButton.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/EmergencyButton.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -686,7 +686,7 @@ EyeScrew {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/EyeScrew.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/EyeScrew.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/EyeScrew.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/EyeScrew.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -720,7 +720,7 @@ Hammer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Hammer.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Hammer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Hammer.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Hammer.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -749,7 +749,7 @@ Nut {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Nut.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Nut.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Nut.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Nut.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -783,7 +783,7 @@ PaintBucket {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/PaintBucket.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/PaintBucket.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/PaintBucket.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/PaintBucket.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -810,7 +810,7 @@ PlatformCart {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/PlatformCart.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/PlatformCart.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/PlatformCart.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/PlatformCart.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -841,7 +841,7 @@ ScrewHole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/ScrewHole.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/ScrewHole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/ScrewHole.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/ScrewHole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -867,7 +867,7 @@ Screwdriver {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Screwdriver.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Screwdriver.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Screwdriver.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Screwdriver.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -896,7 +896,7 @@ Washer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Washer.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Washer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Washer.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Washer.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -931,7 +931,7 @@ Wrench {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Wrench.proto]({{ url.github_tree  }}/projects/objects/factory/tools/protos/Wrench.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/tools/protos/Wrench.proto]({{ url.github_tree }}/projects/objects/factory/tools/protos/Wrench.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -967,7 +967,7 @@ LargeValve {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/LargeValve.proto]({{ url.github_tree  }}/projects/objects/factory/valves/protos/LargeValve.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/LargeValve.proto]({{ url.github_tree }}/projects/objects/factory/valves/protos/LargeValve.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1002,7 +1002,7 @@ LeverValve {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/LeverValve.proto]({{ url.github_tree  }}/projects/objects/factory/valves/protos/LeverValve.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/LeverValve.proto]({{ url.github_tree }}/projects/objects/factory/valves/protos/LeverValve.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1035,7 +1035,7 @@ SmallValve {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/SmallValve.proto]({{ url.github_tree  }}/projects/objects/factory/valves/protos/SmallValve.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/factory/valves/protos/SmallValve.proto]({{ url.github_tree }}/projects/objects/factory/valves/protos/SmallValve.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-floors.md
+++ b/docs/guide/object-floors.md
@@ -28,7 +28,7 @@ CircleArena {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/CircleArena.proto]({{ url.github_tree  }}/projects/objects/floors/protos/CircleArena.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/CircleArena.proto]({{ url.github_tree }}/projects/objects/floors/protos/CircleArena.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -73,7 +73,7 @@ Floor {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/Floor.proto]({{ url.github_tree  }}/projects/objects/floors/protos/Floor.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/Floor.proto]({{ url.github_tree }}/projects/objects/floors/protos/Floor.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -113,7 +113,7 @@ RectangleArena {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/RectangleArena.proto]({{ url.github_tree  }}/projects/objects/floors/protos/RectangleArena.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/RectangleArena.proto]({{ url.github_tree }}/projects/objects/floors/protos/RectangleArena.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -160,7 +160,7 @@ UnevenTerrain {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/UnevenTerrain.proto]({{ url.github_tree  }}/projects/objects/floors/protos/UnevenTerrain.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/floors/protos/UnevenTerrain.proto]({{ url.github_tree }}/projects/objects/floors/protos/UnevenTerrain.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-freight.md
+++ b/docs/guide/object-freight.md
@@ -21,7 +21,7 @@ IntermodalContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/freight/protos/IntermodalContainer.proto]({{ url.github_tree  }}/projects/objects/freight/protos/IntermodalContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/freight/protos/IntermodalContainer.proto]({{ url.github_tree }}/projects/objects/freight/protos/IntermodalContainer.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -53,7 +53,7 @@ IntermodalOfficeContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/freight/protos/IntermodalOfficeContainer.proto]({{ url.github_tree  }}/projects/objects/freight/protos/IntermodalOfficeContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/freight/protos/IntermodalOfficeContainer.proto]({{ url.github_tree }}/projects/objects/freight/protos/IntermodalOfficeContainer.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-fruits.md
+++ b/docs/guide/object-fruits.md
@@ -22,7 +22,7 @@ Apple {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/Apple.proto]({{ url.github_tree  }}/projects/objects/fruits/protos/Apple.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/Apple.proto]({{ url.github_tree }}/projects/objects/fruits/protos/Apple.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -53,7 +53,7 @@ FruitBowl {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/FruitBowl.proto]({{ url.github_tree  }}/projects/objects/fruits/protos/FruitBowl.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/FruitBowl.proto]({{ url.github_tree }}/projects/objects/fruits/protos/FruitBowl.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -85,7 +85,7 @@ Orange {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/Orange.proto]({{ url.github_tree  }}/projects/objects/fruits/protos/Orange.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/fruits/protos/Orange.proto]({{ url.github_tree }}/projects/objects/fruits/protos/Orange.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-garden.md
+++ b/docs/guide/object-garden.md
@@ -21,7 +21,7 @@ Barbecue {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Barbecue.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Barbecue.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Barbecue.proto]({{ url.github_tree }}/projects/objects/garden/protos/Barbecue.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -50,7 +50,7 @@ DogHouse {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/DogHouse.proto]({{ url.github_tree  }}/projects/objects/garden/protos/DogHouse.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/DogHouse.proto]({{ url.github_tree }}/projects/objects/garden/protos/DogHouse.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -76,7 +76,7 @@ Gnome {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Gnome.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Gnome.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Gnome.proto]({{ url.github_tree }}/projects/objects/garden/protos/Gnome.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -105,7 +105,7 @@ Pergolas {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Pergolas.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Pergolas.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Pergolas.proto]({{ url.github_tree }}/projects/objects/garden/protos/Pergolas.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -133,7 +133,7 @@ PicketFence {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/PicketFence.proto]({{ url.github_tree  }}/projects/objects/garden/protos/PicketFence.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/PicketFence.proto]({{ url.github_tree }}/projects/objects/garden/protos/PicketFence.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -165,7 +165,7 @@ PicketFenceWithDoor {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/PicketFenceWithDoor.proto]({{ url.github_tree  }}/projects/objects/garden/protos/PicketFenceWithDoor.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/PicketFenceWithDoor.proto]({{ url.github_tree }}/projects/objects/garden/protos/PicketFenceWithDoor.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -194,7 +194,7 @@ Slide {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Slide.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Slide.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Slide.proto]({{ url.github_tree }}/projects/objects/garden/protos/Slide.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -219,7 +219,7 @@ Swing {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Swing.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Swing.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Swing.proto]({{ url.github_tree }}/projects/objects/garden/protos/Swing.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -244,7 +244,7 @@ SwingCouch {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/SwingCouch.proto]({{ url.github_tree  }}/projects/objects/garden/protos/SwingCouch.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/SwingCouch.proto]({{ url.github_tree }}/projects/objects/garden/protos/SwingCouch.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -270,7 +270,7 @@ TableWithUmbrella {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/TableWithUmbrella.proto]({{ url.github_tree  }}/projects/objects/garden/protos/TableWithUmbrella.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/TableWithUmbrella.proto]({{ url.github_tree }}/projects/objects/garden/protos/TableWithUmbrella.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -300,7 +300,7 @@ WateringCan {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/WateringCan.proto]({{ url.github_tree  }}/projects/objects/garden/protos/WateringCan.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/WateringCan.proto]({{ url.github_tree }}/projects/objects/garden/protos/WateringCan.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -330,7 +330,7 @@ Wheelbarrow {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Wheelbarrow.proto]({{ url.github_tree  }}/projects/objects/garden/protos/Wheelbarrow.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/garden/protos/Wheelbarrow.proto]({{ url.github_tree }}/projects/objects/garden/protos/Wheelbarrow.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)

--- a/docs/guide/object-geometries.md
+++ b/docs/guide/object-geometries.md
@@ -29,7 +29,7 @@ Extrusion {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/Extrusion.proto]({{ url.github_tree  }}/projects/objects/geometries/protos/Extrusion.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/Extrusion.proto]({{ url.github_tree }}/projects/objects/geometries/protos/Extrusion.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -69,7 +69,7 @@ Rectangle {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/Rectangle.proto]({{ url.github_tree  }}/projects/objects/geometries/protos/Rectangle.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/Rectangle.proto]({{ url.github_tree }}/projects/objects/geometries/protos/Rectangle.proto)"
 
 > **License**: Apache License 2.0
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
@@ -114,7 +114,7 @@ TexturedBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/TexturedBox.proto]({{ url.github_tree  }}/projects/objects/geometries/protos/TexturedBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/TexturedBox.proto]({{ url.github_tree }}/projects/objects/geometries/protos/TexturedBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -176,7 +176,7 @@ TexturedParallelepiped {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/TexturedParallelepiped.proto]({{ url.github_tree  }}/projects/objects/geometries/protos/TexturedParallelepiped.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/geometries/protos/TexturedParallelepiped.proto]({{ url.github_tree }}/projects/objects/geometries/protos/TexturedParallelepiped.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-kitchen.md
+++ b/docs/guide/object-kitchen.md
@@ -25,7 +25,7 @@ BiscuitBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/BiscuitBox.proto]({{ url.github_tree  }}/projects/objects/kitchen/breakfast/protos/BiscuitBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/BiscuitBox.proto]({{ url.github_tree }}/projects/objects/kitchen/breakfast/protos/BiscuitBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -61,7 +61,7 @@ CerealBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/CerealBox.proto]({{ url.github_tree  }}/projects/objects/kitchen/breakfast/protos/CerealBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/CerealBox.proto]({{ url.github_tree }}/projects/objects/kitchen/breakfast/protos/CerealBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -97,7 +97,7 @@ HoneyJar {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/HoneyJar.proto]({{ url.github_tree  }}/projects/objects/kitchen/breakfast/protos/HoneyJar.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/HoneyJar.proto]({{ url.github_tree }}/projects/objects/kitchen/breakfast/protos/HoneyJar.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -132,7 +132,7 @@ JamJar {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/JamJar.proto]({{ url.github_tree  }}/projects/objects/kitchen/breakfast/protos/JamJar.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/breakfast/protos/JamJar.proto]({{ url.github_tree }}/projects/objects/kitchen/breakfast/protos/JamJar.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -166,7 +166,7 @@ HotPlate {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/HotPlate.proto]({{ url.github_tree  }}/projects/objects/kitchen/components/protos/HotPlate.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/HotPlate.proto]({{ url.github_tree }}/projects/objects/kitchen/components/protos/HotPlate.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -196,7 +196,7 @@ Sink {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/Sink.proto]({{ url.github_tree  }}/projects/objects/kitchen/components/protos/Sink.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/Sink.proto]({{ url.github_tree }}/projects/objects/kitchen/components/protos/Sink.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -227,7 +227,7 @@ Worktop {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/Worktop.proto]({{ url.github_tree  }}/projects/objects/kitchen/components/protos/Worktop.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/components/protos/Worktop.proto]({{ url.github_tree }}/projects/objects/kitchen/components/protos/Worktop.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -261,7 +261,7 @@ Fridge {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/fridge/protos/Fridge.proto]({{ url.github_tree  }}/projects/objects/kitchen/fridge/protos/Fridge.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/fridge/protos/Fridge.proto]({{ url.github_tree }}/projects/objects/kitchen/fridge/protos/Fridge.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -293,7 +293,7 @@ Oven {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/oven/protos/Oven.proto]({{ url.github_tree  }}/projects/objects/kitchen/oven/protos/Oven.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/oven/protos/Oven.proto]({{ url.github_tree }}/projects/objects/kitchen/oven/protos/Oven.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -325,7 +325,7 @@ Carafe {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Carafe.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Carafe.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Carafe.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Carafe.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -356,7 +356,7 @@ Cookware {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Cookware.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Cookware.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Cookware.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Cookware.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -388,7 +388,7 @@ Fork {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Fork.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Fork.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Fork.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Fork.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -418,7 +418,7 @@ Glass {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Glass.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Glass.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Glass.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Glass.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -448,7 +448,7 @@ Knife {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Knife.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Knife.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Knife.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Knife.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -479,7 +479,7 @@ Lid {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Lid.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Lid.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Lid.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Lid.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -514,7 +514,7 @@ Plate {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Plate.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Plate.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Plate.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Plate.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -551,7 +551,7 @@ Spoon {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Spoon.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Spoon.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Spoon.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Spoon.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -583,7 +583,7 @@ Wineglass {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Wineglass.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/Wineglass.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/Wineglass.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/Wineglass.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -613,7 +613,7 @@ WoodenSpoon {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/WoodenSpoon.proto]({{ url.github_tree  }}/projects/objects/kitchen/utensils/protos/WoodenSpoon.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/kitchen/utensils/protos/WoodenSpoon.proto]({{ url.github_tree }}/projects/objects/kitchen/utensils/protos/WoodenSpoon.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-lego.md
+++ b/docs/guide/object-lego.md
@@ -20,7 +20,7 @@ LegoLargeMotor {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lego/protos/LegoLargeMotor.proto]({{ url.github_tree  }}/projects/objects/lego/protos/LegoLargeMotor.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lego/protos/LegoLargeMotor.proto]({{ url.github_tree }}/projects/objects/lego/protos/LegoLargeMotor.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -45,7 +45,7 @@ LegoWheel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lego/protos/LegoWheel.proto]({{ url.github_tree  }}/projects/objects/lego/protos/LegoWheel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lego/protos/LegoWheel.proto]({{ url.github_tree }}/projects/objects/lego/protos/LegoWheel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-lights.md
+++ b/docs/guide/object-lights.md
@@ -29,7 +29,7 @@ CeilingLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/CeilingLight.proto]({{ url.github_tree  }}/projects/objects/lights/protos/CeilingLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/CeilingLight.proto]({{ url.github_tree }}/projects/objects/lights/protos/CeilingLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -79,7 +79,7 @@ CeilingSpotLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/CeilingSpotLight.proto]({{ url.github_tree  }}/projects/objects/lights/protos/CeilingSpotLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/CeilingSpotLight.proto]({{ url.github_tree }}/projects/objects/lights/protos/CeilingSpotLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -121,7 +121,7 @@ ConstructionLamp {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/ConstructionLamp.proto]({{ url.github_tree  }}/projects/objects/lights/protos/ConstructionLamp.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/ConstructionLamp.proto]({{ url.github_tree }}/projects/objects/lights/protos/ConstructionLamp.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -160,7 +160,7 @@ DoubleFluorescentLamp {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/DoubleFluorescentLamp.proto]({{ url.github_tree  }}/projects/objects/lights/protos/DoubleFluorescentLamp.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/DoubleFluorescentLamp.proto]({{ url.github_tree }}/projects/objects/lights/protos/DoubleFluorescentLamp.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -198,7 +198,7 @@ FloorLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/FloorLight.proto]({{ url.github_tree  }}/projects/objects/lights/protos/FloorLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/lights/protos/FloorLight.proto]({{ url.github_tree }}/projects/objects/lights/protos/FloorLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-living-room-furniture.md
+++ b/docs/guide/object-living-room-furniture.md
@@ -23,7 +23,7 @@ Armchair {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Armchair.proto]({{ url.github_tree  }}/projects/objects/living_room_furniture/protos/Armchair.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Armchair.proto]({{ url.github_tree }}/projects/objects/living_room_furniture/protos/Armchair.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -55,7 +55,7 @@ Carpet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Carpet.proto]({{ url.github_tree  }}/projects/objects/living_room_furniture/protos/Carpet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Carpet.proto]({{ url.github_tree }}/projects/objects/living_room_furniture/protos/Carpet.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -87,7 +87,7 @@ Sofa {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Sofa.proto]({{ url.github_tree  }}/projects/objects/living_room_furniture/protos/Sofa.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/living\_room\_furniture/protos/Sofa.proto]({{ url.github_tree }}/projects/objects/living_room_furniture/protos/Sofa.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-mirror.md
+++ b/docs/guide/object-mirror.md
@@ -29,7 +29,7 @@ Mirror {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/mirror/protos/Mirror.proto]({{ url.github_tree  }}/projects/objects/mirror/protos/Mirror.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/mirror/protos/Mirror.proto]({{ url.github_tree }}/projects/objects/mirror/protos/Mirror.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-obstacles.md
+++ b/docs/guide/object-obstacles.md
@@ -24,7 +24,7 @@ OilBarrel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/OilBarrel.proto]({{ url.github_tree  }}/projects/objects/obstacles/protos/OilBarrel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/OilBarrel.proto]({{ url.github_tree }}/projects/objects/obstacles/protos/OilBarrel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -57,7 +57,7 @@ Ramp30deg {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/Ramp30deg.proto]({{ url.github_tree  }}/projects/objects/obstacles/protos/Ramp30deg.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/Ramp30deg.proto]({{ url.github_tree }}/projects/objects/obstacles/protos/Ramp30deg.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -89,7 +89,7 @@ ThreeSteps {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/ThreeSteps.proto]({{ url.github_tree  }}/projects/objects/obstacles/protos/ThreeSteps.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/obstacles/protos/ThreeSteps.proto]({{ url.github_tree }}/projects/objects/obstacles/protos/ThreeSteps.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-paintings.md
+++ b/docs/guide/object-paintings.md
@@ -22,7 +22,7 @@ LandscapePainting {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/paintings/protos/LandscapePainting.proto]({{ url.github_tree  }}/projects/objects/paintings/protos/LandscapePainting.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/paintings/protos/LandscapePainting.proto]({{ url.github_tree }}/projects/objects/paintings/protos/LandscapePainting.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -55,7 +55,7 @@ PortraitPainting {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/paintings/protos/PortraitPainting.proto]({{ url.github_tree  }}/projects/objects/paintings/protos/PortraitPainting.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/paintings/protos/PortraitPainting.proto]({{ url.github_tree }}/projects/objects/paintings/protos/PortraitPainting.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-panels.md
+++ b/docs/guide/object-panels.md
@@ -26,7 +26,7 @@ Panel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/panels/protos/Panel.proto]({{ url.github_tree  }}/projects/objects/panels/protos/Panel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/panels/protos/Panel.proto]({{ url.github_tree }}/projects/objects/panels/protos/Panel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -66,7 +66,7 @@ PanelWithTubes {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/panels/protos/PanelWithTubes.proto]({{ url.github_tree  }}/projects/objects/panels/protos/PanelWithTubes.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/panels/protos/PanelWithTubes.proto]({{ url.github_tree }}/projects/objects/panels/protos/PanelWithTubes.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-plants.md
+++ b/docs/guide/object-plants.md
@@ -23,7 +23,7 @@ BunchOfSunFlowers {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/plants/protos/BunchOfSunFlowers.proto]({{ url.github_tree  }}/projects/objects/plants/protos/BunchOfSunFlowers.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/plants/protos/BunchOfSunFlowers.proto]({{ url.github_tree }}/projects/objects/plants/protos/BunchOfSunFlowers.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -59,7 +59,7 @@ PottedTree {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/plants/protos/PottedTree.proto]({{ url.github_tree  }}/projects/objects/plants/protos/PottedTree.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/plants/protos/PottedTree.proto]({{ url.github_tree }}/projects/objects/plants/protos/PottedTree.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-road.md
+++ b/docs/guide/object-road.md
@@ -60,7 +60,7 @@ Road {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Road.proto]({{ url.github_tree  }}/projects/objects/road/protos/Road.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Road.proto]({{ url.github_tree }}/projects/objects/road/protos/Road.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -187,7 +187,7 @@ AddLaneRoadSegment {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/AddLaneRoadSegment.proto]({{ url.github_tree  }}/projects/objects/road/protos/AddLaneRoadSegment.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/AddLaneRoadSegment.proto]({{ url.github_tree }}/projects/objects/road/protos/AddLaneRoadSegment.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -299,7 +299,7 @@ AddLanesRoadSegment {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/AddLanesRoadSegment.proto]({{ url.github_tree  }}/projects/objects/road/protos/AddLanesRoadSegment.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/AddLanesRoadSegment.proto]({{ url.github_tree }}/projects/objects/road/protos/AddLanesRoadSegment.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -388,7 +388,7 @@ CrashBarrier {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/CrashBarrier.proto]({{ url.github_tree  }}/projects/objects/road/protos/CrashBarrier.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/CrashBarrier.proto]({{ url.github_tree }}/projects/objects/road/protos/CrashBarrier.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -437,7 +437,7 @@ Crossroad {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Crossroad.proto]({{ url.github_tree  }}/projects/objects/road/protos/Crossroad.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Crossroad.proto]({{ url.github_tree }}/projects/objects/road/protos/Crossroad.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -515,7 +515,7 @@ CurvedRoadSegment {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/CurvedRoadSegment.proto]({{ url.github_tree  }}/projects/objects/road/protos/CurvedRoadSegment.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/CurvedRoadSegment.proto]({{ url.github_tree }}/projects/objects/road/protos/CurvedRoadSegment.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -633,7 +633,7 @@ HelicoidalRoadSegment {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/HelicoidalRoadSegment.proto]({{ url.github_tree  }}/projects/objects/road/protos/HelicoidalRoadSegment.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/HelicoidalRoadSegment.proto]({{ url.github_tree }}/projects/objects/road/protos/HelicoidalRoadSegment.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -747,7 +747,7 @@ LaneSeparation {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/LaneSeparation.proto]({{ url.github_tree  }}/projects/objects/road/protos/LaneSeparation.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/LaneSeparation.proto]({{ url.github_tree }}/projects/objects/road/protos/LaneSeparation.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -856,7 +856,7 @@ RoadIntersection {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadIntersection.proto]({{ url.github_tree  }}/projects/objects/road/protos/RoadIntersection.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadIntersection.proto]({{ url.github_tree }}/projects/objects/road/protos/RoadIntersection.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -924,7 +924,7 @@ RoadLine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadLine.proto]({{ url.github_tree  }}/projects/objects/road/protos/RoadLine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadLine.proto]({{ url.github_tree }}/projects/objects/road/protos/RoadLine.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -968,7 +968,7 @@ RoadPillars {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadPillars.proto]({{ url.github_tree  }}/projects/objects/road/protos/RoadPillars.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/RoadPillars.proto]({{ url.github_tree }}/projects/objects/road/protos/RoadPillars.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1041,7 +1041,7 @@ Roundabout {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Roundabout.proto]({{ url.github_tree  }}/projects/objects/road/protos/Roundabout.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/Roundabout.proto]({{ url.github_tree }}/projects/objects/road/protos/Roundabout.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1152,7 +1152,7 @@ StraightRoadSegment {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/StraightRoadSegment.proto]({{ url.github_tree  }}/projects/objects/road/protos/StraightRoadSegment.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/road/protos/StraightRoadSegment.proto]({{ url.github_tree }}/projects/objects/road/protos/StraightRoadSegment.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-robotstadium.md
+++ b/docs/guide/object-robotstadium.md
@@ -23,7 +23,7 @@ RobotstadiumGoal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/robotstadium/protos/RobotstadiumGoal.proto]({{ url.github_tree  }}/projects/objects/robotstadium/protos/RobotstadiumGoal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/robotstadium/protos/RobotstadiumGoal.proto]({{ url.github_tree }}/projects/objects/robotstadium/protos/RobotstadiumGoal.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -60,7 +60,7 @@ RobotstadiumSoccerField {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/robotstadium/protos/RobotstadiumSoccerField.proto]({{ url.github_tree  }}/projects/objects/robotstadium/protos/RobotstadiumSoccerField.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/robotstadium/protos/RobotstadiumSoccerField.proto]({{ url.github_tree }}/projects/objects/robotstadium/protos/RobotstadiumSoccerField.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-rocks.md
+++ b/docs/guide/object-rocks.md
@@ -24,7 +24,7 @@ Rock10cm {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/rocks/protos/Rock10cm.proto]({{ url.github_tree  }}/projects/objects/rocks/protos/Rock10cm.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/rocks/protos/Rock10cm.proto]({{ url.github_tree }}/projects/objects/rocks/protos/Rock10cm.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -59,7 +59,7 @@ Rock17cm {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/rocks/protos/Rock17cm.proto]({{ url.github_tree  }}/projects/objects/rocks/protos/Rock17cm.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/rocks/protos/Rock17cm.proto]({{ url.github_tree }}/projects/objects/rocks/protos/Rock17cm.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-school-furniture.md
+++ b/docs/guide/object-school-furniture.md
@@ -21,7 +21,7 @@ Blackboard {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Blackboard.proto]({{ url.github_tree  }}/projects/objects/school_furniture/protos/Blackboard.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Blackboard.proto]({{ url.github_tree }}/projects/objects/school_furniture/protos/Blackboard.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -53,7 +53,7 @@ Book {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Book.proto]({{ url.github_tree  }}/projects/objects/school_furniture/protos/Book.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Book.proto]({{ url.github_tree }}/projects/objects/school_furniture/protos/Book.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -86,7 +86,7 @@ Clock {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Clock.proto]({{ url.github_tree  }}/projects/objects/school_furniture/protos/Clock.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/school\_furniture/protos/Clock.proto]({{ url.github_tree }}/projects/objects/school_furniture/protos/Clock.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-shapes.md
+++ b/docs/guide/object-shapes.md
@@ -39,7 +39,7 @@ TexturedBoxShape {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/shapes/protos/TexturedBoxShape.proto]({{ url.github_tree  }}/projects/objects/shapes/protos/TexturedBoxShape.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/shapes/protos/TexturedBoxShape.proto]({{ url.github_tree }}/projects/objects/shapes/protos/TexturedBoxShape.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-solids.md
+++ b/docs/guide/object-solids.md
@@ -28,7 +28,7 @@ SolidBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidBox.proto]({{ url.github_tree  }}/projects/objects/solids/protos/SolidBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidBox.proto]({{ url.github_tree }}/projects/objects/solids/protos/SolidBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -75,7 +75,7 @@ SolidPipe {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidPipe.proto]({{ url.github_tree  }}/projects/objects/solids/protos/SolidPipe.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidPipe.proto]({{ url.github_tree }}/projects/objects/solids/protos/SolidPipe.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -124,7 +124,7 @@ SolidRoundedBox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidRoundedBox.proto]({{ url.github_tree  }}/projects/objects/solids/protos/SolidRoundedBox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidRoundedBox.proto]({{ url.github_tree }}/projects/objects/solids/protos/SolidRoundedBox.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -170,7 +170,7 @@ SolidTorus {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidTorus.proto]({{ url.github_tree  }}/projects/objects/solids/protos/SolidTorus.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/solids/protos/SolidTorus.proto]({{ url.github_tree }}/projects/objects/solids/protos/SolidTorus.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-stairs.md
+++ b/docs/guide/object-stairs.md
@@ -30,7 +30,7 @@ StraightStairs {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairs.proto]({{ url.github_tree  }}/projects/objects/stairs/protos/StraightStairs.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairs.proto]({{ url.github_tree }}/projects/objects/stairs/protos/StraightStairs.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -86,7 +86,7 @@ StraightStairsLanding {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairsLanding.proto]({{ url.github_tree  }}/projects/objects/stairs/protos/StraightStairsLanding.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairsLanding.proto]({{ url.github_tree }}/projects/objects/stairs/protos/StraightStairsLanding.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -142,7 +142,7 @@ StraightStairsRail {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairsRail.proto]({{ url.github_tree  }}/projects/objects/stairs/protos/StraightStairsRail.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/stairs/protos/StraightStairsRail.proto]({{ url.github_tree }}/projects/objects/stairs/protos/StraightStairsRail.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-street-furniture.md
+++ b/docs/guide/object-street-furniture.md
@@ -20,7 +20,7 @@ Atm {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Atm.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/Atm.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Atm.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/Atm.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -48,7 +48,7 @@ Bench {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Bench.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/Bench.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Bench.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/Bench.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -86,7 +86,7 @@ BusStop {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/BusStop.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/BusStop.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/BusStop.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/BusStop.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -123,7 +123,7 @@ ClothRecyclingContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/ClothRecyclingContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/ClothRecyclingContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/ClothRecyclingContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/ClothRecyclingContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -148,7 +148,7 @@ DrinkingFountain {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/DrinkingFountain.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/DrinkingFountain.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/DrinkingFountain.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/DrinkingFountain.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -173,7 +173,7 @@ ElectricalCabinet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/ElectricalCabinet.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/ElectricalCabinet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/ElectricalCabinet.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/ElectricalCabinet.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -200,7 +200,7 @@ EmergencyPhone {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/EmergencyPhone.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/EmergencyPhone.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/EmergencyPhone.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/EmergencyPhone.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -246,7 +246,7 @@ Fence {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Fence.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/Fence.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Fence.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/Fence.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -296,7 +296,7 @@ FireHydrant {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/FireHydrant.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/FireHydrant.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/FireHydrant.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/FireHydrant.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -328,7 +328,7 @@ Fountain {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Fountain.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/Fountain.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Fountain.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/Fountain.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -361,7 +361,7 @@ GlassRecyclingContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/GlassRecyclingContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/GlassRecyclingContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/GlassRecyclingContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/GlassRecyclingContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -386,7 +386,7 @@ GuardShelter {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/GuardShelter.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/GuardShelter.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/GuardShelter.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/GuardShelter.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -411,7 +411,7 @@ IceFreezerContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/IceFreezerContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/IceFreezerContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/IceFreezerContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/IceFreezerContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -436,7 +436,7 @@ Mailbox {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Mailbox.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/Mailbox.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/Mailbox.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/Mailbox.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -462,7 +462,7 @@ MetallicTrash {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/MetallicTrash.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/MetallicTrash.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/MetallicTrash.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/MetallicTrash.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -491,7 +491,7 @@ NewsStand {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/NewsStand.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/NewsStand.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/NewsStand.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/NewsStand.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -516,7 +516,7 @@ OldBench {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/OldBench.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/OldBench.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/OldBench.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/OldBench.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -541,7 +541,7 @@ PhoneBooth {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PhoneBooth.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/PhoneBooth.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PhoneBooth.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/PhoneBooth.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -568,7 +568,7 @@ PublicBin {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PublicBin.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/PublicBin.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PublicBin.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/PublicBin.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -620,7 +620,7 @@ PublicToilet {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PublicToilet.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/PublicToilet.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/PublicToilet.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/PublicToilet.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -673,7 +673,7 @@ SimpleBench {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SimpleBench.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/SimpleBench.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SimpleBench.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/SimpleBench.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -698,7 +698,7 @@ SmallKiosk {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SmallKiosk.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/SmallKiosk.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SmallKiosk.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/SmallKiosk.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -724,7 +724,7 @@ SnackStand {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SnackStand.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/SnackStand.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/SnackStand.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/SnackStand.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -753,7 +753,7 @@ StoneBench {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/StoneBench.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/StoneBench.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/StoneBench.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/StoneBench.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -778,7 +778,7 @@ StoneFountain {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/StoneFountain.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/StoneFountain.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/StoneFountain.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/StoneFountain.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -806,7 +806,7 @@ TrashBin {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/TrashBin.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/TrashBin.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/TrashBin.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/TrashBin.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -838,7 +838,7 @@ TrashContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/TrashContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/TrashContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/TrashContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/TrashContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -867,7 +867,7 @@ UndergroundContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/UndergroundContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/UndergroundContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/UndergroundContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/UndergroundContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -893,7 +893,7 @@ UrbanFence {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/UrbanFence.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/UrbanFence.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/UrbanFence.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/UrbanFence.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -922,7 +922,7 @@ WorkTrashContainer {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/WorkTrashContainer.proto]({{ url.github_tree  }}/projects/objects/street_furniture/protos/WorkTrashContainer.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/street\_furniture/protos/WorkTrashContainer.proto]({{ url.github_tree }}/projects/objects/street_furniture/protos/WorkTrashContainer.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)

--- a/docs/guide/object-tables.md
+++ b/docs/guide/object-tables.md
@@ -22,7 +22,7 @@ Desk {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/Desk.proto]({{ url.github_tree  }}/projects/objects/tables/protos/Desk.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/Desk.proto]({{ url.github_tree }}/projects/objects/tables/protos/Desk.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -53,7 +53,7 @@ RoundTable {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/RoundTable.proto]({{ url.github_tree  }}/projects/objects/tables/protos/RoundTable.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/RoundTable.proto]({{ url.github_tree }}/projects/objects/tables/protos/RoundTable.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -90,7 +90,7 @@ Table {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/Table.proto]({{ url.github_tree  }}/projects/objects/tables/protos/Table.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/tables/protos/Table.proto]({{ url.github_tree }}/projects/objects/tables/protos/Table.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-telephone.md
+++ b/docs/guide/object-telephone.md
@@ -19,7 +19,7 @@ Telephone {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/telephone/protos/Telephone.proto]({{ url.github_tree  }}/projects/objects/telephone/protos/Telephone.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/telephone/protos/Telephone.proto]({{ url.github_tree }}/projects/objects/telephone/protos/Telephone.proto)"
 
 > **License**: MIT
 [More information.](https://opensource.org/licenses/MIT)
@@ -45,7 +45,7 @@ OfficeTelephone {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/telephone/protos/OfficeTelephone.proto]({{ url.github_tree  }}/projects/objects/telephone/protos/OfficeTelephone.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/telephone/protos/OfficeTelephone.proto]({{ url.github_tree }}/projects/objects/telephone/protos/OfficeTelephone.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-television.md
+++ b/docs/guide/object-television.md
@@ -26,7 +26,7 @@ Television {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/television/protos/Television.proto]({{ url.github_tree  }}/projects/objects/television/protos/Television.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/television/protos/Television.proto]({{ url.github_tree }}/projects/objects/television/protos/Television.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-toys.md
+++ b/docs/guide/object-toys.md
@@ -30,7 +30,7 @@ PaperBoat {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/toys/protos/PaperBoat.proto]({{ url.github_tree  }}/projects/objects/toys/protos/PaperBoat.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/toys/protos/PaperBoat.proto]({{ url.github_tree }}/projects/objects/toys/protos/PaperBoat.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -73,7 +73,7 @@ RubberDuck {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/toys/protos/RubberDuck.proto]({{ url.github_tree  }}/projects/objects/toys/protos/RubberDuck.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/toys/protos/RubberDuck.proto]({{ url.github_tree }}/projects/objects/toys/protos/RubberDuck.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-traffic.md
+++ b/docs/guide/object-traffic.md
@@ -23,7 +23,7 @@ CautionPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CautionPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/CautionPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CautionPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/CautionPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -58,7 +58,7 @@ CautionSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CautionSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/CautionSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CautionSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/CautionSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -101,7 +101,7 @@ ControlledStreetLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ControlledStreetLight.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/ControlledStreetLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ControlledStreetLight.proto]({{ url.github_tree }}/projects/objects/traffic/protos/ControlledStreetLight.proto)"
 
 > **License**: Creative Commons Attribution 3.0 United States License (original model by Andrew Kator & Jennifer Legaz).
 [More information.](https://creativecommons.org/licenses/by/3.0/legalcode)
@@ -145,7 +145,7 @@ CrossRoadsTrafficLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CrossRoadsTrafficLight.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/CrossRoadsTrafficLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/CrossRoadsTrafficLight.proto]({{ url.github_tree }}/projects/objects/traffic/protos/CrossRoadsTrafficLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -201,7 +201,7 @@ DirectionPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/DirectionPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/DirectionPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/DirectionPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/DirectionPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -254,7 +254,7 @@ DivergentIndicator {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/DivergentIndicator.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/DivergentIndicator.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/DivergentIndicator.proto]({{ url.github_tree }}/projects/objects/traffic/protos/DivergentIndicator.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -292,7 +292,7 @@ ExitPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ExitPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/ExitPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ExitPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/ExitPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -327,7 +327,7 @@ ExitSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ExitSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/ExitSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ExitSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/ExitSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -366,7 +366,7 @@ GenericTrafficLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/GenericTrafficLight.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/GenericTrafficLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/GenericTrafficLight.proto]({{ url.github_tree }}/projects/objects/traffic/protos/GenericTrafficLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -413,7 +413,7 @@ HighwayPole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/HighwayPole.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/HighwayPole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/HighwayPole.proto]({{ url.github_tree }}/projects/objects/traffic/protos/HighwayPole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -468,7 +468,7 @@ HighwaySign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/HighwaySign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/HighwaySign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/HighwaySign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/HighwaySign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -508,7 +508,7 @@ OrderPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/OrderPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/OrderPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/OrderPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/OrderPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -543,7 +543,7 @@ OrderSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/OrderSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/OrderSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/OrderSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/OrderSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -581,7 +581,7 @@ ParkingLines {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ParkingLines.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/ParkingLines.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ParkingLines.proto]({{ url.github_tree }}/projects/objects/traffic/protos/ParkingLines.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -616,7 +616,7 @@ ParkingMeter {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ParkingMeter.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/ParkingMeter.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/ParkingMeter.proto]({{ url.github_tree }}/projects/objects/traffic/protos/ParkingMeter.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -644,7 +644,7 @@ PedestrianCrossing {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/PedestrianCrossing.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/PedestrianCrossing.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/PedestrianCrossing.proto]({{ url.github_tree }}/projects/objects/traffic/protos/PedestrianCrossing.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -678,7 +678,7 @@ Pole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/Pole.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/Pole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/Pole.proto]({{ url.github_tree }}/projects/objects/traffic/protos/Pole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -711,7 +711,7 @@ RectangularPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/RectangularPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/RectangularPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/RectangularPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/RectangularPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -748,7 +748,7 @@ SignPole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SignPole.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/SignPole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SignPole.proto]({{ url.github_tree }}/projects/objects/traffic/protos/SignPole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -786,7 +786,7 @@ SpeedLimitPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SpeedLimitPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/SpeedLimitPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SpeedLimitPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/SpeedLimitPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -821,7 +821,7 @@ SpeedLimitSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SpeedLimitSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/SpeedLimitSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/SpeedLimitSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/SpeedLimitSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -859,7 +859,7 @@ StopPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StopPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/StopPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StopPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/StopPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -894,7 +894,7 @@ StopSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StopSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/StopSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StopSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/StopSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -938,7 +938,7 @@ StreetLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StreetLight.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/StreetLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/StreetLight.proto]({{ url.github_tree }}/projects/objects/traffic/protos/StreetLight.proto)"
 
 > **License**: Creative Commons Attribution 3.0 United States License (original model by Andrew Kator & Jennifer Legaz).
 [More information.](https://creativecommons.org/licenses/by/3.0/legalcode)
@@ -982,7 +982,7 @@ TrafficCone {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficCone.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficCone.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficCone.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficCone.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1013,7 +1013,7 @@ TrafficLight {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLight.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficLight.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLight.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficLight.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1047,7 +1047,7 @@ TrafficLightArrowLampGeometry {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightArrowLampGeometry.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficLightArrowLampGeometry.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightArrowLampGeometry.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficLightArrowLampGeometry.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1075,7 +1075,7 @@ TrafficLightBigPole {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightBigPole.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficLightBigPole.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightBigPole.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficLightBigPole.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1114,7 +1114,7 @@ TrafficLightHorizontal {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightHorizontal.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficLightHorizontal.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightHorizontal.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficLightHorizontal.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1148,7 +1148,7 @@ TrafficLightStandardLampGeometry {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightStandardLampGeometry.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/TrafficLightStandardLampGeometry.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/TrafficLightStandardLampGeometry.proto]({{ url.github_tree }}/projects/objects/traffic/protos/TrafficLightStandardLampGeometry.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1174,7 +1174,7 @@ WorkBarrier {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/WorkBarrier.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/WorkBarrier.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/WorkBarrier.proto]({{ url.github_tree }}/projects/objects/traffic/protos/WorkBarrier.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -1207,7 +1207,7 @@ YieldPanel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/YieldPanel.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/YieldPanel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/YieldPanel.proto]({{ url.github_tree }}/projects/objects/traffic/protos/YieldPanel.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -1244,7 +1244,7 @@ YieldSign {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/YieldSign.proto]({{ url.github_tree  }}/projects/objects/traffic/protos/YieldSign.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/traffic/protos/YieldSign.proto]({{ url.github_tree }}/projects/objects/traffic/protos/YieldSign.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/object-trees.md
+++ b/docs/guide/object-trees.md
@@ -21,7 +21,7 @@ BigSassafras {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/BigSassafras.proto]({{ url.github_tree  }}/projects/objects/trees/protos/BigSassafras.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/BigSassafras.proto]({{ url.github_tree }}/projects/objects/trees/protos/BigSassafras.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -51,7 +51,7 @@ Cypress {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Cypress.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Cypress.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Cypress.proto]({{ url.github_tree }}/projects/objects/trees/protos/Cypress.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -105,7 +105,7 @@ Forest {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Forest.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Forest.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Forest.proto]({{ url.github_tree }}/projects/objects/trees/protos/Forest.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -155,7 +155,7 @@ Oak {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Oak.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Oak.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Oak.proto]({{ url.github_tree }}/projects/objects/trees/protos/Oak.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -185,7 +185,7 @@ PalmTree {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/PalmTree.proto]({{ url.github_tree  }}/projects/objects/trees/protos/PalmTree.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/PalmTree.proto]({{ url.github_tree }}/projects/objects/trees/protos/PalmTree.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -215,7 +215,7 @@ Pine {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Pine.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Pine.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Pine.proto]({{ url.github_tree }}/projects/objects/trees/protos/Pine.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -245,7 +245,7 @@ Sassafras {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Sassafras.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Sassafras.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Sassafras.proto]({{ url.github_tree }}/projects/objects/trees/protos/Sassafras.proto)"
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
@@ -294,7 +294,7 @@ SimpleTree {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/SimpleTree.proto]({{ url.github_tree  }}/projects/objects/trees/protos/SimpleTree.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/SimpleTree.proto]({{ url.github_tree }}/projects/objects/trees/protos/SimpleTree.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
@@ -341,7 +341,7 @@ Tree {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Tree.proto]({{ url.github_tree  }}/projects/objects/trees/protos/Tree.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/objects/trees/protos/Tree.proto]({{ url.github_tree }}/projects/objects/trees/protos/Tree.proto)"
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)

--- a/docs/guide/p-rob3.md
+++ b/docs/guide/p-rob3.md
@@ -25,7 +25,7 @@ PROTO P-Rob3 [
 ]
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/fp\_robotics/p-rob3/protos/P-Rob3.proto]({{ url.github_tree  }}/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/fp\_robotics/p-rob3/protos/P-Rob3.proto]({{ url.github_tree }}/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto)"
 
 #### P-Rob3 Field Summary
 
@@ -49,7 +49,7 @@ The P-Grip gripper from [F&P Robotics](https://www.fp-robotics.com/en/) can be a
 
 ### Samples
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/fp\_robotics/p-rob3/worlds]({{ url.github_tree  }}/projects/robots/fp_robotics/p-rob3/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/fp\_robotics/p-rob3/worlds]({{ url.github_tree }}/projects/robots/fp_robotics/p-rob3/worlds)".
 
 #### p-rob3.wbt
 

--- a/docs/guide/programming.md
+++ b/docs/guide/programming.md
@@ -23,7 +23,7 @@ Please check this function's description in the [Reference Manual](../reference/
 2. To get the 3D position of any [Transform](../reference/transform.md) (or derived) node placed at the root of the Scene Tree (the nodes visible when the Scene Tree is completely collapsed), you can use the `wb_supervisor_field_get_sf_vec3f` function.
 Here is an [example](supervisor-programming.md#tracking-the-position-of-robots).
 
-A simulation example that shows both the [GPS](../reference/gps.md) and the [Supervisor](../reference/supervisor.md) APIs techniques is included in the Webots installation, you just need to open this world: "[WEBOTS\_HOME/projects/samples/devices/worlds/gps.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/gps.wbt)".
+A simulation example that shows both the [GPS](../reference/gps.md) and the [Supervisor](../reference/supervisor.md) APIs techniques is included in the Webots installation, you just need to open this world: "[WEBOTS\_HOME/projects/samples/devices/worlds/gps.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/gps.wbt)".
 
 #### Get Position in Physics Plugin Code:
 

--- a/docs/guide/robotino3.md
+++ b/docs/guide/robotino3.md
@@ -33,7 +33,7 @@ Robotino3 {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/festo/robotino3/protos/Robotino3.proto]({{ url.github_tree  }}/projects/robots/festo/robotino3/protos/Robotino3.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/festo/robotino3/protos/Robotino3.proto]({{ url.github_tree }}/projects/robots/festo/robotino3/protos/Robotino3.proto)"
 
 #### Robotino 3 Field Summary
 
@@ -47,7 +47,7 @@ Robotino3 {
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/festo/robotino3/worlds]({{ url.github_tree  }}/projects/robots/festo/robotino3/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/festo/robotino3/worlds]({{ url.github_tree }}/projects/robots/festo/robotino3/worlds)".
 
 > **Note:** For the mecanum wheels to behave correctly, the following [ContactProperties](../reference/contactproperties.md) should be added in the `contactProperties` field of the [WorldInfo](../reference/worldinfo.md) node:
 ```

--- a/docs/guide/sample-webots-applications.md
+++ b/docs/guide/sample-webots-applications.md
@@ -1,7 +1,7 @@
 # Sample Webots Applications
 
 This chapter gives an overview of sample worlds provided with the Webots package.
-The example worlds can be tested easily; the ".wbt" files are located in various "worlds" directories of the "[WEBOTS\_HOME/projects]({{ url.github_tree  }}/projects)" directory and can be directly opened from Webots using the `Open Sample World` item in `File` menu.
+The example worlds can be tested easily; the ".wbt" files are located in various "worlds" directories of the "[WEBOTS\_HOME/projects]({{ url.github_tree }}/projects)" directory and can be directly opened from Webots using the `Open Sample World` item in `File` menu.
 The controller code is located in the corresponding "controllers" directory.
 This chapter provides only a short abstract for each example.
 More detailed explanations can be found in the source code.

--- a/docs/guide/samples-demos.md
+++ b/docs/guide/samples-demos.md
@@ -2,10 +2,10 @@
 
 This section provides a list of interesting worlds that broadly illustrate Webots capabilities.
 Several of these examples have stemmed from research or teaching projects.
-You will find the corresponding ".wbt" files in the "[WEBOTS\_HOME/projects/samples/demos/worlds]({{ url.github_tree  }}/projects/samples/demos/worlds)" directory, and their controller source code in the "[WEBOTS\_HOME/projects/samples/demos/controllers]({{ url.github_tree  }}/projects/samples/demos/controllers)" directory.
+You will find the corresponding ".wbt" files in the "[WEBOTS\_HOME/projects/samples/demos/worlds]({{ url.github_tree }}/projects/samples/demos/worlds)" directory, and their controller source code in the "[WEBOTS\_HOME/projects/samples/demos/controllers]({{ url.github_tree }}/projects/samples/demos/controllers)" directory.
 For each demo, the world file and its corresponding controller have the same name.
 
-### [anaglyph.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/anaglyph.wbt)
+### [anaglyph.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/anaglyph.wbt)
 
 **Keywords**: Stereoscopic camera, anachrome red/cyan filters
 
@@ -14,7 +14,7 @@ A stereoscopic camera is mounted on a `iRobot Create` robot.
 At each step, both [Camera](../reference/camera.md) images are merged into a [Display](../reference/display.md) device, one is filtered in red, and the other one is filtered in cyan.
 This produces an anaglyph 3D image that can be seen with low cost red/cyan 3D glassed.
 
-### [gantry.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/gantry.wbt)
+### [gantry.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/gantry.wbt)
 
 **Keywords**: Gantry robot, gripper, Hanoi towers, linear motors, recursive algorithm
 
@@ -22,14 +22,14 @@ This produces an anaglyph 3D image that can be seen with low cost red/cyan 3D gl
 The gantry robot is modeled using a combination of [LinearMotor](../reference/linearmotor.md) and [RotationalMotor](../reference/rotationalmotor.md) devices.
 A recursive algorithm is used to solve the Hanoi Towers problem.
 
-### [hexapod.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/hexapod.wbt)
+### [hexapod.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/hexapod.wbt)
 
 **Keywords**: Legged robot, alternating tripod gait, linear motor
 
 ![hexapod.png](images/samples/hexapod.thumbnail.jpg) In this example, an insect-shaped robot is made of a combination of [LinearMotor](../reference/linearmotor.md) and [RotationalMotor](../reference/rotationalmotor.md) devices.
 The robot moves using an alternating tripod gait.
 
-### [moon.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/moon.wbt)
+### [moon.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/moon.wbt)
 
 **Keywords**: differential wheels, Koala, keyboard, texture
 
@@ -38,7 +38,7 @@ You can modify their trajectories with the arrow keys on your keyboard.
 The moon-like scenery is made of [IndexedFaceSet](../reference/indexedfaceset.md) nodes.
 Both robots use the same controller code.
 
-### [soccer.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/soccer.wbt)
+### [soccer.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/soccer.wbt)
 
 **Keywords**: Soccer, supervisor, differential wheels, label
 
@@ -46,7 +46,7 @@ Both robots use the same controller code.
 A [Supervisor](../reference/supervisor.md) controller is used as the referee; it counts the goals and displays the current score and the remaining time in the 3D view.
 This example shows how a [Supervisor](../reference/supervisor.md) controller can be used to read and change the position of objects.
 
-### [stewart\_platform.wbt]({{ url.github_tree  }}/projects/samples/demos/worlds/stewart_platform.wbt)
+### [stewart\_platform.wbt]({{ url.github_tree }}/projects/samples/demos/worlds/stewart_platform.wbt)
 
 **Keywords**: Stewart platform, linear motion, physics plugin, ball joint, universal joint
 

--- a/docs/guide/samples-devices.md
+++ b/docs/guide/samples-devices.md
@@ -1,8 +1,8 @@
 ## Devices
 
-The "[WEBOTS\_HOME/projects/samples/devices]({{ url.github_tree  }}/projects/samples/devices/)" directory contains Webots worlds that individually demonstrate the Webots devices and their API.
+The "[WEBOTS\_HOME/projects/samples/devices]({{ url.github_tree }}/projects/samples/devices/)" directory contains Webots worlds that individually demonstrate the Webots devices and their API.
 
-The world files are located in the "[WEBOTS\_HOME/projects/samples/devices/worlds]({{ url.github_tree  }}/projects/samples/devices/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/devices/controllers]({{ url.github_tree  }}/projects/samples/devices/controllers/)" directory.
+The world files are located in the "[WEBOTS\_HOME/projects/samples/devices/worlds]({{ url.github_tree }}/projects/samples/devices/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/devices/controllers]({{ url.github_tree }}/projects/samples/devices/controllers/)" directory.
 The world files and the corresponding controllers are named according to the device they demonstrate.
 
 Most of the devices below use a simple two-wheeled blue robot called MyBot moving in a closed square arena containing obstacles (see [figure below](#mybot-in-a-squared-arena)).
@@ -16,14 +16,14 @@ The studied devices are attached on this robot.
 
 %end
 
-### [accelerometer.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/accelerometer.wbt)
+### [accelerometer.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/accelerometer.wbt)
 
 **Keywords**: [Robot](../reference/robot.md), [Accelerometer](../reference/accelerometer.md)
 
 ![accelerometer.png](images/samples/accelerometer.thumbnail.jpg) In this example, the robot turns on a slope.
 Its [Accelerometer](../reference/accelerometer.md) sensor is used to switch on the bottommost LED.
 
-### [battery.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/battery.wbt)
+### [battery.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/battery.wbt)
 
 **Keywords**: [Robot](../reference/robot.md), [Charger](../reference/charger.md), battery
 
@@ -35,14 +35,14 @@ In order to remain powered, the robot must recharge its battery at energy charge
 Only a full charger can recharge the robot's battery.
 The color of a charger changes with its energy level: it is red when completely empty and green when completely full.
 
-### [brake.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/brake.wbt)
+### [brake.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/brake.wbt)
 
 **Keywords**: [Robot](../reference/robot.md), [Brake](../reference/brake.md)
 
 ![brake.png](images/samples/brake.thumbnail.jpg) In this example, a bike wheel turns until it is slowed down by a braking system.
 The red blocks graphically represent the braking system, but the wheel is actually braked using the [Brake](../reference/brake.md) device.
 
-### [bumper.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/bumper.wbt)
+### [bumper.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/bumper.wbt)
 
 **Keywords**: [TouchSensor](../reference/touchsensor.md), bumper
 
@@ -50,7 +50,7 @@ The red blocks graphically represent the braking system, but the wheel is actual
 Its "bumper" [TouchSensor](../reference/touchsensor.md) (represented by a black box) detects collisions.
 `MyBot` moves back and turns a little each time a collision is detected.
 
-### [compass.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/compass.wbt)
+### [compass.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/compass.wbt)
 
 **Keywords**: [Compass](../reference/compass.md)
 
@@ -58,7 +58,7 @@ Its "bumper" [TouchSensor](../reference/touchsensor.md) (represented by a black 
 The robot is equipped with a yellow motorized needle which always indicates towards the north.
 The north direction is computed using a [Compass](../reference/compass.md) node.
 
-### [camera.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/camera.wbt)
+### [camera.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/camera.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), image processing, RGB pixel, Camera noise, PNG, ANSI
 
@@ -68,7 +68,7 @@ When it has detected something, it turns, stops for a few seconds and saves the 
 It also prints a colored message (using ANSI codes) in the `Console` explaining the type of object it has detected.
 White noise is applied on the [Camera](../reference/camera.md).
 
-### [camera\_auto\_focus.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/camera_auto_focus.wbt)
+### [camera\_auto\_focus.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/camera_auto_focus.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), autofocus, depth-of-field
 
@@ -76,21 +76,21 @@ White noise is applied on the [Camera](../reference/camera.md).
 The robot uses a [DistanceSensor](../reference/distancesensor.md) to get the distance to the front object and adjusts the [Camera](../reference/camera.md) focal length accordingly.
 The objects displayed before or after this distance are blurred.
 
-### [camera\_motion\_blur.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/camera_motion_blur.wbt)
+### [camera\_motion\_blur.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/camera_motion_blur.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), motion blur
 
 ![camera_compositor.png](images/samples/camera_motion_blur.thumbnail.jpg) In this example, `MyBot` demonstrates the camera motion blur effect.
 The motion blur response time is given by the `Camera.motionBlur` field.
 
-### [camera\_noise\_mask.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/camera_noise_mask.wbt)
+### [camera\_noise\_mask.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/camera_noise_mask.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), noise mask
 
 ![camera_noise_mask.png](images/samples/camera_noise_mask.thumbnail.jpg) In this example, `MyBot` demonstrates noise effect based on noise mask.
 The noise mask is determined by the `Camera.noiseMaskUrl` field.
 
-### [camera\_recognition.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/camera_recognition.wbt)
+### [camera\_recognition.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/camera_recognition.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), pattern recognition, smart camera
 
@@ -99,7 +99,7 @@ The robot camera displays yellow rectangles around the recognized objects.
 Information about the objects currently recognized are displayed in the `Console`.
 The camera recognizes [Solid](../reference/solid.md) nodes whose `recognitionColors` field is not empty.
 
-### [connector.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/connector.wbt)
+### [connector.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/connector.wbt)
 
 **Keywords**: [Connector](../reference/connector.md), [RotationalMotor](../reference/rotationalmotor.md), [IndexedLineSet](../reference/indexedlineset.md)
 
@@ -111,27 +111,27 @@ Then both robots rotate their handles simultaneously, hence the light robot gets
 Then the light robot gets passed over another time by the second heavy robot and so on...
 All the robots in this simulation use the same controller; the different behaviors are selected according to the robot's name.
 
-### [display.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/display.wbt)
+### [display.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/display.wbt)
 
 **Keywords**: [Display](../reference/display.md), write in textures, overlay
 
 ![display.png](images/samples/display.thumbnail.jpg) This example demonstrates several uses of the [Display](../reference/display.md) device.
 
 - The `MyBot` [Display](../reference/display.md) called "emoticon_display" is displayed as a 2D overlay on top of the 3D window, and is displayed as a texture on the screen mounted on the `MyBot`.
-It loads the [emoticons.png]({{ url.github_tree  }}/projects/samples/devices/controllers/display/emoticons.png) image which contains a grid of emoticons (as a sprite sheet), and randomly selects an emoticon from this image every 30 steps.
+It loads the [emoticons.png]({{ url.github_tree }}/projects/samples/devices/controllers/display/emoticons.png) image which contains a grid of emoticons (as a sprite sheet), and randomly selects an emoticon from this image every 30 steps.
 - The `MyBot` [Display](../reference/display.md) called "camera_display" is displayed as a 2D overlay on top of the 3D window.
 It copies the [Camera](../reference/camera.md) image, and draws a yellow rectangle and text over it where yellow pixels are detected.
 - The [Robot](../reference/robot.md) [Display](../reference/display.md) called "ground display" is displayed as a texture on the floor.
 The [Supervisor](../reference/supervisor.md) controller get the position of `MyBot` and draws a green dot at this location.
 
-### [distance\_sensor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/distance_sensor.wbt)
+### [distance\_sensor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/distance_sensor.wbt)
 
 **Keywords**: [DistanceSensor](../reference/distancesensor.md), Braitenberg
 
 ![distance_sensor.png](images/samples/distance_sensor.thumbnail.jpg) In this example, eight [DistanceSensors](../reference/distancesensor.md) are mounted at regular intervals around the `MyBot` body.
 The robot avoids obstacles using a technique based on Braitenberg vehicles.
 
-### [emitter\_receiver.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/emitter_receiver.wbt)
+### [emitter\_receiver.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/emitter_receiver.wbt)
 
 **Keywords**: [Emitter](../reference/emitter.md), [Receiver](../reference/receiver.md), infra-red transmission
 
@@ -142,7 +142,7 @@ The state of the communication between the two robots is displayed in the Consol
 You can observe this when the *receiver* robot enters the *emitter*'s sphere while no direct obstacle is present on the route, then the communication is established, otherwise the communication is interrupted.
 Note that the communication between "infra-red" [Emitters](../reference/emitter.md) and [Receivers](../reference/receiver.md) can be blocked by an obstacle, this is not the case with "radio" [Emitters](../reference/emitter.md) and [Receivers](../reference/receiver.md).
 
-### [encoders.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/encoders.wbt)
+### [encoders.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/encoders.wbt)
 
 **Keywords**: [PositionSensor](../reference/positionsensor.md), encoders
 
@@ -152,7 +152,7 @@ Then the encoders are reset and the controller chooses new random values.
 [PositionSensor](../reference/positionsensor.md) nodes applied on [HingeJoint](../reference/hingejoint.md) nodes model the encoders.
 The robot does not pay any attention to obstacles.
 
-### [force\_sensor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/force_sensor.wbt)
+### [force\_sensor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/force_sensor.wbt)
 
 **Keywords**: [TouchSensor](../reference/touchsensor.md), force sensor
 
@@ -160,7 +160,7 @@ The robot does not pay any attention to obstacles.
 The only difference is that this robot uses a "force" [TouchSensor](../reference/touchsensor.md) instead of a "bumper".
 So this robot can measure the force of each collision, which is printed in the `Console`.
 
-### [force3d\_sensor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/force3d_sensor.wbt)
+### [force3d\_sensor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/force3d_sensor.wbt)
 
 **Keywords**: [TouchSensor](../reference/touchsensor.md), 3D force sensor
 
@@ -171,7 +171,7 @@ This setup allow to measure the force on the six sides of the [TouchSensor](../r
 The resulting force vector is displayed in the `Console`.
 Moving and rotating the box will change the displayed force.
 
-### [gps.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/gps.wbt)
+### [gps.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/gps.wbt)
 
 **Keywords**: [GPS](../reference/gps.md), keyboard, get robot position
 
@@ -183,7 +183,7 @@ This example implements both techniques, and you can choose either one or the ot
 The <kbd>G</kbd> key prints the robot's [GPS](../reference/gps.md) device position.
 The <kbd>S</kbd> key prints the position read by the [Supervisor](../reference/supervisor.md) controller.
 
-### [gps\_lat\_long.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/gps_lat_long.wbt)
+### [gps\_lat\_long.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/gps_lat_long.wbt)
 
 **Keywords**: [GPS](../reference/gps.md), WGS84, Latitude-Longitude
 
@@ -191,7 +191,7 @@ The <kbd>S</kbd> key prints the position read by the [Supervisor](../reference/s
 The reference is set in the `WorldInfo.gpsCoordinateSytem` and `WorldInfo.gpsReference`.
 The resulting position is displayed in the `Console` at each step.
 
-### [gyro.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/gyro.wbt)
+### [gyro.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/gyro.wbt)
 
 **Keywords**: [Gyro](../reference/gyro.md), angular velocity
 
@@ -200,7 +200,7 @@ A [Gyro](../reference/gyro.md) is mounted on three rotational motors (each motor
 The motors a running consecutively for a while.
 The resulting angular velocity measured by the gyro is displayed in the `Console`.
 
-### [hokuyo.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/hokuyo.wbt)
+### [hokuyo.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/hokuyo.wbt)
 
 **Keywords**: Hokuyo, [Lidar](../reference/lidar.md), [Display](../reference/display.md) plot
 
@@ -208,7 +208,7 @@ The resulting angular velocity measured by the gyro is displayed in the `Console
 Two `Hokuyo` [Lidars](../reference/lidar.md) are mounted on the `MyBot`.
 At each step, the lidars are updated, and their depth output are displayed in distinct [Displays](../reference/display.md).
 
-### [inertial\_unit.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/inertial_unit.wbt)
+### [inertial\_unit.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/inertial_unit.wbt)
 
 **Keywords**: [InertialUnit](../reference/inertialunit.md), roll/pitch/yaw angles
 
@@ -216,7 +216,7 @@ At each step, the lidars are updated, and their depth output are displayed in di
 An [InertialUnit](../reference/inertialunit.md) is mounted on a 3 DOF (Degrees Of Freedom) arm which moves from one random target to another.
 Each time a target is reached, the absolute roll, pitch and yaw angles of the [InertialUnit](../reference/inertialunit.md) are displayed in the `Console`.
 
-### [laser\_pointer.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/laser_pointer.wbt)
+### [laser\_pointer.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/laser_pointer.wbt)
 
 **Keywords**: [DistanceSensor](../reference/distancesensor.md), laser
 
@@ -224,7 +224,7 @@ Each time a target is reached, the absolute roll, pitch and yaw angles of the [I
 `MyBot` turns round with two laser pointers enabled.
 Red dots are displayed where the laser beam hits obstacles.
 
-### [led.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/led.wbt)
+### [led.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/led.wbt)
 
 **Keywords**: [LED](../reference/led.md)
 
@@ -232,7 +232,7 @@ Red dots are displayed where the laser beam hits obstacles.
 Each [LED](../reference/led.md)'s material emissive color and embedded [PointLight](../reference/pointlight.md) are modified accordingly.
 The color choice is printed in the `Console`.
 
-### [lidar.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/lidar.wbt)
+### [lidar.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/lidar.wbt)
 
 **Keywords**: [Lidar](../reference/lidar.md)
 
@@ -240,14 +240,14 @@ The color choice is printed in the `Console`.
 The [Lidar](../reference/lidar.md) mounted on the `MyBot` scans the environment.
 The [Lidar](../reference/lidar.md) point cloud can be shown by enabling the `View / Optional Rendering / Show Lidar Point Cloud`.
 
-### [light\_sensor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/light_sensor.wbt)
+### [light\_sensor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/light_sensor.wbt)
 
 **Keywords**: [LightSensor](../reference/lightsensor.md)
 
 ![light_sensor.png](images/samples/light_sensor.thumbnail.jpg) In this example, `MyBot` uses two [LightSensors](../reference/lightsensor.md) to follow a light source.
 The light source can be moved with the mouse; the robot will follow it.
 
-### [linear\_motor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/linear_motor.wbt)
+### [linear\_motor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/linear_motor.wbt)
 
 **Keywords**: [LinearMotor](../reference/linearmotor.md), set motor position
 
@@ -255,26 +255,26 @@ The light source can be moved with the mouse; the robot will follow it.
 Once done, it comes back to position `0` and restarts.
 A ruler indicates the linear motor progression.
 
-### [motor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/motor.wbt)
+### [motor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/motor.wbt)
 
 **Keywords**: [RotationalMotor](../reference/rotationalmotor.md), force control, energy consumption
 
 ![motor.png](images/samples/motor.thumbnail.jpg) In this example, a rotational motor is controlled in force mode to push a cardboard.
 The force feedback applied on the motor and the energy consumed by the robot are displayed in the `Console`.
 
-### [motor2.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/motor2.wbt)
+### [motor2.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/motor2.wbt)
 
 **Keywords**: [RotationalMotor](../reference/rotationalmotor.md), [Hinge2Joint](../reference/hinge2joint.md)
 
 ![motor2.png](images/samples/motor2.thumbnail.jpg) In this example, two rotational motors are controlling a [Hinge2Joint](../reference/hinge2joint.md) in position.
 
-### [motor3.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/motor3.wbt)
+### [motor3.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/motor3.wbt)
 
 **Keywords**: [RotationalMotor](../reference/rotationalmotor.md), [BallJoint](../reference/balljoint.md)
 
 ![motor3.png](images/samples/motor3.thumbnail.jpg) In this example, three rotational motors are controlling a [BallJoint](../reference/balljoint.md) in position.
 
-### [pen.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/pen.wbt)
+### [pen.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/pen.wbt)
 
 **Keywords**: [Pen](../reference/pen.md), keyboard
 
@@ -283,13 +283,13 @@ The controller randomly chooses the ink color.
 The ink on the floor fades slowly.
 Use the `Y` and `X` keys to switch the [Pen](../reference/pen.md) on and off.
 
-### [position\_sensor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/position_sensor.wbt)
+### [position\_sensor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/position_sensor.wbt)
 
 **Keywords**: [PositionSensor](../reference/positionsensor.md), force control
 
 ![position_sensor.png](images/samples/position_sensor.thumbnail.jpg) In this example, `MyBot` uses a [PositionSensor](../reference/positionsensor.md) to maintain a red log in balance.
 
-### [propeller.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/propeller.wbt)
+### [propeller.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/propeller.wbt)
 
 **Keywords**: [Propeller](../reference/propeller.md), rotors, fan
 
@@ -299,28 +299,28 @@ Use the `Y` and `X` keys to switch the [Pen](../reference/pen.md) on and off.
 - *Green helicopter*: It is composed of 2 coaxial rotors.
 - *Blue helicopter*: It is composed of a single axial rotor.
 
-### [radar.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/radar.wbt)
+### [radar.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/radar.wbt)
 
 **Keywords**: [Radar](../reference/radar.md)
 
 ![radar.png](images/samples/radar.thumbnail.jpg) In this example, the `MyBot` with the black box detects the `MyBot`s with red boxes.
 The black box is a [Radar](../reference/radar.md) device, while the red boxes are [Solids](../reference/solid.md) with a positive `radarCrossSection` (this is required to be detected by the [Radar](../reference/radar.md)).
 
-### [range\_finder.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/range_finder.wbt)
+### [range\_finder.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/range_finder.wbt)
 
 **Keywords**: [RangeFinder](../reference/rangefinder.md)
 
 ![range_finder.png](images/samples/range_finder.thumbnail.jpg) In this example, `MyBot` uses a [RangeFinder](../reference/rangefinder.md) to avoid obstacles.
 The [RangeFinder](../reference/rangefinder.md) measures the distance to objects, so the robot knows if there is enough room to move forward or not.
 
-### [receiver\_noise.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/receiver_noise.wbt)
+### [receiver\_noise.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/receiver_noise.wbt)
 
 **Keywords**: [Receiver](../reference/receiver.md), signal strength, direction noise
 
 ![receiver_noise.png](images/samples/receiver_noise.thumbnail.jpg) In this example, the `MyBot` at the center uses its [Receiver](../reference/receiver.md) device to get the [Emitter](../reference/emitter.md) device position of the other `MyBot`.
 This noisy position is compared to the actual [Emitter](../reference/emitter.md) position measured with a noise-free [GPS](../reference/gps.md).
 
-### [sick.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/sick.wbt)
+### [sick.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/sick.wbt)
 
 **Keywords**: [Sick LMS 291](lidar-sensors.md#sick-lms-291), [Lidar](../reference/lidar.md), 3-wheeled robot, lidar plot
 
@@ -328,14 +328,14 @@ This noisy position is compared to the actual [Emitter](../reference/emitter.md)
 The robot use the lidar depth output to avoid collisions.
 The lidar depth output is also plot into a [Display](../reference/display.md) device.
 
-### [sick\_point\_cloud.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/sick_point_cloud.wbt)
+### [sick\_point\_cloud.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/sick_point_cloud.wbt)
 
 **Keywords**: [Sick LD MRS](lidar-sensors.md#sick-ld-mrs), [Lidar](../reference/lidar.md), cloud point
 
 ![sick_point_cloud.png](images/samples/sick_point_cloud.thumbnail.jpg) Soda cans are transported on a conveyor belt.
 A static robot equipped with a Sick LD-MRS uses the Point Cloud API to count the number of cans in front of it.
 
-### [speaker.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/speaker.wbt)
+### [speaker.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/speaker.wbt)
 
 **Keywords**: [Speaker](../reference/speaker.md), WAV
 
@@ -344,7 +344,7 @@ A WAV file is played on this speaker, while the `MyBot` is moving over the camer
 The intensity of the left and right audio channels differs depending on the robot position.
 The Webots sound should be enabled to hear the result on the computer loudspeakers.
 
-### [speaker\_text\_to\_speech.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/speaker_text_to_speech.wbt)
+### [speaker\_text\_to\_speech.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/speaker_text_to_speech.wbt)
 
 **Keywords**: [Speaker](../reference/speaker.md), text-to-speech, TTS
 
@@ -353,14 +353,14 @@ A text formated in XML is played in this speaker.
 This text is containing voice modulations including pitch, rate and volume modifications.
 The Webots sound should be enabled to hear the result on the computer loudspeakers.
 
-### [spherical\_camera.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/spherical_camera.wbt)
+### [spherical\_camera.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/spherical_camera.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), spherical projection
 
 ![spherical_camera.png](images/samples/spherical_camera.thumbnail.jpg) In this example, a spherical [Camera](../reference/camera.md) device is mounted on the `MyBot`.
 The resulting projection is shown in a 2D camera overlay.
 
-### [supervisor.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/supervisor.wbt)
+### [supervisor.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/supervisor.wbt)
 
 **Keywords**: [Supervisor](../reference/supervisor.md), queries on scene tree
 
@@ -370,7 +370,7 @@ Then it displays the content of the `WorldInfo.gravity` field.
 After two seconds, it moves the [PointLight](../reference/pointlight.md), and then after two more seconds it imports a transformed [Sphere](../reference/sphere.md).
 Finally, it moves the [Sphere](../reference/sphere.md) in a circle.
 
-### [track.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/track.wbt)
+### [track.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/track.wbt)
 
 **Keywords**: [Track](../reference/track.md), caterpillar track, conveyor belt
 

--- a/docs/guide/samples-environments.md
+++ b/docs/guide/samples-environments.md
@@ -2,13 +2,13 @@
 
 This section shows some of the possible environments and objects available in Webots inside composed scenes.
 Webots objects are modular and parametrizable, so other environments can be created simply, starting from these examples.
-The world files for these examples are located in the "[WEBOTS\_HOME/projects/sample/environments/]({{ url.github_tree  }}/projects/samples/environments/)" directory.
+The world files for these examples are located in the "[WEBOTS\_HOME/projects/sample/environments/]({{ url.github_tree }}/projects/samples/environments/)" directory.
 
-Outdoor and urban environments located in the "[WEBOTS\_HOME/projects/vehicles/worlds]({{ url.github_tree  }}/projects/vehicles/worlds)" and are not shown here.
+Outdoor and urban environments located in the "[WEBOTS\_HOME/projects/vehicles/worlds]({{ url.github_tree }}/projects/vehicles/worlds)" and are not shown here.
 
 In this directory, you will find the following world files:
 
-### [apartment.wbt]({{ url.github_tree  }}/projects/samples/environments/indoor/worlds/apartment.wbt)
+### [apartment.wbt]({{ url.github_tree }}/projects/samples/environments/indoor/worlds/apartment.wbt)
 
 **Keywords**: Apartment, domestic environment, furniture
 
@@ -28,7 +28,7 @@ This means that a robot could open a drawer, leave an object inside it, and clos
 Light objects such as the books on the shelf or the fruits in the basket can be grabbed by a robot.
 An e-puck robot patrols on the table and an iRobot Create robot cleans the ground.
 
-### [break\_room.wbt]({{ url.github_tree  }}/projects/samples/environments/indoor/worlds/break_room.wbt)
+### [break\_room.wbt]({{ url.github_tree }}/projects/samples/environments/indoor/worlds/break_room.wbt)
 
 **Keywords**: Break room, domestic environment, furniture
 
@@ -46,7 +46,7 @@ These objects are Webots PROTO nodes, and can be easily moved and resized to cre
 Doors are interactive.
 This means that a robot can open a drawer, leave an object inside it, and close it.
 
-### [complete\_apartment.wbt]({{ url.github_tree  }}/projects/samples/environments/indoor/worlds/complete_apartment.wbt)
+### [complete\_apartment.wbt]({{ url.github_tree }}/projects/samples/environments/indoor/worlds/complete_apartment.wbt)
 
 **Keywords**: Apartment, household environment, furniture
 
@@ -63,7 +63,7 @@ This example is similar to the previous one but the apartement is more complete,
 
 > **Note**: This model was sponsored by Kamal Othman & Prof. Ahmad Rad from AISL-SFU
 
-### [factory.wbt]({{ url.github_tree  }}/projects/samples/environments/factory/worlds/factory.wbt)
+### [factory.wbt]({{ url.github_tree }}/projects/samples/environments/factory/worlds/factory.wbt)
 
 **Keywords**: Factory, workbench, tools, industrial pipes, industrial stairs
 
@@ -80,7 +80,7 @@ These objects are Webots PROTO nodes, and can be easily moved and resized to cre
 The tools and valves are interactive.
 This means that a robot could grab a hammer, or turn a valve handle.
 
-### [hall.wbt]({{ url.github_tree  }}/projects/samples/environments/factory/worlds/hall.wbt)
+### [hall.wbt]({{ url.github_tree }}/projects/samples/environments/factory/worlds/hall.wbt)
 
 **Keywords**: hall, workbench, tools, industrial pipes, industrial stairs
 
@@ -100,7 +100,7 @@ This means that a robot could grab a hammer, turn a valve handle, climb the stai
 
 This environment is sponsored by the [ROSin european project](http://rosin-project.eu/ftp/cross-platform-ros-simulation-for-mobile-manipulators).
 
-### [kitchen.wbt]({{ url.github_tree  }}/projects/samples/environments/indoor/worlds/kitchen.wbt)
+### [kitchen.wbt]({{ url.github_tree }}/projects/samples/environments/indoor/worlds/kitchen.wbt)
 
 **Keywords**: kitchen, utensil
 

--- a/docs/guide/samples-geometries.md
+++ b/docs/guide/samples-geometries.md
@@ -1,11 +1,11 @@
 ## Geometries
 
 This section shows the geometric primitives available in Webots.
-The world files for these examples are located in the "[WEBOTS\_HOME/sample/geometries/worlds]({{ url.github_tree  }}/projects/samples/geometries/worlds/)" directory.
+The world files for these examples are located in the "[WEBOTS\_HOME/sample/geometries/worlds]({{ url.github_tree }}/projects/samples/geometries/worlds/)" directory.
 
 In this directory, you will find the following world files :
 
-### [extended\_solids.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/extended_solids.wbt)
+### [extended\_solids.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/extended_solids.wbt)
 
 **Keywords**: Extended solids, torus, rounded box, pipe
 
@@ -14,7 +14,7 @@ These compound primitives are created using procedural PROTO nodes that generate
 
 In this example, physics laws are applied on these primitives.
 
-### [extrusion.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/extrusion.wbt)
+### [extrusion.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/extrusion.wbt)
 
 **Keywords**: Extrusion
 
@@ -23,7 +23,7 @@ The `Extrusion` PROTO is a procedural PROTO which generates an [IndexedFaceSet](
 The `Extrusion` PROTO fields allow to define a 2D cross-section, and to extrude it along a path.
 In this example, the cross-section is a triangle extruded along a spiral path.
 
-### [floating\_geometries.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/floating_geometries.wbt)
+### [floating\_geometries.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/floating_geometries.wbt)
 
 **Keywords**: Fluid simulation
 
@@ -31,7 +31,7 @@ In this example, the cross-section is a triangle extruded along a spiral path.
 Three [Fluid](../reference/fluid.md) nodes are present; two flowing fluids to simulate a river, and a static fluid to simulate a cylindric pool.
 The small [Solids](../reference/solid.md) are affected by the fluids' viscosity and by forces generated on the [Archimedes' principle](https://en.wikipedia.org/wiki/Archimedes%27_principle).
 
-### [geometric\_primitives.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/geometric_primitives.wbt)
+### [geometric\_primitives.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/geometric_primitives.wbt)
 
 **Keywords**: [Box](../reference/box.md), [Capsule](../reference/capsule.md), [Cone](../reference/cone.md), [Cylinder](../reference/cylinder.md), [ElevationGrid](../reference/elevationgrid.md), [IndexedLineSet](../reference/indexedlineset.md), [IndexedFaceSet](../reference/indexedfaceset.md), [Plane](../reference/plane.md), [Sphere](../reference/sphere.md)
 
@@ -39,7 +39,7 @@ The small [Solids](../reference/solid.md) are affected by the fluids' viscosity 
 The primitives are inserted into [Transform](../reference/transform.md) and [Shape](../reference/shape.md) nodes.
 Therefore they are static, i.e. physics is not applied on them.
 
-### [high\_resolution\_indexedfaceset.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/high_resolution_indexedfaceset.wbt)
+### [high\_resolution\_indexedfaceset.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/high_resolution_indexedfaceset.wbt)
 
 **Keywords**: [IndexedFaceSet](../reference/indexedfaceset.md), High resolution mesh
 
@@ -48,7 +48,7 @@ This mesh is a textured high resolution version of the [Blender's mascot, Suzann
 It is composed of 8000 triangles with UV mapping.
 It has been imported from [Blender](https://www.blender.org/).
 
-### [muscle.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/muscle.wbt)
+### [muscle.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/muscle.wbt)
 
 **Keywords**: [Muscle](../reference/muscle.md)
 
@@ -61,14 +61,14 @@ Two scenarios are shown:
 Depending on the joint motion, one muscle is contracted, and the other one is released.
 2. A muscle is applied on a [SliderJoint](../reference/sliderjoint.md) node.
 
-### [physics\_primitives.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/physics_primitives.wbt)
+### [physics\_primitives.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/physics_primitives.wbt)
 
 **Keywords**: Collisions, physics primitives
 
 ![physics_primitives.png](images/samples/physics_primitives.thumbnail.jpg) This example demonstrates a large set of the possible collisions between the basic physics primitives.
 Three identical sets of primitives composed of [Box](../reference/box.md), a [Capsule](../reference/capsule.md), a [Cylinder](../reference/cylinder.md), a [Sphere](../reference/sphere.md) and an [IndexedFaceSet](../reference/indexedfaceset.md) nodes fall onto three surfaces respectively; a [Box](../reference/box.md), a [Plane](../reference/plane.md) and an [ElevationGrid](../reference/elevationgrid.md) node.
 
-### [polygons.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/polygons.wbt)
+### [polygons.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/polygons.wbt)
 
 **Keywords**: [IndexedFaceSet](../reference/indexedfaceset.md), polygon tesselation
 
@@ -78,26 +78,26 @@ Each polygon is modeled as a list of vertices.
 Webots applies a tesselation algorithm on this list, and creates the minimum number of OpenGL triangles.
 The triangles can be shown using the `View / Wireframe Rendering` menu item.
 
-### [textured\_boxes.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/textured_boxes.wbt)
+### [textured\_boxes.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/textured_boxes.wbt)
 
 **Keywords**: TexturedBox, texture mapping
 
 ![textured_boxes.png](images/samples/textured_boxes.thumbnail.jpg) This example shows the possible UV mappings for the `TexturedBox` PROTO.
 
-### [textured\_proto\_shapes.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/textured_proto_shapes.wbt)
+### [textured\_proto\_shapes.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/textured_proto_shapes.wbt)
 
 **Keywords**: TexturedBoxShape, texture mapping
 
 ![textured_proto_shapes.png](images/samples/textured_proto_shapes.thumbnail.jpg) This example shows the differences between the `TexturedBoxShape` and `TexturedBoxShape` PROTO nodes.
 
-### [textured\_shapes.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/textured_shapes.wbt)
+### [textured\_shapes.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/textured_shapes.wbt)
 
 **Keywords**: Texture mapping
 
 ![textured_shapes.png](images/samples/textured_shapes.thumbnail.jpg) This example shows how textures are applied on basic primitives.
 The same [Appearance](../reference/appearance.md) node is applied on all the basic primitives following VRML rules about texture mapping.
 
-### [webots\_box.wbt]({{ url.github_tree  }}/projects/samples/geometries/worlds/webots_box.wbt)
+### [webots\_box.wbt]({{ url.github_tree }}/projects/samples/geometries/worlds/webots_box.wbt)
 
 **Keywords**: [IndexedFaceSet](../reference/indexedfaceset.md), UV mapping
 

--- a/docs/guide/samples-howto.md
+++ b/docs/guide/samples-howto.md
@@ -1,7 +1,7 @@
 ## How To
 
 This section gives various examples of complex behaviors and/or functionalities.
-The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree  }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers](https://github.com/cyberbotics/webots/tree/master/projects/samples/howto/controllers/)" directory.
+The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree  }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers]({{ url.github_tree  }}/projects/samples/howto/controllers/)" directory.
 For each, the world file and its corresponding controller are named according to the behavior they exemplify.
 
 ### [asymmetric\_friction1.wbt]({{ url.github_tree  }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction1.wbt)

--- a/docs/guide/samples-howto.md
+++ b/docs/guide/samples-howto.md
@@ -1,7 +1,7 @@
 ## How To
 
 This section gives various examples of complex behaviors and/or functionalities.
-The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds](https://github.com/cyberbotics/webots/tree/master/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers](https://github.com/cyberbotics/webots/tree/master/projects/samples/howto/controllers/)" directory.
+The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree  }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers](https://github.com/cyberbotics/webots/tree/master/projects/samples/howto/controllers/)" directory.
 For each, the world file and its corresponding controller are named according to the behavior they exemplify.
 
 ### [asymmetric\_friction1.wbt]({{ url.github_tree  }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction1.wbt)

--- a/docs/guide/samples-howto.md
+++ b/docs/guide/samples-howto.md
@@ -1,10 +1,10 @@
 ## How To
 
 This section gives various examples of complex behaviors and/or functionalities.
-The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree  }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers]({{ url.github_tree  }}/projects/samples/howto/controllers/)" directory.
+The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers]({{ url.github_tree }}/projects/samples/howto/controllers/)" directory.
 For each, the world file and its corresponding controller are named according to the behavior they exemplify.
 
-### [asymmetric\_friction1.wbt]({{ url.github_tree  }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction1.wbt)
+### [asymmetric\_friction1.wbt]({{ url.github_tree }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction1.wbt)
 
 **Keywords**: [ContactProperties](../reference/contactproperties.md), asymmetric friction
 
@@ -13,7 +13,7 @@ A small box slides on two leaning fixed boxes.
 Each of the boxes are striped with black lines.
 There is a smaller friction along the black lines, therefore the box is sliding along the black lines.
 
-### [asymmetric\_friction2.wbt]({{ url.github_tree  }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction2.wbt)
+### [asymmetric\_friction2.wbt]({{ url.github_tree }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction2.wbt)
 
 **Keywords**: [ContactProperties](../reference/contactproperties.md), asymmetric friction
 
@@ -22,14 +22,14 @@ A solid composed of two cylinders is sliding down a leaning plane.
 The black strips on the cylinders indicate the friction direction: there is smaller friction along the black lines.
 Rotate the solid to modify its speed.
 
-### [binocular.wbt]({{ url.github_tree  }}/projects/samples/howto/binocular/worlds/binocular.wbt)
+### [binocular.wbt]({{ url.github_tree }}/projects/samples/howto/binocular/worlds/binocular.wbt)
 
 **Keywords**: [Camera](../reference/camera.md), stereovision, stereoscopic cameras
 
 ![binocular.png](images/samples/binocular.thumbnail.jpg) This example simply shows the use of two [Cameras](../reference/camera.md) for stereovision.
 The example does not actually perform stereovision or any form of computer vision.
 
-### [biped.wbt]({{ url.github_tree  }}/projects/samples/howto/biped/worlds/biped.wbt)
+### [biped.wbt]({{ url.github_tree }}/projects/samples/howto/biped/worlds/biped.wbt)
 
 **Keywords**: Humanoid robot, biped robot, power off, passive joint
 
@@ -37,7 +37,7 @@ The example does not actually perform stereovision or any form of computer visio
 After a few seconds, all the motors are turned off and the robot collapses.
 This example illustrates the build of a simple articulated robot and also how to turn off motor power.
 
-### [center\_of\_mass.wbt]({{ url.github_tree  }}/projects/samples/howto/center_of_mass/worlds/center_of_mass.wbt)
+### [center\_of\_mass.wbt]({{ url.github_tree }}/projects/samples/howto/center_of_mass/worlds/center_of_mass.wbt)
 
 **Keywords**: Center of mass
 
@@ -46,7 +46,7 @@ The inertia of the heavy mass lets the robot base turn round.
 The overall center of mass of the robot is changing.
 This can be visualized with the `View / Optional Rendering / Show Center of Mass...` or `mass` tab of in the node editor when the robot is selected.
 
-### [custom\_robot\_window\_simple.wbt]({{ url.github_tree  }}/projects/samples/howto/custom_robot_window_simple/worlds/custom_robot_window_simple.wbt)
+### [custom\_robot\_window\_simple.wbt]({{ url.github_tree }}/projects/samples/howto/custom_robot_window_simple/worlds/custom_robot_window_simple.wbt)
 
 **Keywords**: custom robot window, [controller plugin](controller-plugin.md), HTML, JavaScript
 
@@ -54,7 +54,7 @@ This can be visualized with the `View / Optional Rendering / Show Center of Mass
 The JavaScript and Python files deal with the interactions between the page and the robot, using the WWI API to exchange string messages.
 
 
-### [custom\_robot\_window.wbt]({{ url.github_tree  }}/projects/samples/howto/custom_robot_window/worlds/custom_robot_window.wbt)
+### [custom\_robot\_window.wbt]({{ url.github_tree }}/projects/samples/howto/custom_robot_window/worlds/custom_robot_window.wbt)
 
 **Keywords**: custom robot window, [controller plugin](controller-plugin.md), HTML, JavaScript, CSS
 
@@ -63,14 +63,14 @@ The HTML file contains the page content.
 The CSS file contains the page style.
 The JavaScript and C files deal with the interactions between the page and the robot, using the WWI API to exchange string messages.
 
-### [cylinder\_stack.wbt]({{ url.github_tree  }}/projects/samples/howto/cylinder_stack/worlds/cylinder_stack.wbt)
+### [cylinder\_stack.wbt]({{ url.github_tree }}/projects/samples/howto/cylinder_stack/worlds/cylinder_stack.wbt)
 
 **Keywords**: [Supervisor](../reference/supervisor.md), contact points, cylinder collisions
 
 ![cylinder_stack.png](images/samples/cylinder_stack.thumbnail.jpg) In this example, a stack of cylinders collapses.
 A [Supervisor](../reference/supervisor.md) controller gets information on the contact points and displays the reaction forces in the `Console`.
 
-### [force\_control.wbt]({{ url.github_tree  }}/projects/samples/howto/force_control/worlds/force_control.wbt)
+### [force\_control.wbt]({{ url.github_tree }}/projects/samples/howto/force_control/worlds/force_control.wbt)
 
 **Keywords**: Force control, linear motor, spring and damper
 
@@ -81,7 +81,7 @@ When the simulation starts, the motor force is used to move the boxes apart.
 Then, the motor force is turned off and the boxes oscillate for a while, according to the spring and damping equations programmed in the controller.
 In addition, there is an equivalent version of a MATLAB controller `force_control_matlab` that you can switch to.
 
-### [four\_wheels.wbt]({{ url.github_tree  }}/projects/samples/howto/four_wheels/worlds/four_wheels.wbt)
+### [four\_wheels.wbt]({{ url.github_tree }}/projects/samples/howto/four_wheels/worlds/four_wheels.wbt)
 
 **Keywords**: four-wheeled frame
 
@@ -91,14 +91,14 @@ In the second layout, the four motorized wheels are oriented in the same directi
 In the third layout, a simple [Ackermann steering geometry](https://en.wikipedia.org/wiki/Ackermann_steering_geometry) is shown.
 Note that more completed Ackermann steering geometry can be achieved using the [`AckermannVehicle` PROTO](../automobile/ackermannvehicle.md), and the [`car` library](../automobile/car-library.md).
 
-### [inverted\_pendulum.wbt]({{ url.github_tree  }}/projects/samples/howto/inverted_pendulum/worlds/inverted_pendulum.wbt)
+### [inverted\_pendulum.wbt]({{ url.github_tree }}/projects/samples/howto/inverted_pendulum/worlds/inverted_pendulum.wbt)
 
 **Keywords**: Inverted pendulum, PID, [LinearMotor](../reference/linearmotor.md)
 
 ![inverted_pendulum.png](images/samples/inverted_pendulum.thumbnail.jpg) In this example, a robot moves from left to right in order to keep an inverted pendulum upright.
 This is known as the "Inverted Pendulum Problem", and it is solved in our example by using a PID (Proportional Integral Differential) controller.
 
-### [mouse\_events.wbt]({{ url.github_tree  }}/projects/samples/howto/mouse_events/worlds/mouse_events.wbt)
+### [mouse\_events.wbt]({{ url.github_tree }}/projects/samples/howto/mouse_events/worlds/mouse_events.wbt)
 
 **Keywords**: Mouse events, user input
 
@@ -107,7 +107,7 @@ When the simulation is running, the [Supervisor](../reference/supervisor.md) con
 The controller of this simulation is blocking, which means it will block until a mouse click is detected and it will not advance the simulation time.
 An alternative non blocking controller called `mouse_events_non_blocking.c` is also available for this example.
 
-### [omni\_wheels.wbt]({{ url.github_tree  }}/projects/samples/howto/omni_wheels/worlds/omni_wheels.wbt)
+### [omni\_wheels.wbt]({{ url.github_tree }}/projects/samples/howto/omni_wheels/worlds/omni_wheels.wbt)
 
 **Keywords**: Omnidirectional wheels
 
@@ -115,7 +115,7 @@ An alternative non blocking controller called `mouse_events_non_blocking.c` is a
 In this example, the omnidirectional wheels are modeled with two layers of joints and cylinders solids.
 Faster omnidirectional wheels implementations could be achieved using asymmetric friction (cf. `Youbot` model).
 
-### [passive\_dynamic\_walker.wbt]({{ url.github_tree  }}/projects/samples/howto/passive_dynamic_walker/worlds/passive_dynamic_walker.wbt)
+### [passive\_dynamic\_walker.wbt]({{ url.github_tree }}/projects/samples/howto/passive_dynamic_walker/worlds/passive_dynamic_walker.wbt)
 
 **Keywords**: Passive dynamic walker
 
@@ -123,14 +123,14 @@ Faster omnidirectional wheels implementations could be achieved using asymmetric
 This biped robot is not motorized.
 It goes down the slope with a smooth motion simply because of its shape and its potential energy.
 
-### [pedal\_racer.wbt]({{ url.github_tree  }}/projects/samples/howto/pedal_racer/worlds/pedal_racer.wbt)
+### [pedal\_racer.wbt]({{ url.github_tree }}/projects/samples/howto/pedal_racer/worlds/pedal_racer.wbt)
 
 **Keywords**: Pedal racer, apply a force, mechanical loop, [SolidReference](../reference/solidreference.md)
 
 ![pedal_racer.png](images/samples/pedal_racer.thumbnail.jpg) This example shows the mouse interaction with a complex model.
 You can apply a force to the pedals using <kbd>alt</kbd> + mouse left click.
 
-### [physics.wbt]({{ url.github_tree  }}/projects/samples/howto/physics/worlds/physics.wbt)
+### [physics.wbt]({{ url.github_tree }}/projects/samples/howto/physics/worlds/physics.wbt)
 
 **Keywords**: [Physics plugin](../reference/physics-plugin.md), OpenGL drawing, flying robot, [Emitter](../reference/emitter.md), [Receiver](../reference/receiver.md)
 
@@ -143,14 +143,14 @@ This plugins is an example of:
 - How to move objects.
 - How to handle collisions.
 
-### [rope.wbt]({{ url.github_tree  }}/projects/samples/howto/rope/worlds/rope.wbt)
+### [rope.wbt]({{ url.github_tree }}/projects/samples/howto/rope/worlds/rope.wbt)
 
 **Keywords**: [BallJoint](../reference/balljoint.md), rope
 
 ![rope.png](images/samples/rope.thumbnail.jpg) In this example, a rope is simulated.
 The rope is composed of several discrete rigid cylinders attached using ball joints.
 
-### [sick\_terrain\_scanning.wbt]({{ url.github_tree  }}/projects/samples/howto/sick_terrain_scanning/worlds/sick_terrain_scanning.wbt)
+### [sick\_terrain\_scanning.wbt]({{ url.github_tree }}/projects/samples/howto/sick_terrain_scanning/worlds/sick_terrain_scanning.wbt)
 
 **Keywords**: [Lidar](../reference/lidar.md), Sick, scanning
 
@@ -158,14 +158,14 @@ The rope is composed of several discrete rigid cylinders attached using ball joi
 Each lidar scan is displayed in a [Display](../reference/display.md) device.
 A [Supervisor](../reference/supervisor.md) controller applies the scan depth output by removing pixels on a black texture which is applied on the ground.
 
-### [spinning\_top.wbt]({{ url.github_tree  }}/projects/samples/howto/spinning_top/worlds/spinning_top.wbt)
+### [spinning\_top.wbt]({{ url.github_tree }}/projects/samples/howto/spinning_top/worlds/spinning_top.wbt)
 
 **Keywords**: Spinner, chessboard, chess pieces, apply a torque
 
 ![spinning_top.png](images/samples/spinning_top.thumbnail.jpg) This example shows rotating objects, in order to play with the torque application feature.
 To apply a torque on the spinner, use the <kbd>alt</kbd> + mouse right click sequence.
 
-### [supervisor\_draw\_trail.wbt]({{ url.github_tree  }}/projects/samples/howto/supervisor_draw_trail/worlds/supervisor_draw_trail.wbt)
+### [supervisor\_draw\_trail.wbt]({{ url.github_tree }}/projects/samples/howto/supervisor_draw_trail/worlds/supervisor_draw_trail.wbt)
 
 **Keywords**: [Supervisor](../reference/supervisor.md), [IndexedLineSet](../reference/indexedlineset.md), draw trail
 
@@ -174,7 +174,7 @@ The target node is a [Transform](../reference/transform.md) node mounted in the 
 At the beginning of the simulation, the [Supervisor](../reference/supervisor.md) controller creates programmatically an `IndexedLineSet` node.
 Then at each simulation step, it uses the target node position to update the `IndexedLineSet` node fields.
 
-### [texture\_change.wbt]({{ url.github_tree  }}/projects/samples/howto/texture_change/worlds/texture_change.wbt)
+### [texture\_change.wbt]({{ url.github_tree }}/projects/samples/howto/texture_change/worlds/texture_change.wbt)
 
 **Keywords**: [Supervisor](../reference/supervisor.md), texture, `wb_supervisor_field_set_*` functions, [Camera](../reference/camera.md)
 
@@ -182,7 +182,7 @@ Then at each simulation step, it uses the target node position to update the `In
 The robot watches the panel with its [Camera](../reference/camera.md).
 Meanwhile a [Supervisor](../reference/supervisor.md) controller switches the image displayed on the panel.
 
-### [vision.wbt]({{ url.github_tree  }}/projects/samples/howto/vision/worlds/vision.wbt)
+### [vision.wbt]({{ url.github_tree }}/projects/samples/howto/vision/worlds/vision.wbt)
 
 **Keywords**: [OpenCV](https://opencv.org), color filter
 
@@ -191,7 +191,7 @@ The robot acquires images from a colored scene.
 This controller requires [OpenCV](https://opencv.org/) to be installed (not embedded in Webots), it should therefore be compiled with the `OPENCV_DIR` environment variable set.
 The [Camera](../reference/camera.md) image is given to OpenCV, OpenCV filters are applied on the image, and the result is displayed in a [Display](../reference/display.md) overlay.
 
-### [ziegler\_nichols.wbt]({{ url.github_tree  }}/projects/samples/howto/ziegler_nichols/worlds/ziegler_nichols.wbt)
+### [ziegler\_nichols.wbt]({{ url.github_tree }}/projects/samples/howto/ziegler_nichols/worlds/ziegler_nichols.wbt)
 
 **Keywords**: PID control, Ziegler-Nichols method, plot
 

--- a/docs/guide/samples-rendering.md
+++ b/docs/guide/samples-rendering.md
@@ -2,17 +2,17 @@
 
 This section shows the advanced 3D rendering capabilities of Webots.
 The samples provided here can be used as a starting point to create your own simulations using advanced rendering techniques.
-The world files for these examples are located in the "[WEBOTS\_HOME/projects/samples/rendering/worlds]({{ url.github_tree  }}/projects/samples/rendering/worlds/)" directory.
+The world files for these examples are located in the "[WEBOTS\_HOME/projects/samples/rendering/worlds]({{ url.github_tree }}/projects/samples/rendering/worlds/)" directory.
 
 In this directory, you will find the following world files:
 
-### [animated\_skin.wbt]({{ url.github_tree  }}/projects/samples/rendering/worlds/animated_skin.wbt)
+### [animated\_skin.wbt]({{ url.github_tree }}/projects/samples/rendering/worlds/animated_skin.wbt)
 
 **Keywords**: [PBRAppearance](../reference/pbrappearance.md), skin, animation, salamander, normal map, bump map, metalness, roughness.
 
 ![animated_skin.png](images/samples/animated_skin.thumbnail.jpg) This example shows the use of an animated Skin node on a salamander robot. This Skin node supports the use of the [PBRAppearance](../reference/pbrappearance.md) node to generate very realistic images.
 
-### [physically\_based\_rendering.wbt]({{ url.github_tree  }}/projects/samples/rendering/worlds/physically_based_rendering.wbt)
+### [physically\_based\_rendering.wbt]({{ url.github_tree }}/projects/samples/rendering/worlds/physically_based_rendering.wbt)
 
 **Keywords**: [PBRAppearance](../reference/pbrappearance.md), physically based rendering, shadows, ambient occlusion, normal map, bump map, metalness, roughness.
 
@@ -26,7 +26,7 @@ In this directory, you will find the following world files:
 
 This example illustrates the capabilities of the [PBRAppearance](../reference/pbrappearance.md) node that allows to produce [Physically Based Rendering](https://en.wikipedia.org/wiki/Physically_based_rendering) (PBR) in Webots simulations for both the main 3D view and simulated robot cameras.
 
-### [sponza.wbt]({{ url.github_tree  }}/projects/samples/rendering/worlds/sponza.wbt)
+### [sponza.wbt]({{ url.github_tree }}/projects/samples/rendering/worlds/sponza.wbt)
 
 **Keywords**: [PBRAppearance](../reference/pbrappearance.md), sponza, ambient occlusion, rendering, post-processing.
 

--- a/docs/guide/spot.md
+++ b/docs/guide/spot.md
@@ -35,7 +35,7 @@ Spot {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/boston\_dynamics/spot/protos/Spot.proto]({{ url.github_tree  }}/projects/robots/boston_dynamics/spot/protos/Spot.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/boston\_dynamics/spot/protos/Spot.proto]({{ url.github_tree }}/projects/robots/boston_dynamics/spot/protos/Spot.proto)"
 
 #### Spot Field Summary
 
@@ -43,9 +43,9 @@ Spot {
 
 ### Samples
 
-You will find the following sample in the folder: "[$WEBOTS\_HOME/projects/robots/boston\_dynamics/spot/worlds]({{ url.github_tree  }}/projects/robots/boston_dynamics/spot/worlds)"
+You will find the following sample in the folder: "[$WEBOTS\_HOME/projects/robots/boston\_dynamics/spot/worlds]({{ url.github_tree }}/projects/robots/boston_dynamics/spot/worlds)"
 
-### [spot.wbt]({{ url.github_tree  }}/projects/robots/boston_dynamics/spot/worlds/spot.wbt)
+### [spot.wbt]({{ url.github_tree }}/projects/robots/boston_dynamics/spot/worlds/spot.wbt)
 
 ![spot.wbt.png](images/robots/spot/spot.wbt.thumbnail.jpg) This simulation shows a Spot robot in a simple environment.
 The robot is saying hello with its right leg.

--- a/docs/guide/the-user-interface.md
+++ b/docs/guide/the-user-interface.md
@@ -236,7 +236,7 @@ If the light sensor device is disabled or the first measurement is not available
   - The **Show Pen Painting Rays** allows you to display, or to hide, the rays in which the pen devices paint.
 These rays are drawn as violet lines if painting is enabled, otherwise as gray lines.
 
-- The **Show Normals** allows you to display, or to hide, the normals of the [IndexedFaceSet](../reference/indexedfaceset.md) and [Mesh](../reference/mesh.md) nodes.
+  - The **Show Normals** allows you to display, or to hide, the normals of the [IndexedFaceSet](../reference/indexedfaceset.md) and [Mesh](../reference/mesh.md) nodes. The color of a normal is magenta if it was not creased using the [IndexedFaceSet](../reference/indexedfaceset.md) `creaseAngle`, otherwise, it is yellow. The length of the normal representation is proportional to the [WorldInfo](../reference/worldinfo.md) `lineScale` parameter.  
 
   - The **Show Radar Frustums** allows you to display, or to hide, the radar frustum.
 If the radar device is enabled the frustum is drawn in blue, otherwise if the radar is disabled or the first measurement is not available yet, the frustum is drawn in gray.

--- a/docs/guide/tiago-base.md
+++ b/docs/guide/tiago-base.md
@@ -29,7 +29,7 @@ TiagoBase {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_base/protos/TiagoBase.proto]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_base/protos/TiagoBase.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_base/protos/TiagoBase.proto]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_base/protos/TiagoBase.proto)"
 
 #### TiagoBase Field Summary
 
@@ -38,7 +38,7 @@ TiagoBase {
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_base/worlds]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_base/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_base/worlds]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_base/worlds)".
 
 #### tiago\_base.wbt
 

--- a/docs/guide/tiago-iron.md
+++ b/docs/guide/tiago-iron.md
@@ -26,11 +26,11 @@ TiagoIron {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_iron/protos/TiagoIron.proto]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_iron/protos/TiagoIron.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_iron/protos/TiagoIron.proto]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_iron/protos/TiagoIron.proto)"
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_iron/worlds]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_iron/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_iron/worlds]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_iron/worlds)".
 
 #### tiago\_iron.wbt
 

--- a/docs/guide/tiago-steel.md
+++ b/docs/guide/tiago-steel.md
@@ -26,11 +26,11 @@ TiagoSteel {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_steel/protos/TiagoSteel.proto]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_steel/protos/TiagoSteel.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_steel/protos/TiagoSteel.proto]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_steel/protos/TiagoSteel.proto)"
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_steel/worlds]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_steel/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_steel/worlds]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_steel/worlds)".
 
 #### tiago\_steel.wbt
 

--- a/docs/guide/tiago-titanium.md
+++ b/docs/guide/tiago-titanium.md
@@ -26,11 +26,11 @@ TiagoTitanium {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_titanium/protos/TiagoTitanium.proto]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_titanium/protos/TiagoTitanium.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_titanium/protos/TiagoTitanium.proto]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_titanium/protos/TiagoTitanium.proto)"
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_titanium/worlds]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago_titanium/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago\_titanium/worlds]({{ url.github_tree }}/projects/robots/pal_robotics/tiago_titanium/worlds)".
 
 #### tiago\_titanium.wbt
 

--- a/docs/guide/tiagopp.md
+++ b/docs/guide/tiagopp.md
@@ -31,7 +31,7 @@ Tiago++ {
   MFNode      endEffectorLeftSlot   TiagoGripper { name "left" }
 }
 ```
-> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago++/protos/Tiago++.proto]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago++/protos/Tiago++.proto]({{ url.github_tree }}/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto)"
 
 #### Tiago++ Field Summary
 
@@ -40,7 +40,7 @@ Tiago++ {
 
 ### Sample
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago++/worlds]({{ url.github_tree  }}/projects/robots/pal_robotics/tiago++/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/pal\_robotics/tiago++/worlds]({{ url.github_tree }}/projects/robots/pal_robotics/tiago++/worlds)".
 
 #### tiago++.wbt
 

--- a/docs/guide/transfer-to-your-own-robot.md
+++ b/docs/guide/transfer-to-your-own-robot.md
@@ -53,7 +53,7 @@ Hence, the source code you wrote for the Webots simulation will be executed on t
 This is only possible if the processor on your robot can be programmed respectively in C, C++, Java or Python.
 It is not possible for a processor that can be programmed only in assembler or another specific language.
 Webots includes the source code of such a cross-compilation system for the e-puck and the Hemisson robot.
-Samples are located in the "[WEBOTS\_HOME/projects/robots]({{ url.github_tree  }}/projects/robots)" directory.
+Samples are located in the "[WEBOTS\_HOME/projects/robots]({{ url.github_tree }}/projects/robots)" directory.
 
 #### Developing a Custom Library
 

--- a/docs/guide/translating-webots-to-your-own-language.md
+++ b/docs/guide/translating-webots-to-your-own-language.md
@@ -5,4 +5,4 @@ However, since Webots is always evolving, including new text or changing existin
 As a user of Webots, you are very welcome to help us fix these incomplete or inaccurate translations.
 You can also provide translation files for a new language.
 Your contribution is likely to be integrated into the upcoming releases of Webots, and your name acknowledged in this user guide.
-To proceed with fixing a translation or adding a new one, please follow the instructions [here]({{ url.github_tree  }}/resources/translations).
+To proceed with fixing a translation or adding a new one, please follow the instructions [here]({{ url.github_tree }}/resources/translations).

--- a/docs/guide/turtlebot3-burger.md
+++ b/docs/guide/turtlebot3-burger.md
@@ -27,7 +27,7 @@ TurtleBot3Burger {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto]({{ url.github_tree  }}/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto]({{ url.github_tree }}/projects/robots/robotis/turtlebot/protos/TurtleBot3Burger.proto)"
 
 #### TurtleBot3Burger Field Summary
 
@@ -35,7 +35,7 @@ TurtleBot3Burger {
 
 ### Samples
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robotis/turtlebot/worlds]({{ url.github_tree  }}/projects/robots/robotis/turtlebot/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robotis/turtlebot/worlds]({{ url.github_tree }}/projects/robots/robotis/turtlebot/worlds)".
 
 #### turtlebot3\_burger.wbt
 

--- a/docs/guide/tutorial-2-modification-of-the-environment.md
+++ b/docs/guide/tutorial-2-modification-of-the-environment.md
@@ -181,7 +181,7 @@ The expected result is shown in [this figure](#the-simulation-state-at-the-end-o
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/obstacles.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree }}/projects/samples/tutorials/worlds/obstacles.wbt) as the others is located in the [solution directory]({{ url.github_tree }}/projects/samples/tutorials/worlds/).
 
 %figure "The simulation state at the end of this second tutorial."
 

--- a/docs/guide/tutorial-2-modification-of-the-environment.md
+++ b/docs/guide/tutorial-2-modification-of-the-environment.md
@@ -181,7 +181,7 @@ The expected result is shown in [this figure](#the-simulation-state-at-the-end-o
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/obstacles.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/obstacles.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
 
 %figure "The simulation state at the end of this second tutorial."
 

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -87,13 +87,13 @@ Webots offers several rendering modes available in the `View` menu.
 Then restore the plain rendering mode: `View / Plain Rendering`.
 
 Others rendering features can be helpful:
-- View Coordinates systems: `View / Optional Rendering / Show Coordinates System` <kbd>ctrl</kbd>-<kbd>F1</kbd>
-- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays` <kbd>ctrl</kbd>-<kbd>F10</kbd>
+- View Coordinates systems: `View / Optional Rendering / Show Coordinates System (Ctrl + F1)`.
+- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays (Ctrl + F10)`.
 
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/).
+[This solution](https://github.com/cyberbotics/webots/blob/master/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/master/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -63,9 +63,9 @@ A texture on a rolling object can help to appreciate its movement.
 1. Add an [ImageTexture](../reference/imagetexture.md) node to the `baseColorMap` field of the [PBRAppearance](../reference/pbrappearance.md) node.
 2. Add an item to the [ImageTexture](../reference/imagetexture.md)'s `url` field using the `Add` button.
 3. Then set the value of the newly added `url` item using the "Select" button.
-4. Follow the path "[WEBOTS\_HOME/projects/default/worlds/textures/red\_brick\_wall.jpg]({{ url.github_tree  }}/projects/default/worlds/textures/red_brick_wall.jpg)". Normally it should be "usr/local/webots/projects/default/worlds/textures/red\_brick\_wall.jpg".
+4. Follow the path "[WEBOTS\_HOME/projects/default/worlds/textures/red\_brick\_wall.jpg]({{ url.github_tree }}/projects/default/worlds/textures/red_brick_wall.jpg)". Normally it should be "usr/local/webots/projects/default/worlds/textures/red\_brick\_wall.jpg".
 
-The texture URLs must be defined either relative to the `worlds` directory of your project directory or relative to the default project directory [`WEBOTS_HOME/projects/default/worlds`]({{ url.github_tree  }}/projects/default/worlds).
+The texture URLs must be defined either relative to the `worlds` directory of your project directory or relative to the default project directory [`WEBOTS_HOME/projects/default/worlds`]({{ url.github_tree }}/projects/default/worlds).
 In the default project directory you will find textures that are available for every world.
 
 Open the `red_brick_wall.jpg` texture in an image viewer while you observe how it is mapped onto the [Sphere](../reference/sphere.md) node in Webots.
@@ -93,7 +93,7 @@ Others rendering features can be helpful:
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree }}/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory]({{ url.github_tree }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-3-appearance.md
+++ b/docs/guide/tutorial-3-appearance.md
@@ -87,13 +87,13 @@ Webots offers several rendering modes available in the `View` menu.
 Then restore the plain rendering mode: `View / Plain Rendering`.
 
 Others rendering features can be helpful:
-- View Coordinates systems: `View / Optional Rendering / Show Coordinates System (Ctrl + F1)`.
-- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays (Ctrl + F10)`.
+- View Coordinates systems: `View / Optional Rendering / Show Coordinates System` <kbd>ctrl</kbd>-<kbd>F1</kbd>
+- View distance sensor rays: `View / Optional Rendering / Show DistanceSensor Rays` <kbd>ctrl</kbd>-<kbd>F10</kbd>
 
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/master/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/master/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/appearance.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-4-more-about-controllers.md
+++ b/docs/guide/tutorial-4-more-about-controllers.md
@@ -956,7 +956,7 @@ end
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/collision_avoidance.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree }}/projects/samples/tutorials/worlds/collision_avoidance.wbt) as the others is located in the [solution directory]({{ url.github_tree }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-4-more-about-controllers.md
+++ b/docs/guide/tutorial-4-more-about-controllers.md
@@ -956,7 +956,7 @@ end
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/collision_avoidance.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/collision_avoidance.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-5-compound-solid-and-physics-attributes.md
+++ b/docs/guide/tutorial-5-compound-solid-and-physics-attributes.md
@@ -139,7 +139,7 @@ There are also other physics parameters which are less useful in a regular use o
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/compound_solid.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree }}/projects/samples/tutorials/worlds/compound_solid.wbt) as the others is located in the [solution directory]({{ url.github_tree }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-5-compound-solid-and-physics-attributes.md
+++ b/docs/guide/tutorial-5-compound-solid-and-physics-attributes.md
@@ -139,7 +139,7 @@ There are also other physics parameters which are less useful in a regular use o
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/compound_solid.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/compound_solid.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -558,7 +558,7 @@ end
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/4_wheels_robot.wbt) as the others is located in the [solution directory](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/4_wheels_robot.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -558,7 +558,7 @@ end
 ### Solution: World File
 
 To compare your world with the solution, go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "worlds" folder and open with a text editor the right world.
-[This solution]({{ url.github_tree  }}/projects/samples/tutorials/worlds/4_wheels_robot.wbt) as the others is located in the [solution directory]({{ url.github_tree  }}/projects/samples/tutorials/worlds/).
+[This solution]({{ url.github_tree }}/projects/samples/tutorials/worlds/4_wheels_robot.wbt) as the others is located in the [solution directory]({{ url.github_tree }}/projects/samples/tutorials/worlds/).
 
 ### Conclusion
 

--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -108,7 +108,7 @@ The same mechanism could also be used to expose the `controller` field of the [R
 
 ### Solution: PROTO File
 
-To compare your PROTO file with [the solution](https://github.com/cyberbotics/webots/blob/released/projects/samples/tutorials/protos/FourWheelsRobot.proto), go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "protos" folder and open with a text editor the right PROTO.
+To compare your PROTO file with [the solution]({{ url.github_tree  }}/projects/samples/tutorials/protos/FourWheelsRobot.proto), go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "protos" folder and open with a text editor the right PROTO.
 
 ### Conclusion
 

--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -108,7 +108,7 @@ The same mechanism could also be used to expose the `controller` field of the [R
 
 ### Solution: PROTO File
 
-To compare your PROTO file with [the solution]({{ url.github_tree  }}/projects/samples/tutorials/protos/FourWheelsRobot.proto), go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "protos" folder and open with a text editor the right PROTO.
+To compare your PROTO file with [the solution]({{ url.github_tree }}/projects/samples/tutorials/protos/FourWheelsRobot.proto), go to your files and find the folder named "my\_first\_simulation" created in [Tutorial 1](tutorial-1-your-first-simulation-in-webots.md), then go to the "protos" folder and open with a text editor the right PROTO.
 
 ### Conclusion
 

--- a/docs/guide/tutorials.md
+++ b/docs/guide/tutorials.md
@@ -23,7 +23,7 @@ Moreover we recommend you to ensure you understood all the concepts of a tutoria
 
 The last section will provide you with some hints to address problems that are not covered in this chapter.
 
-The solutions of the tutorials are located into the "[WEBOTS\_HOME/projects/samples/tutorials]({{ url.github_tree  }}/projects/samples/tutorials)" subdirectory of the Webots installation directory.
+The solutions of the tutorials are located into the "[WEBOTS\_HOME/projects/samples/tutorials]({{ url.github_tree }}/projects/samples/tutorials)" subdirectory of the Webots installation directory.
 
 We hope you will enjoy your first steps with Webots.
 Meanwhile, we would really appreciate to receive your feedback regarding this chapter.

--- a/docs/guide/ure.md
+++ b/docs/guide/ure.md
@@ -31,7 +31,7 @@ UR5e/UR5e/UR10e {
 }
 ```
 
-> **File location**: "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR3e.proto]({{ url.github_tree  }}/projects/robots/universal_robots/protos/UR3e.proto)", "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR5e.proto]({{ url.github_tree  }}/projects/robots/universal_robots/protos/UR5e.proto)" and "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR10e.proto]({{ url.github_tree  }}/projects/robots/universal_robots/protos/UR10e.proto)"
+> **File location**: "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR3e.proto]({{ url.github_tree }}/projects/robots/universal_robots/protos/UR3e.proto)", "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR5e.proto]({{ url.github_tree }}/projects/robots/universal_robots/protos/UR5e.proto)" and "[WEBOTS\_HOME/projects/robots/universal\_robots/protos/UR10e.proto]({{ url.github_tree }}/projects/robots/universal_robots/protos/UR10e.proto)"
 
 #### Field Summary
 
@@ -41,16 +41,16 @@ UR5e/UR5e/UR10e {
 
 ### Samples
 
-You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/universal\_robots/worlds]({{ url.github_tree  }}/projects/robots/universal_robots/worlds)".
+You will find the following sample in this folder: "[WEBOTS\_HOME/projects/robots/universal\_robots/worlds]({{ url.github_tree }}/projects/robots/universal_robots/worlds)".
 
-#### [ure.wbt]({{ url.github_tree  }}/projects/robots/universal_robots/worlds/ure.wbt)
+#### [ure.wbt]({{ url.github_tree }}/projects/robots/universal_robots/worlds/ure.wbt)
 
 ![ure.wbt.png](images/robots/ure/ure.wbt.thumbnail.jpg) This simulation shows an UR3e, an UR5e and an UR10e robot, equipped with a [ROBOTIQ 3F Gripper](gripper-actuators.md#robotiq-3f-gripper), grabbing cans on conveyor belts and putting them in crates.
 
 ### ROS
 
 To use ROS with the simulated UR3e/UR5e/UR10e robot in Webots, the `<extern>` controller should be assigned to the robot.
-Then the `ur_e_webots` ROS package located in "[WEBOTS\_HOME/projects/robots/universal\_robots/resources/ros\_package/ur\_e\_webots]({{ url.github_tree  }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots)" should be copied into your catkin workspace.
+Then the `ur_e_webots` ROS package located in "[WEBOTS\_HOME/projects/robots/universal\_robots/resources/ros\_package/ur\_e\_webots]({{ url.github_tree }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots)" should be copied into your catkin workspace.
 
 Once `roscore` is started the `ur5e` (replace `5` by `3` or `10` for the UR3e or UR10e) node of the `ur_e_webots` package can be launched:
 ```

--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -42,7 +42,7 @@ $ sudo ln -s /Applications/MATLAB_R2020b.app/bin/matlab /usr/local/bin/matlab
 
 ### How to Run the Examples?
 
-To test MATLAB in Webots, start Webots and open the "WEBOTS\_HOME/projects/languages/matlab/worlds/e-puck\_matlab.wbt" or "[WEBOTS\_HOME/projects/robots/softbank/nao/worlds/nao\_matlab.wbt]({{ url.github_tree  }}/projects/robots/softbank/nao/worlds/nao_matlab.wbt)" world file.
+To test MATLAB in Webots, start Webots and open the "WEBOTS\_HOME/projects/languages/matlab/worlds/e-puck\_matlab.wbt" or "[WEBOTS\_HOME/projects/robots/softbank/nao/worlds/nao\_matlab.wbt]({{ url.github_tree }}/projects/robots/softbank/nao/worlds/nao_matlab.wbt)" world file.
 Webots automatically starts MATLAB when it detects an m-file in a controller directory.
 Note that the m-file must be named after its directory in order to be identified as a controller file by Webots.
 So, for example, if the directory is named "my\_controller", then the controller m-file must be named "my\_controller/my\_controller.m".

--- a/docs/guide/using-numerical-optimization-methods.md
+++ b/docs/guide/using-numerical-optimization-methods.md
@@ -218,5 +218,5 @@ int main() {
 }
 ```
 
-You will find complete examples of simulations using optimization techniques in Webots distribution: look for the worlds called "advanced\_particle\_swarm\_optimization.wbt" and "advanced\_genetic\_algorithm.wbt" located in the "[WEBOTS\_HOME/projects/samples/curriculum/worlds]({{ url.github_tree  }}/projects/samples/curriculum/worlds)" directory.
+You will find complete examples of simulations using optimization techniques in Webots distribution: look for the worlds called "advanced\_particle\_swarm\_optimization.wbt" and "advanced\_genetic\_algorithm.wbt" located in the "[WEBOTS\_HOME/projects/samples/curriculum/worlds]({{ url.github_tree }}/projects/samples/curriculum/worlds)" directory.
 These examples are described in the *Advanced Programming Exercises* of [Cyberbotics' Robot Curriculum](http://en.wikibooks.org/wiki/Cyberbotics'_Robot_Curriculum).

--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -88,13 +88,13 @@ In this case, you can build your own custom ROS controller.
 
 It is possible to implement such a ROS node in C++ using the "roscpp" library on Linux and macOS.
 However, in this case, you need to setup a build configuration to handle both the "catkin\_make" from ROS and the "Makefile" from Webots to have the resulting binary linked both against the Webots "libController" and the "roscpp" library.
-An example is provided [here]({{ url.github_tree  }}/projects/vehicles/controllers/ros_automobile) to create a specific controller for controlling a vehicle.
+An example is provided [here]({{ url.github_tree }}/projects/vehicles/controllers/ros_automobile) to create a specific controller for controlling a vehicle.
 
 An even more generic solution, is to use an [extern controller](running-extern-robot-controllers.md) and run the controller as a regular ROS node on the ROS side.
-A very simple example is provided [here]({{ url.github_tree  }}/projects/languages/ros/webots_ros/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
+A very simple example is provided [here]({{ url.github_tree }}/projects/languages/ros/webots_ros/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
 A launch file is available to launch Webots with the correct world file, the extern controller and a simple ROS node moving the robot straight as long as there is no obstacle (detected using the front [DistanceSensor](../reference/distancesensor.md)), it can be launched with:
 ```
 roslaunch webots_ros webots_ros_python.launch
 ```
 
-A [second more complicated example]({{ url.github_tree  }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots) shows how to interface a model of a Universal Robots arm in Webots with ROS using [rospy](http://wiki.ros.org/rospy).
+A [second more complicated example]({{ url.github_tree }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots) shows how to interface a model of a Universal Robots arm in Webots with ROS using [rospy](http://wiki.ros.org/rospy).

--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -91,7 +91,7 @@ However, in this case, you need to setup a build configuration to handle both th
 An example is provided [here]({{ url.github_tree  }}/projects/vehicles/controllers/ros_automobile) to create a specific controller for controlling a vehicle.
 
 An even more generic solution, is to use an [extern controller](running-extern-robot-controllers.md) and run the controller as a regular ROS node on the ROS side.
-A very simple example is provided [here](https://github.com/cyberbotics/webots/blob/released/projects/languages/ros/webots_ros/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
+A very simple example is provided [here]({{ url.github_tree  }}/projects/languages/ros/webots_ros/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
 A launch file is available to launch Webots with the correct world file, the extern controller and a simple ROS node moving the robot straight as long as there is no obstacle (detected using the front [DistanceSensor](../reference/distancesensor.md)), it can be launched with:
 ```
 roslaunch webots_ros webots_ros_python.launch

--- a/docs/reference/background.md
+++ b/docs/reference/background.md
@@ -43,7 +43,7 @@ This format allows to have light intensities bigger than 1.0.
 
 HDR backgrounds can be found easily on the internet.
 They often come as single files using an equirectangular projection.
-This [set of image tools](https://github.com/cyberbotics/webots/blob/released/scripts/image_tools) provides basic conversion tools to transform your background resources to Webots ones.
+This [set of image tools]({{ url.github_tree  }}/scripts/image_tools) provides basic conversion tools to transform your background resources to Webots ones.
 Several image editors such as [Gimp](https://www.gimp.org) support this format.
 
 The `luminosity` specifies a scale factor to be applied to the light contribution of the [Background](background.md) node on [Shape](shape.md) nodes using the [PBRAppearance](pbrappearance.md).

--- a/docs/reference/background.md
+++ b/docs/reference/background.md
@@ -43,7 +43,7 @@ This format allows to have light intensities bigger than 1.0.
 
 HDR backgrounds can be found easily on the internet.
 They often come as single files using an equirectangular projection.
-This [set of image tools]({{ url.github_tree  }}/scripts/image_tools) provides basic conversion tools to transform your background resources to Webots ones.
+This [set of image tools]({{ url.github_tree }}/scripts/image_tools) provides basic conversion tools to transform your background resources to Webots ones.
 Several image editors such as [Gimp](https://www.gimp.org) support this format.
 
 The `luminosity` specifies a scale factor to be applied to the light contribution of the [Background](background.md) node on [Shape](shape.md) nodes using the [PBRAppearance](pbrappearance.md).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -18,7 +18,7 @@ Released on XX Xth, 2021.
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
     - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
   - Cleanup
-    - Changed structure of the [projects/samples/howto]({{ url.github_tree  }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
+    - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
 
 ## Webots R2021a
 Released on December 15th, 2020.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -4,7 +4,7 @@ Webots comes with several examples of physics plugins.
 When opening an example, the code of the physics plugin should appear in Webots text editor.
 If it does not appear automatically, then you can always use the menu: `Tools / Edit Physics Plugin`.
 
-A simple example is the "[WEBOTS\_HOME/projects/samples/howto/physics/worlds/physics.wbt]({{ url.github_tree  }}/projects/samples/howto/physics/worlds/physics.wbt)" world.
+A simple example is the "[WEBOTS\_HOME/projects/samples/howto/physics/worlds/physics.wbt]({{ url.github_tree }}/projects/samples/howto/physics/worlds/physics.wbt)" world.
 In this example, the plugin is used to add forces to make the robot fly, to communicate with the Webots model, to detect objects using a `Ray` object, to communicate with a `Robot` to visualize the `Ray` and to define a frictionless collision between the robot and the floor.
 
-The "[WEBOTS\_HOME/projects/robots/epfl/lis/worlds/blimp.wbt]({{ url.github_tree  }}/projects/robots/epfl/lis/worlds/blimp.wbt)" shows how to suppress gravity, and apply a thrust force (propeller) for a blimp model.
+The "[WEBOTS\_HOME/projects/robots/epfl/lis/worlds/blimp.wbt]({{ url.github_tree }}/projects/robots/epfl/lis/worlds/blimp.wbt)" shows how to suppress gravity, and apply a thrust force (propeller) for a blimp model.

--- a/docs/reference/plugin-setup.md
+++ b/docs/reference/plugin-setup.md
@@ -20,4 +20,4 @@ WorldInfo {
 ```
 
 This specifies that the plugin binary file is expected to be at the location "my\_project/plugins/physics/my\_physics/my\_physics[.dll|.dylib|.so]" (actual extension depending on the platform) and that the plugin source file should be located in "my\_project/plugins/physics/my\_physics/my\_physics[.c|.cpp]".
-If Webots does not find the file there, it will also look in the "[WEBOTS\_HOME/resources/projects/plugins/physics]({{ url.github_tree  }}/resources/projects/plugins/physics)" directory.
+If Webots does not find the file there, it will also look in the "[WEBOTS\_HOME/resources/projects/plugins/physics]({{ url.github_tree }}/resources/projects/plugins/physics)" directory.

--- a/docs/reference/propeller.md
+++ b/docs/reference/propeller.md
@@ -45,7 +45,7 @@ The meaning of *q1* and *q2* is pretty similar to the one of *t1* and *t2*.
 
 More details about the above formulae can be found in "Guidance and Control of Ocean Vehicles" from Thor I. Fossen ([ISBN: 9780471941132](https://en.wikipedia.org/wiki/Special:BookSources?isbn=9780471941132)) and "Helicopter Performance, Stability, and Control" from Raymond W. Prouty ([ISBN: 9781575242095](https://en.wikipedia.org/wiki/Special:BookSources?isbn=9781575242095)).
 
-The [propeller.wbt](https://github.com/cyberbotics/webots/blob/released/projects/samples/devices/worlds/propeller.wbt) example shows three different helicopters modeled with [Propeller](#propeller) nodes.
+The [propeller.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/propeller.wbt) example shows three different helicopters modeled with [Propeller](#propeller) nodes.
 
 ### Field Summary
 

--- a/docs/reference/propeller.md
+++ b/docs/reference/propeller.md
@@ -45,7 +45,7 @@ The meaning of *q1* and *q2* is pretty similar to the one of *t1* and *t2*.
 
 More details about the above formulae can be found in "Guidance and Control of Ocean Vehicles" from Thor I. Fossen ([ISBN: 9780471941132](https://en.wikipedia.org/wiki/Special:BookSources?isbn=9780471941132)) and "Helicopter Performance, Stability, and Control" from Raymond W. Prouty ([ISBN: 9781575242095](https://en.wikipedia.org/wiki/Special:BookSources?isbn=9781575242095)).
 
-The [propeller.wbt]({{ url.github_tree  }}/projects/samples/devices/worlds/propeller.wbt) example shows three different helicopters modeled with [Propeller](#propeller) nodes.
+The [propeller.wbt]({{ url.github_tree }}/projects/samples/devices/worlds/propeller.wbt) example shows three different helicopters modeled with [Propeller](#propeller) nodes.
 
 ### Field Summary
 

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -111,6 +111,10 @@ Such a computation assumes a uniform mass distribution in the primitives composi
 Note that the center of mass of the [Solid](#solid) does not depend on its `boundingObject`.
 The center of mass is specified by the `centerOfMass` field of the [Physics](physics.md) node (in coordinates relative to the center of the [Solid](#solid)).
 
+The `boundingObject` of the selected object is displayed in the 3D view by depicting the outline of the `boundingObject` shapes.
+Additionally, if the `View|Optional Rendering|Show All Bounding Objects` option is enabled, all the `boundingObjects` in the scene will be visible.
+The color of the `boundingObject` outline indicates the status of the object: usually the outline is represented by white lines, but these lines turn pink if the solid is colliding with another object and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
+
 ### Unique Solid Name
 
 The capability of identifying uniquely each [Solid](#solid) node is a base requirement for other advanced features, for example to let the viewpoint follow a solid object or to store the preferences for the rendering devices overlays.

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1708,7 +1708,7 @@ void wb_supervisor_node_add_torque(node, torque, relative)
 
 *add force or torque to a Solid node.*
 
-The `wb_supervisor_node_add_force` function adds a force to the [Solid](solid.md) node at its center of mass, the `relative` argument defines if the force is expressed in world coordinate system or relatively to the node.
+The `wb_supervisor_node_add_force` function adds a force to the [Solid](solid.md) node at its center of mass, the `relative` argument defines if the force is expressed in world coordinate system (`relative` set to false) or relatively to the node (`relative` set to true).
 The `wb_supervisor_node_add_force_with_offset` function adds a force to the [Solid](solid.md) node at the location (expressed in the node coordinate system) defined by the `offset` argument.
 The `wb_supervisor_node_add_torque` function adds a torque to the [Solid](solid.md) node.
 

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -901,7 +901,7 @@ box_rot_robot = np.dot(rot_ur10e, np.array(box.getOrientation()).reshape(3, 3))
 
 %end
 
-The "[WEBOTS\_HOME/projects/robots/neuronics/ipr/worlds/ipr\_cube.wbt]({{ url.github_tree  }}/projects/robots/neuronics/ipr/worlds/ipr_cube.wbt)" simulation shows how to use these functions to achieve this.
+The "[WEBOTS\_HOME/projects/robots/neuronics/ipr/worlds/ipr\_cube.wbt]({{ url.github_tree }}/projects/robots/neuronics/ipr/worlds/ipr_cube.wbt)" simulation shows how to use these functions to achieve this.
 
 > **Note**: The returned pointers are valid during one time step only as memory will be deallocated at the next time step.
 
@@ -988,7 +988,7 @@ The `node` argument must be a [Solid](solid.md) node (or a derived node), otherw
 This function returns a vector containing exactly 3 values.
 If the `node` argument has a `NULL` `physics` node, the return value is always the zero vector.
 
-The "[WEBOTS\_HOME/projects/samples/howto/center\_of\_mass/worlds/center\_of\_mass.wbt]({{ url.github_tree  }}/projects/samples/howto/center_of_mass/worlds/center_of_mass.wbt)" simulation shows how to use this function.
+The "[WEBOTS\_HOME/projects/samples/howto/center\_of\_mass/worlds/center\_of\_mass.wbt]({{ url.github_tree }}/projects/samples/howto/center_of_mass/worlds/center_of_mass.wbt)" simulation shows how to use this function.
 
 > **Note**: The returned pointer is valid during one time step only as memory will be deallocated at the next time step.
 
@@ -1097,7 +1097,7 @@ The `wb_supervisor_node_get_number_of_contact_points` function returns the numbe
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.
 The `include_descendants` argument defines whether the descendant nodes should also generate contact points or not. The descendant nodes are the nodes included within the node given as an argument.
 
-The "[WEBOTS\_HOME/projects/samples/howto/cylinder_stack/worlds/cylinder\_stack.wbt]({{ url.github_tree  }}/projects/samples/howto/cylinder_stack/worlds/cylinder_stack.wbt)" project shows how to use this function.
+The "[WEBOTS\_HOME/projects/samples/howto/cylinder_stack/worlds/cylinder\_stack.wbt]({{ url.github_tree }}/projects/samples/howto/cylinder_stack/worlds/cylinder_stack.wbt)" project shows how to use this function.
 
 > **Note**: The returned pointer is valid during one time step only as memory will be deallocated at the next time step.
 

--- a/tests/sources/test_license.py
+++ b/tests/sources/test_license.py
@@ -17,11 +17,17 @@
 """Test that checks that all the source files have the Apache 2 license."""
 
 import unittest
-import datetime
 import os
 import fnmatch
 
 from io import open
+
+with open(os.environ['WEBOTS_HOME'] + os.sep + 'resources' + os.sep + 'version.txt', 'r') as file:
+    version = file.readlines()[0].strip()
+
+year = int(version[1:5])
+if version[-1] == 'a':
+    year -= 1
 
 APACHE2_LICENSE_C = """/*
  * Copyright 1996-20XX Cyberbotics Ltd.
@@ -37,7 +43,7 @@ APACHE2_LICENSE_C = """/*
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */""".replace('20XX', str(datetime.datetime.now().year))
+ */""".replace('20XX', str(year))
 
 APACHE2_LICENSE_CPP = """// Copyright 1996-20XX Cyberbotics Ltd.
 //
@@ -51,7 +57,7 @@ APACHE2_LICENSE_CPP = """// Copyright 1996-20XX Cyberbotics Ltd.
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.""".replace('20XX', str(datetime.datetime.now().year))
+// limitations under the License.""".replace('20XX', str(year))
 
 APACHE2_LICENSE_PYTHON = """# Copyright 1996-20XX Cyberbotics Ltd.
 #
@@ -65,7 +71,7 @@ APACHE2_LICENSE_PYTHON = """# Copyright 1996-20XX Cyberbotics Ltd.
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.""".replace('20XX', str(datetime.datetime.now().year))
+# limitations under the License.""".replace('20XX', str(year))
 
 PYTHON_OPTIONAL_HEADERS = [
     '#!/usr/bin/env python2',


### PR DESCRIPTION
I fixed the merge conflicts and updated the remaining URLs linking to the Webots GitHub repo so that they all use the `url..github_tree` variable.
There are still some links in the ChangeLog referring explicitly to the master branch.

Conflicts:
* docs/guide/appearances.md
* docs/guide/controller-programming.md
* docs/guide/interfacing-webots-to-third-party-software-with-tcp-ip.md
* docs/guide/object-advertising-board.md
* docs/guide/object-apartment-structure.md
* docs/guide/object-backgrounds.md
* docs/guide/object-balls.md
* docs/guide/object-bathroom.md
* docs/guide/object-bedroom.md
* docs/guide/object-buildings.md
* docs/guide/object-cabinet.md
* docs/guide/object-chairs.md
* docs/guide/object-computers.md
* docs/guide/object-create-wall.md
* docs/guide/object-drinks.md
* docs/guide/object-factory.md
* docs/guide/object-floors.md
* docs/guide/object-freight.md
* docs/guide/object-fruits.md
* docs/guide/object-garden.md
* docs/guide/object-geometries.md
* docs/guide/object-kitchen.md
* docs/guide/object-lego.md
* docs/guide/object-lights.md
* docs/guide/object-living-room-furniture.md
* docs/guide/object-mirror.md
* docs/guide/object-obstacles.md
* docs/guide/object-paintings.md
* docs/guide/object-panels.md
* docs/guide/object-plants.md
* docs/guide/object-road.md
* docs/guide/object-robotstadium.md
* docs/guide/object-rocks.md
* docs/guide/object-school-furniture.md
* docs/guide/object-shapes.md
* docs/guide/object-solids.md
* docs/guide/object-stairs.md
* docs/guide/object-street-furniture.md
* docs/guide/object-tables.md
* docs/guide/object-telephone.md
* docs/guide/object-television.md
* docs/guide/object-toys.md
* docs/guide/object-traffic.md
* docs/guide/object-trees.md
* docs/guide/p-rob3.md
* docs/guide/programming.md
* docs/guide/robotino3.md