### PR TITLE
fix reproductibility issue when resetting

### DIFF
--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -355,8 +355,10 @@ void WbControlledWorld::step() {
     }
   }
 
-  mIsExecutingStep = true;
-  WbSimulationWorld::step();
+  if (mNewControllers.isEmpty()) {
+    mIsExecutingStep = true;
+    WbSimulationWorld::step();
+  }
 
   waitForRobotWindowIfNeededAndCompleteStep();
 }


### PR DESCRIPTION
This is gonna be a little long winded but it's kinda necessary.

**Related issue**
This fix addresses issue #2658

**Test world**
Same as #2658, just printing to console instead of to file for simplicity. Results are the same in this case.

**Description**
To summarize, the situation is :
- ROBOT_A (is a supervisor)
  - has a controller `position_tracker`
  - this controller spawns ROBOT_B and tracks it
- ROBOT_B (is a supervisor)
  - has a controller  `dummy_controller`
  - this controller applies a force to itself

After looking into it the lack of reproducibility boils down to these 2 situations that should be equal but aren't. 

**Situation (1)**
1. load scenario
2. step, step, step, step (call this output RESULTS_1)
3. reset from GUI
4. step, step, step, step (call this output RESULTS_2)
5. reset from GUI
6. step, step, step, step (call this output RESULTS_3)

**conclusion:** no issues, RESULTS_1 = RESULTS_2 = RESULTS_3

**Situation (2)**

1. load scenario
2. run simulation (call this output RESULTS_1)
3. reset from GUI
4. (simulations runs again by itself) (call this output RESULTS_2)
5. reset from GUI
6. (simulations runs again by itself) (call this output RESULTS_3)

**conclusion:** RESULTS_2 = RESULTS_3 but RESULTS_1 is not equal to either

Looking closer at the differences, it's oddly small and doesn't really diverge
```
RESULT_1
step   : x                  y                   z
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000474074074074 -0.0003072000000000 0.0000000000000000
0.0960 : 0.0001422222222222 -0.0006144000000000 0.0000000000000000
0.1280 : 0.0002844444444444 -0.0010240000000000 0.0000000000000000
RESULT_2
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000000000000000 -0.0003072000000000 0.0000000000000000 <-- shenanigans (spoiler: caused by gravity)
0.0960 : 0.0000474074074074 -0.0006144000000000 0.0000000000000000
0.1280 : 0.0001422222222222 -0.0010240000000000 0.0000000000000000
```
When checking the data, the **x** of RESULT_2 is just like RESULT_1 but shifted by one timestep and the **y** is unchanged.
This remains true for much longer captures, and any consecutive reset will look exactly like RESULT_2 so it is 
reproducible from a physics standpoint but not from a "logic" one, basically the first run and the successive ones don't do the same "thing".

This is situation (1) code-wise, through some console prints inside function `WbControlledWorld::step` :
```
world is loaded
<< USER INPUT: STEP <<<
WbControlledWorld::step (SimulationState [isPaused=0][isStep=1]) <-- sequence of step() calls that don't reach  
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])     the end  of the function, controllers are 
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])     spawned etc
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0]) 
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0]) <-- notice that we're paused, as we're 
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])     doing it step by step
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:                                                  <-- when we finally reach the end of the 
    position_tracker: isRunning? YES                                 function, both controllers are in 
    dummy_controller: isRunning? YES                                 mControllers and both are running
CALLING WbSimulationWorld::step()                                <-- doing the simulation step
done
<< USER INPUT: STEP <<<
WbControlledWorld::step (SimulationState [isPaused=0][isStep=1])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES
    dummy_controller: isRunning? YES
CALLING WbSimulationWorld::step()                                <-- same, all is fine
done
<< USER INPUT: RESET FROM GUI <<<                                <-- manual reset
<< USER INPUT: STEP <<<
WbControlledWorld::step (SimulationState [isPaused=0][isStep=1]) 
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])  
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])  
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=1][isStep=0])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES
    dummy_controller: isRunning? YES
CALLING WbSimulationWorld::step()                                 <-- again by the time we reach the end,  
done                                                                  the controllers are up and running
<< USER INPUT: STEP <<<
WbControlledWorld::step (SimulationState [isPaused=0][isStep=1])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES
    dummy_controller: isRunning? YES
CALLING WbSimulationWorld::step()
done

```

and indeed the console output is
```
INFO: position_tracker: Starting controller: python3 -u position_tracker.py
INFO: dummy_controller: Starting controller: python3 -u dummy_controller.py
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000474074074074 -0.0003072000000000 0.0000000000000000
INFO: position_tracker: Starting controller: python3 -u position_tracker.py
INFO: dummy_controller: Starting controller: python3 -u dummy_controller.py
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000474074074074 -0.0003072000000000 0.0000000000000000
```
showing nothing anomalous.
Doing the same thing for situation (2) yields (the world was reloaded before doing this test):

```
world is loaded
<< USER INPUT: REALTIME <<<
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0]) <-- sequence of step() calls that don't reach 
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])     the end of the function
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0]) <-- notice that now we're not paused anymore
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES                             <-- the world was reloaded, so the starting 
    dummy_controller: isRunning? YES                                 procedure is the same as the previous   
CALLING WbSimulationWorld::step()                                    case, hence, all is good so far 
done

[ ... more steps like this ... ]                                 <-- everything fine, RESULT_1 won't change

<< USER INPUT: RESET FROM GUI <<<                                <-- manual reset
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0]) 
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
    dummy_controller: isRunning? NO                              <-- effect of the reset
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES
CALLING WbSimulationWorld::step()                                <-- here's the culprit, a simulation step is
done                                                                 taken despite one of the controllers not
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])     yet active
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
WbControlledWorld::step (SimulationState [isPaused=0][isStep=0])
-- controllers at the END of the function WbControlledWorld::step
- mNewControllers:
- mWaitingControllers:
- mControllers:
    position_tracker: isRunning? YES                             <-- the other timesteps are fine, but since 
    dummy_controller: isRunning? YES                                 we've made a simulation step we shouldn't, 
CALLING WbSimulationWorld::step()                                    it won't produce the same result
done

[ ... more steps like this ... ]                                 <-- running
```

and the console output is
```
INFO: position_tracker: Starting controller: python3 -u position_tracker.py
INFO: dummy_controller: Starting controller: python3 -u dummy_controller.py
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000474074074074 -0.0003072000000000 0.0000000000000000
0.0960 : 0.0001422222222222 -0.0006144000000000 0.0000000000000000
0.1280 : 0.0002844444444444 -0.0010240000000000 0.0000000000000000
0.1600 : 0.0004740740740741 -0.0015360000000000 0.0000000000000000
INFO: position_tracker: Starting controller: python3 -u position_tracker.py
INFO: dummy_controller: Starting controller: python3 -u dummy_controller.py
0.0320 : 0.0000000000000000 -0.0001024000000000 0.0000000000000000
0.0640 : 0.0000000000000000 -0.0003072000000000 0.0000000000000000 <-- parasitic step, gravity affects box
0.0960 : 0.0000474074074074 -0.0006144000000000 0.0000000000000000 <-- from this point dummy_controller is    
0.1280 : 0.0001422222222222 -0.0010240000000000 0.0000000000000000     up and running and it applies a 
0.1600 : 0.0002844444444444 -0.0015360000000000 0.0000000000000000     force to itself
```

The culprit is therefore a different resetting behavior for the two cases, and the reason is that either [L429-L433](https://github.com/cyberbotics/webots/blob/592090f4e1967575e9f0bd5e984f9c43caa6ec1b/src/webots/control/WbControlledWorld.cpp#L429-L433) or [L445-L450](https://github.com/cyberbotics/webots/blob/592090f4e1967575e9f0bd5e984f9c43caa6ec1b/src/webots/control/WbControlledWorld.cpp#L445-L450) (in this specific case it's this latter that triggers) the `dummy_controller` is added in one case to the mNewControllers list and in the other to the mWaitingControllers. According to the headers:
```
QList<WbController *> mWaitingControllers;  // controllers inserted in previous step and waiting to be started in current step
QList<WbController *> mNewControllers;      // controllers inserted in current step mode and waiting next step to start
```
So what happens is that in situation (1), after the reset the `dummy_controller` is added and activated in the same step call hence by the time we reach the end of the function it's ready to go. In situation (2),  `dummy_controller`  is moved from mNewControllers to mWaitingController only AFTER a `WbSimulationWorld::step()` is executed ([change occurs here](https://github.com/cyberbotics/webots/blob/592090f4e1967575e9f0bd5e984f9c43caa6ec1b/src/webots/control/WbControlledWorld.cpp#L361)).
Which explains the results obtained, as in this additional simulation step, nothing but gravity is affecting the box which results in the **y** dip and only in the successive step the controller kicks in, but that's enough for the data to mismatch.

**Proposed fix:**
execute the line `WbSimulationWorld::step()` only if `mNewControllers` is empty.

It gets the job done in this specific case and test_suite is all green, but I don't know if it messes up with the controller logic more in general. The starting procedure it's quite convoluted (between waiting for external controllers, and some being spawned by startControllers and others by other means) so although this seems like an appropriate fix I don't know if it might be overkill to prevent it every time since the problem so far appears only to arise in the specific situation of a reset. Whatever the case, at least it should clarify the origin of the problem.
