### PR TITLE
Update the list of exported images when streaming to x3d

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Don't display warnings for recent Intel and AMD graphics cards ([#2623](https://github.com/cyberbotics/webots/pull/2623)).
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
   - Bug fixes
+    - Fixed adding textures to a simulation while a streaming-viewer is running ([#2703](https://github.com/cyberbotics/webots/pull/2703)).
     - Fixed [X3D export](https://www.cyberbotics.com/doc/guide/web-interface) of USE nodes linking to DEF nodes declared in PROTO exposed fields ([#2687](https://github.com/cyberbotics/webots/pull/2687)).
     - Fixed memory leak in [Display](display.md) image ([#2663](https://github.com/cyberbotics/webots/issues/2663)).
     - Fixed high DPI support on Windows and Linux ([#2631](https://github.com/cyberbotics/webots/pull/2631)).

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -203,6 +203,9 @@ void WbX3dStreamingServer::propagateNodeAddition(WbNode *node) {
     QString nodeString;
     WbVrmlWriter writer(&nodeString, node->modelName() + ".x3d");
     node->write(writer);
+
+    mX3dWorldTextures.insert(writer.texturesList());
+
     foreach (QWebSocket *client, mWebSocketClients)
       // add root <nodes> element to handle correctly multiple root elements like in case of PBRAppearance node.
       client->sendTextMessage(QString("node:%1:<nodes>%2</nodes>").arg(node->parentNode()->uniqueId()).arg(nodeString));


### PR DESCRIPTION
**Description**
Currently the list of textures that webots can serve to the streaming-viewer is defined only when the world is exported as x3d.

The problem is that if we add appearances with new textures to the simulation while it is streaming, the new textures will not be added to the list and therefore not served to the streaming-viewer.

I solved this issue by adding the new textures to the existing list when the server exports new nodes to the streaming-viewer.
