### PR TITLE
Fixed discord updater

### DIFF
--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        ref: released 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -26,7 +27,6 @@ jobs:
       run: |
         git config --global user.name ${GITHUB_ACTOR}
         git config --global user.email ${GITHUB_ACTOR}@github.com
-        git checkout released
         git checkout -b discord-doc-update
         git add ./docs/discord
         git commit -m "Update discord docs."

--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         git config --global user.name ${GITHUB_ACTOR}
         git config --global user.email ${GITHUB_ACTOR}@github.com
+        git checkout released
         git checkout -b discord-doc-update
         git add ./docs/discord
         git commit -m "Update discord docs."
@@ -35,7 +36,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         source_branch: discord-doc-update
-        destination_branch: master
+        destination_branch: released
         pr_title: Update Discord Docs
         pr_body: Automatic update of the docs from the Discord channels (https://cyberbotics.com/doc/discord/index?version=discord-doc-update).
         pr_reviewer: Maintainers


### PR DESCRIPTION
This PR aims at fixing a problem spotted in #2702: the update of the discord pages should target the released branch in order to be immediately displayed on cyberbotics.com web site.