### PR TITLE
Don't test source code on the released branch

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -3,6 +3,8 @@ name: Test Sources
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    branches-ignore:
+      - 'released'
   schedule:
     - cron:  '0 22 * * *'
 


### PR DESCRIPTION
Any PR targeting the `released` branch should skip the source code tests as they are irrelevant and causing maintenance overhead.
See details here: https://github.community/t/how-to-ignore-branch-names-on-pull-requests/16627/5