### PR TITLE
Postpone sending logs to consoles during the world load

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,7 +10,8 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
   - Bug fixes
-    - Fixed synchronization of [Supervisor](supervisor.md) simulation reset that was applied after the step and now it is applied at the very end of the step ([#2720](https://github.com/cyberbotics/webots/pull/720)).
+    - Fixed invalid world loading errors cleared from the console when reverting to the empty world ([#2737](https://github.com/cyberbotics/webots/pull/2737)).
+    - Fixed synchronization of [Supervisor](supervisor.md) simulation reset that was applied after the step and now it is applied at the very end of the step ([#2720](https://github.com/cyberbotics/webots/pull/2720)).
     - Fixed [Camera](camera.md) image update in controllers after simulation reset ([#2725](https://github.com/cyberbotics/webots/pull/2725)).
     - Fixed adding textures to a simulation while a streaming-viewer is running ([#2704](https://github.com/cyberbotics/webots/pull/2704)).
     - Fixed compilation of default controllers using Qt on Windows ([#2718](https://github.com/cyberbotics/webots/pull/2718)).

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -238,7 +238,7 @@ bool WbApplication::cancelWorldLoading(bool loadEmptyWorld, bool deleteWorld) {
   return false;
 }
 
-bool WbApplication::isValidWorldFile(const QString &worldName) {
+bool WbApplication::isValidWorldFileName(const QString &worldName) {
   QFileInfo worldNameInfo(worldName);
   if (!worldNameInfo.exists() || !worldNameInfo.isFile() || !worldNameInfo.isReadable()) {
     WbLog::error(tr("Could not open file: '%1'.").arg(worldName));

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -238,7 +238,7 @@ bool WbApplication::cancelWorldLoading(bool loadEmptyWorld, bool deleteWorld) {
   return false;
 }
 
-bool WbApplication::checkWorldFile(const QString &worldName) {
+bool WbApplication::isValidWorldFile(const QString &worldName) {
   QFileInfo worldNameInfo(worldName);
   if (!worldNameInfo.exists() || !worldNameInfo.isFile() || !worldNameInfo.isReadable()) {
     WbLog::error(tr("Could not open file: '%1'.").arg(worldName));

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -238,16 +238,7 @@ bool WbApplication::cancelWorldLoading(bool loadEmptyWorld, bool deleteWorld) {
   return false;
 }
 
-bool WbApplication::loadWorld(QString worldName, bool reloading) {
-  delete mWorldLoadTimer;
-  mWorldLoadTimer = NULL;
-  if (qgetenv("WEBOTS_DISABLE_WORLD_LOADING_DIALOG").isEmpty()) {
-    mWorldLoadTimer = new QElapsedTimer();
-    mWorldLoadTimer->start();
-  }
-  mWorldLoadingCanceled = false;
-  mWorldLoadingProgressDialogCreated = false;
-
+bool WbApplication::checkWorldFile(const QString &worldName) {
   QFileInfo worldNameInfo(worldName);
   if (!worldNameInfo.exists() || !worldNameInfo.isFile() || !worldNameInfo.isReadable()) {
     WbLog::error(tr("Could not open file: '%1'.").arg(worldName));
@@ -257,6 +248,18 @@ bool WbApplication::loadWorld(QString worldName, bool reloading) {
     WbLog::error(tr("Could not open file: '%1'. The world file extension must be '.wbt'.").arg(worldName));
     return false;
   }
+  return true;
+}
+
+bool WbApplication::loadWorld(QString worldName, bool reloading) {
+  delete mWorldLoadTimer;
+  mWorldLoadTimer = NULL;
+  if (qgetenv("WEBOTS_DISABLE_WORLD_LOADING_DIALOG").isEmpty()) {
+    mWorldLoadTimer = new QElapsedTimer();
+    mWorldLoadTimer->start();
+  }
+  mWorldLoadingCanceled = false;
+  mWorldLoadingProgressDialogCreated = false;
 
   WbNodeOperations::instance()->enableSolidNameClashCheckOnNodeRegeneration(false);
 

--- a/src/webots/app/WbApplication.hpp
+++ b/src/webots/app/WbApplication.hpp
@@ -47,8 +47,8 @@ public:
   // load a world .wbt file
   // worldName must be absolute or specified with respect to WEBOTS_HOME
   // return true on success, false otherwise
-  bool loadWorld(const QString &worldName, bool reloading);
   bool loadWorld(QString worldName, bool reloading);
+  bool isValidWorldFile(const QString &worldName);
 
   // take a sceenshot of the 3d view
   // quality must be between 0 and 100 included

--- a/src/webots/app/WbApplication.hpp
+++ b/src/webots/app/WbApplication.hpp
@@ -47,6 +47,7 @@ public:
   // load a world .wbt file
   // worldName must be absolute or specified with respect to WEBOTS_HOME
   // return true on success, false otherwise
+  bool loadWorld(const QString &worldName, bool reloading);
   bool loadWorld(QString worldName, bool reloading);
 
   // take a sceenshot of the 3d view

--- a/src/webots/app/WbApplication.hpp
+++ b/src/webots/app/WbApplication.hpp
@@ -48,7 +48,7 @@ public:
   // worldName must be absolute or specified with respect to WEBOTS_HOME
   // return true on success, false otherwise
   bool loadWorld(QString worldName, bool reloading);
-  bool isValidWorldFile(const QString &worldName);
+  bool isValidWorldFileName(const QString &worldName);
 
   // take a sceenshot of the 3d view
   // quality must be between 0 and 100 included

--- a/src/webots/core/WbLog.cpp
+++ b/src/webots/core/WbLog.cpp
@@ -32,8 +32,6 @@ void WbLog::cleanup() {
 WbLog *WbLog::instance() {
   if (!gInstance) {
     gInstance = new WbLog();
-    gInstance->mPopUpMessagesPostponed = false;
-    gInstance->mConsoleLogsPostponed = false;
     qRegisterMetaType<WbLog::Level>("WbLog::Level");
     qAddPostRoutine(WbLog::cleanup);
   }

--- a/src/webots/core/WbLog.cpp
+++ b/src/webots/core/WbLog.cpp
@@ -33,6 +33,7 @@ WbLog *WbLog::instance() {
   if (!gInstance) {
     gInstance = new WbLog();
     gInstance->mPopUpMessagesPostponed = false;
+    gInstance->mConsoleLogsPostponed = false;
     qRegisterMetaType<WbLog::Level>("WbLog::Level");
     qAddPostRoutine(WbLog::cleanup);
   }
@@ -64,7 +65,8 @@ void WbLog::debug(const QString &message, const QString &name, bool popup) {
 
   fprintf(stderr, "DEBUG: %s\n", qPrintable(message));
   fflush(stderr);
-  if (instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool, const QString &))) > 1)
+  if (!instance()->mConsoleLogsPostponed &&
+      instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool, const QString &))) > 1)
     instance()->emitLog(DEBUG, "DEBUG: " + message, popup, name);
   else
     instance()->enqueueMessage(instance()->mPendingConsoleMessages, "DEBUG: " + message, name, DEBUG);
@@ -77,7 +79,7 @@ void WbLog::info(const QString &message, const QString &name, bool popup) {
   }
 
   const int numberOfReceivers = instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool, const QString &)));
-  if (numberOfReceivers > 1)
+  if (!instance()->mConsoleLogsPostponed && numberOfReceivers > 1)
     instance()->emitLog(INFO, "INFO: " + message, popup, name);
   else {
     if (numberOfReceivers == 0)
@@ -93,7 +95,7 @@ void WbLog::warning(const QString &message, const QString &name, bool popup) {
   }
 
   const int numberOfReceivers = instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool, const QString &)));
-  if (numberOfReceivers > 1)
+  if (!instance()->mConsoleLogsPostponed && numberOfReceivers > 1)
     instance()->emitLog(WARNING, "WARNING: " + message, popup, name);
   else {
     if (numberOfReceivers == 0)
@@ -109,7 +111,7 @@ void WbLog::error(const QString &message, const QString &name, bool popup) {
   }
 
   const int numberOfReceivers = instance()->receivers(SIGNAL(logEmitted(WbLog::Level, const QString &, bool, const QString &)));
-  if (numberOfReceivers > 1)
+  if (!instance()->mConsoleLogsPostponed && numberOfReceivers > 1)
     instance()->emitLog(ERROR, "ERROR: " + message, popup, name);
   else {
     if (numberOfReceivers == 0)

--- a/src/webots/core/WbLog.hpp
+++ b/src/webots/core/WbLog.hpp
@@ -97,7 +97,7 @@ signals:
   void popupClosed();
 
 private:
-  WbLog() : mPopUpMessagesPostponed(false) {}
+  WbLog() : mPopUpMessagesPostponed(false), mConsoleLogsPostponed(false) {}
   virtual ~WbLog() {}
   void emitLog(Level level, const QString &message, bool popup, const QString &name);
   static void cleanup();

--- a/src/webots/core/WbLog.hpp
+++ b/src/webots/core/WbLog.hpp
@@ -86,6 +86,7 @@ public:
   // queue pop up messages to be shown later
   static void setPopUpPostponed(bool postponed) { instance()->mPopUpMessagesPostponed = postponed; }
   static void showPostponedPopUpMessages();
+  static void setConsoleLogsPostponed(bool postponed) { instance()->mConsoleLogsPostponed = postponed; }
   // show messages in console emitted before WbConsole was listening
   static void showPendingConsoleMessages();
 
@@ -107,6 +108,7 @@ private:
     Level level;
   };
   bool mPopUpMessagesPostponed;
+  bool mConsoleLogsPostponed;
   QList<PostponedMessage> mPostponedPopUpMessageQueue;
   QList<PostponedMessage> mPendingConsoleMessages;
   void enqueueMessage(QList<PostponedMessage> &list, const QString &message, const QString &name, Level level);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1321,14 +1321,16 @@ bool WbMainWindow::proposeToSaveWorld(bool reloading) {
 bool WbMainWindow::loadWorld(const QString &fileName, bool reloading) {
   if (!proposeToSaveWorld(reloading))
     return true;
-  if (!WbApplication::instance()->checkWorldFile(fileName))
+  if (!WbApplication::instance()->isValidWorldFile(fileName))
     return false;  // invalid filename, abort without affecting the current simulation
   mSimulationView->cancelSupervisorMovieRecording();
   logActiveControllersTermination();
   WbLog::setConsoleLogsPostponed(true);
   const bool success = WbApplication::instance()->loadWorld(fileName, reloading);
-  if (!success)
+  if (!success) {
     WbLog::setConsoleLogsPostponed(false);
+    WbLog::showPostponedPopUpMessages();
+  }
   // else will be reset in updateAfterWorldLoading()
   return success;
 }

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1286,6 +1286,7 @@ void WbMainWindow::restorePerspective(bool reloading, bool firstLoad, bool loadi
   // Refreshing
   mSimulationView->repaintView3D();
 
+  WbLog::setConsoleLogsPostponed(false);
   WbLog::instance()->showPendingConsoleMessages();
 }
 
@@ -1321,7 +1322,7 @@ bool WbMainWindow::proposeToSaveWorld(bool reloading) {
 bool WbMainWindow::loadWorld(const QString &fileName, bool reloading) {
   if (!proposeToSaveWorld(reloading))
     return true;
-  if (!WbApplication::instance()->isValidWorldFile(fileName))
+  if (!WbApplication::instance()->isValidWorldFileName(fileName))
     return false;  // invalid filename, abort without affecting the current simulation
   mSimulationView->cancelSupervisorMovieRecording();
   logActiveControllersTermination();
@@ -1329,9 +1330,9 @@ bool WbMainWindow::loadWorld(const QString &fileName, bool reloading) {
   const bool success = WbApplication::instance()->loadWorld(fileName, reloading);
   if (!success) {
     WbLog::setConsoleLogsPostponed(false);
-    WbLog::showPostponedPopUpMessages();
+    WbLog::showPendingConsoleMessages();
   }
-  // else will be reset in updateAfterWorldLoading()
+  // else console messages will be forwarded after world load in restorePerspective()
   return success;
 }
 
@@ -1412,7 +1413,6 @@ void WbMainWindow::updateAfterWorldLoading(bool reloading, bool firstLoad) {
   WbActionManager::instance()->setFocusObject(mSimulationView->view3D());
 
   WbLog::setPopUpPostponed(false);
-  WbLog::setConsoleLogsPostponed(false);
   WbLog::showPostponedPopUpMessages();
   connect(WbProject::current(), &WbProject::pathChanged, this, &WbMainWindow::updateProjectPath);
 }


### PR DESCRIPTION
Fixes #2671:
logs generated during world load were sent to the consoles of the previous world and thus no longer visible once the load and the new world consoles were open.
This fix consists in queuing the logs during the world load and send them to the new console once they have been opened.