### PR TITLE
Fix controllers logs printed in Webots console one step too late

### DIFF
--- a/docs/guide/the-console.md
+++ b/docs/guide/the-console.md
@@ -1,6 +1,8 @@
 ## The Console
 
 The Webots console displays the logs coming from Webots (such as parsing warnings or errors when opening a world, compilation outputs, ODE warnings, etc.) and the outputs of the controllers.
+To guarantee that the log printed in the Webots console is deterministic, the output coming from the controllers is not printed immediately when receiving it but it is grouped by controller and printed at the end of the simulation step.
+This means that if your simulation contains robot A and robot B, the output of robot A will be printed in the console before the output of robot B independently if some robot B output messages were received before the ones of robot A.
 
 
 %figure "Console Window"

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,6 +10,8 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
   - Bug fixes
+    - Fixed step button status if simulation is reset from UI when the step button is disabled ([#2741](https://github.com/cyberbotics/webots/pull/2741)).
+    - Fixed controllers output printed in the Webots console one step too late when running the simulation step-by-step ([#2741](https://github.com/cyberbotics/webots/pull/2741)).
     - Fixed invalid world loading errors cleared from the console when reverting to the empty world ([#2737](https://github.com/cyberbotics/webots/pull/2737)).
     - Fixed synchronization of [Supervisor](supervisor.md) simulation reset that was applied after the step and now it is applied at the very end of the step ([#2720](https://github.com/cyberbotics/webots/pull/2720)).
     - Fixed [Camera](camera.md) image update in controllers after simulation reset ([#2725](https://github.com/cyberbotics/webots/pull/2725)).

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -290,19 +290,19 @@ void WbControlledWorld::checkIfReadRequestCompleted() {
       // if the simulation is running these messages will be sent within the step message
       // otherwise we want to send them as soon as the libController request is over
       writePendingImmediateAnswer();
-      // print controller logs to Webots console(s)
-      // wait until read request completed to guarantee the printout determinism
-      // logs are ordered by controller and not by receiving time
-      foreach (WbController *const controller, mControllers)
-        controller->flushBuffers();
     }
+
+    // print controller logs to Webots console(s)
+    // wait until read request completed to guarantee the printout determinism
+    // logs are ordered by controller and not by receiving time
+    foreach (WbController *const controller, mControllers)
+      controller->flushBuffers();
   }
 }
 
 void WbControlledWorld::step() {
-  if (mFirstStep && !mRetryEnabled) {
+  if (mFirstStep && !mRetryEnabled)
     startControllers();
-  }
 
   WbSimulationState *const simulationState = WbSimulationState::instance();
 
@@ -503,7 +503,6 @@ void WbControlledWorld::waitForRobotWindowIfNeededAndCompleteStep() {
   WbSimulationState *const simulationState = WbSimulationState::instance();
   for (int i = 0; i < controllersCount; ++i) {
     WbController *controller = mControllers[i];
-    controller->flushBuffers();
     if (!controller->isRequestPending())
       continue;
     double rt = controller->requestTime() + controller->deltaTimeRequested();

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -40,6 +40,7 @@ public:
   bool needToWait(bool *waitForExternControllerStart = NULL);
   void writePendingImmediateAnswer();
   bool isExecutingStep() const { return mIsExecutingStep; }
+  void checkIfReadRequestCompleted();
 
   void reset(bool restartControllers) override;
 

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -1091,16 +1091,7 @@ void WbController::readRequest() {
     if (immediateMessagesPending)
       writeAnswer(true);
 
-    if (!WbControlledWorld::instance()->needToWait()) {
-      WbSimulationState *state = WbSimulationState::instance();
-      emit state->controllerReadRequestsCompleted();
-      if (state->isPaused() || state->isStep())
-        // in order to avoid mixing immediate messages sent by Webots and the libController
-        // some Webots immediate messages could have been postponed
-        // if the simulation is running these messages will be sent within the step message
-        // otherwise we want to send them as soon as the libController request is over
-        WbControlledWorld::instance()->writePendingImmediateAnswer();
-    }
+    WbControlledWorld::instance()->checkIfReadRequestCompleted();
   }
 
   WbPerformanceLog *log = WbPerformanceLog::instance();

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1547,6 +1547,7 @@ void WbMainWindow::resetGui(bool restartControllers) {
   if (WbWorld::instance() && restartControllers)
     mSimulationView->cancelSupervisorMovieRecording();
   mSimulationView->view3D()->renderLater();
+  mSimulationView->disableStepButton(false);
 }
 
 void WbMainWindow::importVrml() {

--- a/src/webots/gui/WbSimulationView.hpp
+++ b/src/webots/gui/WbSimulationView.hpp
@@ -94,6 +94,7 @@ signals:
 
 public slots:
   void disableRendering(bool disabled);
+  void disableStepButton(bool disabled);
 
 protected slots:
   void keyReleaseEvent(QKeyEvent *event) override;
@@ -119,7 +120,6 @@ private slots:
   void updateVisibility();
   void writeScreenshot(QImage image);
   void updateTitleBarTitle();
-  void disableStepButton(bool disabled);
   void updatePlayButtons();
   void updateRendering();
   void updateSoundButtons();


### PR DESCRIPTION
Fixes #2709:
execute the instructions to flush the controller buffers once all the read requests are completed.

Additionally, I also fixed an issue with the step button that is not enabled after simulation reset (BUG B in #2284) if the reset button is clicked during the step computation, i.e. when the step button was disabled.