### PR TITLE
Improve webots server caching 

### DIFF
--- a/src/webots/core/WbHttpReply.cpp
+++ b/src/webots/core/WbHttpReply.cpp
@@ -14,6 +14,7 @@
 
 #include "WbHttpReply.hpp"
 
+#include <QtCore/QCryptographicHash>
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 
@@ -41,7 +42,7 @@ QByteArray WbHttpReply::forgeHTMLReply(const QString &htmlContent) {
   return reply;
 }
 
-QByteArray WbHttpReply::forgeFileReply(const QString &fileName) {
+QByteArray WbHttpReply::forgeFileReply(const QString &fileName, const QString &etag) {
   QByteArray reply;
 
   QFile file(fileName);
@@ -49,14 +50,26 @@ QByteArray WbHttpReply::forgeFileReply(const QString &fileName) {
     return forge404Reply();
 
   const QByteArray data = file.readAll();
-  const QString mimeType = WbHttpReply::mimeType(fileName, true);
-  reply.append("HTTP/1.1 200 OK\r\n");
-  reply.append("Access-Control-Allow-Origin: *\r\n");
-  reply.append("Cache-Control: public, max-age=3600\r\n");  // Help the browsers to cache the file for 1 hour.
-  reply.append(QString("Content-Type: %1\r\n").arg(mimeType).toUtf8());
-  reply.append(QString("Content-Length: %1\r\n").arg(data.length()).toUtf8());
-  reply.append("\r\n");
-  reply.append(data);
+
+  const QByteArray hash = QCryptographicHash::hash(data, QCryptographicHash::Md5);
+
+  if (!etag.isEmpty() && hash.toHex().compare(etag.toLocal8Bit(), Qt::CaseSensitive) == 0) {
+    reply.append("HTTP/1.1 304 Not modified\r\n");
+    reply.append("Access-Control-Allow-Origin: *\r\n");
+    reply.append("Cache-Control: public, max-age=3600\r\n");  // Help the browsers to cache the file for 1 hour.
+    reply.append("etag: ").append(hash.toHex()).append("\r\n");
+    reply.append("\r\n");
+  } else {
+    const QString mimeType = WbHttpReply::mimeType(fileName, true);
+    reply.append("HTTP/1.1 200 OK\r\n");
+    reply.append("Access-Control-Allow-Origin: *\r\n");
+    reply.append("Cache-Control: public, max-age=3600\r\n");  // Help the browsers to cache the file for 1 hour.
+    reply.append("etag: ").append(hash.toHex()).append("\r\n");
+    reply.append(QString("Content-Type: %1\r\n").arg(mimeType).toUtf8());
+    reply.append(QString("Content-Length: %1\r\n").arg(data.length()).toUtf8());
+    reply.append("\r\n");
+    reply.append(data);
+  }
 
   return reply;
 }

--- a/src/webots/core/WbHttpReply.hpp
+++ b/src/webots/core/WbHttpReply.hpp
@@ -20,7 +20,7 @@
 namespace WbHttpReply {
   QByteArray forge404Reply();
   QByteArray forgeHTMLReply(const QString &htmlContent);
-  QByteArray forgeFileReply(const QString &fileName);
+  QByteArray forgeFileReply(const QString &fileName, const QString &etag);
   QString mimeType(const QString &url, bool generic = false);
 };  // namespace WbHttpReply
 

--- a/src/webots/gui/WbMultimediaStreamingServer.cpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.cpp
@@ -67,9 +67,9 @@ void WbMultimediaStreamingServer::start(int port) {
   connect(&mLimiterTimer, &QTimer::timeout, this, &WbMultimediaStreamingServer::processLimiterTimeout);
 }
 
-void WbMultimediaStreamingServer::sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket) {
+void WbMultimediaStreamingServer::sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) {
   if (requestedUrl != "mjpeg") {
-    WbStreamingServer::sendTcpRequestReply(requestedUrl, socket);
+    WbStreamingServer::sendTcpRequestReply(requestedUrl, etag, socket);
     return;
   }
   socket->readAll();

--- a/src/webots/gui/WbMultimediaStreamingServer.hpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.hpp
@@ -48,7 +48,7 @@ private slots:
 
 private:
   void start(int port) override;
-  void sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket) override;
+  void sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) override;
   int bytesToWrite();
   void sendContextMenuInfo(const WbMatter *node);
   void sendLastImage(QTcpSocket *client = NULL);

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -174,7 +174,7 @@ void WbStreamingServer::onNewTcpData() {
     const QString &requestedUrl(tokens[1].replace(QRegExp("^/"), ""));
     if (!requestedUrl.isEmpty()) {  // "/" is reserved for the websocket.
       bool hasEtag = false;
-      QString etag = "";
+      QString etag;
       for (const auto &i : tokens) {
         if (i == "If-None-Match:")
           hasEtag = true;

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -176,9 +176,9 @@ void WbStreamingServer::onNewTcpData() {
       bool hasEtag = false;
       QString etag = "";
       for (const auto &i : tokens) {
-        if (i == "If-None-Match:") {
+        if (i == "If-None-Match:")
           hasEtag = true;
-        } else if (hasEtag) {
+        else if (hasEtag) {
           etag = i;
           break;
         }

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -172,12 +172,23 @@ void WbStreamingServer::onNewTcpData() {
   QStringList tokens = QString(line).split(QRegExp("[ \r\n][ \r\n]*"));
   if (tokens[0] == "GET") {
     const QString &requestedUrl(tokens[1].replace(QRegExp("^/"), ""));
-    if (!requestedUrl.isEmpty())  // "/" is reserved for the websocket.
-      sendTcpRequestReply(requestedUrl, socket);
+    if (!requestedUrl.isEmpty()) {  // "/" is reserved for the websocket.
+      bool hasEtag = false;
+      QString etag = "";
+      for (const auto &i : tokens) {
+        if (i == "If-None-Match:") {
+          hasEtag = true;
+        } else if (hasEtag) {
+          etag = i;
+          break;
+        }
+      }
+      sendTcpRequestReply(requestedUrl, etag, socket);
+    }
   }
 }
 
-void WbStreamingServer::sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket) {
+void WbStreamingServer::sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) {
   if (!requestedUrl.startsWith("robot_windows/")) {
     WbLog::warning(tr("Unsupported URL %1").arg(requestedUrl));
     socket->write(WbHttpReply::forge404Reply());
@@ -190,7 +201,7 @@ void WbStreamingServer::sendTcpRequestReply(const QString &requestedUrl, QTcpSoc
     return;
   }
   WbLog::info(tr("Received request for %1").arg(fileName));
-  socket->write(WbHttpReply::forgeFileReply(fileName));
+  socket->write(WbHttpReply::forgeFileReply(fileName, etag));
 }
 
 void WbStreamingServer::onNewWebSocketConnection() {

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -55,7 +55,7 @@ protected:
   virtual bool prepareWorld();
   virtual void connectNewRobot(const WbRobot *robot);
   virtual void sendWorldToClient(QWebSocket *client);
-  virtual void sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket);
+  virtual void sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket);
 
   bool isActive() const { return mWebSocketServer != NULL; }
   void destroy();

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -68,11 +68,11 @@ void WbX3dStreamingServer::create(int port) {
   generateX3dWorld();
 }
 
-void WbX3dStreamingServer::sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket) {
+void WbX3dStreamingServer::sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) {
   if (!mX3dWorldTextures.contains(requestedUrl))
-    WbStreamingServer::sendTcpRequestReply(requestedUrl, socket);
+    WbStreamingServer::sendTcpRequestReply(requestedUrl, etag, socket);
   else
-    socket->write(WbHttpReply::forgeFileReply(mX3dWorldTextures[requestedUrl]));
+    socket->write(WbHttpReply::forgeFileReply(mX3dWorldTextures[requestedUrl], etag));
 }
 
 void WbX3dStreamingServer::processTextMessage(QString message) {

--- a/src/webots/gui/WbX3dStreamingServer.hpp
+++ b/src/webots/gui/WbX3dStreamingServer.hpp
@@ -38,7 +38,7 @@ private slots:
 
 private:
   void create(int port) override;
-  void sendTcpRequestReply(const QString &requestedUrl, QTcpSocket *socket) override;
+  void sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) override;
   void connectNewRobot(const WbRobot *robot) override;
   bool prepareWorld() override;
   void deleteWorld() override;


### PR DESCRIPTION
**Description**
Webots does no check to verify if a streaming-viewer client already has an image in its cache or not.

To fix that, I implemented a simple etag mecanism.
- When webots send a file, it put the hash off the image in the etag header.
- If a browser want to query again webots about a file, it will put the hash from the etag field in the "If-None-Match" header. (this is done automatically by the browser)
- When receiving a query about a file, webots will check if their is a "If-None-Match" header and compare its content with the hash of the requested file. If the two hashes are the same, webots will answer with a 304 Not modified and not transfer the file again.

I implemented it by hand because I did not find such an preexisting option in Qt.
