### PR TITLE
Fix update of PointSet

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,6 +10,7 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
   - Bug fixes
+    - Fixed update of [PointSet](pointset.md) subnodes ([#2766](https://github.com/cyberbotics/webots/pull/2766)).
     - Fixed step button status if simulation is reset from UI when the step button is disabled ([#2741](https://github.com/cyberbotics/webots/pull/2741)).
     - Fixed controllers output printed in the Webots console one step too late when running the simulation step-by-step ([#2741](https://github.com/cyberbotics/webots/pull/2741)).
     - Windows: Fixed double-click opening of a world file located in a path with UTF-8 characters ([#2750](https://github.com/cyberbotics/webots/pull/2750)). 

--- a/src/webots/nodes/WbPointSet.cpp
+++ b/src/webots/nodes/WbPointSet.cpp
@@ -172,11 +172,11 @@ int WbPointSet::computeCoordsAndColorData(float *coordsData, float *colorData) {
 }
 
 void WbPointSet::updateCoord() {
-  if (!sanitizeFields())
-    return;
-
   if (coord())
     connect(coord(), &WbCoordinate::fieldChanged, this, &WbPointSet::updateCoord, Qt::UniqueConnection);
+
+  if (!sanitizeFields())
+    return;
 
   if (areWrenObjectsInitialized())
     buildWrenMesh();
@@ -188,11 +188,11 @@ void WbPointSet::updateCoord() {
 }
 
 void WbPointSet::updateColor() {
-  if (!sanitizeFields())
-    return;
-
   if (color())
     connect(color(), &WbCoordinate::fieldChanged, this, &WbPointSet::updateColor, Qt::UniqueConnection);
+
+  if (!sanitizeFields())
+    return;
 
   if (areWrenObjectsInitialized())
     buildWrenMesh();


### PR DESCRIPTION
Fix #2752: always connect to new subnodes even if they are not valid yet.
Otherwise all the subsequent changes to the subnode won't be notified.