### PR TITLE
Add missing help for --no-rendering command line option

### DIFF
--- a/docs/guide/starting-webots.md
+++ b/docs/guide/starting-webots.md
@@ -45,7 +45,7 @@ Options:
     argument must be either pause, realtime or fast.
 
   --no-rendering
-    Disable 3D rendering for the main 3D view.
+    Disable rendering in the main 3D view.
 
   --fullscreen
     Start Webots in fullscreen.

--- a/docs/guide/starting-webots.md
+++ b/docs/guide/starting-webots.md
@@ -44,6 +44,9 @@ Options:
     Choose the startup mode, overriding application preferences. The <mode>
     argument must be either pause, realtime or fast.
 
+  --no-rendering
+    Disable 3D rendering for the main 3D view.
+
   --fullscreen
     Start Webots in fullscreen.
 

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -63,6 +63,8 @@ void WbSingleTaskApplication::showHelp() const {
   cout << "  --mode=<mode>" << endl;
   cout << tr("    Choose the startup mode, overriding application preferences. The <mode>").toUtf8().constData() << endl;
   cout << tr("    argument must be either pause, realtime or fast.").toUtf8().constData() << endl << endl;
+  cout << "  --no-rendering" << endl;
+  cout << tr("    Disable 3D rendering for the main 3D view.").toUtf8().constData() << endl << endl;
   cout << "  --fullscreen" << endl;
   cout << tr("    Start Webots in fullscreen.").toUtf8().constData() << endl << endl;
   cout << "  --minimize" << endl;

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -64,7 +64,7 @@ void WbSingleTaskApplication::showHelp() const {
   cout << tr("    Choose the startup mode, overriding application preferences. The <mode>").toUtf8().constData() << endl;
   cout << tr("    argument must be either pause, realtime or fast.").toUtf8().constData() << endl << endl;
   cout << "  --no-rendering" << endl;
-  cout << tr("    Disable 3D rendering for the main 3D view.").toUtf8().constData() << endl << endl;
+  cout << tr("    Disable rendering in the main 3D view.").toUtf8().constData() << endl << endl;
   cout << "  --fullscreen" << endl;
   cout << tr("    Start Webots in fullscreen.").toUtf8().constData() << endl << endl;
   cout << "  --minimize" << endl;


### PR DESCRIPTION
It seems we forgot in  #2286 to document this command line option from the `webots --help` message (and document it).

https://www.cyberbotics.com/doc/guide/starting-webots?version=fix-no-rendering-help