### PR TITLE
Physics-plugin-group-fix

### DIFF
--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -429,6 +429,18 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
   return false;
 }
 
+void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID o2) {
+  if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
+    // colliding a mContext->space() with something
+    dSpaceCollide2(o1, o2, data, odeNearCallback);
+    // collide all geoms internal to the mContext->space()(s)
+    if (dGeomIsSpace(o1))
+      dSpaceCollide((dSpaceID)o1, data, odeNearCallback);
+    if (dGeomIsSpace(o2))
+      dSpaceCollide((dSpaceID)o2, data, odeNearCallback);
+  }
+}
+
 void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   // retrieve data
   WbOdeGeomData *const odeGeomData1 = static_cast<WbOdeGeomData *>(dGeomGetData(o1));
@@ -445,6 +457,8 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
 
     const int pluginContacts = physicsPlugin->collide(o1, o2);
 
+    if (pluginContacts == 0)
+      handleCollisionIfSpace(data, o1, o2);
     if (pluginContacts == 2) {  // Webots will change the boundingObject color to notify collision
       if (webotsGeom1) {
         s1 = odeGeomData1->solid();
@@ -461,18 +475,11 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       return;
     } else if (pluginContacts == 1 || !webotsGeom1 || !webotsGeom2)  // Webots won't attempt to manipulate user-defined dGeoms
       return;
-  }
+  } else
+    handleCollisionIfSpace(data, o1, o2);
 
-  if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
-    // colliding a mContext->space() with something
-    dSpaceCollide2(o1, o2, data, odeNearCallback);
-    // collide all geoms internal to the mContext->space()(s)
-    if (dGeomIsSpace(o1))
-      dSpaceCollide((dSpaceID)o1, data, odeNearCallback);
-    if (dGeomIsSpace(o2))
-      dSpaceCollide((dSpaceID)o2, data, odeNearCallback);
+  if (dGeomIsSpace(o1) || dGeomIsSpace(o2))
     return;
-  }
 
   // yvan: we are never interested in the collision between 2 ray geoms
   // (rays geoms can be either distance sensor, emitter-receiver or light sensor rays)

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -462,7 +462,7 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     } else if (pluginContacts == 1 || !webotsGeom1 || !webotsGeom2)  // Webots won't attempt to manipulate user-defined dGeoms
       return;
   }
-  
+
   if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
     // colliding a mContext->space() with something
     dSpaceCollide2(o1, o2, data, odeNearCallback);

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -430,16 +430,6 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
 }
 
 void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
-  if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
-    // colliding a mContext->space() with something
-    dSpaceCollide2(o1, o2, data, odeNearCallback);
-    // collide all geoms internal to the mContext->space()(s)
-    if (dGeomIsSpace(o1))
-      dSpaceCollide((dSpaceID)o1, data, odeNearCallback);
-    if (dGeomIsSpace(o2))
-      dSpaceCollide((dSpaceID)o2, data, odeNearCallback);
-  }
-
   // retrieve data
   WbOdeGeomData *const odeGeomData1 = static_cast<WbOdeGeomData *>(dGeomGetData(o1));
   WbOdeGeomData *const odeGeomData2 = static_cast<WbOdeGeomData *>(dGeomGetData(o2));
@@ -472,9 +462,17 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     } else if (pluginContacts == 1 || !webotsGeom1 || !webotsGeom2)  // Webots won't attempt to manipulate user-defined dGeoms
       return;
   }
-
-  if (dGeomIsSpace(o1) || dGeomIsSpace(o2))
+  
+  if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
+    // colliding a mContext->space() with something
+    dSpaceCollide2(o1, o2, data, odeNearCallback);
+    // collide all geoms internal to the mContext->space()(s)
+    if (dGeomIsSpace(o1))
+      dSpaceCollide((dSpaceID)o1, data, odeNearCallback);
+    if (dGeomIsSpace(o2))
+      dSpaceCollide((dSpaceID)o2, data, odeNearCallback);
     return;
+  }
 
   // yvan: we are never interested in the collision between 2 ray geoms
   // (rays geoms can be either distance sensor, emitter-receiver or light sensor rays)

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -57,6 +57,7 @@ private:
   QList<WbKinematicDifferentialWheels *> mCollisionedRobots;
   void handleKinematicsCollisions();
   void swapBuffer();
+  static void handleCollisionIfSpace(void *data, dGeomID o1, dGeomID o2);
   static const WbContactProperties *fillSurfaceParameters(const WbSolid *s1, const WbSolid *s2, const WbGeometry *wg1,
                                                           const WbGeometry *wg2, dContact *contact);
   static void fillImmersionSurfaceParameters(const WbSolid *s, const WbImmersionProperties *ip,


### PR DESCRIPTION
Should fix this issue: https://github.com/cyberbotics/webots/issues/2584

To my understanding, if one or both bounding objects were groups (group means space NOT geom), then the collision was executed before we checked for physics plugin. I moved that part AFTER the physics plugin check. This should fix the issue.  I cannot compile and test it at the moment though.