### PR TITLE
export coordinateSystem

### DIFF
--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -378,6 +378,7 @@ void WbWorldInfo::exportNodeFields(WbVrmlWriter &writer) const {
     }
 
     writer << " basicTimeStep=\'" << mBasicTimeStep->value() << "\'";
+    writer << " coordinateSystem=\'" << mCoordinateSystem->value() << "\'";
 
     if (!findField("window")->isDefault())
       writer << " window='" << mWindow->value() << "'";


### PR DESCRIPTION
**Description**
Exporting the coordinate system type was not needed in the old version of the streaming-viewer as it supported only NUE.
But as we want to support several coordinate systems in the new version, we need Webots to export it.
