### PR TITLE
Clear Pen ink on simulation reset

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -11,6 +11,7 @@ Released on XX Xth, 2021.
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
   - Bug fixes
+    - Fixed erasing [Pen](pen.md) ink on simulation reset ([#2796](https://github.com/cyberbotics/webots/pull/2796)).
     - Fixed update of [PointSet](pointset.md) subnodes ([#2766](https://github.com/cyberbotics/webots/pull/2766)).
     - Fixed [`wb_supervisor_node_get_velocity`](supervisor.md#wb_supervisor_node_get_velocity) in MATLAB API returning 3 elements instead of 6 ([#2764](https://github.com/cyberbotics/webots/pull/2764)).
     - Fixed step button status if simulation is reset from UI when the step button is disabled ([#2741](https://github.com/cyberbotics/webots/pull/2741)).

--- a/src/webots/nodes/utils/WbPaintTexture.cpp
+++ b/src/webots/nodes/utils/WbPaintTexture.cpp
@@ -95,6 +95,7 @@ void WbPaintTexture::clearTexture() {
     mData[++k] = 1.0f;
     mData[++k] = 0.0f;
   }
+  wr_drawable_texture_clear(mTexture);
 
   if (mEvaporation)
     memset(mEvaporation, 0, size * sizeof(double));


### PR DESCRIPTION
Fix #2757:
on simulation reset the paint data on Webots side was correctly reset, but the WREN paint texture was not cleared.