### PR TITLE
Separate visible and hidden fields more clearly in the docs

### DIFF
--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -8,6 +8,7 @@ BallJoint {
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   SFNode  jointParameters3 NULL   # {JointParameters, PROTO}
   MFNode  device3          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
+  SFFloat position3        0      # [0, inf)
 }
 ```
 
@@ -40,3 +41,5 @@ If these fields are empty, the `springConstant`, `dampingConstant` and `staticFr
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.
+
+- `position3`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -8,6 +8,7 @@ BallJoint {
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   SFNode  jointParameters3 NULL   # {JointParameters, PROTO}
   MFNode  device3          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
+  # hidden fields
   SFFloat position3        0      # [0, inf)
 }
 ```
@@ -41,5 +42,7 @@ If these fields are empty, the `springConstant`, `dampingConstant` and `staticFr
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.
+
+### Hidden Field Summary
 
 - `position3`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/balljoint.md
+++ b/docs/reference/balljoint.md
@@ -8,7 +8,6 @@ BallJoint {
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   SFNode  jointParameters3 NULL   # {JointParameters, PROTO}
   MFNode  device3          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
-  SFFloat position3        0      # [0, inf)
 }
 ```
 
@@ -41,5 +40,3 @@ If these fields are empty, the `springConstant`, `dampingConstant` and `staticFr
 
 - `device3`: this field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device for the third axis.
 If no motor is specified, the corresponding axis is passive.
-
-- `position3`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -55,7 +55,7 @@ Released on December 15th, 2020.
     - Fixed performance regression (thanks to [Acwok](https://github.com/Acwok)) ([#2434](https://github.com/cyberbotics/webots/pull/2434)).
     - **Deprecated all the device getter methods in Python.** They are replaced by a new [`Robot.getDevice`](robot.md#wb_robot_get_device) method which is closer to the C API ([#2510](https://github.com/cyberbotics/webots/pull/2510)).
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
-    - Fixed the [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function so that it gets called even if the [`boundingObject`](solid.md#solid-fields) is a [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
+    - Fixed the [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function so that it gets called even if the [`boundingObject`](solid.md#solid-field-summary) is a [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -55,7 +55,7 @@ Released on December 15th, 2020.
     - Fixed performance regression (thanks to [Acwok](https://github.com/Acwok)) ([#2434](https://github.com/cyberbotics/webots/pull/2434)).
     - **Deprecated all the device getter methods in Python.** They are replaced by a new [`Robot.getDevice`](robot.md#wb_robot_get_device) method which is closer to the C API ([#2510](https://github.com/cyberbotics/webots/pull/2510)).
     - **Fixed reversed pixel bytes order for [Display](display.md) images loaded with [`wb_display_image_new`](display.md#wb_display_image_new)** ([#2452](https://github.com/cyberbotics/webots/pull/2452)).
-    - Fixed the [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function so that it gets called even if the [`boundingObject`](solid.md#solid-field-summary) is a [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
+    - Fixed the [webots\_physics\_collide(dGeomID, dGeomID)](callback-functions.md) callback function so that it gets called even if the [`boundingObject`](solid.md#field-summary) is a [Group](group.md) node ([#2505](https://github.com/cyberbotics/webots/pull/2505)).
   - Cleanup
     - **Deleted `run` mode as the same behavior now can be achieved by using `fast` mode while keeping the rendering turned on ([#2286](https://github.com/cyberbotics/webots/pull/2286)).**
     - **Changed ROS message type published by the [GPS](gps.md) node when it is configured to work in `local` GPS coordinate system ([#2368](https://github.com/cyberbotics/webots/pull/2368))**.

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -7,6 +7,7 @@ Hinge2Joint {
   SFNode  jointParameters  NULL   # {HingeJointParameters, PROTO}
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   MFNode  device2          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
+  SFFloat position2        0      # [0, inf)
 }
 ```
 
@@ -41,3 +42,5 @@ If the `jointParameters2` field is left empty, default values of the [JointParam
 
 - `device2`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached to the second axis.
 If no motor is specified, this part of the joint is passive.
+
+- `position2`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -7,7 +7,6 @@ Hinge2Joint {
   SFNode  jointParameters  NULL   # {HingeJointParameters, PROTO}
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   MFNode  device2          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
-  SFFloat position2        0      # [0, inf)
 }
 ```
 
@@ -42,5 +41,3 @@ If the `jointParameters2` field is left empty, default values of the [JointParam
 
 - `device2`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached to the second axis.
 If no motor is specified, this part of the joint is passive.
-
-- `position2`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/hinge2joint.md
+++ b/docs/reference/hinge2joint.md
@@ -7,6 +7,7 @@ Hinge2Joint {
   SFNode  jointParameters  NULL   # {HingeJointParameters, PROTO}
   SFNode  jointParameters2 NULL   # {JointParameters, PROTO}
   MFNode  device2          [ ]    # {RotationalMotor, PositionSensor, Brake, PROTO}
+  # hidden fields
   SFFloat position2        0      # [0, inf)
 }
 ```
@@ -42,5 +43,7 @@ If the `jointParameters2` field is left empty, default values of the [JointParam
 
 - `device2`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device attached to the second axis.
 If no motor is specified, this part of the joint is passive.
+
+### Hidden Field Summary
 
 - `position2`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/hingejoint.md
+++ b/docs/reference/hingejoint.md
@@ -5,6 +5,7 @@ Derived from [Joint](joint.md).
 ```
 HingeJoint {
   MFNode  device   [ ] # {RotationalMotor, PositionSensor, Brake, PROTO}
+  # hidden fields
   SFFloat position 0   # [0, inf)
 }
 ```
@@ -26,5 +27,7 @@ If empty, [HingeJointParameters](hingejointparameters.md) default values apply.
 
 - `device`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device.
 If no motor is specified, the joint is passive joint.
+
+### Hidden Field Summary
 
 - `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/hingejoint.md
+++ b/docs/reference/hingejoint.md
@@ -5,6 +5,7 @@ Derived from [Joint](joint.md).
 ```
 HingeJoint {
   MFNode  device   [ ] # {RotationalMotor, PositionSensor, Brake, PROTO}
+  SFFloat position 0   # [0, inf)
 }
 ```
 
@@ -25,3 +26,5 @@ If empty, [HingeJointParameters](hingejointparameters.md) default values apply.
 
 - `device`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device.
 If no motor is specified, the joint is passive joint.
+
+- `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/hingejoint.md
+++ b/docs/reference/hingejoint.md
@@ -5,7 +5,6 @@ Derived from [Joint](joint.md).
 ```
 HingeJoint {
   MFNode  device   [ ] # {RotationalMotor, PositionSensor, Brake, PROTO}
-  SFFloat position 0   # [0, inf)
 }
 ```
 
@@ -26,5 +25,3 @@ If empty, [HingeJointParameters](hingejointparameters.md) default values apply.
 
 - `device`: This field optionally specifies a [RotationalMotor](rotationalmotor.md), an angular [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device.
 If no motor is specified, the joint is passive joint.
-
-- `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/joint.md
+++ b/docs/reference/joint.md
@@ -39,5 +39,5 @@ These fields, which are not visible from the Scene Tree, are used to store insid
 As a result joint positions are restored when reloading the simulation just the same way they would be if [JointParameters](jointparameters.md) nodes were used.
 
 For [HingeJoint](hingejoint.md) and [SliderJoint](sliderjoint.md) nodes containing no [JointParameters](jointparameters.md), Webots uses the hidden field named `position`.
-For a [Hinge2Joint](hingejoint.md) node, an additional hidden field named `position2` is used to store the joint position with respect the second hinge.
+For a [Hinge2Joint](hingejoint.md) node, an additional hidden field named `position2` is used to store the joint position with respect to the second axis.
 For a [BallJoint](balljoint.md) node, an additional hidden field named `position3` is used to store the joint position with respect the third axis.

--- a/docs/reference/joint.md
+++ b/docs/reference/joint.md
@@ -34,9 +34,10 @@ Alternatively, a [Slot](slot.md) node can be inserted in the `endPoint` field, b
 ### Joint's Hidden Position Fields
 
 If the `jointParameters` is set to NULL, joint positions are then not visible from the Scene Tree.
-In this case Webots keeps track of the initial positions of [Joint](#joint) nodes (except for the [BallJoint](balljoint.md)) by means of hidden position fields.
+In this case Webots keeps track of the initial positions of [Joint](#joint) nodes by means of hidden position fields.
 These fields, which are not visible from the Scene Tree, are used to store inside the world file the current joint positions when the simulation is saved.
 As a result joint positions are restored when reloading the simulation just the same way they would be if [JointParameters](jointparameters.md) nodes were used.
 
 For [HingeJoint](hingejoint.md) and [SliderJoint](sliderjoint.md) nodes containing no [JointParameters](jointparameters.md), Webots uses the hidden field named `position`.
 For a [Hinge2Joint](hingejoint.md) node, an additional hidden field named `position2` is used to store the joint position with respect the second hinge.
+For a [BallJoint](balljoint.md) node, an additional hidden field named `position3` is used to store the joint position with respect the third axis.

--- a/docs/reference/joint.md
+++ b/docs/reference/joint.md
@@ -40,4 +40,4 @@ As a result joint positions are restored when reloading the simulation just the 
 
 For [HingeJoint](hingejoint.md) and [SliderJoint](sliderjoint.md) nodes containing no [JointParameters](jointparameters.md), Webots uses the hidden field named `position`.
 For a [Hinge2Joint](hingejoint.md) node, an additional hidden field named `position2` is used to store the joint position with respect to the second axis.
-For a [BallJoint](balljoint.md) node, an additional hidden field named `position3` is used to store the joint position with respect the third axis.
+For a [BallJoint](balljoint.md) node, an additional hidden field named `position3` is used to store the joint position with respect to the third axis.

--- a/docs/reference/sliderjoint.md
+++ b/docs/reference/sliderjoint.md
@@ -5,6 +5,7 @@ Derived from [Joint](joint.md).
 ```
 SliderJoint {
   MFNode  device   [ ]   # {LinearMotor, PositionSensor, Brake, PROTO}
+  # hidden fields
   SFFloat position 0     # [0, inf)
 }
 ```
@@ -26,5 +27,7 @@ If empty, [JointParameters](jointparameters.md) default values apply.
 
 - `device`: This field optionally specifies a [LinearMotor](linearmotor.md), a linear [PositionSensor](positionsensor.md) and/or a [Brake](brake.md) device.
 If no motor is specified, the joint is passive joint.
+
+### Hidden Field Summary
 
 - `position`: This field is not visible from the Scene Tree, see [joint's hidden position field](joint.md#joints-hidden-position-fields).

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -79,7 +79,7 @@ The colors defined in this field are returned for this object if recognized by a
 - `translationStep` and `rotationStep`: these fields specify the minimum step size that will be used by the translate and rotate handles appearing in the 3D window when selecting a top solid.
 Continuous increment is obtained by setting the step value to -1.
 
-### Hidden Solid Field Summary
+### Hidden Field Summary
 
 - `linearVelocity` and `angularVelocity`: these fields, which aren't visible from the Scene Tree, are used by Webots when saving a world file to store the initial linear and angular velocities of a [Solid](#solid) with a non-NULL [Physics](physics.md) node.
 If the [Solid](#solid) node is merged into a solid assembly (see [implicit solid merging](physics.md#implicit-solid-merging-and-joints)), then these fields will be effective only for the [Solid](#solid) at the top of the assembly.

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -31,7 +31,7 @@ The [Solid](#solid) class is the base class for collision-detected objects.
 Robots and device classes are subclasses of the [Solid](#solid) class.
 In the 3D window, [Solid](#solid) nodes can be manipulated (dragged, lifted, rotated, etc) using the mouse.
 
-### Solid Field Summary
+### Field Summary
 
 Note that in the [Solid](#solid) node, the `scale` field inherited from the [Transform](transform.md) must always remain uniform, i.e., of the form `x x x` where `x` is any positive real number.
 This ensures that all primitive geometries will remain suitable for ODE collision detection.

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -16,6 +16,7 @@ Solid {
   MFColor  recognitionColors   []            # any color
   SFFloat  translationStep     0.01          # [0, inf)
   SFFloat  rotationStep        0.261799387   # [0, inf)
+  # hidden fields
   SFVec3f  linearVelocity      0 0 0         # any vector
   SFVec3f  angularVelocity     0 0 0         # any vector
 }
@@ -30,7 +31,7 @@ The [Solid](#solid) class is the base class for collision-detected objects.
 Robots and device classes are subclasses of the [Solid](#solid) class.
 In the 3D window, [Solid](#solid) nodes can be manipulated (dragged, lifted, rotated, etc) using the mouse.
 
-### Solid Fields
+### Solid Field Summary
 
 Note that in the [Solid](#solid) node, the `scale` field inherited from the [Transform](transform.md) must always remain uniform, i.e., of the form `x x x` where `x` is any positive real number.
 This ensures that all primitive geometries will remain suitable for ODE collision detection.
@@ -77,6 +78,8 @@ The colors defined in this field are returned for this object if recognized by a
 
 - `translationStep` and `rotationStep`: these fields specify the minimum step size that will be used by the translate and rotate handles appearing in the 3D window when selecting a top solid.
 Continuous increment is obtained by setting the step value to -1.
+
+### Hidden Solid Field Summary
 
 - `linearVelocity` and `angularVelocity`: these fields, which aren't visible from the Scene Tree, are used by Webots when saving a world file to store the initial linear and angular velocities of a [Solid](#solid) with a non-NULL [Physics](physics.md) node.
 If the [Solid](#solid) node is merged into a solid assembly (see [implicit solid merging](physics.md#implicit-solid-merging-and-joints)), then these fields will be effective only for the [Solid](#solid) at the top of the assembly.


### PR DESCRIPTION
For consistency with the rest of the docs, hidden fields in joint nodes shouldn't be mentioned. The position field is visible in JointParameters and should be mentioned only there.