### PR TITLE
Fix Lidar.getLayerRangeImage returning full image on Python and Java

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
   - Bug fixes
     - Fixed erasing [Pen](pen.md) ink on simulation reset ([#2796](https://github.com/cyberbotics/webots/pull/2796)).
     - Fixed update of [PointSet](pointset.md) subnodes ([#2766](https://github.com/cyberbotics/webots/pull/2766)).
+    - Fixed [`Lidar.getLayerRangeImage`](lidar.md#wb_lidar_get_layer_range_image) Python and Java functions wrongly returning the full image ([#2799](https://github.com/cyberbotics/webots/pull/2799)).
     - Fixed [`wb_supervisor_node_get_velocity`](supervisor.md#wb_supervisor_node_get_velocity) in MATLAB API returning 3 elements instead of 6 ([#2764](https://github.com/cyberbotics/webots/pull/2764)).
     - Fixed step button status if simulation is reset from UI when the step button is disabled ([#2741](https://github.com/cyberbotics/webots/pull/2741)).
     - Fixed controllers output printed in the Webots console one step too late when running the simulation step-by-step ([#2741](https://github.com/cyberbotics/webots/pull/2741)).

--- a/docs/reference/lidar.md
+++ b/docs/reference/lidar.md
@@ -547,7 +547,7 @@ from controller import Lidar
 
 class Lidar (Device):
     def getPointCloud(self, data_type='list'):
-    def getLayerPointCloud(self, layer):
+    def getLayerPointCloud(self, layer, data_type='list'):
     def getNumberOfPoints(self):
     # ...
 ```
@@ -609,7 +609,7 @@ The `wb_lidar_get_layer_point_cloud` function is a convenient way of getting dir
 
 The `wb_lidar_get_number_of_points` function returns the total number of points contained in the point cloud (each layer is assumed to have the same number of points associated to).
 
-> **Note** [Python]: The `getPointCloud` method has `data_type` parameter which can be `list` (default) or `buffer`.
+> **Note** [Python]: The `getPointCloud` and `getLayerPointCloud` methods have `data_type` parameter which can be `list` (default) or `buffer`.
 If `data_type` is equal to `list` then the function returns a list of points, but it is slow as it has to create a list of objects.
 If `data_type` is equal to `buffer` then the function returns `bytearray` and it is fast as there is no memory copying.
 

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -495,20 +495,21 @@ namespace webots {
 };
 
 %typemap(out) float [] {
-  $result = SWIG_JavaArrayOutFloat(jenv, $1, arg1->getHorizontalResolution()*arg1->getNumberOfLayers());
+  int size = arg1->getHorizontalResolution();
+  const string functionName("$name");
+  if (functionName != "getLayerRangeImage")
+    size *= arg1->getNumberOfLayers();
+  $result = SWIG_JavaArrayOutFloat(jenv, $1, size);
 }
 
 %apply float[] {const float *};
 
 %javamethodmodifiers getPointCloud() const "private"
 %javamethodmodifiers getLayerPointCloud(int layer) const "private"
-%javamethodmodifiers getLayerRangeImage(int layer) const "private"
 %rename("getPointCloudPrivate") getPointCloud() const;
 %rename("getLayerPointCloudPrivate") getLayerPointCloud(int layer) const;
-%rename("getLayerRangeImagePrivate") getLayerRangeImage(int layer) const;
 %javamethodmodifiers getPoint(int index) const "private"
 %javamethodmodifiers getLayerPoint(int layer, int index) const "private"
-%javamethodmodifiers getLayerRangeValue(int layer, int index) const "private"
 
 %extend webots::Lidar {
   webots::LidarPoint getPoint(int index) const {
@@ -519,11 +520,6 @@ namespace webots {
   webots::LidarPoint getLayerPoint(int layer, int index) const {
     const webots::LidarPoint *point = $self->getLayerPointCloud(layer);
     return point[index];
-  }
-
-  float getLayerRangeValue(int layer, int index) const {
-    const float *data = $self->getLayerRangeImage(layer);
-    return data[index];
   }
 };
 
@@ -541,14 +537,6 @@ namespace webots {
     LidarPoint ret[] = new LidarPoint[numberOfPoints];
     for (int i = 0; i < numberOfPoints; ++i)
       ret[i] = this.getLayerPoint(layer, i);
-    return ret;
-  }
-
-  public float[] getLayerRangeImage(int layer) {
-    int numberOfPoints = wrapperJNI.Lidar_getHorizontalResolution(swigCPtr, this);
-    float ret[] = new float[numberOfPoints];
-    for (int i = 0; i < numberOfPoints; ++i)
-      ret[i] = this.getLayerRangeValue(layer, i);
     return ret;
   }
 %}

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -502,10 +502,13 @@ namespace webots {
 
 %javamethodmodifiers getPointCloud() const "private"
 %javamethodmodifiers getLayerPointCloud(int layer) const "private"
+%javamethodmodifiers getLayerRangeImage(int layer) const "private"
 %rename("getPointCloudPrivate") getPointCloud() const;
 %rename("getLayerPointCloudPrivate") getLayerPointCloud(int layer) const;
+%rename("getLayerRangeImagePrivate") getLayerRangeImage(int layer) const;
 %javamethodmodifiers getPoint(int index) const "private"
 %javamethodmodifiers getLayerPoint(int layer, int index) const "private"
+%javamethodmodifiers getLayerRangeValue(int layer, int index) const "private"
 
 %extend webots::Lidar {
   webots::LidarPoint getPoint(int index) const {
@@ -516,6 +519,11 @@ namespace webots {
   webots::LidarPoint getLayerPoint(int layer, int index) const {
     const webots::LidarPoint *point = $self->getLayerPointCloud(layer);
     return point[index];
+  }
+
+  float getLayerRangeValue(int layer, int index) const {
+    const float *data = $self->getLayerRangeImage(layer);
+    return data[index];
   }
 };
 
@@ -533,6 +541,14 @@ namespace webots {
     LidarPoint ret[] = new LidarPoint[numberOfPoints];
     for (int i = 0; i < numberOfPoints; ++i)
       ret[i] = this.getLayerPoint(layer, i);
+    return ret;
+  }
+
+  public float[] getLayerRangeImage(int layer) {
+    int numberOfPoints = wrapperJNI.Lidar_getHorizontalResolution(swigCPtr, this);
+    float ret[] = new float[numberOfPoints];
+    for (int i = 0; i < numberOfPoints; ++i)
+      ret[i] = this.getLayerRangeValue(layer, i);
     return ret;
   }
 %}

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -91,7 +91,7 @@ using namespace std;
 // manage double arrays
 %typemap(out) const double * {
   int len = 3;
-  string test("$name");
+  const string test("$name");
   if (test == "getSFVec2f" || test == "getMFVec2f")
     len = 2;
   else if (test == "getSFRotation" || test == "getQuaternion")
@@ -105,7 +105,7 @@ using namespace std;
     PyList_SetItem($result, i, PyFloat_FromDouble($1[i]));
 }
 %typemap(out) const double *getLookupTable {
-  int len = arg1->getLookupTableSize()*3;
+  const int len = arg1->getLookupTableSize()*3;
   $result = PyList_New(len);
   for (int i = 0; i < len; ++i)
     PyList_SetItem($result, i, PyFloat_FromDouble($1[i]));
@@ -115,7 +115,7 @@ using namespace std;
     PyErr_SetString(PyExc_TypeError, "in method '$name', expected 'PyList'\n");
     return NULL;
   }
-  int len = PyList_Size($input);
+  const int len = PyList_Size($input);
   $1 = (double*)malloc(len * sizeof(double));
   for (int i = 0; i < len; ++i)
     $1[i] = PyFloat_AsDouble(PyList_GetItem($input, i));
@@ -128,7 +128,7 @@ using namespace std;
     PyErr_SetString(PyExc_TypeError, "in method '$name', expected 'PyList'\n");
     return NULL;
   }
-  int len = PyList_Size($input);
+  const int len = PyList_Size($input);
   $1 = (int*)malloc(len * sizeof(int));
   for (int i = 0; i < len; ++i)
     $1[i] = PyInt_AsLong(PyList_GetItem($input, i));
@@ -273,8 +273,8 @@ class AnsiCodes(object):
 
 
 %typemap(out) unsigned char * {
-  int width = arg1->getWidth();
-  int height = arg1->getHeight();
+  const int width = arg1->getWidth();
+  const int height = arg1->getHeight();
   if ($1)
     $result = PyBytes_FromStringAndSize((const char*)$1, 4 * width * height);
   else
@@ -285,8 +285,8 @@ class AnsiCodes(object):
 %extend webots::Camera {
   PyObject *getImageArray() {
     const unsigned char *im = $self->getImage();
-    int width = $self->getWidth();
-    int height = $self->getHeight();
+    const int width = $self->getWidth();
+    const int height = $self->getHeight();
     PyObject *ret = Py_None;
     if (im) {
       ret = PyList_New(width);
@@ -309,7 +309,7 @@ class AnsiCodes(object):
       PyErr_SetString(PyExc_TypeError, "in method 'Camera_imageGetRed', argument 2 of type 'PyString'\n");
       return NULL;
     }
-    unsigned char *s = (unsigned char*)PyString_AsString(im);
+    const unsigned char *s = (unsigned char*)PyString_AsString(im);
     return PyInt_FromLong(s[4 * (y * width + x) + 2]);
   }
 
@@ -318,7 +318,7 @@ class AnsiCodes(object):
       PyErr_SetString(PyExc_TypeError, "in method 'Camera_imageGetGreen', argument 2 of type 'PyString'\n");
       return NULL;
     }
-    unsigned char *s = (unsigned char*)PyString_AsString(im);
+    const unsigned char *s = (unsigned char*)PyString_AsString(im);
     return PyInt_FromLong(s[4 * (y * width + x) + 1]);
   }
 
@@ -327,7 +327,7 @@ class AnsiCodes(object):
       PyErr_SetString(PyExc_TypeError, "in method 'Camera_imageGetBlue', argument 2 of type 'PyString'\n");
       return NULL;
     }
-    unsigned char *s = (unsigned char*)PyString_AsString(im);
+    const unsigned char *s = (unsigned char*)PyString_AsString(im);
     return PyInt_FromLong(s[4 * (y * width + x)]);
   }
 
@@ -336,7 +336,7 @@ class AnsiCodes(object):
       PyErr_SetString(PyExc_TypeError, "in method 'Camera_imageGetGrey', argument 2 of type 'PyString'\n");
       return NULL;
     }
-    unsigned char *s = (unsigned char*)PyString_AsString(im);
+    const unsigned char *s = (unsigned char*)PyString_AsString(im);
     return PyInt_FromLong((s[4 * (y * width + x)] + s[4 * (y * width + x) + 1] + s[4 * (y * width + x) + 2]) / 3);
   }
 
@@ -345,7 +345,7 @@ class AnsiCodes(object):
       PyErr_SetString(PyExc_TypeError, "in method 'Camera_imageGetGrey', argument 2 of type 'PyString'\n");
       return NULL;
     }
-    unsigned char *s = (unsigned char*)PyString_AsString(im);
+    const unsigned char *s = (unsigned char*)PyString_AsString(im);
     return PyInt_FromLong((s[4 * (y * width + x)] + s[4 * (y * width + x) + 1] + s[4 * (y * width + x) + 2]) / 3);
   }
 
@@ -364,8 +364,8 @@ class AnsiCodes(object):
 
   PyObject *getRecognitionSegmentationImageArray() {
     const unsigned char *im = $self->getRecognitionSegmentationImage();
-    int width = $self->getWidth();
-    int height = $self->getHeight();
+    const int width = $self->getWidth();
+    const int height = $self->getHeight();
     PyObject *ret = Py_None;
     if (im) {
       ret = PyList_New(width);
@@ -410,19 +410,19 @@ class AnsiCodes(object):
     return NULL;
   }
   if (PyList_Check($input)) {
-    int len1 = PyList_Size($input);
+    const int len1 = PyList_Size($input);
     PyObject *l2 = PyList_GetItem($input, 0);
     if (!PyList_Check(l2)) {
       PyErr_SetString(PyExc_TypeError, "expected 'PyList' of 'PyList'\n");
       return NULL;
     }
-    int len2 = PyList_Size(l2);
+    const int len2 = PyList_Size(l2);
     PyObject *l3 = PyList_GetItem(l2, 0);
     if (!PyList_Check(l3)) {
       PyErr_SetString(PyExc_TypeError, "expected 'PyList' of 'PyList' of 'PyList'\n");
       return NULL;
     }
-    int len3 = PyList_Size(l3);
+    const int len3 = PyList_Size(l3);
     $1 = (void *)malloc(len1 * len2 * len3 * sizeof(unsigned char));
     need_to_delete = true;
     for (int i = 0; i < len1; ++i)
@@ -536,12 +536,14 @@ class AnsiCodes(object):
 %include <webots/lidar_point.h>
 
 %typemap(out) float * {
-  int width = arg1->getHorizontalResolution();
-  int height = arg1->getNumberOfLayers();
-  int len = width * height;
-  string functionName("$name");
+  const int width = arg1->getHorizontalResolution();
+  const int height = arg1->getNumberOfLayers();
+  const string functionName("$name");
+  int len;
   if (functionName == "getLayerRangeImage")
     len = width;
+  else
+    len = width * height;
   if ($1) {
     $result = PyList_New(len);
     for (int x = 0; x < len; ++x)
@@ -598,8 +600,8 @@ class AnsiCodes(object):
 
   PyObject *getRangeImageArray() {
     const float *im = $self->getRangeImage();
-    int width = $self->getHorizontalResolution();
-    int height = $self->getNumberOfLayers();
+    const int width = $self->getHorizontalResolution();
+    const int height = $self->getNumberOfLayers();
     PyObject *ret = Py_None;
     if (im) {
       ret = PyList_New(width);
@@ -776,8 +778,8 @@ class AnsiCodes(object):
 
   PyObject *getRangeImageArray() {
     const float *im = $self->getRangeImage();
-    int width = $self->getWidth();
-    int height = $self->getHeight();
+    const int width = $self->getWidth();
+    const int height = $self->getHeight();
     PyObject *ret = Py_None;
     if (im) {
       ret = PyList_New(width);

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -558,7 +558,7 @@ class AnsiCodes(object):
   PyObject *__getPointCloudBuffer(int layer) const {
     const char *points = layer < 0 ? (const char *)$self->getPointCloud() : (const char *)$self->getLayerPointCloud(layer);
     const int numberOfPoints = layer < 0 ? $self->getNumberOfPoints() : $self->getHorizontalResolution();
-    const int size = number_of_points * sizeof(WbLidarPoint);
+    const int size = numberOfPoints * sizeof(WbLidarPoint);
     return PyBytes_FromStringAndSize(points, size);
   }
 

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -557,7 +557,7 @@ class AnsiCodes(object):
 
   PyObject *__getPointCloudBuffer(int layer) const {
     const char *points = layer < 0 ? (const char *)$self->getPointCloud() : (const char *)$self->getLayerPointCloud(layer);
-    const int number_of_points = layer < 0 ? $self->getNumberOfPoints() : $self->getHorizontalResolution();
+    const int numberOfPoints = layer < 0 ? $self->getNumberOfPoints() : $self->getHorizontalResolution();
     const int size = number_of_points * sizeof(WbLidarPoint);
     return PyBytes_FromStringAndSize(points, size);
   }

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -539,8 +539,8 @@ class AnsiCodes(object):
   int width = arg1->getHorizontalResolution();
   int height = arg1->getNumberOfLayers();
   int len = width * height;
-  string function_name("$name");
-  if (function_name == "getLayerRangeImage")
+  string functionName("$name");
+  if (functionName == "getLayerRangeImage")
     len = width;
   if ($1) {
     $result = PyList_New(len);

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -549,6 +549,7 @@ class AnsiCodes(object):
 
 %ignore webots::Lidar::getPointCloud();
 %ignore webots::Lidar::getLayerPointCloud();
+%ignore webots::Lidar::getLayerRangeImage();
 
 %extend webots::Lidar {
 
@@ -580,6 +581,11 @@ class AnsiCodes(object):
     return point[index];
   }
 
+  float getLayerRangeValue(int layer, int index) const {
+    const float *point = $self->getLayerRangeImage(layer);
+    return point[index];
+  }
+
   %pythoncode %{
   import sys
 
@@ -597,6 +603,12 @@ class AnsiCodes(object):
      for i in range(self.getHorizontalResolution()):
        ret.append(self.getLayerPoint(layer, i))
      return ret
+
+  def getLayerRangeImage(self, layer):
+    ret = []
+    for i in range(self.getHorizontalResolution()):
+      ret.append(self.getLayerRangeValue(layer, i))
+    return ret
   %}
 
   PyObject *getRangeImageArray() {


### PR DESCRIPTION
Fix #2672:
overwrite default SWIG implementation of `Lidar.getLayerRangeImage` to return just part of the full image array.
This approach is the same also used for the `Lidar.getLayerPointCloud` function.