### PR TITLE
Fix physics example

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -34,7 +34,6 @@ Released on XX Xth, 2021.
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
     - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
     - Fixed the return value handling from the `webots_physics_collide` when the [Group](group.md) node is one of the colliding objects ([#2781](https://github.com/cyberbotics/webots/pull/2781)).
-    - Fixed the ray collision in the [physics.wbt](https://github.com/cyberbotics/webots/blob/master/projects/samples/howto/physics/worlds/physics.wbt) example ([#2801](https://github.com/cyberbotics/webots/pull/2801)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
   - Dependency Updates

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -34,6 +34,7 @@ Released on XX Xth, 2021.
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
     - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
     - Fixed the return value handling from the `webots_physics_collide` when the [Group](group.md) node is one of the colliding objects ([#2781](https://github.com/cyberbotics/webots/pull/2781)).
+    - Fixed the ray collision in the [physics.wbt](https://github.com/cyberbotics/webots/blob/master/projects/samples/howto/physics/worlds/physics.wbt) example ([#2801](https://github.com/cyberbotics/webots/pull/2801)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
   - Dependency Updates

--- a/projects/samples/howto/physics/plugins/physics/flying_mybot/flying_mybot.c
+++ b/projects/samples/howto/physics/plugins/physics/flying_mybot/flying_mybot.c
@@ -284,8 +284,8 @@ int webots_physics_collide(dGeomID g1, dGeomID g2) {
      * But in the case the collision is with the robot's body, we ignore
      * it. They will not create any collision.
      */
-    if ((dAreGeomsSame(g2, ray_geom) && dSpaceQuery((dSpaceID)robot_geom, g1) == 1) ||
-        (dAreGeomsSame(g1, ray_geom) && dSpaceQuery((dSpaceID)robot_geom, g2) == 1)) {
+    if ((dAreGeomsSame(g2, ray_geom) && (dSpaceQuery((dSpaceID)robot_geom, g1) == 1 || dGeomIsSpace(g1))) ||
+        (dAreGeomsSame(g1, ray_geom) && (dSpaceQuery((dSpaceID)robot_geom, g2) == 1 || dGeomIsSpace(g1)))) {
       ray_color = 0;
       dWebotsSend(2, &ray_color, sizeof(int));
       return 1;


### PR DESCRIPTION
Fixes #2643

Since #2505 the callback function is called for Group nodes (spaces) as well, so the ray was colliding with the Group node in the robot's body.