### PR TITLE
Fix URDF exporting of leaf nodes

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -33,6 +33,7 @@ Released on XX Xth, 2021.
     - Fixed external force/torque logic such that the closest dynamic Solid ancestor is picked if the selected one lacks it ([#2635](https://github.com/cyberbotics/webots/pull/2635)).
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
     - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
+    - Fixed the `robot_get_urdf` function to include leaf nodes in URDF ([#2803](https://github.com/cyberbotics/webots/pull/2803)).
     - Fixed the return value handling from the `webots_physics_collide` when the [Group](group.md) node is one of the colliding objects ([#2781](https://github.com/cyberbotics/webots/pull/2781)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/vrml/WbMFNode.cpp
+++ b/src/webots/vrml/WbMFNode.cpp
@@ -210,7 +210,7 @@ void WbMFNode::write(WbVrmlWriter &writer) const {
   int c = 0;
   const int size = mVector.size();
   for (int i = 0; i < size; ++i) {
-    if (writer.isWebots() || mVector[i]->shallExport()) {
+    if (writer.isWebots() || writer.isUrdf() || mVector[i]->shallExport()) {
       writer.writeMFSeparator(c == 0, smallSeparator(i));
       writeItem(writer, i);
       ++c;

--- a/tests/api/controllers/robot_urdf/prob3_reference.urdf
+++ b/tests/api/controllers/robot_urdf/prob3_reference.urdf
@@ -248,27 +248,34 @@
       </geometry>
     </collision>
   </link>
+  <link name="ts_emitter">
+  </link>
+  <joint name="link_6_top_ts_emitter_joint" type="fixed">
+    <parent link="link_6_top"/>
+    <child link="ts_emitter"/>
+    <origin xyz="0 0 0.02075" rpy="0 0 0"/>
+  </joint>
   <link name="link_base_tcp180_50200">
     <visual>
-      <origin xyz="0 0 0.04675" rpy="0 0 0"/>
+      <origin xyz="0 0 0.026" rpy="0 0 0"/>
       <geometry>
         <sphere radius="0.08"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 0 0.04675" rpy="0 0 0"/>
+      <origin xyz="0 0 0.026" rpy="0 0 0"/>
       <geometry>
         <sphere radius="0.08"/>
       </geometry>
     </collision>
     <visual>
-      <origin xyz="0 1.34683e-07 0.00675" rpy="-3.1415894 0 0"/>
+      <origin xyz="0 1.34683e-07 -0.014" rpy="-3.1415894 0 0"/>
       <geometry>
         <cylinder radius="0.08" length="0.07"/>
       </geometry>
     </visual>
     <collision>
-      <origin xyz="0 1.34683e-07 0.00675" rpy="-3.1415894 0 0"/>
+      <origin xyz="0 1.34683e-07 -0.014" rpy="-3.1415894 0 0"/>
       <geometry>
         <cylinder radius="0.08" length="0.07"/>
       </geometry>
@@ -277,7 +284,14 @@
   <joint name="link_6_top_link_base_tcp180_50200_joint" type="fixed">
     <parent link="link_6_top"/>
     <child link="link_base_tcp180_50200"/>
-    <origin xyz="0 0 0.0985" rpy="0 0 0"/>
+    <origin xyz="0 0 0.07775" rpy="0 0 0"/>
+  </joint>
+  <link name="gripper middle distance sensor">
+  </link>
+  <joint name="link_base_tcp180_50200_gripper middle distance sensor_joint" type="fixed">
+    <parent link="link_base_tcp180_50200"/>
+    <child link="gripper middle distance sensor"/>
+    <origin xyz="0 0 0.085" rpy="0 -1.5707897 0"/>
   </joint>
   <joint name="7 left" type="revolute">
     <parent link="link_base_tcp180_50200"/>
@@ -372,6 +386,34 @@
       </geometry>
     </collision>
   </link>
+  <link name="left finger sensor 3">
+  </link>
+  <joint name="left finger_50285_left finger sensor 3_joint" type="fixed">
+    <parent link="left finger_50285"/>
+    <child link="left finger sensor 3"/>
+    <origin xyz="-6.75982e-08 0.0173238 0.0871813" rpy="7.8457396e-07 0.26179942 1.5708023"/>
+  </joint>
+  <link name="left finger sensor 2">
+  </link>
+  <joint name="left finger_50285_left finger sensor 2_joint" type="fixed">
+    <parent link="left finger_50285"/>
+    <child link="left finger sensor 2"/>
+    <origin xyz="-7.548e-10 0.0214379 0.13449" rpy="-3.3035767e-06 -1.1257437 -1.5707953"/>
+  </joint>
+  <link name="left finger sensor 1">
+  </link>
+  <joint name="left finger_50285_left finger sensor 1_joint" type="fixed">
+    <parent link="left finger_50285"/>
+    <child link="left finger sensor 1"/>
+    <origin xyz="-0.013 0.02 0.118" rpy="0 0 3.1415927"/>
+  </joint>
+  <link name="left finger sensor 0">
+  </link>
+  <joint name="left finger_50285_left finger sensor 0_joint" type="fixed">
+    <parent link="left finger_50285"/>
+    <child link="left finger sensor 0"/>
+    <origin xyz="0.013 0.02 0.118" rpy="0 0 0"/>
+  </joint>
   <joint name="7" type="revolute">
     <parent link="link_base_tcp180_50200"/>
     <child link="right finger_50237"/>
@@ -465,6 +507,34 @@
       </geometry>
     </collision>
   </link>
+  <link name="right finger sensor 3">
+  </link>
+  <joint name="right finger_50237_right finger sensor 3_joint" type="fixed">
+    <parent link="right finger_50237"/>
+    <child link="right finger sensor 3"/>
+    <origin xyz="-6.75982e-08 0.0173238 0.0871813" rpy="7.8457396e-07 0.26179942 1.5708023"/>
+  </joint>
+  <link name="right finger sensor 2">
+  </link>
+  <joint name="right finger_50237_right finger sensor 2_joint" type="fixed">
+    <parent link="right finger_50237"/>
+    <child link="right finger sensor 2"/>
+    <origin xyz="-7.548e-10 0.0214379 0.13449" rpy="-3.3035767e-06 -1.1257437 -1.5707953"/>
+  </joint>
+  <link name="right finger sensor 1">
+  </link>
+  <joint name="right finger_50237_right finger sensor 1_joint" type="fixed">
+    <parent link="right finger_50237"/>
+    <child link="right finger sensor 1"/>
+    <origin xyz="-0.013 0.02 0.118" rpy="0 0 3.1415927"/>
+  </joint>
+  <link name="right finger sensor 0">
+  </link>
+  <joint name="right finger_50237_right finger sensor 0_joint" type="fixed">
+    <parent link="right finger_50237"/>
+    <child link="right finger sensor 0"/>
+    <origin xyz="0.013 0.02 0.118" rpy="0 0 0"/>
+  </joint>
   <link name="button 7">
   </link>
   <joint name="link_6_top_button 7_joint" type="fixed">

--- a/tests/api/controllers/robot_urdf/tiago_reference.urdf
+++ b/tests/api/controllers/robot_urdf/tiago_reference.urdf
@@ -280,6 +280,27 @@
     <child link="base_cover_link"/>
     <origin xyz="0 0 0.03" rpy="0 0 0"/>
   </joint>
+  <link name="gyro">
+  </link>
+  <joint name="base_link_gyro_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="gyro"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <link name="inertial unit">
+  </link>
+  <joint name="base_link_inertial unit_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="inertial unit"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+  <link name="accelerometer">
+  </link>
+  <joint name="base_link_accelerometer_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="accelerometer"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
   <link name="Hokuyo URG-04LX-UG01">
     <visual>
       <origin xyz="0 -0.0175 0" rpy="0 0 0"/>
@@ -501,6 +522,13 @@
       </geometry>
     </collision>
   </link>
+  <link name="ts_emitter">
+  </link>
+  <joint name="head_2_link_ts_emitter_joint" type="fixed">
+    <parent link="head_2_link"/>
+    <child link="ts_emitter"/>
+    <origin xyz="0.107 0.0802 0" rpy="0 0 0"/>
+  </joint>
   <link name="TIAGo left arm_43965">
     <visual>
       <origin xyz="0.026 0.14 -0.232" rpy="0 0 1.5708"/>

--- a/tests/api/controllers/robot_urdf/ur5e_reference.urdf
+++ b/tests/api/controllers/robot_urdf/ur5e_reference.urdf
@@ -303,4 +303,11 @@
     <child link="track_307"/>
     <origin xyz="0 0.1 0" rpy="0 0 0"/>
   </joint>
+  <link name="ts_emitter">
+  </link>
+  <joint name="wrist_3_link_ts_emitter_joint" type="fixed">
+    <parent link="wrist_3_link"/>
+    <child link="ts_emitter"/>
+    <origin xyz="0 0.1 0" rpy="0 0 0"/>
+  </joint>
 </robot>


### PR DESCRIPTION
This PR should fix #2503. URDF links were not generated for the leaf nodes.

Visual inspection to check for regressions:
![image](https://user-images.githubusercontent.com/2135826/109672012-e1398c80-7b74-11eb-90c5-18fa81a8569e.png)

![image](https://user-images.githubusercontent.com/2135826/109699971-819daa00-7b91-11eb-8c7c-8cafd592157b.png)

Visualization command (may be useful in the future):
```
ros2 launch urdf_tutorial display.launch.py model:=/tmp/robot.urdf
```