### PR TITLE
Fix wireframe rendering

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -31,6 +31,7 @@ Released on XX Xth, 2021.
     - Fixed in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
     - Fixed a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).
     - Fixed external force/torque logic such that the closest dynamic Solid ancestor is picked if the selected one lacks it ([#2635](https://github.com/cyberbotics/webots/pull/2635)).
+    - Fixed the wireframe rendering badly affected by lighting ([#2806](https://github.com/cyberbotics/webots/pull/2806)).
     - Fixed the [robot window example](../guide/samples-howto.md#custom_robot_window-wbt) ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
     - Fixed visual bug where the [Lidar](lidar.md) point cloud disappears when out-of-range points are present ([#2666](https://github.com/cyberbotics/webots/pull/2666)).
     - Fixed the return value handling from the `webots_physics_collide` when the [Group](group.md) node is one of the colliding objects ([#2781](https://github.com/cyberbotics/webots/pull/2781)).

--- a/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/pbr_stencil_ambient_emissive.frag
@@ -13,6 +13,7 @@ layout(location = 1) out vec4 fragNormal;
 
 uniform sampler2D inputTextures[13];
 uniform samplerCube cubeTextures[1];
+uniform int wireframeRendering;
 
 // Material parameters for this renderable
 layout(std140) uniform PbrMaterial {
@@ -174,12 +175,13 @@ void main() {
     color = mix(color, color * ao, material.roughnessMetalnessNormalMapFactorOcclusion.w);
   }
 
-  vec3 emissive = material.emissiveColorAndIntensity.rgb;
+  vec3 emissive = (wireframeRendering != 0) ? material.baseColorAndTransparency.rgb : material.emissiveColorAndIntensity.rgb;
 
   if (material.normalBrdfEmissiveBackgroundFlags.z > 0.0)
     emissive = texture(inputTextures[6], texUv).rgb;
 
-  emissive *= material.emissiveColorAndIntensity.w;
+  if (wireframeRendering != 0)
+    emissive *= material.emissiveColorAndIntensity.w;
   color += emissive;
 
   fragColor = vec4(color, baseColor.a);

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -40,6 +40,7 @@
 #include "WbWrenGtao.hpp"
 #include "WbWrenHdr.hpp"
 #include "WbWrenRenderingContext.hpp"
+#include "WbWrenShaders.hpp"
 #include "WbWrenSmaa.hpp"
 
 #ifdef _WIN32
@@ -49,6 +50,7 @@
 #include <wren/camera.h>
 #include <wren/node.h>
 #include <wren/scene.h>
+#include <wren/shader_program.h>
 #include <wren/transform.h>
 #include <wren/viewport.h>
 
@@ -922,10 +924,17 @@ void WbViewpoint::applyOptionalRenderingToWren() {
 }
 
 void WbViewpoint::applyRenderingModeToWren() {
-  if (WbWrenRenderingContext::instance()->renderingMode() == WbWrenRenderingContext::RM_WIREFRAME)
+  int wireframeRendering;
+  if (WbWrenRenderingContext::instance()->renderingMode() == WbWrenRenderingContext::RM_WIREFRAME) {
     wr_viewport_set_polygon_mode(mWrenViewport, WR_VIEWPORT_POLYGON_MODE_LINE);
-  else
+    wireframeRendering = 1;
+  } else {
     wr_viewport_set_polygon_mode(mWrenViewport, WR_VIEWPORT_POLYGON_MODE_FILL);
+    wireframeRendering = 0;
+  }
+  wr_shader_program_set_custom_uniform_value(WbWrenShaders::pbrStencilAmbientEmissiveShader(), "wireframeRendering",
+                                             WR_SHADER_PROGRAM_UNIFORM_TYPE_INT,
+                                             reinterpret_cast<const char *>(&wireframeRendering));
 
   wr_viewport_set_visibility_mask(mWrenViewport, WbWrenRenderingContext::instance()->visibilityMask());
 }

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -589,6 +589,10 @@ void WbWrenCamera::init() {
   emit cameraInitialized();
 
   WbWrenOpenGlContext::doneWren();
+
+  int wireframeRendering = 1;
+  wr_shader_program_set_custom_uniform_value(WbWrenShaders::pbrStencilAmbientEmissiveShader(), "wireframeRendering", WR_SHADER_PROGRAM_UNIFORM_TYPE_INT, reinterpret_cast<const char *>(&wireframeRendering));
+
 }
 
 void WbWrenCamera::cleanup() {

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -589,10 +589,6 @@ void WbWrenCamera::init() {
   emit cameraInitialized();
 
   WbWrenOpenGlContext::doneWren();
-
-  int wireframeRendering = 1;
-  wr_shader_program_set_custom_uniform_value(WbWrenShaders::pbrStencilAmbientEmissiveShader(), "wireframeRendering", WR_SHADER_PROGRAM_UNIFORM_TYPE_INT, reinterpret_cast<const char *>(&wireframeRendering));
-
 }
 
 void WbWrenCamera::cleanup() {

--- a/src/webots/wren/WbWrenShaders.cpp
+++ b/src/webots/wren/WbWrenShaders.cpp
@@ -870,6 +870,11 @@ WrShaderProgram *WbWrenShaders::pbrStencilAmbientEmissiveShader() {
     wr_shader_program_use_uniform(gShaders[SHADER_PBR_STENCIL_AMBIENT_EMISSIVE], WR_GLSL_LAYOUT_UNIFORM_MODEL_TRANSFORM);
     wr_shader_program_use_uniform(gShaders[SHADER_PBR_STENCIL_AMBIENT_EMISSIVE], WR_GLSL_LAYOUT_UNIFORM_TEXTURE_TRANSFORM);
 
+    int wireframeRendering = 0;
+    wr_shader_program_create_custom_uniform(gShaders[SHADER_PBR_STENCIL_AMBIENT_EMISSIVE], "wireframeRendering",
+                                            WR_SHADER_PROGRAM_UNIFORM_TYPE_INT,
+                                            reinterpret_cast<const char *>(&wireframeRendering));
+
     wr_shader_program_use_uniform_buffer(gShaders[SHADER_PBR_STENCIL_AMBIENT_EMISSIVE],
                                          WR_GLSL_LAYOUT_UNIFORM_BUFFER_MATERIAL_PBR);
     wr_shader_program_use_uniform_buffer(gShaders[SHADER_PBR_STENCIL_AMBIENT_EMISSIVE],


### PR DESCRIPTION
This PR should eventually fix #1738.

---

Notice: I am directly accessing WREN's low-level functions (e.g. `wr_shader_program_set_custom_uniform_value`) from `WbViewpoint`. Please let me know if it is a good approach or you have some kind of convention for this kind of thing.