### PR TITLE
Fixes nightly builds of Webots R2021b on Windows

### DIFF
--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -13,7 +13,7 @@ include/controller/c/
 include/controller/c/webots/
 include/controller/c/webots/*.h
 include/controller/c/webots/plugins/
-include/controller/c/webots/plugins/robot_window
+include/controller/c/webots/plugins/robot_window/
 include/controller/c/webots/plugins/robot_window/*.h
 include/controller/c/webots/plugins/robot_window/generic_robot_window/
 include/controller/c/webots/plugins/robot_window/generic_robot_window/*.h


### PR DESCRIPTION
This should fix the failure of the nightly builds for Webots R2021b on Windows.