### PR TITLE
Fixed default python version on Windows

### DIFF
--- a/scripts/install/msys.sh
+++ b/scripts/install/msys.sh
@@ -7,6 +7,6 @@ cd ~
 else
 WINDOWS_DRIVE=${1:1:1}:\\${1:3}
 export WEBOTS_HOME=${WINDOWS_DRIVE////\\}
-export PATH="$PYTHON39_HOME:$PYTHON39_HOME/Scripts:$1/msys64/mingw64/bin":/mingw64/bin:/usr/bin:$JAVA_HOME/bin:/c/WINDOWS/system32:/c/WINDOWS:$MATLAB_HOME/bin:$1/bin/node
+export PATH="$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$1/msys64/mingw64/bin":/mingw64/bin:/usr/bin:$JAVA_HOME/bin:/c/WINDOWS/system32:/c/WINDOWS:$MATLAB_HOME/bin:$1/bin/node
 cd "$1"
 fi


### PR DESCRIPTION
Python 3.9 is not yet mature enough to be used in all Webots scripts (some dependencies are missing), this PR reverts to Python 3.8.