### PR TITLE
Significantly simplify the usage of the `ros` controller

### DIFF
--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -68,7 +68,7 @@ In the following table you can find the list of `ros` controller arguments.
 | `--synchronize`   | By default the `ros` controller is not blocking the simulation even if no ROS node is connected to it. In order to synchronize the simulation with the ROS node, the `--synchronize` argument can be specified, so that the simulation will not run as long as the robot `time_step` service is not called. |
 | `--clock`   | Publish the Webots time using the `clock` topic. |
 | `--use-sim-time` | Specify that the Webots time should be used as ROS time. To work correctly you should also define the `--clock` argument and set the ROS parameter `use_sim_time` to true. |
-| `--auto-publish` | Force the controller to automatically enable all devices on startup and create corresponding topics. |
+| `--auto-publish` | Force the controller to automatically enable all devices on startup and create the corresponding topics. |
 | `--use-ros-control` | Initialize the `controller_manager` from the [`ros_control`](http://wiki.ros.org/ros_control). |
 | `--robot-description[={robot_description_prefix}]` | Expose the `robot_description` ROS parameter that contains the URDF of the robot. The `robot_description_prefix` parameter is optional and it corresponds to the `prefix` argument of the [`wb_robot_get_urdf`](../reference/robot.md#wb_robot_get_urdf) function. |
 

--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -68,6 +68,10 @@ In the following table you can find the list of `ros` controller arguments.
 | `--synchronize`   | By default the `ros` controller is not blocking the simulation even if no ROS node is connected to it. In order to synchronize the simulation with the ROS node, the `--synchronize` argument can be specified, so that the simulation will not run as long as the robot `time_step` service is not called. |
 | `--clock`   | Publish the Webots time using the `clock` topic. |
 | `--use-sim-time` | Specify that the Webots time should be used as ROS time. To work correctly you should also define the `--clock` argument and set the ROS parameter `use_sim_time` to true. |
+| `--auto-publish` | Force the controller to automatically enable all devices on startup and create corresponding topics. |
+| `--use-ros-control` | Initialize the `controller_manager` from the [`ros_control`](http://wiki.ros.org/ros_control). |
+| `--robot-description[={robot_description_prefix}]` | Expose the `robot_description` ROS parameter that contains the URDF of the robot. The `robot_description_prefix` parameter is optional and it corresponds to the `prefix` argument of the [`wb_robot_get_urdf`](../reference/robot.md#wb_robot_get_urdf) function. |
+
 
 %end
 

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -20,7 +20,7 @@ Released on June, Xth, 2021.
       - Split the generic robot window code in different libraries and JS files so that it can be easily reused for custom projects.
     - Allowed the [Robot](robot.md) node to be added inside the [Group](group.md) node and other nodes derived from the Group node like [Transform](transform.md) and [Solid](solid.md) ([#2732](https://github.com/cyberbotics/webots/pull/2732)).
     - Allowed the `wb_supervisor_node_reset_physics` function to reset the physics of solid descendants of the given node ([#2742](https://github.com/cyberbotics/webots/pull/2742)).
-    - Simplified usage of the `ros` controller ([#2822](https://github.com/cyberbotics/webots/pull/2822)).
+    - Simplified the usage of the `ros` controller ([#2822](https://github.com/cyberbotics/webots/pull/2822)).
       - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -21,7 +21,7 @@ Released on June, Xth, 2021.
     - Allowed the [Robot](robot.md) node to be added inside the [Group](group.md) node and other nodes derived from the Group node like [Transform](transform.md) and [Solid](solid.md) ([#2732](https://github.com/cyberbotics/webots/pull/2732)).
     - Allowed the `wb_supervisor_node_reset_physics` function to reset the physics of solid descendants of the given node ([#2742](https://github.com/cyberbotics/webots/pull/2742)).
     - Simplified the usage of the `ros` controller ([#2822](https://github.com/cyberbotics/webots/pull/2822)).
-      - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
+      - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow the usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
   - New Samples:

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -20,6 +20,10 @@ Released on June, Xth, 2021.
       - Split the generic robot window code in different libraries and JS files so that it can be easily reused for custom projects.
     - Allowed the [Robot](robot.md) node to be added inside the [Group](group.md) node and other nodes derived from the Group node like [Transform](transform.md) and [Solid](solid.md) ([#2732](https://github.com/cyberbotics/webots/pull/2732)).
     - Allowed the `wb_supervisor_node_reset_physics` function to reset the physics of solid descendants of the given node ([#2742](https://github.com/cyberbotics/webots/pull/2742)).
+    - Simplified usage of the `ros` controller ([#2822](https://github.com/cyberbotics/webots/pull/2822)).
+      - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
+      - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create corresponding topics.
+      - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added a generic gear proto and a demo showing it being used in a collision-based transmission ([#2805](https://github.com/cyberbotics/webots/pull/2805)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -22,7 +22,7 @@ Released on June, Xth, 2021.
     - Allowed the `wb_supervisor_node_reset_physics` function to reset the physics of solid descendants of the given node ([#2742](https://github.com/cyberbotics/webots/pull/2742)).
     - Simplified the usage of the `ros` controller ([#2822](https://github.com/cyberbotics/webots/pull/2822)).
       - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow the usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
-      - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create corresponding topics.
+      - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create the corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -76,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -76,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system -lclass_loader -lroslib
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -49,6 +49,7 @@ release debug profile clean:
 	@echo "# \033[0;33mROS_DISTRO should not be a ROS2 distribution\033[0m"
 else
 CXX_SOURCES = $(wildcard *.cpp)
+CXX_SOURCES += $(wildcard highlevel/*.cpp)
 
 ifeq ($(OSTYPE),windows)
  ros.exe: $(CXX_SOURCES:.cxx=.d)
@@ -75,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)
@@ -98,7 +99,7 @@ CFLAGS += -Wno-unused-local-typedefs
 CFLAGS += -std=c++11
 endif
 
-FILES_TO_REMOVE += include/webots_ros include/messages include/services headersGenerator.pyc include/XmlRpcDecl.h include/XmlRpcValue.h include/geometry_msgs include/log4cxx include/ros include/rosconsole include/rosgraph_msgs include/sensor_msgs include/std_msgs include/boost __pycache__ $(wildcard include/*.zip)
+FILES_TO_REMOVE += include/webots_ros include/messages include/services headersGenerator.pyc include/XmlRpcDecl.h include/XmlRpcValue.h include/geometry_msgs include/log4cxx include/ros include/rosconsole include/rosgraph_msgs include/sensor_msgs include/std_msgs include/hardware_interface include/controller_manager include/boost __pycache__ $(wildcard include/*.zip)
 
 ### Do not modify: this includes Webots global Makefile.include
 

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -76,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -76,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system -lclass_loader -lroslib -librospack.so
+LIBRARIES += -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -76,7 +76,7 @@ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include 
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system -lclass_loader -lroslib
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system -lclass_loader -lroslib -librospack.so
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -76,6 +76,7 @@ Ros::Ros() :
   mShouldPublishClock(false),
   mIsSynchronized(false),
   mUseWebotsSimTime(false),
+  mAutoPublish(false),
   mRosControl(NULL) {
 }
 
@@ -138,6 +139,8 @@ void Ros::launchRos(int argc, char **argv) {
       mUseWebotsSimTime = true;
     else if (strcmp(argv[i], "--use-ros-control") == 0)
       mRosControl = new highlevel::RosControl(mRobot);
+    else if (strcmp(argv[i], "--auto-publish") == 0)
+      mAutoPublish = true;
     else
       ROS_ERROR("ERROR: unkown argument %s.", argv[i]);
   }
@@ -386,6 +389,10 @@ void Ros::setRosDevices(const char **hiddenDevices, int numberHiddenDevices) {
     }
     if (previousDevicesCount < mDeviceList.size())
       mDeviceList.back()->init();
+  }
+  if (mAutoPublish) {
+    for (RosSensor *rosSensor : mSensorList)
+      rosSensor->enableSensor(mRobot->getBasicTimeStep());
   }
   mSensorList.push_back(static_cast<RosSensor *>(new RosBatterySensor(mRobot, this)));
   mDeviceList.push_back(static_cast<RosDevice *>(mSensorList.back()));

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -448,6 +448,7 @@ void Ros::run(int argc, char **argv) {
   ros::AsyncSpinner spinner(2);
   spinner.start();
 
+  mNodeHandle->setParam("robot_description", mRobot->getUrdf(""));
   if (mRosControl) {
     mRosControl->init();
     mControllerManager = new controller_manager::ControllerManager(mRosControl, *mNodeHandle);

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -78,6 +78,8 @@ Ros::Ros() :
   mIsSynchronized(false),
   mUseWebotsSimTime(false),
   mAutoPublish(false),
+  mRobotDescriptionPrefix(""),
+  mSetRobotDescription(false),
   mRosControl(NULL) {
 }
 
@@ -104,6 +106,7 @@ Ros::~Ros() {
 
   ros::shutdown();
   delete mRobot;
+  delete mRosControl;
   for (unsigned int i = 0; i < mDeviceList.size(); i++)
     delete mDeviceList[i];
   delete mRosJoystick;

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -30,8 +30,8 @@
 #include <webots_ros/robot_set_mode.h>
 #include <webots_ros/robot_wait_for_user_input_event.h>
 
-#include <highlevel/RosControl.hpp>
 #include <controller_manager/controller_manager.h>
+#include <highlevel/RosControl.hpp>
 
 using namespace webots;
 

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -123,6 +123,7 @@ private:
   bool mShouldPublishClock;
   bool mIsSynchronized;
   bool mUseWebotsSimTime;
+  bool mAutoPublish;
   highlevel::RosControl *mRosControl;
   controller_manager::ControllerManager *mControllerManager;
 };

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -30,6 +30,9 @@
 #include <webots_ros/robot_set_mode.h>
 #include <webots_ros/robot_wait_for_user_input_event.h>
 
+#include <highlevel/RosControl.hpp>
+#include <controller_manager/controller_manager.h>
+
 using namespace webots;
 
 class RosSensor;
@@ -120,6 +123,8 @@ private:
   bool mShouldPublishClock;
   bool mIsSynchronized;
   bool mUseWebotsSimTime;
+  highlevel::RosControl *mRosControl;
+  controller_manager::ControllerManager *mControllerManager;
 };
 
 #endif  // ROS_HPP

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -30,7 +30,6 @@
 #include <webots_ros/robot_set_mode.h>
 #include <webots_ros/robot_wait_for_user_input_event.h>
 
-#include <controller_manager/controller_manager.h>
 #include <highlevel/RosControl.hpp>
 
 using namespace webots;
@@ -124,8 +123,9 @@ private:
   bool mIsSynchronized;
   bool mUseWebotsSimTime;
   bool mAutoPublish;
+  std::string mRobotDescriptionPrefix;
+  bool mSetRobotDescription;
   highlevel::RosControl *mRosControl;
-  controller_manager::ControllerManager *mControllerManager;
 };
 
 #endif  // ROS_HPP

--- a/projects/default/controllers/ros/RosSensor.cpp
+++ b/projects/default/controllers/ros/RosSensor.cpp
@@ -34,6 +34,7 @@ RosSensor::~RosSensor() {
 // create a topic for the requested sampling period if it doesn't exist yet,
 // enable the sensor with the new period if needed and
 // store publisher and it's details into the mPublishList vector
+// cppcheck-suppress constParameter
 bool RosSensor::sensorEnableCallback(webots_ros::set_int::Request &req, webots_ros::set_int::Response &res) {
   res.success = enableSensor(req.value);
   return true;

--- a/projects/default/controllers/ros/RosSensor.cpp
+++ b/projects/default/controllers/ros/RosSensor.cpp
@@ -35,6 +35,7 @@ RosSensor::~RosSensor() {
 // enable the sensor with the new period if needed and
 // store publisher and it's details into the mPublishList vector
 // cppcheck-suppress constParameter
+// cppcheck-suppress constParameterCallback
 bool RosSensor::sensorEnableCallback(webots_ros::set_int::Request &req, webots_ros::set_int::Response &res) {
   res.success = enableSensor(req.value);
   return true;

--- a/projects/default/controllers/ros/RosSensor.cpp
+++ b/projects/default/controllers/ros/RosSensor.cpp
@@ -35,35 +35,41 @@ RosSensor::~RosSensor() {
 // enable the sensor with the new period if needed and
 // store publisher and it's details into the mPublishList vector
 bool RosSensor::sensorEnableCallback(webots_ros::set_int::Request &req, webots_ros::set_int::Response &res) {
-  if (req.value == 0) {
-    res.success = true;
+  res.success = enableSensor(req.value);
+  return true;
+}
+
+bool RosSensor::enableSensor(int timestep) {
+  if (timestep == 0) {
     for (unsigned int i = 0; i < mPublishList.size(); ++i)
       mPublishList[i].mPublisher.shutdown();
     mPublishList.clear();
     rosDisable();
-  } else if (req.value % (mRos->stepSize()) == 0) {
+    return true;
+  }
+
+  if (timestep % (mRos->stepSize()) == 0) {
     int copy = 0;
-    int minPeriod = req.value;
+    int minPeriod = timestep;
     for (unsigned int i = 0; i < mPublishList.size(); ++i) {
       if (mPublishList[i].mSamplingPeriod < minPeriod)
         minPeriod = mPublishList[i].mSamplingPeriod;
-      if (mPublishList[i].mSamplingPeriod == req.value)
+      if (mPublishList[i].mSamplingPeriod == timestep)
         copy++;
     }
     if (copy == 0) {
       mPublishList.push_back(publisherDetails());
-      mPublishList.back().mSamplingPeriod = req.value;
+      mPublishList.back().mSamplingPeriod = timestep;
       mPublishList.back().mNewPublisher = true;
       mPublishList.back().mPublisher = createPublisher();
-      if (minPeriod == req.value)
-        rosEnable(req.value);
+      if (minPeriod == timestep)
+        rosEnable(timestep);
     }
-    res.success = true;
-  } else {
-    ROS_WARN("Wrong sampling period: %d for device: %s.", req.value, deviceName().c_str());
-    res.success = false;
+    return true;
   }
-  return true;
+
+  ROS_WARN("Wrong sampling period: %d for device: %s.", timestep, deviceName().c_str());
+  return false;
 }
 
 bool RosSensor::samplingPeriodCallback(webots_ros::get_int::Request &req, webots_ros::get_int::Response &res) {

--- a/projects/default/controllers/ros/RosSensor.hpp
+++ b/projects/default/controllers/ros/RosSensor.hpp
@@ -31,6 +31,7 @@ public:
   bool sensorEnableCallback(webots_ros::set_int::Request &req, webots_ros::set_int::Response &res);
   bool samplingPeriodCallback(webots_ros::get_int::Request &req, webots_ros::get_int::Response &res);
   void publishValues(int step);
+  bool enableSensor(int timestep);
 
 protected:
   RosSensor(std::string deviceName, Device *device, Ros *ros, bool enableDefaultServices = true);

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -44,6 +44,7 @@ namespace highlevel {
     }
     registerInterface(&mJointStateInterface);
     registerInterface(&mPositionJointInteraface);
+    registerInterface(&mVelocityJointInteraface);
   }
 
   void RosControl::addMotor(webots::Motor *motor) {
@@ -70,10 +71,20 @@ namespace highlevel {
 
   void RosControl::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
                             const std::list<hardware_interface::ControllerInfo> &stopList) {
-    hardware_interface::RobotHW::doSwitch(startList, stopList);
     for (ControlledMotor &controlledMotor : mControlledMotors) {
       controlledMotor.command_velocity = NAN;
       controlledMotor.command_position = NAN;
     }
+
+    // TODO: Prepare for resource for the standard controllers
+    for (hardware_interface::ControllerInfo controllerInfo : startList) {
+        for (hardware_interface::InterfaceResources interfaceResources : controllerInfo.claimed_resources) {
+            ROS_INFO("%s", interfaceResources.hardware_interface.c_str());
+            for (std::string resource : interfaceResources.resources)
+                ROS_INFO("%s", interfaceResources.hardware_interface.c_str());
+        }
+    }
+
+    hardware_interface::RobotHW::doSwitch(startList, stopList);
   }
 }  // namespace highlevel

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -33,12 +33,12 @@ namespace highlevel {
 
         // Register `position` handle
         hardware_interface::JointHandle positionHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
-                                                       &controlledMotor.command_position);
+                                                       &controlledMotor.commandPosition);
         mPositionJointInteraface.registerHandle(positionHandle);
 
         // Register `velocity` handle
         hardware_interface::JointHandle velocityHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
-                                                       &controlledMotor.command_velocity);
+                                                       &controlledMotor.commandVelocity);
         mVelocityJointInteraface.registerHandle(velocityHandle);
       }
     }
@@ -49,7 +49,7 @@ namespace highlevel {
 
   void RosControl::addMotor(webots::Motor *motor) {
     ControlledMotor controlledMotor = {
-      .motor = motor, .command_position = NAN, .command_velocity = NAN, .position = 0, .velocity = 0, .effort = 0};
+      .motor = motor, .commandPosition = NAN, .commandVelocity = NAN, .position = 0, .velocity = 0, .effort = 0};
     mControlledMotors.push_back(controlledMotor);
   }
 
@@ -62,27 +62,30 @@ namespace highlevel {
 
   void RosControl::write() {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
-      if (!isnan(controlledMotor.command_velocity))
-        controlledMotor.motor->setVelocity(controlledMotor.command_velocity);
-      if (!isnan(controlledMotor.command_position))
-        controlledMotor.motor->setPosition(controlledMotor.command_position);
+      if (!isnan(controlledMotor.commandVelocity))
+        controlledMotor.motor->setVelocity(controlledMotor.commandVelocity);
+      if (!isnan(controlledMotor.commandPosition))
+        controlledMotor.motor->setPosition(controlledMotor.commandPosition);
     }
   }
 
   void RosControl::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
                             const std::list<hardware_interface::ControllerInfo> &stopList) {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
-      controlledMotor.command_velocity = NAN;
-      controlledMotor.command_position = NAN;
+      controlledMotor.commandVelocity = NAN;
+      controlledMotor.commandPosition = NAN;
     }
 
-    // TODO: Prepare for resource for the standard controllers
+    // Change motor's behavior depending on control type (e.g. position or velocity)
     for (hardware_interface::ControllerInfo controllerInfo : startList) {
-        for (hardware_interface::InterfaceResources interfaceResources : controllerInfo.claimed_resources) {
-            ROS_INFO("%s", interfaceResources.hardware_interface.c_str());
-            for (std::string resource : interfaceResources.resources)
-                ROS_INFO("%s", interfaceResources.hardware_interface.c_str());
+      for (hardware_interface::InterfaceResources interfaceResources : controllerInfo.claimed_resources) {
+        for (std::string resource : interfaceResources.resources) {
+          if (interfaceResources.hardware_interface == "hardware_interface::VelocityJointInterface")
+            mRobot->getMotor(resource)->setPosition(INFINITY);
+          else if (interfaceResources.hardware_interface == "hardware_interface::PositionJointInterface")
+            mRobot->getMotor(resource)->setVelocity(mRobot->getMotor(resource)->getMaxVelocity());
         }
+      }
     }
 
     hardware_interface::RobotHW::doSwitch(startList, stopList);

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -18,76 +18,17 @@
 
 namespace highlevel {
 
-  RosControl::RosControl(webots::Robot *robot) : mRobot(robot) {}
-
-  void RosControl::init() {
-    for (ControlledMotor &controlledMotor : mControlledMotors) {
-      webots::PositionSensor *positionSensor = controlledMotor.motor->getPositionSensor();
-      if (positionSensor) {
-        positionSensor->enable(mRobot->getBasicTimeStep());
-
-        // Register `state` handle
-        hardware_interface::JointStateHandle stateHandle(controlledMotor.motor->getName(), &controlledMotor.position,
-                                                         &controlledMotor.velocity, &controlledMotor.effort);
-        mJointStateInterface.registerHandle(stateHandle);
-
-        // Register `position` handle
-        hardware_interface::JointHandle positionHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
-                                                       &controlledMotor.commandPosition);
-        mPositionJointInteraface.registerHandle(positionHandle);
-
-        // Register `velocity` handle
-        hardware_interface::JointHandle velocityHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
-                                                       &controlledMotor.commandVelocity);
-        mVelocityJointInteraface.registerHandle(velocityHandle);
-      }
-    }
-    registerInterface(&mJointStateInterface);
-    registerInterface(&mPositionJointInteraface);
-    registerInterface(&mVelocityJointInteraface);
-  }
-
-  void RosControl::addMotor(webots::Motor *motor) {
-    ControlledMotor controlledMotor = {
-      .motor = motor, .commandPosition = NAN, .commandVelocity = NAN, .position = 0, .velocity = 0, .effort = 0};
-    mControlledMotors.push_back(controlledMotor);
+  RosControl::RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle) {
+    mWebotsHw = new WebotsHw(robot);
+    mControllerManager = new controller_manager::ControllerManager(mWebotsHw, *nodeHandle);
+    mLastUpdate = ros::Time::now();
   }
 
   void RosControl::read() {
-    for (ControlledMotor &controlledMotor : mControlledMotors) {
-      controlledMotor.position = controlledMotor.motor->getPositionSensor()->getValue();
-      controlledMotor.velocity = controlledMotor.motor->getVelocity();
-    }
+    mWebotsHw->read();
+    mControllerManager->update(ros::Time::now(), ros::Time::now() - mLastUpdate);
+    mLastUpdate = ros::Time::now();
   }
 
-  void RosControl::write() {
-    for (ControlledMotor &controlledMotor : mControlledMotors) {
-      if (!isnan(controlledMotor.commandVelocity))
-        controlledMotor.motor->setVelocity(controlledMotor.commandVelocity);
-      if (!isnan(controlledMotor.commandPosition))
-        controlledMotor.motor->setPosition(controlledMotor.commandPosition);
-    }
-  }
-
-  void RosControl::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
-                            const std::list<hardware_interface::ControllerInfo> &stopList) {
-    for (ControlledMotor &controlledMotor : mControlledMotors) {
-      controlledMotor.commandVelocity = NAN;
-      controlledMotor.commandPosition = NAN;
-    }
-
-    // Change motor's behavior depending on control type (e.g. position or velocity)
-    for (hardware_interface::ControllerInfo controllerInfo : startList) {
-      for (hardware_interface::InterfaceResources interfaceResources : controllerInfo.claimed_resources) {
-        for (std::string resource : interfaceResources.resources) {
-          if (interfaceResources.hardware_interface == "hardware_interface::VelocityJointInterface")
-            mRobot->getMotor(resource)->setPosition(INFINITY);
-          else if (interfaceResources.hardware_interface == "hardware_interface::PositionJointInterface")
-            mRobot->getMotor(resource)->setVelocity(mRobot->getMotor(resource)->getMaxVelocity());
-        }
-      }
-    }
-
-    hardware_interface::RobotHW::doSwitch(startList, stopList);
-  }
+  void RosControl::write() { mWebotsHw->write(); }
 }  // namespace highlevel

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -1,0 +1,74 @@
+// Copyright 1996-2021 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Description: Webots integration with for `ros_control`.
+
+#include "RosControl.hpp"
+
+namespace highlevel {
+
+  RosControl::RosControl(webots::Robot *robot) : mRobot(robot) {}
+
+  void RosControl::init() {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      webots::PositionSensor *positionSensor = controlledMotor.motor->getPositionSensor();
+      if (positionSensor) {
+        positionSensor->enable(mRobot->getBasicTimeStep());
+
+        // Register `state` handle
+        hardware_interface::JointStateHandle stateHandle(controlledMotor.motor->getName(), &controlledMotor.position,
+                                                         &controlledMotor.velocity, &controlledMotor.effort);
+        mJointStateInterface.registerHandle(stateHandle);
+
+        // Register `position` handle
+        hardware_interface::JointHandle positionHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
+                                                       &controlledMotor.command_position);
+        mPositionJointInteraface.registerHandle(positionHandle);
+      }
+    }
+    registerInterface(&mJointStateInterface);
+    registerInterface(&mPositionJointInteraface);
+  }
+
+  void RosControl::addMotor(webots::Motor *motor) {
+    ControlledMotor controlledMotor = {
+      .motor = motor, .command_position = NAN, .command_velocity = NAN, .position = 0, .velocity = 0, .effort = 0};
+    mControlledMotors.push_back(controlledMotor);
+  }
+
+  void RosControl::read() {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      controlledMotor.position = controlledMotor.motor->getPositionSensor()->getValue();
+      controlledMotor.velocity = controlledMotor.motor->getVelocity();
+    }
+  }
+
+  void RosControl::write() {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      if (controlledMotor.command_velocity != NAN)
+        controlledMotor.motor->setPosition(controlledMotor.command_velocity);
+      if (controlledMotor.command_position != NAN)
+        controlledMotor.motor->setPosition(controlledMotor.command_position);
+    }
+  }
+
+  void RosControl::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
+                            const std::list<hardware_interface::ControllerInfo> &stopList) {
+    RosControl::doSwitch(startList, stopList);
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      controlledMotor.command_velocity = NAN;
+      controlledMotor.command_position = NAN;
+    }
+  }
+}  // namespace highlevel

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -24,6 +24,11 @@ namespace highlevel {
     mLastUpdate = ros::Time::now();
   }
 
+  RosControl::~RosControl() {
+    delete mWebotsHw;
+    delete mControllerManager;
+  }
+
   void RosControl::read() {
     mWebotsHw->read();
     mControllerManager->update(ros::Time::now(), ros::Time::now() - mLastUpdate);

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -19,21 +19,21 @@
 namespace highlevel {
 
   RosControl::RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle) {
-    mWebotsHw = new WebotsHw(robot);
-    mControllerManager = new controller_manager::ControllerManager(mWebotsHw, *nodeHandle);
+    mWebotsHW = new WebotsHW(robot);
+    mControllerManager = new controller_manager::ControllerManager(mWebotsHW, *nodeHandle);
     mLastUpdate = ros::Time::now();
   }
 
   RosControl::~RosControl() {
-    delete mWebotsHw;
+    delete mWebotsHW;
     delete mControllerManager;
   }
 
   void RosControl::read() {
-    mWebotsHw->read();
+    mWebotsHW->read();
     mControllerManager->update(ros::Time::now(), ros::Time::now() - mLastUpdate);
     mLastUpdate = ros::Time::now();
   }
 
-  void RosControl::write() { mWebotsHw->write(); }
+  void RosControl::write() { mWebotsHW->write(); }
 }  // namespace highlevel

--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -35,6 +35,11 @@ namespace highlevel {
         hardware_interface::JointHandle positionHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
                                                        &controlledMotor.command_position);
         mPositionJointInteraface.registerHandle(positionHandle);
+
+        // Register `velocity` handle
+        hardware_interface::JointHandle velocityHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
+                                                       &controlledMotor.command_velocity);
+        mVelocityJointInteraface.registerHandle(velocityHandle);
       }
     }
     registerInterface(&mJointStateInterface);
@@ -56,16 +61,16 @@ namespace highlevel {
 
   void RosControl::write() {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
-      if (controlledMotor.command_velocity != NAN)
-        controlledMotor.motor->setPosition(controlledMotor.command_velocity);
-      if (controlledMotor.command_position != NAN)
+      if (!isnan(controlledMotor.command_velocity))
+        controlledMotor.motor->setVelocity(controlledMotor.command_velocity);
+      if (!isnan(controlledMotor.command_position))
         controlledMotor.motor->setPosition(controlledMotor.command_position);
     }
   }
 
   void RosControl::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
                             const std::list<hardware_interface::ControllerInfo> &stopList) {
-    RosControl::doSwitch(startList, stopList);
+    hardware_interface::RobotHW::doSwitch(startList, stopList);
     for (ControlledMotor &controlledMotor : mControlledMotors) {
       controlledMotor.command_velocity = NAN;
       controlledMotor.command_position = NAN;

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -19,7 +19,7 @@
 
 #include <controller_manager/controller_manager.h>
 
-#include "WebotsHw.hpp"
+#include "WebotsHW.hpp"
 
 namespace highlevel {
   class RosControl {
@@ -32,7 +32,7 @@ namespace highlevel {
     void write();
 
   private:
-    WebotsHw *mWebotsHw;
+    WebotsHW *mWebotsHW;
     ros::Time mLastUpdate;
     controller_manager::ControllerManager *mControllerManager;
   };

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -1,0 +1,56 @@
+// Copyright 1996-2021 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS_CONTROL_HPP
+#define ROS_CONTROL_HPP
+
+#include <vector>
+
+#include <webots/Motor.hpp>
+#include <webots/PositionSensor.hpp>
+#include <webots/Robot.hpp>
+
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+
+namespace highlevel {
+  struct ControlledMotor {
+    webots::Motor *motor;
+    double command_position;
+    double command_velocity;
+    double position;
+    double velocity;
+    double effort;
+  };
+
+  class RosControl : public hardware_interface::RobotHW {
+  public:
+    RosControl(webots::Robot *robot);
+    void init();
+    void addMotor(webots::Motor *motor);
+    void read();
+    void write();
+    void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
+                  const std::list<hardware_interface::ControllerInfo> &stopList) override;
+
+  private:
+    hardware_interface::JointStateInterface mJointStateInterface;
+    hardware_interface::PositionJointInterface mPositionJointInteraface;
+    std::vector<ControlledMotor> mControlledMotors;
+    webots::Robot *mRobot;
+  };
+}  // namespace highlevel
+
+#endif

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -26,6 +26,7 @@ namespace highlevel {
   public:
     RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle);
     RosControl(const RosControl &rosControl) = delete;
+    RosControl &operator=(const RosControl &) = delete;
     ~RosControl();
     void read();
     void write();

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -15,42 +15,23 @@
 #ifndef ROS_CONTROL_HPP
 #define ROS_CONTROL_HPP
 
-#include <vector>
-
-#include <webots/Motor.hpp>
-#include <webots/PositionSensor.hpp>
 #include <webots/Robot.hpp>
 
-#include <hardware_interface/joint_command_interface.h>
-#include <hardware_interface/joint_state_interface.h>
-#include <hardware_interface/robot_hw.h>
+#include <controller_manager/controller_manager.h>
+
+#include "WebotsHw.hpp"
 
 namespace highlevel {
-  struct ControlledMotor {
-    webots::Motor *motor;
-    double commandPosition;
-    double commandVelocity;
-    double position;
-    double velocity;
-    double effort;
-  };
-
-  class RosControl : public hardware_interface::RobotHW {
+  class RosControl {
   public:
-    RosControl(webots::Robot *robot);
-    void init();
-    void addMotor(webots::Motor *motor);
+    RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle);
     void read();
     void write();
-    void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
-                  const std::list<hardware_interface::ControllerInfo> &stopList) override;
 
   private:
-    hardware_interface::JointStateInterface mJointStateInterface;
-    hardware_interface::PositionJointInterface mPositionJointInteraface;
-    hardware_interface::VelocityJointInterface mVelocityJointInteraface;
-    std::vector<ControlledMotor> mControlledMotors;
-    webots::Robot *mRobot;
+    WebotsHw *mWebotsHw;
+    ros::Time mLastUpdate;
+    controller_manager::ControllerManager *mControllerManager;
   };
 }  // namespace highlevel
 

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -25,6 +25,7 @@ namespace highlevel {
   class RosControl {
   public:
     RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle);
+    RosControl(const RosControl &rosControl) = delete;
     ~RosControl();
     void read();
     void write();

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -48,6 +48,7 @@ namespace highlevel {
   private:
     hardware_interface::JointStateInterface mJointStateInterface;
     hardware_interface::PositionJointInterface mPositionJointInteraface;
+    hardware_interface::VelocityJointInterface mVelocityJointInteraface;
     std::vector<ControlledMotor> mControlledMotors;
     webots::Robot *mRobot;
   };

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -28,8 +28,8 @@
 namespace highlevel {
   struct ControlledMotor {
     webots::Motor *motor;
-    double command_position;
-    double command_velocity;
+    double commandPosition;
+    double commandVelocity;
     double position;
     double velocity;
     double effort;

--- a/projects/default/controllers/ros/highlevel/RosControl.hpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.hpp
@@ -25,6 +25,7 @@ namespace highlevel {
   class RosControl {
   public:
     RosControl(webots::Robot *robot, ros::NodeHandle *nodeHandle);
+    ~RosControl();
     void read();
     void write();
 

--- a/projects/default/controllers/ros/highlevel/WebotsHW.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHW.cpp
@@ -14,11 +14,11 @@
 
 // Description: Webots integration with for `ros_control`.
 
-#include "WebotsHw.hpp"
+#include "WebotsHW.hpp"
 
 namespace highlevel {
 
-  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(robot) {
+  WebotsHW::WebotsHW(webots::Robot *robot) : mRobot(robot) {
     // Find all motors
     const int nDevices = mRobot->getNumberOfDevices();
     for (int i = 0; i < nDevices; i++) {
@@ -59,14 +59,14 @@ namespace highlevel {
     registerInterface(&mVelocityJointInteraface);
   }
 
-  void WebotsHw::read() {
+  void WebotsHW::read() {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
       controlledMotor.position = controlledMotor.motor->getPositionSensor()->getValue();
       controlledMotor.velocity = controlledMotor.motor->getVelocity();
     }
   }
 
-  void WebotsHw::write() {
+  void WebotsHW::write() {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
       if (!isnan(controlledMotor.commandVelocity))
         controlledMotor.motor->setVelocity(controlledMotor.commandVelocity);
@@ -75,7 +75,7 @@ namespace highlevel {
     }
   }
 
-  void WebotsHw::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
+  void WebotsHW::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
                           const std::list<hardware_interface::ControllerInfo> &stopList) {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
       controlledMotor.commandVelocity = NAN;

--- a/projects/default/controllers/ros/highlevel/WebotsHW.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHW.hpp
@@ -37,10 +37,10 @@ namespace highlevel {
     double effort;
   };
 
-  class WebotsHw : public hardware_interface::RobotHW {
+  class WebotsHW : public hardware_interface::RobotHW {
   public:
-    explicit WebotsHw(webots::Robot *robot);
-    WebotsHw() = delete;
+    explicit WebotsHW(webots::Robot *robot);
+    WebotsHW() = delete;
     void read();
     void write();
     void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,

--- a/projects/default/controllers/ros/highlevel/WebotsHw.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.cpp
@@ -18,7 +18,9 @@
 
 namespace highlevel {
 
-  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(robot) {
+  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(NULL) {
+    mRobot = robot;
+
     // Find all motors
     const int nDevices = mRobot->getNumberOfDevices();
     for (int i = 0; i < nDevices; i++) {

--- a/projects/default/controllers/ros/highlevel/WebotsHw.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.cpp
@@ -18,9 +18,7 @@
 
 namespace highlevel {
 
-  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(NULL) {
-    mRobot = robot;
-
+  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(robot) {
     // Find all motors
     const int nDevices = mRobot->getNumberOfDevices();
     for (int i = 0; i < nDevices; i++) {

--- a/projects/default/controllers/ros/highlevel/WebotsHw.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.cpp
@@ -1,0 +1,99 @@
+// Copyright 1996-2021 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Description: Webots integration with for `ros_control`.
+
+#include "WebotsHw.hpp"
+
+namespace highlevel {
+
+  WebotsHw::WebotsHw(webots::Robot *robot) : mRobot(robot) {
+    // Find all motors
+    const int nDevices = mRobot->getNumberOfDevices();
+    for (int i = 0; i < nDevices; i++) {
+      webots::Device *tempDevice = mRobot->getDeviceByIndex(i);
+      if (tempDevice->getNodeType() == webots::Node::ROTATIONAL_MOTOR ||
+          tempDevice->getNodeType() == webots::Node::LINEAR_MOTOR) {
+        webots::Motor *motor = dynamic_cast<webots::Motor *>(tempDevice);
+        ControlledMotor controlledMotor = {
+          .motor = motor, .commandPosition = NAN, .commandVelocity = NAN, .position = 0, .velocity = 0, .effort = 0};
+        mControlledMotors.push_back(controlledMotor);
+      }
+    }
+
+    // Create RobotHW interface
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      webots::PositionSensor *positionSensor = controlledMotor.motor->getPositionSensor();
+      if (positionSensor) {
+        positionSensor->enable(mRobot->getBasicTimeStep());
+
+        // Register `state` handle
+        hardware_interface::JointStateHandle stateHandle(controlledMotor.motor->getName(), &controlledMotor.position,
+                                                         &controlledMotor.velocity, &controlledMotor.effort);
+        mJointStateInterface.registerHandle(stateHandle);
+
+        // Register `position` handle
+        hardware_interface::JointHandle positionHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
+                                                       &controlledMotor.commandPosition);
+        mPositionJointInteraface.registerHandle(positionHandle);
+
+        // Register `velocity` handle
+        hardware_interface::JointHandle velocityHandle(mJointStateInterface.getHandle(controlledMotor.motor->getName()),
+                                                       &controlledMotor.commandVelocity);
+        mVelocityJointInteraface.registerHandle(velocityHandle);
+      }
+    }
+    registerInterface(&mJointStateInterface);
+    registerInterface(&mPositionJointInteraface);
+    registerInterface(&mVelocityJointInteraface);
+  }
+
+  void WebotsHw::read() {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      controlledMotor.position = controlledMotor.motor->getPositionSensor()->getValue();
+      controlledMotor.velocity = controlledMotor.motor->getVelocity();
+    }
+  }
+
+  void WebotsHw::write() {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      if (!isnan(controlledMotor.commandVelocity))
+        controlledMotor.motor->setVelocity(controlledMotor.commandVelocity);
+      if (!isnan(controlledMotor.commandPosition))
+        controlledMotor.motor->setPosition(controlledMotor.commandPosition);
+    }
+  }
+
+  void WebotsHw::doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
+                          const std::list<hardware_interface::ControllerInfo> &stopList) {
+    for (ControlledMotor &controlledMotor : mControlledMotors) {
+      controlledMotor.commandVelocity = NAN;
+      controlledMotor.commandPosition = NAN;
+    }
+
+    // Change motor's behavior depending on control type (e.g. position or velocity)
+    for (hardware_interface::ControllerInfo controllerInfo : startList) {
+      for (hardware_interface::InterfaceResources interfaceResources : controllerInfo.claimed_resources) {
+        for (std::string resource : interfaceResources.resources) {
+          if (interfaceResources.hardware_interface == "hardware_interface::VelocityJointInterface")
+            mRobot->getMotor(resource)->setPosition(INFINITY);
+          else if (interfaceResources.hardware_interface == "hardware_interface::PositionJointInterface")
+            mRobot->getMotor(resource)->setVelocity(mRobot->getMotor(resource)->getMaxVelocity());
+        }
+      }
+    }
+
+    hardware_interface::RobotHW::doSwitch(startList, stopList);
+  }
+}  // namespace highlevel

--- a/projects/default/controllers/ros/highlevel/WebotsHw.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.hpp
@@ -40,6 +40,7 @@ namespace highlevel {
   class WebotsHw : public hardware_interface::RobotHW {
   public:
     WebotsHw(webots::Robot *robot);
+    WebotsHw() = delete;
     void read();
     void write();
     void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,

--- a/projects/default/controllers/ros/highlevel/WebotsHw.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.hpp
@@ -40,8 +40,6 @@ namespace highlevel {
   class WebotsHw : public hardware_interface::RobotHW {
   public:
     WebotsHw(webots::Robot *robot);
-    void init();
-    void addMotor(webots::Motor *motor);
     void read();
     void write();
     void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,

--- a/projects/default/controllers/ros/highlevel/WebotsHw.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.hpp
@@ -39,7 +39,7 @@ namespace highlevel {
 
   class WebotsHw : public hardware_interface::RobotHW {
   public:
-    WebotsHw(webots::Robot *robot);
+    explicit WebotsHw(webots::Robot *robot);
     WebotsHw() = delete;
     void read();
     void write();

--- a/projects/default/controllers/ros/highlevel/WebotsHw.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHw.hpp
@@ -1,0 +1,59 @@
+// Copyright 1996-2021 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WEBOTS_HW_HPP
+#define WEBOTS_HW_HPP
+
+#include <vector>
+
+#include <webots/Device.hpp>
+#include <webots/Motor.hpp>
+#include <webots/Node.hpp>
+#include <webots/PositionSensor.hpp>
+#include <webots/Robot.hpp>
+
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+
+namespace highlevel {
+  struct ControlledMotor {
+    webots::Motor *motor;
+    double commandPosition;
+    double commandVelocity;
+    double position;
+    double velocity;
+    double effort;
+  };
+
+  class WebotsHw : public hardware_interface::RobotHW {
+  public:
+    WebotsHw(webots::Robot *robot);
+    void init();
+    void addMotor(webots::Motor *motor);
+    void read();
+    void write();
+    void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
+                  const std::list<hardware_interface::ControllerInfo> &stopList) override;
+
+  private:
+    hardware_interface::JointStateInterface mJointStateInterface;
+    hardware_interface::PositionJointInterface mPositionJointInteraface;
+    hardware_interface::VelocityJointInterface mVelocityJointInteraface;
+    std::vector<ControlledMotor> mControlledMotors;
+    webots::Robot *mRobot;
+  };
+}  // namespace highlevel
+
+#endif

--- a/projects/vehicles/controllers/ros_automobile/Makefile
+++ b/projects/vehicles/controllers/ros_automobile/Makefile
@@ -42,6 +42,7 @@ release debug profile clean:
 else
 CXX_SOURCES = $(wildcard *.cpp)
 CXX_SOURCES += $(wildcard $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/Ros*.cpp)
+CXX_SOURCES += $(wildcard $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/highlevel/*.cpp)
 
 ifeq ($(OSTYPE),windows)
  ros_automobile.exe: $(CXX_SOURCES:.cxx=.d)

--- a/projects/vehicles/controllers/ros_automobile/Makefile
+++ b/projects/vehicles/controllers/ros_automobile/Makefile
@@ -55,7 +55,7 @@ LIBRARIES += -lCppDriver -lCppCar -ldriver -lcar
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime
+LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -19,7 +19,7 @@ fi
 sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 apt update -qq
-apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf ros-$ROS_DISTRO-ros-controllers ros-$ROS_DISTRO-controller-manager ros-$ROS_DISTRO-ros-control liburdfdom-tools
+apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf ros-$ROS_DISTRO-ros-controllers ros-$ROS_DISTRO-controller-manager ros-$ROS_DISTRO-ros-control ros-$ROS_DISTRO-class-loader ros-$ROS_DISTRO-roslib liburdfdom-tools
 
 if [[ $1 != "--norecurse" ]]; then
 	script_full_path=$(dirname "$0")

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -19,7 +19,7 @@ fi
 sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 apt update -qq
-apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf liburdfdom-tools
+apt-get install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf ros-$ROS_DISTRO-ros-controllers ros-$ROS_DISTRO-controller-manager ros-$ROS_DISTRO-ros-control liburdfdom-tools
 
 if [[ $1 != "--norecurse" ]]; then
 	script_full_path=$(dirname "$0")


### PR DESCRIPTION
This PR significantly simplifies the usage of the `ros` controller:
- Integrates `ros_control` (the `--use-ros-control` flag) to allow usage of a differential drive, joint state publisher, trajectory follower, and other controllers.
- Adds the `--auto-publish` flag that automatically enables all sensors and creates necessary topics.
- Adds the `robot_description` ROS param which contains the robot's URDF (necessary for many ROS packages).

**Impact**
Take [the Pioneer controller](https://github.com/cyberbotics/webots_ros/blob/master/src/pioneer3at.cpp) from the `webots_ros` package as an example. The controller with over 300 lines of code is not needed anymore. Furthermore, to simplify the controller, we "cheated" by calculating odometry from GPS and IMU. There is no way something like that would work in the real world. The odometry is now calculated from the wheel encoders.

**Tasks**
- [x] Proof of concept
- [x] Test with differential drive
  - [x] We need `robot_state_publisher` here. `Robot description couldn't be retrieved from param server.` 
- [ ] ~~Test with MoveIt~~ (I think it is better to finish this in another PR)
- [x] Rethink namespaces (e.g. `/robot_description`, URDF prefix...)
- [x] Document
- [x] Changelog 

**Useful commands**
```bash
rosrun controller_manager controller_manager list
```