### PR TITLE
Fixed Makefile in case JAVA_HOME is not set and javac is not available on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 include resources/Makefile.os.include
 
 ifeq ($(JAVA_HOME)$(OSTYPE),linux)
-JAVAC:=`which javac`
+JAVAC:=$(shell which javac)
 ifneq ($(JAVAC),)
 export JAVA_HOME:=$(shell dirname $(dir $(shell readlink -f $(JAVAC))))
 endif


### PR DESCRIPTION
On Linux, if JAVA_HOME is not set and `javac` is not found, the following error is displayed when running the top Makefile:
```bash
readlink: missing operand
Try 'readlink --help' for more information.
```
This PR fixes this problem.
