### PR TITLE
Fix blog index

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -4,6 +4,7 @@ Welcome to the Webots blog!
 
 Here are the latest articles:
 
+- [Webots R2021a](Webots-2021-a-release.md)
 - [Webots R2020b](Webots-2020-b-release.md)
 - [Webots R2020a](Webots-2020-a-release.md)
 - [Webots R2019b](Webots-2019-b-release.md)


### PR DESCRIPTION
We currently miss the last post in the index: https://cyberbotics.com/doc/blog/index
This PR fixes it.