### PR TITLE
Fix the `workflow-run-cleanup-action` version

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -16,7 +16,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -16,7 +16,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -11,7 +11,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -11,7 +11,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -13,7 +13,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -13,7 +13,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -8,7 +8,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -8,7 +8,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -17,7 +17,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -12,7 +12,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -12,7 +12,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   build:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -28,7 +28,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@master
+    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -28,7 +28,7 @@ jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@0.3.0
+    - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
It seems that:
`https://github.com/rokroskar/workflow-run-cleanup-action/pull/14`
broke our tests.

In any case, I believe it is better to specify the version of our dependencies to be more resilient to similar issues.