### PR TITLE
Fix ROS api compilation

### DIFF
--- a/projects/default/controllers/ros/highlevel/WebotsHW.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHW.cpp
@@ -68,9 +68,9 @@ namespace highlevel {
 
   void WebotsHW::write() {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
-      if (!isnan(controlledMotor.commandVelocity))
+      if (!std::isnan(controlledMotor.commandVelocity))
         controlledMotor.motor->setVelocity(controlledMotor.commandVelocity);
-      if (!isnan(controlledMotor.commandPosition))
+      if (!std::isnan(controlledMotor.commandPosition))
         controlledMotor.motor->setPosition(controlledMotor.commandPosition);
     }
   }


### PR DESCRIPTION
This is an attempt to fix the ROS API compilation that fails when creating the snap package due to `isnan` not declared.
