### PR TITLE
Ability to restrict Emitter/Receiver channels

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,6 +10,7 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
+    - Added an allowedChannels field in the Emitter and Receiver node to restrict channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
     - Fixed start-up of extern controllers in case a remaining temporary folder resulting from a previous Webots crash was still there ([#2800](https://github.com/cyberbotics/webots/pull/2800)).
     - Fixed erasing [Pen](pen.md) ink on simulation reset ([#2796](https://github.com/cyberbotics/webots/pull/2796)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,7 +10,7 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
-    - Added an allowedChannels field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
+    - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
     - Fixed start-up of extern controllers in case a remaining temporary folder resulting from a previous Webots crash was still there ([#2800](https://github.com/cyberbotics/webots/pull/2800)).
     - Fixed erasing [Pen](pen.md) ink on simulation reset ([#2796](https://github.com/cyberbotics/webots/pull/2796)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -10,7 +10,7 @@ Released on XX Xth, 2021.
     - Rework of car meshes to have more realistic rear lights for Mercedes Benz, Lincoln, Citroen, BMW and Range Rover models ([#2615](https://github.com/cyberbotics/webots/pull/2615)).
     - Add an example that shows an integration of OpenAI Gym with Webots ([#2711](https://github.com/cyberbotics/webots/pull/2711)).
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
-    - Added an allowedChannels field in the Emitter and Receiver node to restrict channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
+    - Added an allowedChannels field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
     - Fixed start-up of extern controllers in case a remaining temporary folder resulting from a previous Webots crash was still there ([#2800](https://github.com/cyberbotics/webots/pull/2800)).
     - Fixed erasing [Pen](pen.md) ink on simulation reset ([#2796](https://github.com/cyberbotics/webots/pull/2796)).

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -313,7 +313,7 @@ channel = wb_emitter_get_channel(tag)
 *set and get the emitter's channel.*
 
 The `wb_emitter_set_channel` function allows the controller to change the transmission channel.
-Target channel must be present between `allowedChannels` or `allowedChannels` is empty.
+The target channel must be included in `allowedChannels` or `allowedChannels` should be empty.
 This modifies the `channel` field of the corresponding [Emitter](#emitter) node.
 Normally, an emitter can send data only to receivers that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used for broadcasting to all channels.

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -72,7 +72,7 @@ This is usually 8 (the default), but can be more if control bits are used.
 The total number of bytes in the packets enqueued in the emitter cannot exceed this number.
 A `bufferSize` of -1 (the default) is regarded as unlimited buffer size.
 
-- `allowedChannels`: specifies allowed channels Emitter is allowed to emit to.
+- `allowedChannels`: specifies allowed channels [Emitter](#emitter) is allowed to emit to.
 Empty list (default) gives unlimited access.
 
 > **Note**: [Emitter](#emitter) nodes can also be used to communicate with the physics plugin (see [this chapter](physics-plugin.md)).
@@ -313,7 +313,7 @@ channel = wb_emitter_get_channel(tag)
 *set and get the emitter's channel.*
 
 The `wb_emitter_set_channel` function allows the controller to change the transmission channel.
-Target channel must be present between allowedChannels or allowedChannels is empty.
+Target channel must be present between `allowedChannels` or `allowedChannels` is empty.
 This modifies the `channel` field of the corresponding [Emitter](#emitter) node.
 Normally, an emitter can send data only to receivers that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used for broadcasting to all channels.

--- a/docs/reference/emitter.md
+++ b/docs/reference/emitter.md
@@ -4,14 +4,15 @@ Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 Emitter {
-  SFString type       "radio"   # {"radio", "serial", "infra-red"}
-  SFFloat  range      -1        # {-1, [0, inf)}
-  SFFloat  maxRange   -1        # {-1, [0, inf)}
-  SFFloat  aperture   -1        # {-1 ,[0, 2*pi]}
-  SFInt32  channel    0         # [0, inf)
-  SFInt32  baudRate   -1        # {-1, [0, inf)}
-  SFInt32  byteSize   8         # [8, inf)
-  SFInt32  bufferSize -1        # {-1, [0, inf)}
+  SFString type             "radio"   # {"radio", "serial", "infra-red"}
+  SFFloat  range            -1        # {-1, [0, inf)}
+  SFFloat  maxRange         -1        # {-1, [0, inf)}
+  SFFloat  aperture         -1        # {-1 ,[0, 2*pi]}
+  SFInt32  channel          0         # [0, inf)
+  SFInt32  baudRate         -1        # {-1, [0, inf)}
+  SFInt32  byteSize         8         # [8, inf)
+  SFInt32  bufferSize       -1        # {-1, [0, inf)}
+  MFInt32  allowedChannels  [ ]       # [0, inf)
 }
 ```
 
@@ -70,6 +71,9 @@ This is usually 8 (the default), but can be more if control bits are used.
 - `bufferSize`: specifies the size (in bytes) of the transmission buffer.
 The total number of bytes in the packets enqueued in the emitter cannot exceed this number.
 A `bufferSize` of -1 (the default) is regarded as unlimited buffer size.
+
+- `allowedChannels`: specifies allowed channels Emitter is allowed to emit to.
+Empty list (default) gives unlimited access.
 
 > **Note**: [Emitter](#emitter) nodes can also be used to communicate with the physics plugin (see [this chapter](physics-plugin.md)).
 In this case the channel must be set to 0 (the default).
@@ -309,6 +313,7 @@ channel = wb_emitter_get_channel(tag)
 *set and get the emitter's channel.*
 
 The `wb_emitter_set_channel` function allows the controller to change the transmission channel.
+Target channel must be present between allowedChannels or allowedChannels is empty.
 This modifies the `channel` field of the corresponding [Emitter](#emitter) node.
 Normally, an emitter can send data only to receivers that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used for broadcasting to all channels.

--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -645,7 +645,7 @@ channel = wb_receiver_get_channel(tag)
 *set and get the receiver's channel.*
 
 The `wb_receiver_set_channel` function allows a receiver to change its reception channel.
-Target channel must be present between `allowedChannels` or `allowedChannels` is empty.
+The target channel must be included in `allowedChannels` or `allowedChannels` should be empty.
 It modifies the `channel` field of the corresponding [Receiver](#receiver) node.
 Normally, a receiver can only receive data packets from emitters that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used to listen simultaneously to all channels.

--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -62,7 +62,7 @@ The noise is proportionnal to the signal strength, e.g., a `signalStrengthNoise`
 - `directionNoise`: standard deviation of the gaussian noise added to each of the components of the direction returned by `wb_receiver_get_emitter_direction`.
 The noise is not dependent on the distance between emitter-receiver.
 
-- `allowedChannels`: specifies allowed channels Receiver is allowed to listen to.
+- `allowedChannels`: specifies allowed channels [Receiver](#receiver) is allowed to listen to.
 Empty list (default) gives unlimited access.
 
 ### Receiver Functions
@@ -645,7 +645,7 @@ channel = wb_receiver_get_channel(tag)
 *set and get the receiver's channel.*
 
 The `wb_receiver_set_channel` function allows a receiver to change its reception channel.
-Target channel must be present between allowedChannels or allowedChannels is empty.
+Target channel must be present between `allowedChannels` or `allowedChannels` is empty.
 It modifies the `channel` field of the corresponding [Receiver](#receiver) node.
 Normally, a receiver can only receive data packets from emitters that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used to listen simultaneously to all channels.

--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -12,6 +12,7 @@ Receiver {
   SFInt32  bufferSize          -1        # {-1, [0, inf)}
   SFFloat  signalStrengthNoise 0         # [0, inf)
   SFFloat  directionNoise      0         # [0, inf)
+  MFInt32  allowedChannels     [ ]       # [0, inf)
 }
 ```
 
@@ -60,6 +61,9 @@ The noise is proportionnal to the signal strength, e.g., a `signalStrengthNoise`
 
 - `directionNoise`: standard deviation of the gaussian noise added to each of the components of the direction returned by `wb_receiver_get_emitter_direction`.
 The noise is not dependent on the distance between emitter-receiver.
+
+- `allowedChannels`: specifies allowed channels Receiver is allowed to listen to.
+Empty list (default) gives unlimited access.
 
 ### Receiver Functions
 
@@ -641,6 +645,7 @@ channel = wb_receiver_get_channel(tag)
 *set and get the receiver's channel.*
 
 The `wb_receiver_set_channel` function allows a receiver to change its reception channel.
+Target channel must be present between allowedChannels or allowedChannels is empty.
 It modifies the `channel` field of the corresponding [Receiver](#receiver) node.
 Normally, a receiver can only receive data packets from emitters that use the same channel.
 However, the special WB\_CHANNEL\_BROADCAST value can be used to listen simultaneously to all channels.

--- a/resources/nodes/Emitter.wrl
+++ b/resources/nodes/Emitter.wrl
@@ -21,14 +21,15 @@ Emitter {
   field     SFFloat    radarCrossSection   0.0          # radar cross section of this solid
   field     MFColor    recognitionColors   []           # colors returned for this Solid by Cameras with a Recognition node
   #fields specific to the Emitter node:
-  field     SFString{"infra-red", "radio", "serial"} type       "radio" # communication medium
-  field     SFFloat                                  range      -1      # radius of emission in meters (-1 for infinite)
-  field     SFFloat                                  maxRange   -1      # maximal radius of emission in meters (-1 for infinite)
-  field     SFFloat                                  aperture   -1      # emission cone aperture (for "infra-red" only, -1 for infinite)
-  field     SFInt32                                  channel    0       # ir emmiter id or radio frequency
-  field     SFInt32                                  baudRate   -1      # speed expressed in number of bits per second (-1 for infinite)
-  field     SFInt32                                  byteSize   8       # might be 8 or more depending on control bits
-  field     SFInt32                                  bufferSize -1      # emmision buffer size in bytes (-1 for unlimited)
+  field     SFString{"infra-red", "radio", "serial"} type            "radio" # communication medium
+  field     SFFloat                                  range           -1      # radius of emission in meters (-1 for infinite)
+  field     SFFloat                                  maxRange        -1      # maximal radius of emission in meters (-1 for infinite)
+  field     SFFloat                                  aperture        -1      # emission cone aperture (for "infra-red" only, -1 for infinite)
+  field     SFInt32                                  channel         0       # ir emmiter id or radio frequency
+  field     SFInt32                                  baudRate        -1      # speed expressed in number of bits per second (-1 for infinite)
+  field     SFInt32                                  byteSize        8       # might be 8 or more depending on control bits
+  field     SFInt32                                  bufferSize      -1      # emmision buffer size in bytes (-1 for unlimited)
+  field     MFInt32                                  allowedChannels []      # allowed channels to emit to (empty for unlimited access)
 
   # hidden fields
   hiddenField SFVec3f linearVelocity  0 0 0   # (m/s) Solid's initial linear velocity

--- a/resources/nodes/Receiver.wrl
+++ b/resources/nodes/Receiver.wrl
@@ -29,6 +29,7 @@ Receiver {
   field     SFInt32                                  bufferSize          -1      # reception buffer size in bytes (-1 for unlimited)
   field     SFFloat                                  signalStrengthNoise 0       # standard deviation of the noise applied to the signal strength (0 for no noise)
   field     SFFloat                                  directionNoise      0       # standard deviation of the noise applied to the direction (0 for no noise)
+  field     MFInt32                                  allowedChannels     []      # allowed channels to listen to (empty for unlimited access)
 
   # hidden fields
   hiddenField SFVec3f linearVelocity  0 0 0   # (m/s) Solid's initial linear velocity

--- a/src/controller/c/emitter.c
+++ b/src/controller/c/emitter.c
@@ -162,6 +162,7 @@ static void emitter_read_answer(WbDevice *d, WbRequest *r) {
     case C_EMITTER_SET_ALLOWED_CHANNELS: {
       Emitter *es = d->pdata;
       es->allowed_channels_size = request_read_int32(r);
+      es->allowed_channels = (int *)realloc(es->allowed_channels, es->allowed_channels_size * sizeof(int));
       for (int i = 0; i < es->allowed_channels_size; i++)
         es->allowed_channels[i] = request_read_int32(r);
       break;

--- a/src/controller/c/emitter.c
+++ b/src/controller/c/emitter.c
@@ -159,6 +159,13 @@ static void emitter_read_answer(WbDevice *d, WbRequest *r) {
       es->buffer_size = request_read_int32(r);
       break;
     }
+    case C_EMITTER_SET_ALLOWED_CHANNELS: {
+      Emitter *es = d->pdata;
+      es->allowed_channels_size = request_read_int32(r);
+      for (int i = 0; i < es->allowed_channels_size; i++)
+        es->allowed_channels[i] = request_read_int32(r);
+      break;
+    }
     default:
       ROBOT_ASSERT(0);
   }

--- a/src/controller/c/messages.h
+++ b/src/controller/c/messages.h
@@ -145,6 +145,7 @@
 #define C_EMITTER_SET_RANGE 2
 // sim -> ctr
 #define C_EMITTER_SET_BUFFER_SIZE 3
+#define C_EMITTER_SET_ALLOWED_CHANNELS 4
 
 // for the receiver device
 // ctr -> sim

--- a/src/controller/c/receiver.c
+++ b/src/controller/c/receiver.c
@@ -132,7 +132,7 @@ static void receiver_read_answer(WbDevice *d, WbRequest *r) {
       rs->buffer_size = request_read_int32(r);
       rs->channel = request_read_int32(r);
       rs->allowed_channels_size = request_read_int32(r);
-      rs->allowed_channels = (int *)malloc(rs->allowed_channels_size * sizeof(int));
+      rs->allowed_channels = (int *)realloc(rs->allowed_channels, rs->allowed_channels_size * sizeof(int));
       for (int i = 0; i < rs->allowed_channels_size; i++)
         rs->allowed_channels[i] = request_read_int32(r);
       break;

--- a/src/controller/c/receiver.c
+++ b/src/controller/c/receiver.c
@@ -57,14 +57,16 @@ static void packet_destroy(PacketStruct *ps) {
 }
 
 typedef struct {
-  int enable : 1;       // need to enable device ?
-  int set_channel : 1;  // need to change receiver's channel ?
-  int sampling_period;  // milliseconds
-  int channel;          // receiver's channel
-  PacketStruct *queue;  // reception queue
-  int queue_length;     // number of packets in the reception queue
-  int buffer_size;      // reception buffer size (as in Receiver.bufferSize)
-  int buffer_used;      // sum of all packet data size
+  int enable : 1;             // need to enable device ?
+  int set_channel : 1;        // need to change receiver's channel ?
+  int sampling_period;        // milliseconds
+  int channel;                // receiver's channel
+  int *allowed_channels;      // allowed channels receiver is allowed to listen to
+  PacketStruct *queue;        // reception queue
+  int queue_length;           // number of packets in the reception queue
+  int buffer_size;            // reception buffer size (as in Receiver.bufferSize)
+  int buffer_used;            // sum of all packet data size
+  int allowed_channels_size;  // size of allowed_channels array
 } Receiver;
 
 static Receiver *receiver_create() {
@@ -73,10 +75,12 @@ static Receiver *receiver_create() {
   rs->set_channel = false;
   rs->sampling_period = 0;
   rs->channel = -1;
+  rs->allowed_channels = NULL;
   rs->queue = NULL;
   rs->queue_length = 0;
   rs->buffer_size = -1;
   rs->buffer_used = 0;
+  rs->allowed_channels_size = -1;
   return rs;
 }
 
@@ -127,6 +131,10 @@ static void receiver_read_answer(WbDevice *d, WbRequest *r) {
     case C_CONFIGURE:
       rs->buffer_size = request_read_int32(r);
       rs->channel = request_read_int32(r);
+      rs->allowed_channels_size = request_read_int32(r);
+      rs->allowed_channels = (int *)malloc(rs->allowed_channels_size * sizeof(int));
+      for (int i = 0; i < rs->allowed_channels_size; i++)
+        rs->allowed_channels[i] = request_read_int32(r);
       break;
 
     case C_RECEIVER_RECEIVE: {
@@ -175,6 +183,7 @@ static void receiver_write_request(WbDevice *d, WbRequest *r) {
 static void receiver_cleanup(WbDevice *d) {
   Receiver *rs = d->pdata;
   receiver_empty_queue(rs);
+  free(rs->allowed_channels);
   free(rs);
 }
 
@@ -238,8 +247,26 @@ void wb_receiver_set_channel(WbDeviceTag tag, int channel) {
   if (!rs)
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
   else if (channel != rs->channel) {
-    rs->set_channel = true;
-    rs->channel = channel;
+    bool is_allowed = true;
+
+    if (rs->allowed_channels_size > 0) {
+      is_allowed = false;
+      for (int i = 0; i < rs->allowed_channels_size; i++) {
+        if (rs->allowed_channels[i] == channel) {
+          is_allowed = true;
+          break;
+        }
+      }
+    }
+
+    if (!is_allowed)
+      fprintf(stderr,
+              "Error: %s() called with channel=%d, which is not between allowed channels. Please use an allowed channel.\n",
+              __FUNCTION__, channel);
+    else {
+      rs->set_channel = true;
+      rs->channel = channel;
+    }
   }
   robot_mutex_unlock_step();
 }

--- a/src/webots/nodes/WbEmitter.cpp
+++ b/src/webots/nodes/WbEmitter.cpp
@@ -37,6 +37,7 @@ void WbEmitter::init() {
   mNeedToSetRange = false;
   mNeedToSetChannel = false;
   mNeedToSetBufferSize = false;
+  mNeedToSetAllowedChannels = false;
   mMediumType = WbDataPacket::UNKNOWN;
   mByteRate = -1.0;
 }
@@ -122,8 +123,14 @@ bool WbEmitter::isChannelAllowed() {
 }
 
 void WbEmitter::updateAllowedChannels() {
-  if (!isChannelAllowed())
-    parsingWarn(tr("'allowedChannels' does not contain current 'channel'"));
+  if (!isChannelAllowed()) {
+    parsingWarn(
+      tr("'allowedChannels' does not contain current 'channel'. Setting 'channel' to %1.").arg(mAllowedChannels->item(0)));
+    mChannel->setValue(mAllowedChannels->item(0));
+    mNeedToSetChannel = true;
+  }
+
+  mNeedToSetAllowedChannels = true;
 }
 
 void WbEmitter::updateChannel() {
@@ -149,6 +156,7 @@ void WbEmitter::writeConfigure(QDataStream &stream) {
   mNeedToSetRange = false;
   mNeedToSetChannel = false;
   mNeedToSetBufferSize = false;
+  mNeedToSetAllowedChannels = false;
 }
 
 void WbEmitter::writeAnswer(QDataStream &stream) {
@@ -169,6 +177,13 @@ void WbEmitter::writeAnswer(QDataStream &stream) {
     stream << (unsigned char)C_EMITTER_SET_BUFFER_SIZE;
     stream << (int)mBufferSize->value();
     mNeedToSetBufferSize = false;
+  }
+  if (mNeedToSetAllowedChannels) {
+    stream << tag();
+    stream << (unsigned char)C_EMITTER_SET_ALLOWED_CHANNELS;
+    stream << (int)mAllowedChannels->size();
+    for (int i = 0; i < mAllowedChannels->size(); i++)
+      stream << (int)mAllowedChannels->item(i);
   }
 }
 

--- a/src/webots/nodes/WbEmitter.cpp
+++ b/src/webots/nodes/WbEmitter.cpp
@@ -127,7 +127,6 @@ void WbEmitter::updateAllowedChannels() {
     parsingWarn(
       tr("'allowedChannels' does not contain current 'channel'. Setting 'channel' to %1.").arg(mAllowedChannels->item(0)));
     mChannel->setValue(mAllowedChannels->item(0));
-    mNeedToSetChannel = true;
   }
 
   mNeedToSetAllowedChannels = true;
@@ -135,9 +134,10 @@ void WbEmitter::updateAllowedChannels() {
 
 void WbEmitter::updateChannel() {
   if (!isChannelAllowed()) {
-    parsingWarn(tr("'channel' is not included in 'allowedChannels'"));
-    return;
+    parsingWarn(tr("'channel' is not included in 'allowedChannels'. Setting 'channel' to %1").arg(mAllowedChannels->item(0)));
+    mChannel->setValue(mAllowedChannels->item(0));
   }
+
   mNeedToSetChannel = true;
 }
 

--- a/src/webots/nodes/WbEmitter.hpp
+++ b/src/webots/nodes/WbEmitter.hpp
@@ -57,6 +57,7 @@ private:
   bool mNeedToSetRange;
   bool mNeedToSetChannel;
   bool mNeedToSetBufferSize;
+  bool mNeedToSetAllowedChannels;
 
   // user accessible fields
   WbSFString *mType;

--- a/src/webots/nodes/WbEmitter.hpp
+++ b/src/webots/nodes/WbEmitter.hpp
@@ -15,6 +15,7 @@
 #ifndef WB_EMITTER_HPP
 #define WB_EMITTER_HPP
 
+#include "WbMFInt.hpp"
 #include "WbSFDouble.hpp"
 #include "WbSFInt.hpp"
 #include "WbSolidDevice.hpp"
@@ -66,17 +67,20 @@ private:
   WbSFInt *mBaudRate;
   WbSFInt *mByteSize;
   WbSFInt *mBufferSize;
+  WbMFInt *mAllowedChannels;
 
   // private functions
   WbEmitter &operator=(const WbEmitter &);  // non copyable
   WbNode *clone() const override { return new WbEmitter(*this); }
   void init();
+  bool isChannelAllowed();
 
 private slots:
   void updateTransmissionSetup();
   void updateBufferSize();
   void updateRange();
   void updateChannel();
+  void updateAllowedChannels();
 };
 
 #endif  // WB_EMITTER_HPP

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -177,6 +177,11 @@ void WbReceiver::updateTransmissionSetup() {
   WbFieldChecker::resetIntIfNonPositiveAndNotDisabled(this, mBaudRate, -1, -1);
   WbFieldChecker::resetIntIfLess(this, mByteSize, 8, 8);
 
+  if (!isChannelAllowed()) {
+    parsingWarn(tr("'channel' is not included in 'allowedChannels'. Setting 'channel' to %1").arg(mAllowedChannels->item(0)));
+    mChannel->setValue(mAllowedChannels->item(0));
+  }
+
   mNeedToConfigure = true;
 }
 

--- a/src/webots/nodes/WbReceiver.cpp
+++ b/src/webots/nodes/WbReceiver.cpp
@@ -194,8 +194,13 @@ bool WbReceiver::isChannelAllowed() {
 }
 
 void WbReceiver::updateAllowedChannels() {
-  if (!isChannelAllowed())
-    parsingWarn(tr("'allowedChannels' does not contain current 'channel'"));
+  if (!isChannelAllowed()) {
+    parsingWarn(
+      tr("'allowedChannels' does not contain current 'channel'. Setting 'channel' to %1.").arg(mAllowedChannels->item(0)));
+    mChannel->setValue(mAllowedChannels->item(0));
+  }
+
+  mNeedToConfigure = true;
 }
 
 void WbReceiver::writeConfigure(QDataStream &stream) {

--- a/src/webots/nodes/WbReceiver.hpp
+++ b/src/webots/nodes/WbReceiver.hpp
@@ -15,6 +15,7 @@
 #ifndef WB_RECEIVER_HPP
 #define WB_RECEIVER_HPP
 
+#include "WbMFInt.hpp"
 #include "WbSFDouble.hpp"
 #include "WbSFInt.hpp"
 #include "WbSolidDevice.hpp"
@@ -80,6 +81,7 @@ private:
   WbSFInt *mBufferSize;
   WbSFDouble *mSignalStrengthNoise;
   WbSFDouble *mDirectionNoise;
+  WbMFInt *mAllowedChannels;
 
   bool mNeedToConfigure;
 
@@ -91,9 +93,11 @@ private:
   void receivePacketIfPossible(WbDataPacket *packet);
   bool checkApertureAndRange(const WbEmitter *emitter, const WbReceiver *receiver, bool checkRangeOnly = false) const;
   void updateRaysSetupIfNeeded() override;
+  bool isChannelAllowed();
 
 private slots:
   void updateTransmissionSetup();
+  void updateAllowedChannels();
 };
 
 #endif  // WB_RECEIVER_HPP


### PR DESCRIPTION
* closes 2826

Signed-off-by: Adrian Matejov <ado.matejov@gmail.com>

**Description**
This feature allows to specify allowed channels for Emitter and Receiver nodes. When calling `wb_emitter_set_channel` or `wb_receiver_set_channel`, the channel is checked against allowed channels.

**Related Issues**
This pull-request fixes issue #2826 

**Tasks**
  - [x] Check whether initial channel is allowed during initialization
  - [x] Implement `updateAllowedChannels`

**Documentation**
https://www.cyberbotics.com/doc/reference/emitter
https://www.cyberbotics.com/doc/reference/receiver

**Additional context**
There are some small things that I don't know how or where to implement, so I would appreciate some advice on those :)
I'm also not that good in C++, so there might be some non-compilable mistakes there.
