### PR TITLE
Fix `ros_control` velocity feedback

### DIFF
--- a/projects/default/controllers/ros/highlevel/RosControl.cpp
+++ b/projects/default/controllers/ros/highlevel/RosControl.cpp
@@ -30,8 +30,9 @@ namespace highlevel {
   }
 
   void RosControl::read() {
-    mWebotsHW->read();
-    mControllerManager->update(ros::Time::now(), ros::Time::now() - mLastUpdate);
+    const ros::Duration duration = ros::Time::now() - mLastUpdate;
+    mWebotsHW->read(duration);
+    mControllerManager->update(ros::Time::now(), duration);
     mLastUpdate = ros::Time::now();
   }
 

--- a/projects/default/controllers/ros/highlevel/WebotsHW.cpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHW.cpp
@@ -59,10 +59,13 @@ namespace highlevel {
     registerInterface(&mVelocityJointInteraface);
   }
 
-  void WebotsHW::read() {
+  void WebotsHW::read(const ros::Duration &duration) {
     for (ControlledMotor &controlledMotor : mControlledMotors) {
-      controlledMotor.position = controlledMotor.motor->getPositionSensor()->getValue();
-      controlledMotor.velocity = controlledMotor.motor->getVelocity();
+      const double previousPosition = controlledMotor.position;
+      const double newPosition = controlledMotor.motor->getPositionSensor()->getValue();
+
+      controlledMotor.position = newPosition;
+      controlledMotor.velocity = (newPosition - previousPosition) / duration.toSec();
     }
   }
 

--- a/projects/default/controllers/ros/highlevel/WebotsHW.hpp
+++ b/projects/default/controllers/ros/highlevel/WebotsHW.hpp
@@ -41,7 +41,7 @@ namespace highlevel {
   public:
     explicit WebotsHW(webots::Robot *robot);
     WebotsHW() = delete;
-    void read();
+    void read(const ros::Duration &duration);
     void write();
     void doSwitch(const std::list<hardware_interface::ControllerInfo> &startList,
                   const std::list<hardware_interface::ControllerInfo> &stopList) override;


### PR DESCRIPTION
Before, `wb_motor_get_velocity` returns the same value as `wb_motor_get_max_velocity` if we are doing position control. This PR makes the `ros_control` returns the real velocity.