### PR TITLE
Changed chained joints collision logic to ignore superposed joints

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -25,6 +25,7 @@ Released on June, Xth, 2021.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create the corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
     - Exposed `stopERP` and `stopCFM` parameters in [HingeJointParameters](hingejointparameters.md) that define the local `ERP` and `CFM` used by joint limits.
+    - Altered the collision detection logic to ignore longer chains of joints if the intermediary joints share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added HingeJointWithBacklash proto that extends [HingeJoint](hingejoint.md) to model the effect of backlash and a corresponding sample world ([#2786](https://github.com/cyberbotics/webots/pull/2786)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -25,7 +25,7 @@ Released on June, Xth, 2021.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create the corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
     - Exposed `stopERP` and `stopCFM` parameters in [HingeJointParameters](hingejointparameters.md) that define the local `ERP` and `CFM` used by joint limits.
-    - Altered the collision detection logic to ignore longer chains of joints if the intermediary joints share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
+    - Altered the collision detection logic to ignore longer chains of joints if the intermediary joints all share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added HingeJointWithBacklash proto that extends [HingeJoint](hingejoint.md) to model the effect of backlash and a corresponding sample world ([#2786](https://github.com/cyberbotics/webots/pull/2786)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -25,7 +25,7 @@ Released on June, Xth, 2021.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create the corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
     - Exposed `stopERP` and `stopCFM` parameters in [HingeJointParameters](hingejointparameters.md) that define the local `ERP` and `CFM` used by joint limits.
-    - Altered the collision detection logic to ignore longer chains of joints if the intermediary joints all share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
+    - Altered the collision detection logic for [Robot.selfCollision](robot.md) to ignore chains of joints if the intermediary joints all share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added HingeJointWithBacklash proto that extends [HingeJoint](hingejoint.md) to model the effect of backlash and a corresponding sample world ([#2786](https://github.com/cyberbotics/webots/pull/2786)).

--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -61,8 +61,8 @@ This is useful for complex articulated robots for which the controller doesn't p
 Enabling self collision is, however, likely to decrease the simulation speed, as more collisions will be generated during the simulation.
 Note that only collisions between non-consecutive solids will be detected.
 For consecutive solids, e.g., two solids attached to each other with a joint, no collision detection is performed, even if the self collision is enabled.
-Collision detection is also ignored for longer chains of consecutive solids in the event that all intermediary joints connecting the two colliding bodies all share the same `anchor` point.
-The reason is that this type of collision detection is usually not wanted by the user, because a very accurate design of the bounding objects of the solids would be required.
+Collision detection is also ignored for longer chains of consecutive solids in the event that all intermediary joints connecting the two colliding bodies all share the same `anchor` point. If even just one of them is different, standard rules apply.
+The reason for these exceptions is that these types of collision detections are usually not wanted by the user, because a very accurate design of the bounding objects of the solids would be required.
 To prevent two consecutive solid nodes from penetrating each other, the `minStop` and `maxStop` fields of the corresponding joint node should be adjusted accordingly.
 Here is an example of a robot leg with self collision enabled:
 

--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -61,6 +61,7 @@ This is useful for complex articulated robots for which the controller doesn't p
 Enabling self collision is, however, likely to decrease the simulation speed, as more collisions will be generated during the simulation.
 Note that only collisions between non-consecutive solids will be detected.
 For consecutive solids, e.g., two solids attached to each other with a joint, no collision detection is performed, even if the self collision is enabled.
+Collision detection is also ignored for longer chains of consecutive solids in the event that all intermediary joints connecting the two colliding bodies all share the same `anchor` point.
 The reason is that this type of collision detection is usually not wanted by the user, because a very accurate design of the bounding objects of the solids would be required.
 To prevent two consecutive solid nodes from penetrating each other, the `minStop` and `maxStop` fields of the corresponding joint node should be adjusted accordingly.
 Here is an example of a robot leg with self collision enabled:

--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -61,7 +61,8 @@ This is useful for complex articulated robots for which the controller doesn't p
 Enabling self collision is, however, likely to decrease the simulation speed, as more collisions will be generated during the simulation.
 Note that only collisions between non-consecutive solids will be detected.
 For consecutive solids, e.g., two solids attached to each other with a joint, no collision detection is performed, even if the self collision is enabled.
-Collision detection is also ignored for longer chains of consecutive solids in the event that all intermediary joints connecting the two colliding bodies all share the same `anchor` point. If even just one of them is different, standard rules apply.
+Collision detection is also ignored for longer chains of consecutive solids in the event that all intermediary joints connecting the two colliding bodies all share the same `anchor` point.
+If even just one of them is different, standard rules apply.
 The reason for these exceptions is that these types of collision detections are usually not wanted by the user, because a very accurate design of the bounding objects of the solids would be required.
 To prevent two consecutive solid nodes from penetrating each other, the `minStop` and `maxStop` fields of the corresponding joint node should be adjusted accordingly.
 Here is an example of a robot leg with self collision enabled:

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -601,7 +601,7 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       if (joint) {
         if (firstAnchor.isNan())
           firstAnchor = joint->anchor();
-        if (!firstAnchor.almostEquals(joint->anchor()))
+        else if (!firstAnchor.almostEquals(joint->anchor()))
           break;
       }
       n = n->parentNode();

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -586,13 +586,13 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
 
   // ignore collision if bodies are connected by a chain of HingeJoint (or derivatives) sharing a same anchor
   if (b1 && b2) {
-    WbNode *n; // climb up the chain from the lowest level
-    dBodyID b; // stop when we reach this body
-    if (s1->level() > s2->level()) { 
-      n = dynamic_case<WbNode *>(s1);
+    WbNode *n;  // climb up the chain from the lowest level
+    dBodyID b;  // stop when we reach this body
+    if (s1->level() > s2->level()) {
+      n = dynamic_cast<WbNode *>(s1);
       b = b2;
     } else {
-      n = dynamic_case<WbNode *>(s2);
+      n = dynamic_cast<WbNode *>(s2);
       b = b1;
     }
 

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -606,10 +606,9 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
 
     if (anchors.size() > 1) {  // the case where a single joint separates the two bodies is taken care already
       bool isSameAnchor = true;
-      for (int i = 1; i < anchors.size(); ++i) {
+      for (int i = 1; i < anchors.size(); ++i)
         if (!anchors.at(i).almostEquals(anchors.at(0)))
           isSameAnchor = false;
-      }
 
       if (isSameAnchor)
         return;

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -585,11 +585,11 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   // ignore collision if bodies are connected by a chain of HingeJoint (or derivatives) sharing a same anchor
-  WbNode *const node_s1 = dynamic_cast<WbNode *>(s1);
-  WbNode *const node_s2 = dynamic_cast<WbNode *>(s2);
-  if (b1 && b2 && node_s1 && node_s2) {
-    WbNode *n = node_s1->level() > node_s2->level() ? node_s1 : node_s2;  // climb the chain from the lowest level
-    dBodyID b = node_s1->level() > node_s2->level() ? b2 : b1;            // stop when we reach this body
+  WbNode *const nodeS1 = dynamic_cast<WbNode *>(s1);
+  WbNode *const nodeS2 = dynamic_cast<WbNode *>(s2);
+  if (b1 && b2 && nodeS1 && nodeS2) {
+    WbNode *n = nodeS1->level() > nodeS2->level() ? nodeS1 : nodeS2;  // climb the chain from the lowest level
+    dBodyID b = nodeS1->level() > nodeS2->level() ? b2 : b1;          // stop when we reach this body
 
     QVector<WbVector3> anchors;
     while (n && n->level() >= 1) {

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -585,11 +585,16 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   // ignore collision if bodies are connected by a chain of HingeJoint (or derivatives) sharing a same anchor
-  WbNode *const nodeS1 = dynamic_cast<WbNode *>(s1);
-  WbNode *const nodeS2 = dynamic_cast<WbNode *>(s2);
-  if (b1 && b2 && nodeS1 && nodeS2) {
-    WbNode *n = nodeS1->level() > nodeS2->level() ? nodeS1 : nodeS2;  // climb the chain from the lowest level
-    dBodyID b = nodeS1->level() > nodeS2->level() ? b2 : b1;          // stop when we reach this body
+  if (b1 && b2) {
+    WbNode *n; // climb up the chain from the lowest level
+    dBodyID b; // stop when we reach this body
+    if (s1->level() > s2->level()) { 
+      n = dynamic_case<WbNode *>(s1);
+      b = b2;
+    } else {
+      n = dynamic_case<WbNode *>(s2);
+      b = b1;
+    }
 
     WbVector3 firstAnchor(NAN, NAN, NAN);
     while (n && n->level() >= 1) {

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -585,16 +585,11 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   // ignore collision if bodies are connected by a chain of HingeJoint (or derivatives) sharing a same anchor
-  if (b1 && b2) {
-    WbNode *const node_s1 = dynamic_cast<WbNode *>(s1);
-    WbNode *const node_s2 = dynamic_cast<WbNode *>(s2);
-    WbNode *n = NULL;
-    dBodyID b;
-
-    if (node_s1 && node_s2) {
-      n = node_s1->level() > node_s2->level() ? node_s1 : node_s2;  // climb the chain from the lowest level
-      b = node_s1->level() > node_s2->level() ? b2 : b1;            // stop when we reach this body
-    }
+  WbNode *const node_s1 = dynamic_cast<WbNode *>(s1);
+  WbNode *const node_s2 = dynamic_cast<WbNode *>(s2);
+  if (b1 && b2 && node_s1 && node_s2) {
+    WbNode *n = node_s1->level() > node_s2->level() ? node_s1 : node_s2;  // climb the chain from the lowest level
+    dBodyID b = node_s1->level() > node_s2->level() ? b2 : b1;            // stop when we reach this body
 
     QVector<WbVector3> anchors;
     while (n && n->level() >= 1) {


### PR DESCRIPTION
**Description**
Currently, when `selfCollision` is active, only consecutive bodies connected by a joint are ignored. With this PR, colliding bodies connected by a chain of joints which share a common `anchor` are also ignored. For instance when using `HingeJointWithBacklash` or `Hinge2JointWithBacklash`, by construction the hidden limiting joints in these PROTOs are superposed and the presence of intermediary bodies for each triggers collisions despite not being interested in them.

- [x] collision logic
- [x] update documentation
- [x] changelog