### PR TITLE
Change initial position of the Tiago arm

### DIFF
--- a/projects/robots/pal_robotics/tiago_extensions/protos/TiagoFrontArm.proto
+++ b/projects/robots/pal_robotics/tiago_extensions/protos/TiagoFrontArm.proto
@@ -46,7 +46,7 @@ PROTO TiagoFrontArm [
       }
       DEF ARM_1_JOINT HingeJoint {
         jointParameters HingeJointParameters {
-          position 0.07
+          position 0.071
           axis 0 0 1
           anchor 0.025 0.194 -0.16
           dampingConstant 1
@@ -66,7 +66,7 @@ PROTO TiagoFrontArm [
         ]
         endPoint DEF ARM_1 Solid {
           translation 0.0251 0.194 -0.171
-          rotation 0 0 1 0
+          rotation 0 0 1 0.01
           children [
             DEF ARM_1_SH1 Shape {
               appearance GlossyPaint {


### PR DESCRIPTION
The initial position of the `ARM_1_JOINT` joint is equal to the `minPosition`. In some scenarios, this throws out-of-bounds errors as the initial position is very close to `minPosition`.