### PR TITLE
Improve URDF naming convention

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -33,6 +33,8 @@ Released on June, Xth, 2021.
   - Bug fixes:
     - Fixed the [`wb_supervisor_field_get_count`](supervisor.md#wb_supervisor_field_get_count) function's returned value not updated after modifying the fields from the GUI or from another [Supervisor](supervisor.md) controller ([#2812](https://github.com/cyberbotics/webots/pull/2812)).
     - Fixed the conversion from quaternions to euler angles in the [InertialUnit](inertialunit.md) for the ENU coordinate system ([#2768](https://github.com/cyberbotics/webots/pull/2768)).
+  - Enhancements
+    -  Improved the URDF naming convention ([#2875](https://github.com/cyberbotics/webots/pull/2875)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
 

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -24,6 +24,7 @@ Released on June, Xth, 2021.
       - Integrated `ros_control` (activated through the `--use-ros-control` flag) to allow the usage of a `diff_drive_controller` and `joint_state_controller` from the [`ros_controllers`](https://github.com/ros-controls/ros_controllers) package.
       - Added an option (activated through the `--auto-publish` flag) to automatically enable all devices on startup and create the corresponding topics.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
+    - Improved the URDF naming convention ([#2875](https://github.com/cyberbotics/webots/pull/2875)).
     - Exposed `stopERP` and `stopCFM` parameters in [HingeJointParameters](hingejointparameters.md) that define the local `ERP` and `CFM` used by joint limits.
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
@@ -33,8 +34,6 @@ Released on June, Xth, 2021.
   - Bug fixes:
     - Fixed the [`wb_supervisor_field_get_count`](supervisor.md#wb_supervisor_field_get_count) function's returned value not updated after modifying the fields from the GUI or from another [Supervisor](supervisor.md) controller ([#2812](https://github.com/cyberbotics/webots/pull/2812)).
     - Fixed the conversion from quaternions to euler angles in the [InertialUnit](inertialunit.md) for the ENU coordinate system ([#2768](https://github.com/cyberbotics/webots/pull/2768)).
-  - Enhancements
-    -  Improved the URDF naming convention ([#2875](https://github.com/cyberbotics/webots/pull/2875)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
 

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1110,9 +1110,9 @@ const QString WbNode::urdfName() const {
     name = this->defName();
   else
     name = QString(mModel->name().toLower());
-
-  // Add prefix if needed
   QString fullName = getUrdfPrefix() + name;
+
+  // Add suffix if needed
   if (gUrdfNames.values().contains(fullName))
     fullName += "_" + QString::number(gUrdfNameIndex++);
 

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -59,7 +59,9 @@ struct ProtoParameters {
 };
 static QList<ProtoParameters *> gProtoParameterList;
 static QList<const WbNode *> gUrdfNodesQueue;
+static QMap<int, QString> gUrdfNames;
 static const WbNode *gUrdfCurrentNode;
+static int gUrdfNameIndex = 0;
 
 static bool gInstantiateMode = true;
 static QVector<WbNode *> gNodes = {NULL};  // id 0 is reserved for root node
@@ -990,6 +992,12 @@ void WbNode::write(WbVrmlWriter &writer) const {
     }
   }
   if (writer.isUrdf()) {
+    // Start naming from scratch
+    if (isRobot()) {
+      gUrdfNames.clear();
+      gUrdfNameIndex = 0;
+    }
+
     if (gUrdfCurrentNode != this && isJoint() && !gUrdfNodesQueue.contains(this)) {
       gUrdfNodesQueue.append(this);
       return;
@@ -1090,23 +1098,27 @@ QStringList WbNode::listTextureFiles() const {
 }
 
 const QString WbNode::urdfName() const {
+  // Use existing name if already given
+  if (gUrdfNames.contains(uniqueId()))
+    return gUrdfNames[uniqueId()];
+
+  // Name the link/joint according to priority: name -> def -> model
   QString name;
-  if (this->findSFString("name")) {
+  if (this->findSFString("name") && this->findSFString("name")->value() != "") 
     name = this->findSFString("name")->value();
+  else if (this->defName() != "") 
+    name = this->defName();
+  else
+    name = QString(mModel->name().toLower());
 
-    // Make sure there are no duplicates
-    const QList<WbNode *> children = findRobotRootNode()->subNodes(true, true, true);
-    for (int i = 0; i < children.size(); i++) {
-      const WbNode *const child = children.at(i);
-      if (child != this && child->findSFString("name") && child->findSFString("name")->value() == name) {
-        name += "_" + QString::number(mUniqueId);
-        break;
-      }
-    }
-  } else
-    name = QString(mModel->name().toLower() + "_" + QString::number(mUniqueId));
+  // Add prefix if needed
+  QString fullName = getUrdfPrefix() + name;
+  if (gUrdfNames.values().contains(fullName))
+    fullName += "_" + QString::number(gUrdfNameIndex++);
 
-  return getUrdfPrefix() + name;
+  // Return
+  gUrdfNames[uniqueId()] = fullName;
+  return fullName;
 }
 
 bool WbNode::exportNodeHeader(WbVrmlWriter &writer) const {

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1104,9 +1104,9 @@ const QString WbNode::urdfName() const {
 
   // Name the link/joint according to priority: name -> def -> model
   QString name;
-  if (this->findSFString("name") && this->findSFString("name")->value() != "") 
+  if (this->findSFString("name") && this->findSFString("name")->value() != "")
     name = this->findSFString("name")->value();
-  else if (this->defName() != "") 
+  else if (this->defName() != "")
     name = this->defName();
   else
     name = QString(mModel->name().toLower());

--- a/tests/api/controllers/robot_urdf/prob3_reference.urdf
+++ b/tests/api/controllers/robot_urdf/prob3_reference.urdf
@@ -255,7 +255,7 @@
     <child link="ts_emitter"/>
     <origin xyz="0 0 0.02075" rpy="0 0 0"/>
   </joint>
-  <link name="link_base_tcp180_50200">
+  <link name="link_base_tcp180">
     <visual>
       <origin xyz="0 0 0.026" rpy="0 0 0"/>
       <geometry>
@@ -281,26 +281,26 @@
       </geometry>
     </collision>
   </link>
-  <joint name="link_6_top_link_base_tcp180_50200_joint" type="fixed">
+  <joint name="link_6_top_link_base_tcp180_joint" type="fixed">
     <parent link="link_6_top"/>
-    <child link="link_base_tcp180_50200"/>
+    <child link="link_base_tcp180"/>
     <origin xyz="0 0 0.07775" rpy="0 0 0"/>
   </joint>
   <link name="gripper middle distance sensor">
   </link>
-  <joint name="link_base_tcp180_50200_gripper middle distance sensor_joint" type="fixed">
-    <parent link="link_base_tcp180_50200"/>
+  <joint name="link_base_tcp180_gripper middle distance sensor_joint" type="fixed">
+    <parent link="link_base_tcp180"/>
     <child link="gripper middle distance sensor"/>
     <origin xyz="0 0 0.085" rpy="0 -1.5707897 0"/>
   </joint>
   <joint name="7 left" type="revolute">
-    <parent link="link_base_tcp180_50200"/>
-    <child link="left finger_50285"/>
+    <parent link="link_base_tcp180"/>
+    <child link="left finger"/>
     <axis xyz="-1 -2.614661e-06 4.528642e-07"/>
     <limit effort="5.44164" lower="0" upper="1.0472" velocity="1.0472"/>
     <origin xyz="0 0 0.058" rpy="0.3430009 4.528642e-07 3.14159"/>
   </joint>
-  <link name="left finger_50285">
+  <link name="left finger">
     <visual>
       <origin xyz="0 0.0437334 0.0442707" rpy="-0.2879853 0 0"/>
       <geometry>
@@ -388,40 +388,40 @@
   </link>
   <link name="left finger sensor 3">
   </link>
-  <joint name="left finger_50285_left finger sensor 3_joint" type="fixed">
-    <parent link="left finger_50285"/>
+  <joint name="left finger_left finger sensor 3_joint" type="fixed">
+    <parent link="left finger"/>
     <child link="left finger sensor 3"/>
     <origin xyz="-6.75982e-08 0.0173238 0.0871813" rpy="7.8457396e-07 0.26179942 1.5708023"/>
   </joint>
   <link name="left finger sensor 2">
   </link>
-  <joint name="left finger_50285_left finger sensor 2_joint" type="fixed">
-    <parent link="left finger_50285"/>
+  <joint name="left finger_left finger sensor 2_joint" type="fixed">
+    <parent link="left finger"/>
     <child link="left finger sensor 2"/>
     <origin xyz="-7.548e-10 0.0214379 0.13449" rpy="-3.3035767e-06 -1.1257437 -1.5707953"/>
   </joint>
   <link name="left finger sensor 1">
   </link>
-  <joint name="left finger_50285_left finger sensor 1_joint" type="fixed">
-    <parent link="left finger_50285"/>
+  <joint name="left finger_left finger sensor 1_joint" type="fixed">
+    <parent link="left finger"/>
     <child link="left finger sensor 1"/>
     <origin xyz="-0.013 0.02 0.118" rpy="0 0 3.1415927"/>
   </joint>
   <link name="left finger sensor 0">
   </link>
-  <joint name="left finger_50285_left finger sensor 0_joint" type="fixed">
-    <parent link="left finger_50285"/>
+  <joint name="left finger_left finger sensor 0_joint" type="fixed">
+    <parent link="left finger"/>
     <child link="left finger sensor 0"/>
     <origin xyz="0.013 0.02 0.118" rpy="0 0 0"/>
   </joint>
   <joint name="7" type="revolute">
-    <parent link="link_base_tcp180_50200"/>
-    <child link="right finger_50237"/>
+    <parent link="link_base_tcp180"/>
+    <child link="right finger"/>
     <axis xyz="-1 0 0"/>
     <limit effort="5.44164" lower="0" upper="1.0472" velocity="1.0472"/>
     <origin xyz="0 0 0.058" rpy="0.343 0 0"/>
   </joint>
-  <link name="right finger_50237">
+  <link name="right finger">
     <visual>
       <origin xyz="0 0.0437334 0.0442707" rpy="-0.2879853 0 0"/>
       <geometry>
@@ -509,29 +509,29 @@
   </link>
   <link name="right finger sensor 3">
   </link>
-  <joint name="right finger_50237_right finger sensor 3_joint" type="fixed">
-    <parent link="right finger_50237"/>
+  <joint name="right finger_right finger sensor 3_joint" type="fixed">
+    <parent link="right finger"/>
     <child link="right finger sensor 3"/>
     <origin xyz="-6.75982e-08 0.0173238 0.0871813" rpy="7.8457396e-07 0.26179942 1.5708023"/>
   </joint>
   <link name="right finger sensor 2">
   </link>
-  <joint name="right finger_50237_right finger sensor 2_joint" type="fixed">
-    <parent link="right finger_50237"/>
+  <joint name="right finger_right finger sensor 2_joint" type="fixed">
+    <parent link="right finger"/>
     <child link="right finger sensor 2"/>
     <origin xyz="-7.548e-10 0.0214379 0.13449" rpy="-3.3035767e-06 -1.1257437 -1.5707953"/>
   </joint>
   <link name="right finger sensor 1">
   </link>
-  <joint name="right finger_50237_right finger sensor 1_joint" type="fixed">
-    <parent link="right finger_50237"/>
+  <joint name="right finger_right finger sensor 1_joint" type="fixed">
+    <parent link="right finger"/>
     <child link="right finger sensor 1"/>
     <origin xyz="-0.013 0.02 0.118" rpy="0 0 3.1415927"/>
   </joint>
   <link name="right finger sensor 0">
   </link>
-  <joint name="right finger_50237_right finger sensor 0_joint" type="fixed">
-    <parent link="right finger_50237"/>
+  <joint name="right finger_right finger sensor 0_joint" type="fixed">
+    <parent link="right finger"/>
     <child link="right finger sensor 0"/>
     <origin xyz="0.013 0.02 0.118" rpy="0 0 0"/>
   </joint>

--- a/tests/api/controllers/robot_urdf/tiago_reference.urdf
+++ b/tests/api/controllers/robot_urdf/tiago_reference.urdf
@@ -38,7 +38,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_12060" type="continuous">
+  <joint name="CASTER_WHEEL_BACK_LEFT_JOINT" type="continuous">
     <parent link="base_link"/>
     <child link="caster_back_left_1_link"/>
     <axis xyz="0 0 1"/>
@@ -58,7 +58,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_12063" type="continuous">
+  <joint name="SMALL_WHEEL_JOINT" type="continuous">
     <parent link="caster_back_left_1_link"/>
     <child link="caster_back_left_2_link"/>
     <axis xyz="0 -3.6732051e-06 1"/>
@@ -78,7 +78,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_12025" type="continuous">
+  <joint name="CASTER_WHEEL_BACK_RIGHT_JOINT" type="continuous">
     <parent link="base_link"/>
     <child link="caster_back_right_1_link"/>
     <axis xyz="0 0 1"/>
@@ -98,7 +98,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_12028" type="continuous">
+  <joint name="SMALL_WHEEL_JOINT_0" type="continuous">
     <parent link="caster_back_right_1_link"/>
     <child link="caster_back_right_2_link"/>
     <axis xyz="0 -3.6732051e-06 1"/>
@@ -118,7 +118,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_11990" type="continuous">
+  <joint name="CASTER_WHEEL_FRONT_LEFT_JOINT" type="continuous">
     <parent link="base_link"/>
     <child link="caster_front_left_1_link"/>
     <axis xyz="0 0 1"/>
@@ -138,7 +138,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_11993" type="continuous">
+  <joint name="SMALL_WHEEL_JOINT_1" type="continuous">
     <parent link="caster_front_left_1_link"/>
     <child link="caster_front_left_2_link"/>
     <axis xyz="0 -3.6732051e-06 1"/>
@@ -158,7 +158,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_11955" type="continuous">
+  <joint name="CASTER_WHEEL_FRONT_RIGHT_JOINT" type="continuous">
     <parent link="base_link"/>
     <child link="caster_front_right_1_link"/>
     <axis xyz="0 0 1"/>
@@ -178,7 +178,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="hingejoint_11958" type="continuous">
+  <joint name="SMALL_WHEEL_JOINT_2" type="continuous">
     <parent link="caster_front_right_1_link"/>
     <child link="caster_front_right_2_link"/>
     <axis xyz="0 -3.6732051e-06 1"/>
@@ -529,7 +529,7 @@
     <child link="ts_emitter"/>
     <origin xyz="0.107 0.0802 0" rpy="0 0 0"/>
   </joint>
-  <link name="TIAGo left arm_43965">
+  <link name="TIAGo left arm">
     <visual>
       <origin xyz="0.026 0.14 -0.232" rpy="0 0 1.5708"/>
       <geometry>
@@ -567,19 +567,19 @@
       </geometry>
     </collision>
   </link>
-  <joint name="torso_lift_link_TIAGo left arm_43965_joint" type="fixed">
+  <joint name="torso_lift_link_TIAGo left arm_joint" type="fixed">
     <parent link="torso_lift_link"/>
-    <child link="TIAGo left arm_43965"/>
+    <child link="TIAGo left arm"/>
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </joint>
   <joint name="arm_left_1_joint" type="revolute">
-    <parent link="TIAGo left arm_43965"/>
-    <child link="TIAGo_left_arm_43980"/>
+    <parent link="TIAGo left arm"/>
+    <child link="TIAGo_left_arm"/>
     <axis xyz="0 0 -1"/>
     <limit effort="43" lower="-1.11" upper="1.5" velocity="1.95"/>
     <origin xyz="0.025 0.194 -0.16" rpy="0 0 1.5708"/>
   </joint>
-  <link name="TIAGo_left_arm_43980">
+  <link name="TIAGo_left_arm">
     <visual>
       <origin xyz="-3.673205e-10 -0.0001 0.002" rpy="-3.141589 0 0"/>
       <geometry>
@@ -630,13 +630,13 @@
     </collision>
   </link>
   <joint name="arm_left_2_joint" type="revolute">
-    <parent link="TIAGo_left_arm_43980"/>
-    <child link="arm_left_2_link_44013"/>
+    <parent link="TIAGo_left_arm"/>
+    <child link="arm_left_2_link"/>
     <axis xyz="0 -3.6732051e-06 -1"/>
     <limit effort="43" lower="-1.11" upper="1.5" velocity="1.95"/>
     <origin xyz="0.125 0.0194 -0.042" rpy="1.5708 0 0"/>
   </joint>
-  <link name="arm_left_2_link_44013">
+  <link name="arm_left_2_link">
     <visual>
       <origin xyz="0.056 5.5098077e-09 -0.0005" rpy="1.5707963 0 -1.5708"/>
       <geometry>
@@ -663,13 +663,13 @@
     </collision>
   </link>
   <joint name="arm_left_3_joint" type="revolute">
-    <parent link="arm_left_2_link_44013"/>
-    <child link="arm_left_3_link_44027"/>
+    <parent link="arm_left_2_link"/>
+    <child link="arm_left_3_link"/>
     <axis xyz="-6.056618e-05 -6.055936e-05 -1"/>
     <limit effort="26" lower="-0.72" upper="3.86" velocity="2.35"/>
     <origin xyz="0.0895 5.5098077e-09 -1.0118208e-14" rpy="1.5708569 -0.0001126458 -1.5708569"/>
   </joint>
-  <link name="arm_left_3_link_44027">
+  <link name="arm_left_3_link">
     <visual>
       <origin xyz="1.3930222e-07 1.3928653e-07 -0.1037" rpy="-3.7000516e-06 0 0"/>
       <geometry>
@@ -696,13 +696,13 @@
     </collision>
   </link>
   <joint name="arm_left_4_joint" type="revolute">
-    <parent link="arm_left_3_link_44027"/>
-    <child link="arm_left_4_link_44061"/>
+    <parent link="arm_left_3_link"/>
+    <child link="arm_left_4_link"/>
     <axis xyz="2.8276386e-06 -2.8276306e-06 1"/>
     <limit effort="26" lower="-0.32" upper="2.29" velocity="2.35"/>
     <origin xyz="-0.01999986 -0.026999861 -0.2197" rpy="2.356193 -1.5707923 2.356193"/>
   </joint>
-  <link name="arm_left_4_link_44061">
+  <link name="arm_left_4_link">
     <visual>
       <origin xyz="0 0.001 -0.002" rpy="-3.141589 0 0"/>
       <geometry>
@@ -729,13 +729,13 @@
     </collision>
   </link>
   <joint name="arm_left_5_joint" type="revolute">
-    <parent link="arm_left_4_link_44061"/>
-    <child link="arm_left_5_link_44095"/>
+    <parent link="arm_left_4_link"/>
+    <child link="arm_left_5_link"/>
     <axis xyz="-3.6732051e-06 0 -1"/>
     <limit effort="3" lower="-2.07" upper="2.07" velocity="1.95"/>
     <origin xyz="-0.162 0.02 0.027" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="arm_left_5_link_44095">
+  <link name="arm_left_5_link">
     <visual>
       <origin xyz="0 0 0.04" rpy="3.1407962 0 0"/>
       <geometry>
@@ -774,13 +774,13 @@
     </collision>
   </link>
   <joint name="arm_left_6_joint" type="revolute">
-    <parent link="arm_left_5_link_44095"/>
-    <child link="arm_left_6_link_44110"/>
+    <parent link="arm_left_5_link"/>
+    <child link="arm_left_6_link"/>
     <axis xyz="-2.8276386e-06 2.8276306e-06 -1"/>
     <limit effort="6.6" lower="-1.39" upper="1.39" velocity="1.76"/>
     <origin xyz="0 0 0.15" rpy="2.356193 -1.5707923 2.356193"/>
   </joint>
-  <link name="arm_left_6_link_44110">
+  <link name="arm_left_6_link">
     <visual>
       <origin xyz="0.0409 0 0" rpy="1.5707963 0 -1.5708"/>
       <geometry>
@@ -795,13 +795,13 @@
     </collision>
   </link>
   <joint name="arm_left_7_joint" type="revolute">
-    <parent link="arm_left_6_link_44110"/>
-    <child link="arm_left_7_link_44125"/>
+    <parent link="arm_left_6_link"/>
+    <child link="arm_left_7_link"/>
     <axis xyz="2.8276306e-06 -2.8276386e-06 -1"/>
     <limit effort="6.6" lower="-2.07" upper="2.07" velocity="1.76"/>
     <origin xyz="0 0 0" rpy="1.5707991 -2.8276386e-06 1.5707991"/>
   </joint>
-  <link name="arm_left_7_link_44125">
+  <link name="arm_left_7_link">
     <visual>
       <origin xyz="-1.5551969e-07 1.5552013e-07 0.055" rpy="-3.141589 0 0"/>
       <geometry>
@@ -815,7 +815,7 @@
       </geometry>
     </collision>
   </link>
-  <link name="wrist_left_ft_tool_link_44137">
+  <link name="wrist_left_ft_tool_link">
     <visual>
       <origin xyz="-1.5551969e-07 1.5552013e-07 0.055" rpy="1.5707963 1.110223e-16 1.57"/>
       <geometry>
@@ -829,12 +829,12 @@
       </geometry>
     </collision>
   </link>
-  <joint name="arm_left_7_link_44125_wrist_left_ft_tool_link_44137_joint" type="fixed">
-    <parent link="arm_left_7_link_44125"/>
-    <child link="wrist_left_ft_tool_link_44137"/>
+  <joint name="arm_left_7_link_wrist_left_ft_tool_link_joint" type="fixed">
+    <parent link="arm_left_7_link"/>
+    <child link="wrist_left_ft_tool_link"/>
     <origin xyz="-1.5551969e-07 1.5552013e-07 0.067725" rpy="2.356193 -1.5707923 2.356193"/>
   </joint>
-  <link name="left_48654">
+  <link name="left">
     <visual>
       <origin xyz="0 0 0" rpy="3.1407962 0 0"/>
       <geometry>
@@ -896,19 +896,19 @@
       </geometry>
     </collision>
   </link>
-  <joint name="wrist_left_ft_tool_link_44137_left_48654_joint" type="fixed">
-    <parent link="wrist_left_ft_tool_link_44137"/>
-    <child link="left_48654"/>
+  <joint name="wrist_left_ft_tool_link_left_joint" type="fixed">
+    <parent link="wrist_left_ft_tool_link"/>
+    <child link="left"/>
     <origin xyz="0.016 -5.877128e-08 0" rpy="-2.356193 1.5707923 0.78539306"/>
   </joint>
   <joint name="left_hand_gripper_right_finger_joint" type="prismatic">
-    <parent link="left_48654"/>
-    <child link="gripper_right_finger_link_49215"/>
+    <parent link="left"/>
+    <child link="gripper_right_finger_link"/>
     <axis xyz="1 0 0"/>
     <origin xyz="0 0 0" rpy="0 0 0"/>
     <limit effort="16" lower="0" upper="0.045" velocity="0.05"/>
   </joint>
-  <link name="gripper_right_finger_link_49215">
+  <link name="gripper_right_finger_link">
     <visual>
       <origin xyz="0.004 0 -0.1741" rpy="0 0 0"/>
       <geometry>
@@ -947,13 +947,13 @@
     </collision>
   </link>
   <joint name="left_hand_gripper_left_finger_joint" type="prismatic">
-    <parent link="left_48654"/>
-    <child link="gripper_left_finger_link_49182"/>
+    <parent link="left"/>
+    <child link="gripper_left_finger_link"/>
     <axis xyz="1 9.265359e-05 0"/>
     <origin xyz="0 0 0" rpy="0 0 3.1415"/>
     <limit effort="16" lower="0" upper="0.045" velocity="0.05"/>
   </joint>
-  <link name="gripper_left_finger_link_49182">
+  <link name="gripper_left_finger_link">
     <visual>
       <origin xyz="0.004 0 -0.1741" rpy="0 0 0"/>
       <geometry>
@@ -991,147 +991,147 @@
       </geometry>
     </collision>
   </link>
-  <link name="cap screw(19)_49154">
+  <link name="cap screw(19)">
   </link>
-  <joint name="left_48654_cap screw(19)_49154_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(19)_49154"/>
+  <joint name="left_cap screw(19)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(19)"/>
     <origin xyz="0.0415 -0.0029 -0.0004" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(18)_49130">
+  <link name="cap screw(18)">
   </link>
-  <joint name="left_48654_cap screw(18)_49130_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(18)_49130"/>
+  <joint name="left_cap screw(18)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(18)"/>
     <origin xyz="-0.0415 0.0029 -0.0004" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(17)_49106">
+  <link name="cap screw(17)">
   </link>
-  <joint name="left_48654_cap screw(17)_49106_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(17)_49106"/>
+  <joint name="left_cap screw(17)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(17)"/>
     <origin xyz="0.0433 0.0315 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(16)_49082">
+  <link name="cap screw(16)">
   </link>
-  <joint name="left_48654_cap screw(16)_49082_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(16)_49082"/>
+  <joint name="left_cap screw(16)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(16)"/>
     <origin xyz="-0.0433 -0.0315 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(15)_49058">
+  <link name="cap screw(15)">
   </link>
-  <joint name="left_48654_cap screw(15)_49058_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(15)_49058"/>
+  <joint name="left_cap screw(15)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(15)"/>
     <origin xyz="0 0.033 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(14)_49034">
+  <link name="cap screw(14)">
   </link>
-  <joint name="left_48654_cap screw(14)_49034_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(14)_49034"/>
+  <joint name="left_cap screw(14)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(14)"/>
     <origin xyz="0 -0.033 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(13)_49010">
+  <link name="cap screw(13)">
   </link>
-  <joint name="left_48654_cap screw(13)_49010_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(13)_49010"/>
+  <joint name="left_cap screw(13)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(13)"/>
     <origin xyz="0.0426 -0.0094 -0.09448" rpy="0 0 0"/>
   </joint>
-  <link name="cap screw(12)_48986">
+  <link name="cap screw(12)">
   </link>
-  <joint name="left_48654_cap screw(12)_48986_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(12)_48986"/>
+  <joint name="left_cap screw(12)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(12)"/>
     <origin xyz="-0.0425 0.0094 -0.0945" rpy="0 0 0"/>
   </joint>
-  <link name="cap screw(11)_48962">
+  <link name="cap screw(11)">
   </link>
-  <joint name="left_48654_cap screw(11)_48962_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(11)_48962"/>
+  <joint name="left_cap screw(11)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(11)"/>
     <origin xyz="-0.0477 -0.008 -0.0108" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(10)_48938">
+  <link name="cap screw(10)">
   </link>
-  <joint name="left_48654_cap screw(10)_48938_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(10)_48938"/>
+  <joint name="left_cap screw(10)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(10)"/>
     <origin xyz="-0.0477 -0.008 -0.043" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(9)_48914">
+  <link name="cap screw(9)">
   </link>
-  <joint name="left_48654_cap screw(9)_48914_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(9)_48914"/>
+  <joint name="left_cap screw(9)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(9)"/>
     <origin xyz="-0.0477 -0.008 -0.075" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(8)_48890">
+  <link name="cap screw(8)">
   </link>
-  <joint name="left_48654_cap screw(8)_48890_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(8)_48890"/>
+  <joint name="left_cap screw(8)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(8)"/>
     <origin xyz="-0.0477 0.008 -0.075" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(7)_48866">
+  <link name="cap screw(7)">
   </link>
-  <joint name="left_48654_cap screw(7)_48866_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(7)_48866"/>
+  <joint name="left_cap screw(7)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(7)"/>
     <origin xyz="-0.0477 0.008 -0.043" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(6)_48842">
+  <link name="cap screw(6)">
   </link>
-  <joint name="left_48654_cap screw(6)_48842_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(6)_48842"/>
+  <joint name="left_cap screw(6)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(6)"/>
     <origin xyz="-0.0477 0.008 -0.0108" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(5)_48818">
+  <link name="cap screw(5)">
   </link>
-  <joint name="left_48654_cap screw(5)_48818_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(5)_48818"/>
+  <joint name="left_cap screw(5)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(5)"/>
     <origin xyz="0.0477 -0.008 -0.0108" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(4)_48794">
+  <link name="cap screw(4)">
   </link>
-  <joint name="left_48654_cap screw(4)_48794_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(4)_48794"/>
+  <joint name="left_cap screw(4)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(4)"/>
     <origin xyz="0.0477 -0.008 -0.043" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(3)_48770">
+  <link name="cap screw(3)">
   </link>
-  <joint name="left_48654_cap screw(3)_48770_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(3)_48770"/>
+  <joint name="left_cap screw(3)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(3)"/>
     <origin xyz="0.0477 -0.008 -0.075" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(2)_48746">
+  <link name="cap screw(2)">
   </link>
-  <joint name="left_48654_cap screw(2)_48746_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(2)_48746"/>
+  <joint name="left_cap screw(2)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(2)"/>
     <origin xyz="0.0477 0.008 -0.075" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(1)_48722">
+  <link name="cap screw(1)">
   </link>
-  <joint name="left_48654_cap screw(1)_48722_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw(1)_48722"/>
+  <joint name="left_cap screw(1)_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw(1)"/>
     <origin xyz="0.0477 0.008 -0.043" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw_48698">
+  <link name="cap screw">
   </link>
-  <joint name="left_48654_cap screw_48698_joint" type="fixed">
-    <parent link="left_48654"/>
-    <child link="cap screw_48698"/>
+  <joint name="left_cap screw_joint" type="fixed">
+    <parent link="left"/>
+    <child link="cap screw"/>
     <origin xyz="0.0477 0.008 -0.0108" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="TIAGo right arm_42520">
+  <link name="TIAGo right arm">
     <visual>
       <origin xyz="0.026 -0.14 -0.232" rpy="0 0 1.5708"/>
       <geometry>
@@ -1169,19 +1169,19 @@
       </geometry>
     </collision>
   </link>
-  <joint name="torso_lift_link_TIAGo right arm_42520_joint" type="fixed">
+  <joint name="torso_lift_link_TIAGo right arm_joint" type="fixed">
     <parent link="torso_lift_link"/>
-    <child link="TIAGo right arm_42520"/>
+    <child link="TIAGo right arm"/>
     <origin xyz="1.3492402e-12 -3.6732052e-07 0" rpy="0 0 4.6928203e-06"/>
   </joint>
   <joint name="arm_right_1_joint" type="revolute">
-    <parent link="TIAGo right arm_42520"/>
-    <child link="TIAGo_right_arm_42535"/>
+    <parent link="TIAGo right arm"/>
+    <child link="TIAGo_right_arm"/>
     <axis xyz="0 0 1"/>
     <limit effort="43" lower="-1.11" upper="1.5" velocity="1.95"/>
     <origin xyz="0.025 -0.194 -0.17" rpy="0 0 1.5708"/>
   </joint>
-  <link name="TIAGo_right_arm_42535">
+  <link name="TIAGo_right_arm">
     <visual>
       <origin xyz="-3.673205e-10 -0.0001 0.012" rpy="-3.141589 0 0"/>
       <geometry>
@@ -1232,13 +1232,13 @@
     </collision>
   </link>
   <joint name="arm_right_2_joint" type="revolute">
-    <parent link="TIAGo_right_arm_42535"/>
-    <child link="arm_right_2_link_42569"/>
+    <parent link="TIAGo_right_arm"/>
+    <child link="arm_right_2_link"/>
     <axis xyz="0 3.6732051e-06 1"/>
     <limit effort="43" lower="-1.11" upper="1.5" velocity="1.95"/>
     <origin xyz="-0.125 0.0194 -0.032" rpy="1.5708 0 0"/>
   </joint>
-  <link name="arm_right_2_link_42569">
+  <link name="arm_right_2_link">
     <visual>
       <origin xyz="-0.056 5.5098077e-09 -0.0005" rpy="1.5707963 0 -1.5708"/>
       <geometry>
@@ -1265,13 +1265,13 @@
     </collision>
   </link>
   <joint name="arm_right_3_joint" type="revolute">
-    <parent link="arm_right_2_link_42569"/>
-    <child link="arm_right_3_link_42583"/>
+    <parent link="arm_right_2_link"/>
+    <child link="arm_right_3_link"/>
     <axis xyz="-2.8276306e-06 2.8276386e-06 1"/>
     <limit effort="26" lower="-0.72" upper="3.86" velocity="2.35"/>
     <origin xyz="0.0895 5.5098077e-09 -1.0118208e-14" rpy="1.5707991 -2.8276386e-06 1.5707991"/>
   </joint>
-  <link name="arm_right_3_link_42583">
+  <link name="arm_right_3_link">
     <visual>
       <origin xyz="5.021872e-07 0.0014995021 -0.2821" rpy="-3.7000516e-06 0 0"/>
       <geometry>
@@ -1298,13 +1298,13 @@
     </collision>
   </link>
   <joint name="arm_right_4_joint" type="revolute">
-    <parent link="arm_right_3_link_42583"/>
-    <child link="arm_right_4_link_42617"/>
+    <parent link="arm_right_3_link"/>
+    <child link="arm_right_4_link"/>
     <axis xyz="2.8276386e-06 2.8276306e-06 -1"/>
     <limit effort="26" lower="-0.32" upper="2.29" velocity="2.35"/>
     <origin xyz="0.020000502 0.0014995021 -0.3991" rpy="2.356193 1.5707923 -2.356193"/>
   </joint>
-  <link name="arm_right_4_link_42617">
+  <link name="arm_right_4_link">
     <visual>
       <origin xyz="7.3518606e-08 0.0010000735 -0.028" rpy="-3.141589 0 0"/>
       <geometry>
@@ -1331,13 +1331,13 @@
     </collision>
   </link>
   <joint name="arm_right_5_joint" type="revolute">
-    <parent link="arm_right_4_link_42617"/>
-    <child link="arm_right_5_link_42651"/>
+    <parent link="arm_right_4_link"/>
+    <child link="arm_right_5_link"/>
     <axis xyz="1.349254e-11 5.1946963e-06 1"/>
     <limit effort="3" lower="-2.07" upper="2.07" velocity="1.95"/>
     <origin xyz="0.16300008 0.020000074 0.001" rpy="-1.5707937 -1.5707911 -1.5707937"/>
   </joint>
-  <link name="arm_right_5_link_42651">
+  <link name="arm_right_5_link">
     <visual>
       <origin xyz="0 0 0.04" rpy="3.1407962 0 0"/>
       <geometry>
@@ -1376,13 +1376,13 @@
     </collision>
   </link>
   <joint name="arm_right_6_joint" type="revolute">
-    <parent link="arm_right_5_link_42651"/>
-    <child link="arm_right_6_link_42666"/>
+    <parent link="arm_right_5_link"/>
+    <child link="arm_right_6_link"/>
     <axis xyz="2.8276386e-06 2.8276306e-06 -1"/>
     <limit effort="6.6" lower="-1.39" upper="1.39" velocity="1.76"/>
     <origin xyz="0 0 0.15" rpy="2.356193 1.5707923 -2.356193"/>
   </joint>
-  <link name="arm_right_6_link_42666">
+  <link name="arm_right_6_link">
     <visual>
       <origin xyz="-0.0409 0 0" rpy="1.5707963 0 -1.5708"/>
       <geometry>
@@ -1397,13 +1397,13 @@
     </collision>
   </link>
   <joint name="arm_right_7_joint" type="revolute">
-    <parent link="arm_right_6_link_42666"/>
-    <child link="arm_right_7_link_42681"/>
+    <parent link="arm_right_6_link"/>
+    <child link="arm_right_7_link"/>
     <axis xyz="2.8276306e-06 -2.8276386e-06 1"/>
     <limit effort="6.6" lower="-2.07" upper="2.07" velocity="1.76"/>
     <origin xyz="0 0 0" rpy="-1.5707991 2.8276386e-06 1.5707991"/>
   </joint>
-  <link name="arm_right_7_link_42681">
+  <link name="arm_right_7_link">
     <visual>
       <origin xyz="1.5551969e-07 -1.5552013e-07 0.055" rpy="-3.141589 0 0"/>
       <geometry>
@@ -1417,7 +1417,7 @@
       </geometry>
     </collision>
   </link>
-  <link name="wrist_right_ft_tool_link_42693">
+  <link name="wrist_right_ft_tool_link">
     <visual>
       <origin xyz="1.5551969e-07 -1.5552013e-07 0.055" rpy="1.5707963 1.110223e-16 1.57"/>
       <geometry>
@@ -1431,12 +1431,12 @@
       </geometry>
     </collision>
   </link>
-  <joint name="arm_right_7_link_42681_wrist_right_ft_tool_link_42693_joint" type="fixed">
-    <parent link="arm_right_7_link_42681"/>
-    <child link="wrist_right_ft_tool_link_42693"/>
+  <joint name="arm_right_7_link_wrist_right_ft_tool_link_joint" type="fixed">
+    <parent link="arm_right_7_link"/>
+    <child link="wrist_right_ft_tool_link"/>
     <origin xyz="1.5551969e-07 -1.5552013e-07 0.067725" rpy="2.356193 -1.5707923 2.356193"/>
   </joint>
-  <link name="right_46739">
+  <link name="right">
     <visual>
       <origin xyz="0 0 0" rpy="3.1407962 0 0"/>
       <geometry>
@@ -1498,19 +1498,19 @@
       </geometry>
     </collision>
   </link>
-  <joint name="wrist_right_ft_tool_link_42693_right_46739_joint" type="fixed">
-    <parent link="wrist_right_ft_tool_link_42693"/>
-    <child link="right_46739"/>
+  <joint name="wrist_right_ft_tool_link_right_joint" type="fixed">
+    <parent link="wrist_right_ft_tool_link"/>
+    <child link="right"/>
     <origin xyz="0.016 -5.877128e-08 0" rpy="-2.356193 1.5707923 0.78539306"/>
   </joint>
   <joint name="right_hand_gripper_right_finger_joint" type="prismatic">
-    <parent link="right_46739"/>
-    <child link="gripper_right_finger_link_47300"/>
+    <parent link="right"/>
+    <child link="gripper_right_finger_link_3"/>
     <axis xyz="1 0 0"/>
     <origin xyz="0 0 0" rpy="0 0 0"/>
     <limit effort="16" lower="0" upper="0.045" velocity="0.05"/>
   </joint>
-  <link name="gripper_right_finger_link_47300">
+  <link name="gripper_right_finger_link_3">
     <visual>
       <origin xyz="0.004 0 -0.1741" rpy="0 0 0"/>
       <geometry>
@@ -1549,13 +1549,13 @@
     </collision>
   </link>
   <joint name="right_hand_gripper_left_finger_joint" type="prismatic">
-    <parent link="right_46739"/>
-    <child link="gripper_left_finger_link_47267"/>
+    <parent link="right"/>
+    <child link="gripper_left_finger_link_4"/>
     <axis xyz="1 9.265359e-05 0"/>
     <origin xyz="0 0 0" rpy="0 0 3.1415"/>
     <limit effort="16" lower="0" upper="0.045" velocity="0.05"/>
   </joint>
-  <link name="gripper_left_finger_link_47267">
+  <link name="gripper_left_finger_link_4">
     <visual>
       <origin xyz="0.004 0 -0.1741" rpy="0 0 0"/>
       <geometry>
@@ -1593,144 +1593,144 @@
       </geometry>
     </collision>
   </link>
-  <link name="cap screw(19)_47239">
+  <link name="cap screw(19)_5">
   </link>
-  <joint name="right_46739_cap screw(19)_47239_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(19)_47239"/>
+  <joint name="right_cap screw(19)_5_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(19)_5"/>
     <origin xyz="0.0415 -0.0029 -0.0004" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(18)_47215">
+  <link name="cap screw(18)_6">
   </link>
-  <joint name="right_46739_cap screw(18)_47215_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(18)_47215"/>
+  <joint name="right_cap screw(18)_6_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(18)_6"/>
     <origin xyz="-0.0415 0.0029 -0.0004" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(17)_47191">
+  <link name="cap screw(17)_7">
   </link>
-  <joint name="right_46739_cap screw(17)_47191_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(17)_47191"/>
+  <joint name="right_cap screw(17)_7_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(17)_7"/>
     <origin xyz="0.0433 0.0315 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(16)_47167">
+  <link name="cap screw(16)_8">
   </link>
-  <joint name="right_46739_cap screw(16)_47167_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(16)_47167"/>
+  <joint name="right_cap screw(16)_8_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(16)_8"/>
     <origin xyz="-0.0433 -0.0315 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(15)_47143">
+  <link name="cap screw(15)_9">
   </link>
-  <joint name="right_46739_cap screw(15)_47143_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(15)_47143"/>
+  <joint name="right_cap screw(15)_9_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(15)_9"/>
     <origin xyz="0 0.033 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(14)_47119">
+  <link name="cap screw(14)_10">
   </link>
-  <joint name="right_46739_cap screw(14)_47119_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(14)_47119"/>
+  <joint name="right_cap screw(14)_10_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(14)_10"/>
     <origin xyz="0 -0.033 0.0026" rpy="3.14159 0 0"/>
   </joint>
-  <link name="cap screw(13)_47095">
+  <link name="cap screw(13)_11">
   </link>
-  <joint name="right_46739_cap screw(13)_47095_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(13)_47095"/>
+  <joint name="right_cap screw(13)_11_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(13)_11"/>
     <origin xyz="0.0426 -0.0094 -0.09448" rpy="0 0 0"/>
   </joint>
-  <link name="cap screw(12)_47071">
+  <link name="cap screw(12)_12">
   </link>
-  <joint name="right_46739_cap screw(12)_47071_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(12)_47071"/>
+  <joint name="right_cap screw(12)_12_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(12)_12"/>
     <origin xyz="-0.0425 0.0094 -0.0945" rpy="0 0 0"/>
   </joint>
-  <link name="cap screw(11)_47047">
+  <link name="cap screw(11)_13">
   </link>
-  <joint name="right_46739_cap screw(11)_47047_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(11)_47047"/>
+  <joint name="right_cap screw(11)_13_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(11)_13"/>
     <origin xyz="-0.0477 -0.008 -0.0108" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(10)_47023">
+  <link name="cap screw(10)_14">
   </link>
-  <joint name="right_46739_cap screw(10)_47023_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(10)_47023"/>
+  <joint name="right_cap screw(10)_14_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(10)_14"/>
     <origin xyz="-0.0477 -0.008 -0.043" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(9)_46999">
+  <link name="cap screw(9)_15">
   </link>
-  <joint name="right_46739_cap screw(9)_46999_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(9)_46999"/>
+  <joint name="right_cap screw(9)_15_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(9)_15"/>
     <origin xyz="-0.0477 -0.008 -0.075" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(8)_46975">
+  <link name="cap screw(8)_16">
   </link>
-  <joint name="right_46739_cap screw(8)_46975_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(8)_46975"/>
+  <joint name="right_cap screw(8)_16_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(8)_16"/>
     <origin xyz="-0.0477 0.008 -0.075" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(7)_46951">
+  <link name="cap screw(7)_17">
   </link>
-  <joint name="right_46739_cap screw(7)_46951_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(7)_46951"/>
+  <joint name="right_cap screw(7)_17_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(7)_17"/>
     <origin xyz="-0.0477 0.008 -0.043" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(6)_46927">
+  <link name="cap screw(6)_18">
   </link>
-  <joint name="right_46739_cap screw(6)_46927_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(6)_46927"/>
+  <joint name="right_cap screw(6)_18_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(6)_18"/>
     <origin xyz="-0.0477 0.008 -0.0108" rpy="3.1415927 1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(5)_46903">
+  <link name="cap screw(5)_19">
   </link>
-  <joint name="right_46739_cap screw(5)_46903_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(5)_46903"/>
+  <joint name="right_cap screw(5)_19_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(5)_19"/>
     <origin xyz="0.0477 -0.008 -0.0108" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(4)_46879">
+  <link name="cap screw(4)_20">
   </link>
-  <joint name="right_46739_cap screw(4)_46879_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(4)_46879"/>
+  <joint name="right_cap screw(4)_20_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(4)_20"/>
     <origin xyz="0.0477 -0.008 -0.043" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(3)_46855">
+  <link name="cap screw(3)_21">
   </link>
-  <joint name="right_46739_cap screw(3)_46855_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(3)_46855"/>
+  <joint name="right_cap screw(3)_21_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(3)_21"/>
     <origin xyz="0.0477 -0.008 -0.075" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(2)_46831">
+  <link name="cap screw(2)_22">
   </link>
-  <joint name="right_46739_cap screw(2)_46831_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(2)_46831"/>
+  <joint name="right_cap screw(2)_22_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(2)_22"/>
     <origin xyz="0.0477 0.008 -0.075" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw(1)_46807">
+  <link name="cap screw(1)_23">
   </link>
-  <joint name="right_46739_cap screw(1)_46807_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw(1)_46807"/>
+  <joint name="right_cap screw(1)_23_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw(1)_23"/>
     <origin xyz="0.0477 0.008 -0.043" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
-  <link name="cap screw_46783">
+  <link name="cap screw_24">
   </link>
-  <joint name="right_46739_cap screw_46783_joint" type="fixed">
-    <parent link="right_46739"/>
-    <child link="cap screw_46783"/>
+  <joint name="right_cap screw_24_joint" type="fixed">
+    <parent link="right"/>
+    <child link="cap screw_24"/>
     <origin xyz="0.0477 0.008 -0.0108" rpy="3.1415927 -1.5707927 3.1415927"/>
   </joint>
 </robot>

--- a/tests/api/controllers/robot_urdf/ur5e_reference.urdf
+++ b/tests/api/controllers/robot_urdf/ur5e_reference.urdf
@@ -296,11 +296,11 @@
       </geometry>
     </collision>
   </link>
-  <link name="track_307">
+  <link name="track">
   </link>
-  <joint name="wrist_3_link_track_307_joint" type="fixed">
+  <joint name="wrist_3_link_track_joint" type="fixed">
     <parent link="wrist_3_link"/>
-    <child link="track_307"/>
+    <child link="track"/>
     <origin xyz="0 0.1 0" rpy="0 0 0"/>
   </joint>
   <link name="ts_emitter">


### PR DESCRIPTION
This PR solves the problem of inconsistent link/joint names as a suffix for non-unique names is generated from `WbNode::uniqueId()` (identifies nodes within a whole world -> if the world changes the IDs change as well).

In addition:
- a name generation is much faster as there is no recursive check and
- DEF name is also added as a fallback option (if node name is not defined).