### PR TITLE
Calibrated Robocup ball

### DIFF
--- a/projects/objects/balls/protos/RobocupSoccerBall.proto
+++ b/projects/objects/balls/protos/RobocupSoccerBall.proto
@@ -73,8 +73,8 @@ PROTO RobocupSoccerBall [
       density -1
       centerOfMass [ 0 0 0.0001 ]  # to introduce some randomness in motion
       damping Damping {
-        linear 0.7
-        angular 0.7
+        linear 0.77
+        angular 0.77
       }
     }
   }

--- a/projects/samples/contests/robocup/worlds/adult.wbt
+++ b/projects/samples/contests/robocup/worlds/adult.wbt
@@ -23,7 +23,12 @@ WorldInfo {
       coulombFriction [
         0.5
       ]
+      bounce 0.76
       softCFM 0.05
+    }
+    ContactProperties {
+      material2 "robocup soccer ball"
+      bounce 0.76
     }
   ]
 }

--- a/projects/samples/contests/robocup/worlds/kid.wbt
+++ b/projects/samples/contests/robocup/worlds/kid.wbt
@@ -23,7 +23,12 @@ WorldInfo {
       coulombFriction [
         0.5
       ]
+      bounce 0.76
       softCFM 0.05
+    }
+    ContactProperties {
+      material2 "robocup soccer ball"
+      bounce 0.76
     }
   ]
 }


### PR DESCRIPTION
# Description
The Robocup ball was calibrated according to the following measurements:

## Damping
We recorded a shoot:

https://user-images.githubusercontent.com/1264964/111494285-a02da480-873e-11eb-882c-bbc9e3d28330.mp4

The length of the artificial grass is 1.07 m.
The initial velocity of the ball (computed on the first two frames) is 0.841 m/s.
The distance traveled is (computed) 0.621 m.
When testing in Webots, we applied a force of 3.28 N at the top of the ball, so that the initial velocity was 0.84 m/s.
The distance traveled by the simulated ball was 0.62 m.

## Bounce
We dropped the ball from 2 m on the artificial grass and it bounced up to about 0.5 m.
The bounce parameter in the simulation was adjusted so that when dropping the ball from 2 m, it bounced up to about 0.5 m.
