### PR TITLE
Added backlash in robocup worlds

### DIFF
--- a/projects/samples/contests/robocup/worlds/adult.wbt
+++ b/projects/samples/contests/robocup/worlds/adult.wbt
@@ -5,7 +5,8 @@ WorldInfo {
     "Version 0.2"
   ]
   title "Robocup V-HL Adult"
-  basicTimeStep 16
+  basicTimeStep 8
+  optimalThreadCount 8
   physicsDisableTime 0.1
   physicsDisableLinearThreshold 0.1
   physicsDisableAngularThreshold 0.1
@@ -48,21 +49,24 @@ RobocupSoccerBall {
   translation 0 0 0.12
   size 5
 }
-DEF RED_1 Darwin-op {
+DEF RED_1 Darwin-opHinge2 {
   translation 6.51 0 0.24
   rotation 5.25424e-07 -1.21381e-06 1 3.14159
   name "player red 1"
-  controller "walk"
+  controller "soccer"
+  selfCollision TRUE
   cameraWidth 640
   cameraHeight 480
   jersey RobotisJersey {
   }
+  backlash TRUE
 }
-DEF RED_2 Darwin-op {
+DEF RED_2 Darwin-opHinge2 {
   translation 1.75 0 0.24
   rotation 5.25424e-07 -1.21381e-06 1 3.14159
   name "player red 2"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 640
   cameraHeight 480
   jersey RobotisJersey {
@@ -70,12 +74,14 @@ DEF RED_2 Darwin-op {
       "textures/robotis-op2_2_red.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_1 Darwin-op {
+DEF BLUE_1 Darwin-opHinge2 {
   translation -6.51 0 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 1"
-  controller "walk"
+  controller "soccer"
+  selfCollision TRUE
   cameraWidth 640
   cameraHeight 480
   jersey RobotisJersey {
@@ -83,12 +89,14 @@ DEF BLUE_1 Darwin-op {
       "textures/robotis-op2_1_blue.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_2 Darwin-op {
+DEF BLUE_2 Darwin-opHinge2 {
   translation -1.75 0 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 2"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 640
   cameraHeight 480
   jersey RobotisJersey {
@@ -96,4 +104,5 @@ DEF BLUE_2 Darwin-op {
       "textures/robotis-op2_2_blue.png"
     ]
   }
+  backlash TRUE
 }

--- a/projects/samples/contests/robocup/worlds/kid.wbt
+++ b/projects/samples/contests/robocup/worlds/kid.wbt
@@ -5,7 +5,8 @@ WorldInfo {
     "Version 0.2"
   ]
   title "Robocup V-HL Kid"
-  basicTimeStep 16
+  basicTimeStep 8
+  optimalThreadCount 8
   physicsDisableTime 0.1
   physicsDisableLinearThreshold 0.1
   physicsDisableAngularThreshold 0.1
@@ -48,21 +49,24 @@ RobocupSoccerField {
 RobocupSoccerBall {
   translation 0 0 0.08
 }
-DEF RED_1 Darwin-op {
+DEF RED_1 Darwin-opHinge2 {
   translation 4 0 0.24
   rotation 5.25424e-07 -1.21381e-06 1 3.14159
   name "player red 1"
-  controller "walk"
+  controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
   }
+  backlash TRUE
 }
-DEF RED_2 Darwin-op {
+DEF RED_2 Darwin-opHinge2 {
   translation 2.5 0 0.24
   rotation 5.25424e-07 -1.21381e-06 1 3.14159
   name "player red 2"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -70,12 +74,14 @@ DEF RED_2 Darwin-op {
       "textures/robotis-op2_2_red.png"
     ]
   }
+  backlash TRUE
 }
-DEF RED_3 Darwin-op {
+DEF RED_3 Darwin-opHinge2 {
   translation 0.8 -0.5 0.24
   rotation -6.897009999981874e-08 -2.291579999993978e-06 0.9999999999973721 3.14159
   name "player red 3"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -83,12 +89,14 @@ DEF RED_3 Darwin-op {
       "textures/robotis-op2_3_red.png"
     ]
   }
+  backlash TRUE
 }
-DEF RED_4 Darwin-op {
+DEF RED_4 Darwin-opHinge2 {
   translation 0.8 0.5 0.24
   rotation 5.25424e-07 -1.21381e-06 1 3.14159
   name "player red 4"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -96,12 +104,14 @@ DEF RED_4 Darwin-op {
       "textures/robotis-op2_4_red.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_1 Darwin-op {
+DEF BLUE_1 Darwin-opHinge2 {
   translation -4 0 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 1"
-  controller "walk"
+  controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -109,12 +119,14 @@ DEF BLUE_1 Darwin-op {
       "textures/robotis-op2_1_blue.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_2 Darwin-op {
+DEF BLUE_2 Darwin-opHinge2 {
   translation -2.5 0 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 2"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -122,12 +134,14 @@ DEF BLUE_2 Darwin-op {
       "textures/robotis-op2_2_blue.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_3 Darwin-op {
+DEF BLUE_3 Darwin-opHinge2 {
   translation -0.8 -0.5 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 3"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -135,12 +149,14 @@ DEF BLUE_3 Darwin-op {
       "textures/robotis-op2_3_blue.png"
     ]
   }
+  backlash TRUE
 }
-DEF BLUE_4 Darwin-op {
+DEF BLUE_4 Darwin-opHinge2 {
   translation -0.8 0.5 0.24
   rotation -0.8804878560490522 0.40018993457295293 0.2541439584500076 -5.307179586466759e-06
   name "player blue 4"
   controller "soccer"
+  selfCollision TRUE
   cameraWidth 320
   cameraHeight 240
   jersey RobotisJersey {
@@ -148,4 +164,5 @@ DEF BLUE_4 Darwin-op {
       "textures/robotis-op2_4_blue.png"
     ]
   }
+  backlash TRUE
 }


### PR DESCRIPTION
This PR add Hinge2 joints and backlash in all Robocup worlds.
It also enable the cameras for all players, including the goal keepers for a fair performance evaluation.
