### PR TITLE
Fix incorrect stopCFM and stopERP imposition when world uses non-default global CFM/ERP

### DIFF
--- a/docs/reference/hingejointparameters.md
+++ b/docs/reference/hingejointparameters.md
@@ -9,8 +9,8 @@ HingeJointParameters {
   SFFloat suspensionSpringConstant  0       # [0, inf)
   SFFloat suspensionDampingConstant 0       # [0, inf)
   SFVec3f suspensionAxis            1 0 0   # unit axis
-  SFFloat stopERP                   0.2     # [0, inf)
-  SFFloat stopCFM                   0.00001 # (0, inf)
+  SFFloat stopERP                   -1      # [0, inf)
+  SFFloat stopCFM                   -1      # (0, inf)
 }
 ```
 
@@ -30,9 +30,9 @@ It is expressed in relative coordinates with respect to the closest upper [Trans
 
 - `suspensionAxis`: This field specifies the direction of the suspension axis.
 
-- `stopERP`: This field specifies the local `ERP` used by joint limits. It can be different from the global `ERP`.
+- `stopERP`: This field specifies the local `ERP` used by joint limits. By default it imposes the global `ERP` (value -1) but can be different from it.
 
-- `stopCFM`: This field specifies the local `CFM` used by joint limits. It can be different from the global `CFM`.
+- `stopCFM`: This field specifies the local `CFM` used by joint limits. By default it imposes the global `CFM` (value -1) but can be different from it.
 
 The `suspensionSpringConstant` and `suspensionDampingConstant` fields can be used to add a linear spring and/or damping behavior *along* the axis defined in `suspensionAxis`.
 These fields are described in more detail in [JointParameters](jointparameters.md)'s ["Springs and Dampers"](jointparameters.md#springs-and-dampers) section.

--- a/docs/reference/hingejointparameters.md
+++ b/docs/reference/hingejointparameters.md
@@ -9,8 +9,8 @@ HingeJointParameters {
   SFFloat suspensionSpringConstant  0       # [0, inf)
   SFFloat suspensionDampingConstant 0       # [0, inf)
   SFVec3f suspensionAxis            1 0 0   # unit axis
-  SFFloat stopERP                   -1      # [0, inf)
-  SFFloat stopCFM                   -1      # (0, inf)
+  SFFloat stopERP                   -1      # -1 or [0, inf)
+  SFFloat stopCFM                   -1      # -1 or (0, inf)
 }
 ```
 

--- a/resources/nodes/HingeJointParameters.wrl
+++ b/resources/nodes/HingeJointParameters.wrl
@@ -12,6 +12,6 @@ HingeJointParameters {
   field SFFloat    suspensionSpringConstant  0       # suspension spring constant along the suspension axis
   field SFFloat    suspensionDampingConstant 0       # suspension damping constant along the suspension axis
   field SFVec3f    suspensionAxis            1 0 0   # direction of the suspension axis
-  field SFFloat    stopERP                   0.2     # error reduction parameter used by the stops
-  field SFFloat    stopCFM                   0.00001 # constraint force mixing used by the stops
+  field SFFloat    stopERP                   -1      # error reduction parameter used by the stops
+  field SFFloat    stopCFM                   -1      # constraint force mixing used by the stops
 }

--- a/src/webots/nodes/WbHingeJoint.cpp
+++ b/src/webots/nodes/WbHingeJoint.cpp
@@ -139,7 +139,7 @@ void WbHingeJoint::applyToOdeStopErp() {
 
   const WbHingeJointParameters *const p = hingeJointParameters();
   const WbWorldInfo *const wi = WbWorld::instance()->worldInfo();
-  const double erp = p ? p->stopErp() : wi->erp();
+  const double erp = (p && p->stopErp() != -1) ? p->stopErp() : wi->erp();
 
   if (nodeType() == WB_NODE_HINGE_JOINT)
     dJointSetHingeParam(mJoint, dParamStopERP, erp);
@@ -150,7 +150,7 @@ void WbHingeJoint::applyToOdeStopCfm() {
 
   const WbHingeJointParameters *const p = hingeJointParameters();
   const WbWorldInfo *const wi = WbWorld::instance()->worldInfo();
-  const double cfm = p ? p->stopCfm() : wi->cfm();
+  const double cfm = (p && p->stopCfm() != -1) ? p->stopCfm() : wi->cfm();
 
   if (nodeType() == WB_NODE_HINGE_JOINT)
     dJointSetHingeParam(mJoint, dParamStopCFM, cfm);

--- a/src/webots/nodes/WbHingeJointParameters.cpp
+++ b/src/webots/nodes/WbHingeJointParameters.cpp
@@ -14,8 +14,6 @@
 
 #include "WbHingeJointParameters.hpp"
 
-#include "WbWorld.hpp"
-
 void WbHingeJointParameters::init(bool fromDeprecatedHinge2JointParameters) {
   mAnchor = findSFVector3("anchor");
   mSuspensionSpringConstant = findSFDouble("suspensionSpringConstant");
@@ -102,7 +100,7 @@ void WbHingeJointParameters::updateSuspension() {
 void WbHingeJointParameters::updateStopErp() {
   if (mStopErp->value() < 0.0 && mStopErp->value() != -1) {
     mStopErp->setValue(-1);
-    parsingWarn(tr("'stopERP' must be greater or equal to zero or -1. Reverting to -1 (use the global ERP)."));
+    parsingWarn(tr("'stopERP' must be greater or equal to zero or -1. Reverting to -1 (use global ERP)."));
     return;
   }
 

--- a/src/webots/nodes/WbHingeJointParameters.cpp
+++ b/src/webots/nodes/WbHingeJointParameters.cpp
@@ -100,10 +100,9 @@ void WbHingeJointParameters::updateSuspension() {
 }
 
 void WbHingeJointParameters::updateStopErp() {
-  const WbWorldInfo *const wi = WbWorld::instance()->worldInfo();
-  if (mStopErp->value() < 0.0) {
-    mStopErp->setValue(wi->erp());
-    parsingWarn(tr("'stopERP' must be greater than or equal to zero. Reverting to global ERP."));
+  if (mStopErp->value() < 0.0 && mStopErp->value() != -1) {
+    mStopErp->setValue(-1);
+    parsingWarn(tr("'stopERP' must be greater or equal to zero or -1. Reverting to -1 (use the global ERP)."));
     return;
   }
 
@@ -111,10 +110,9 @@ void WbHingeJointParameters::updateStopErp() {
 }
 
 void WbHingeJointParameters::updateStopCfm() {
-  const WbWorldInfo *const wi = WbWorld::instance()->worldInfo();
-  if (mStopCfm->value() <= 0.0) {
-    mStopCfm->setValue(wi->cfm());
-    parsingWarn(tr("'stopCFM' must be greater than zero. Reverting to global CFM."));
+  if (mStopCfm->value() <= 0.0 && mStopCfm->value() != -1) {
+    mStopCfm->setValue(-1);
+    parsingWarn(tr("'stopCFM' must be greater than zero or -1. Reverting to -1 (use global CFM)."));
     return;
   }
 


### PR DESCRIPTION
**Description**
The current version loads user-defined `stopERP` and `stopCFM` correctly and also handles invalid values. However, if the world being loaded uses non-default values for global `ERP` and `CFM` (i.e not 0.2 and 1e-5), then in [this](https://github.com/cyberbotics/webots/blob/e80fb802139d4645eed30f9865017a742607c185/src/webots/nodes/WbHingeJoint.cpp#L142) line the `stopERP` and `stopCFM` actually being imposed on the joint are the default ones defined in `HingeJointParameters` [here](https://github.com/cyberbotics/webots/blob/e80fb802139d4645eed30f9865017a742607c185/resources/nodes/HingeJointParameters.wrl#L15) which could be fine as long as the global ones are also at default. If they aren't however, it doesn't respect it and imposes 0.2 and 1e-5 anyway. In other words, currently the global values are imposed to the stops if and only if `jointParameters` isn't defined which isn't enough.

The proposed solution uses `-1` to represent that the global values must be enforced.