### PR TITLE
Fix randomBuilding proto

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -40,7 +40,7 @@ Released on June, Xth, 2021.
   - Bug fixes:
     - Fixed the [`wb_supervisor_field_get_count`](supervisor.md#wb_supervisor_field_get_count) function's returned value not updated after modifying the fields from the GUI or from another [Supervisor](supervisor.md) controller ([#2812](https://github.com/cyberbotics/webots/pull/2812)).
     - Fixed the conversion from quaternions to euler angles in the [InertialUnit](inertialunit.md) for the ENU coordinate system ([#2768](https://github.com/cyberbotics/webots/pull/2768)).
-    - Fixed RandomBuilding proto where having different instances generated the same building ([#2893](https://github.com/cyberbotics/webots/pull/2893)).
+    - Fixed RandomBuilding proto where having different instances generated the same building ([#2897](https://github.com/cyberbotics/webots/pull/2897)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
 

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -40,6 +40,7 @@ Released on June, Xth, 2021.
   - Bug fixes:
     - Fixed the [`wb_supervisor_field_get_count`](supervisor.md#wb_supervisor_field_get_count) function's returned value not updated after modifying the fields from the GUI or from another [Supervisor](supervisor.md) controller ([#2812](https://github.com/cyberbotics/webots/pull/2812)).
     - Fixed the conversion from quaternions to euler angles in the [InertialUnit](inertialunit.md) for the ENU coordinate system ([#2768](https://github.com/cyberbotics/webots/pull/2768)).
+    - Fixed RandomBuilding proto where having different instances generated the same building ([#2893](https://github.com/cyberbotics/webots/pull/2893)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
 

--- a/projects/objects/buildings/protos/RandomBuilding.proto
+++ b/projects/objects/buildings/protos/RandomBuilding.proto
@@ -1,7 +1,6 @@
 #VRML_SIM R2021b utf8
 # license: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 # license url: https://cyberbotics.com/webots_assets_license
-# tags: static
 # A customizable building, the size and geometry can fully be defined.
 # The texture of the wall is selected randomly.
 # The roof shape can be either 'flat' or 'pyramidal' (in case of pyramidal roof it is possible to define the height).
@@ -31,6 +30,7 @@ PROTO RandomBuilding [
   %{
     local wbcore = require('wbcore')
     local wbrandom = require('wbrandom')
+    wbrandom.seed(context.id)
     local wallTypes = {
       "glass building",
       "classic building",


### PR DESCRIPTION
**Description**
As discussed in #2893 (specifically [here](https://github.com/cyberbotics/webots/pull/2893#discussion_r599545236)) the `RandomBuilding` proto is supposed to generate (potentially) different buildings for every instance. As such, neither the change introduced in #2893, nor the prior state of the proto, results in the desired behavior.
