### PR TITLE
Remove conditional around startpoint for HingeJointWithBacklash

### DIFF
--- a/projects/joints/protos/HingeJointWithBacklash.proto
+++ b/projects/joints/protos/HingeJointWithBacklash.proto
@@ -46,11 +46,9 @@ PROTO HingeJointWithBacklash [
       endPoint Solid {
         name %{='"start_point_' .. context.id .. '"'}% # prevent name clashes
         children [
-          %{ if fields.startPoint.value ~= nil then}%
           Group {
             children IS startPoint
           }
-          %{ end }%
           HingeJoint {
             jointParameters HingeJointParameters {
               axis %{= axis.x}% %{= axis.y}% %{= axis.z}%


### PR DESCRIPTION
**Description**
The conditional here, as is, doesn't actually work as `startPoint` is actually a MF and can't be checked against `nil`. Irrespective of that, having the conditional to begin with is undesirable as if this block doesn't exist when loading a world, users can't add anything to the `startPoint` since no compatible nodes show up in the interface.
