### PR TITLE
RoboCup controllers: correction of halftimeStartingPose in config files

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/team_1.json
@@ -5,8 +5,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-4, 0, 0.24],
-        "rotation": [0, 0, 1, 0]
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -21,8 +21,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-2.5, 0, 0.24],
-        "rotation": [0, 0, 1, 0]
+        "translation": [-3.5, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -37,8 +37,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-0.8, 0.5, 0.24],
-        "rotation": [0, 0, 1, -0.5]
+        "translation": [-0.75, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -53,8 +53,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-0.8, -0.5, 0.24],
-        "rotation": [0, 0, 1, 0.5]
+        "translation": [-0.75, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],

--- a/projects/samples/contests/robocup/controllers/referee/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/team_2.json
@@ -5,8 +5,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-4, 0, 0.24],
-        "rotation": [0, 0, 1, 0]
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -21,8 +21,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-2.5, 0, 0.24],
-        "rotation": [0, 0, 1, 0]
+        "translation": [-3.5, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -37,8 +37,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-0.8, 0.5, 0.24],
-        "rotation": [0, 0, 1, -0.5]
+        "translation": [-0.75, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],
@@ -53,8 +53,8 @@
       "proto": "RobocupRobot",
       "robotStartCmd": "TODO: docker pulling + starting with optional arguments",
       "halfTimeStartingPose": {
-        "translation": [-0.8, -0.5, 0.24],
-        "rotation": [0, 0, 1, 0.5]
+        "translation": [-0.75, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
       },
       "reentryStartingPose": {
         "translation": [-3, -3.11, 0.24],


### PR DESCRIPTION
In the files provided initially, the initial pose of the robot at start of half time were invalid because they were inside the field.