### PR TITLE
Lidar endpoint for remote control api

### DIFF
--- a/include/controller/c/webots/remote_control.h
+++ b/include/controller/c/webots/remote_control.h
@@ -60,6 +60,7 @@ void wbr_display_save_image(WbDeviceTag tag, int id, int width, int height, unsi
 void wbr_camera_set_image(WbDeviceTag tag, const unsigned char *image);
 unsigned char *wbr_camera_get_image_buffer(WbDeviceTag tag);
 
+void wbr_lidar_set_image(WbDeviceTag tag, const float *image);
 // Actuator functions (values written by the controller)
 typedef struct WbrInterface {
   // mandatory functions :
@@ -117,6 +118,8 @@ typedef struct WbrInterface {
   void (*wbr_display_image_delete)(WbDeviceTag tag, int id);
   void (*wbr_display_image_paste)(WbDeviceTag tag, int id, int x, int y);
   void (*wbr_display_image_save)(WbDeviceTag tag, int id);
+
+  void (*wbr_lidar_set_frequency)(WbDeviceTag tag, double frequency);
 
 } WbrInterface;
 

--- a/src/controller/c/Controller.def
+++ b/src/controller/c/Controller.def
@@ -430,6 +430,8 @@ wbr_display_save_image
 wbr_distance_sensor_set_value
 wbr_gps_set_values
 wbr_gyro_set_values
+wbr_lidar_set_image
+wbr_lidar_set_frequency
 wbr_light_sensor_set_value
 wbr_microphone_set_buffer
 wbr_motor_set_force_feedback

--- a/src/controller/c/lidar.c
+++ b/src/controller/c/lidar.c
@@ -190,6 +190,16 @@ int wb_lidar_get_unique_id(WbDevice *d) {
   return ac->unique_id;
 }
 
+
+void wbr_lidar_set_image(WbDeviceTag t, const float *image) {
+  WbDevice *d = lidar_get_device(t);
+  if (d)
+    wbr_abstract_camera_set_image(d, (const unsigned char *)image);
+  else
+    fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
+}
+
+/*
 void wbr_lidar_set_image(WbDeviceTag t, const unsigned char *image) {
   WbDevice *d = lidar_get_device(t);
   if (d)
@@ -197,6 +207,7 @@ void wbr_lidar_set_image(WbDeviceTag t, const unsigned char *image) {
   else
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
 }
+*/
 
 unsigned char *wbr_lidar_get_image_buffer(WbDeviceTag t) {
   WbDevice *d = lidar_get_device(t);

--- a/src/controller/c/remote_control.c
+++ b/src/controller/c/remote_control.c
@@ -280,6 +280,7 @@ static void handleMessage(WbRequest *r, WbDeviceTag tag, WbNodeType type) {
     case WB_NODE_DISTANCE_SENSOR:
     case WB_NODE_GPS:
     case WB_NODE_GYRO:
+    case WB_NODE_LIDAR:
     case WB_NODE_LIGHT_SENSOR:
     case WB_NODE_MICROPHONE:
     case WB_NODE_POSITION_SENSOR:
@@ -291,6 +292,22 @@ static void handleMessage(WbRequest *r, WbDeviceTag tag, WbNodeType type) {
       else {
         // devices that have C_SET_SAMPLING_PERIOD and also other command
         switch (type) {
+          case WB_NODE_LIDAR:
+            switch (c){
+            case C_LIDAR_ENABLE_POINT_CLOUD:
+              //What should I do here?
+              break;
+            case C_LIDAR_SET_FREQUENCY:
+              CALL_INTERFACE_FUNCTION(wbr_lidar_set_frequency, tag, request_read_double(r));
+              break;
+            case C_CAMERA_GET_IMAGE:
+              wb_abstract_camera_update_timestamp(robot_get_device_with_node(tag, WB_NODE_LIDAR, true));
+              break;
+            default:
+              REQUEST_ASSERT(0, tag, type, c);
+              break;
+            }
+            break;
           case WB_NODE_CAMERA:
             switch (c) {
               case C_CAMERA_SET_FOV:


### PR DESCRIPTION
**Description**
I'm trying to add support for lidar in remote control API such that we can get and visualize real time point cloud from lidar.

**Current Issue**
I'm currently facing some problems concerning this feature as discussed on your discord.
The tests I have made so far shows that the internal data container of the lidar remains null (c->image->data).
The memory can't be **allocated** in the remote plugin like this as suggested:

```
const unsigned char *lidar_data_from_robot = malloc(...);
wbr_lidar_set_image(camera->tag(), lidar_data_from_robot);
```
because:

```
wbr_lidar_set_image(WbDeviceTag t, const float *image) => wbr_abstract_camera_set_image(WbDevice *d, const unsigned char *image)

void wbr_abstract_camera_set_image(WbDevice *d, const unsigned char *image) {
  AbstractCamera *c = d->pdata;
  if (c && c->image->data)
    memcpy(c->image->data, image, 4 * c->height * c->width);
}
```

See if "c->image->data" has not been allocated before, calling wbr_lidar_set_image is pointless.
I don't see where this `c->image->data` is supposed to be allocated at least in remote control mode.

**Suggestion**

I'm quiet sure that's not the correct way of doing because it's way too obvious but why not allocating the memory directly while the abstract camera is being instantiated like this ? After all the image's size is known at compilation time.

```
void wb_abstract_camera_new(WbDevice *d, unsigned int id, int w, int h, double fov, double camnear, bool spherical) {
  wb_abstract_camera_cleanup(d);
  AbstractCamera *c = malloc(sizeof(AbstractCamera));
  c->enable = false;
  c->unique_id = id;
  c->width = w;
  c->height = h;
  c->fov = fov;
  c->camnear = camnear;
  c->spherical = spherical;
  c->sampling_period = 0;
  c->image = image_new();
  c->image->data = (unsigned char*) calloc(w*h,4);

  d->pdata = c;
}
```

by doing this I'm now able to read my sensor data in webots with `wb_lidar_get_range_image` **but** the point cloud is not 
rendered in remote control mode, only in simulation mode.
Thanks in advance for considering this.

[Question-remote-api.pdf](https://github.com/cyberbotics/webots/files/6216224/Question-remote-api.pdf)

