### PR TITLE
Fix camera object recognition detection using bounding sphere

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).
     - Fixed reset of [Charger](charger.md) energy when the recharging [Robot](robot.md) battery is full ([#2879](https://github.com/cyberbotics/webots/pull/2879)).
     - Fixed [PedestrianCrossing](../guide/object-traffic.md#pedestriancrossing) PROTO model not correctly displaying the yellow stripes ([#2857](https://github.com/cyberbotics/webots/pull/2857)).
     - Fixed start-up of extern controllers in case a remaining temporary folder resulting from a previous Webots crash was still there ([#2800](https://github.com/cyberbotics/webots/pull/2800)).

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -66,6 +66,7 @@
 #include "WbTemplateManager.hpp"
 #include "WbVideoRecorder.hpp"
 #include "WbView3D.hpp"
+#include "WbVisualBoundingSphere.hpp"
 #include "WbWebotsUpdateDialog.hpp"
 #include "WbWebotsUpdateManager.hpp"
 #include "WbWrenOpenGlContext.hpp"
@@ -1078,6 +1079,7 @@ void WbMainWindow::closeEvent(QCloseEvent *event) {
   mSimulationView->view3D()->cleanupFullScreenOverlay();
   mSimulationView->cleanup();
   WbClipboard::deleteInstance();
+  WbVisualBoundingSphere::deleteInstance();
 
   // really close
   if (WbApplication::instance()) {
@@ -1351,6 +1353,7 @@ void WbMainWindow::updateBeforeWorldLoading(bool reloading) {
   if (!reloading && WbClipboard::instance()->type() == WB_SF_NODE)
     WbClipboard::instance()->replaceAllExternalDefNodesInString();
   mSimulationView->prepareWorldLoading();
+  WbVisualBoundingSphere::deleteInstance();
 
   foreach (WbConsole *console, mConsoles) {
     mDockWidgets.removeAll(console);
@@ -1387,6 +1390,11 @@ void WbMainWindow::updateAfterWorldLoading(bool reloading, bool firstLoad) {
     ->action(WbAction::DISABLE_RENDERING)
     ->setChecked(perspective->isUserInteractionDisabled(WbAction::DISABLE_RENDERING));
   mSimulationView->disableRendering(perspective->isUserInteractionDisabled(WbAction::DISABLE_RENDERING));
+  if (!WbSysInfo::environmentVariable("WEBOTS_DEBUG").isEmpty()) {
+    WbVisualBoundingSphere::enable(perspective->isGlobalOptionalRenderingEnabled("BoundingSphere"), NULL);
+    connect(mSimulationView->sceneTree(), &WbSceneTree::nodeSelected, WbVisualBoundingSphere::instance(),
+            &WbVisualBoundingSphere::show);
+  }
 
 #ifdef _WIN32
   QWebSettings::globalSettings()->clearMemoryCaches();

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -38,7 +38,6 @@
 #include "WbVideoRecorder.hpp"
 #include "WbView3D.hpp"
 #include "WbViewpoint.hpp"
-#include "WbVisualBoundingSphere.hpp"
 #include "WbWorld.hpp"
 #include "WbWorldInfo.hpp"
 
@@ -794,10 +793,6 @@ void WbSimulationView::prepareWorldLoading() {
   disconnect(mSelection, &WbSelection::selectionChangedFromView3D, mSceneTree, &WbSceneTree::selectTransform);
   disconnect(mSelection, &WbSelection::selectionConfirmedFromView3D, mSceneTree, &WbSceneTree::selectTransform);
   disconnect(mSceneTree, &WbSceneTree::nodeSelected, mSelection, &WbSelection::selectNodeFromSceneTree);
-  if (!WbSysInfo::environmentVariable("WEBOTS_DEBUG").isEmpty()) {
-    disconnect(mSceneTree, &WbSceneTree::nodeSelected, WbVisualBoundingSphere::instance(), &WbVisualBoundingSphere::show);
-    WbVisualBoundingSphere::instance()->show(NULL);
-  }
 }
 
 void WbSimulationView::setWorld(WbSimulationWorld *w) {
@@ -828,9 +823,6 @@ void WbSimulationView::setWorld(WbSimulationWorld *w) {
   connect(mSelection, &WbSelection::selectionChangedFromView3D, mSceneTree, &WbSceneTree::selectTransform);
   connect(mSelection, &WbSelection::selectionConfirmedFromView3D, mSceneTree, &WbSceneTree::selectTransform);
   connect(mSceneTree, &WbSceneTree::nodeSelected, mSelection, &WbSelection::selectNodeFromSceneTree);
-  if (!WbSysInfo::environmentVariable("WEBOTS_DEBUG").isEmpty())
-    connect(mSceneTree, &WbSceneTree::nodeSelected, WbVisualBoundingSphere::instance(), &WbVisualBoundingSphere::show);
-
   connect(WbActionManager::instance()->action(WbAction::FRONT_VIEW), &QAction::triggered,
           WbSimulationWorld::instance()->viewpoint(), &WbViewpoint::frontView);
   connect(WbActionManager::instance()->action(WbAction::BACK_VIEW), &QAction::triggered,

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -103,7 +103,7 @@ void WbCamera::init() {
   mExposure = findSFDouble("exposure");
 
   // backward compatibility
-  WbSFString *type = findSFString("type");
+  const WbSFString *type = findSFString("type");
   if (type->value().startsWith('r', Qt::CaseInsensitive))
     parsingWarn("Range finder type is not available for camera since Webots 8.4, please use a RangeFinder node instead.");
 
@@ -269,51 +269,44 @@ void WbCamera::updateRecognizedObjectsOverlay(double screenX, double screenY, do
   // check if mouse is over an object
   int objectIndex = -1;
   for (int i = 0; i < mRecognizedObjects.size(); ++i) {
-    if (overlayX < (mRecognizedObjects.at(i)->positionOnImage().x()) - (mRecognizedObjects.at(i)->pixelSize().x() / 2))
+    const WbVector2 positionOnImage = mRecognizedObjects.at(i)->positionOnImage();
+    const WbVector2 pixelsSize = mRecognizedObjects.at(i)->pixelSize();
+    if (overlayX < positionOnImage.x() - pixelsSize.x() / 2)
       continue;
-    if (overlayX > (mRecognizedObjects.at(i)->positionOnImage().x()) + (mRecognizedObjects.at(i)->pixelSize().x() / 2))
+    if (overlayX > positionOnImage.x() + pixelsSize.x() / 2)
       continue;
-    if (overlayY < (mRecognizedObjects.at(i)->positionOnImage().y()) - (mRecognizedObjects.at(i)->pixelSize().y() / 2))
+    if (overlayY < positionOnImage.y() - pixelsSize.y() / 2)
       continue;
-    if (overlayY > (mRecognizedObjects.at(i)->positionOnImage().y()) + (mRecognizedObjects.at(i)->pixelSize().y() / 2))
+    if (overlayY > positionOnImage.y() + pixelsSize.y() / 2)
       continue;
     objectIndex = i;
     break;
   }
   // display information of the object (if any) in an overlay
   if (objectIndex >= 0) {
-    QString text(mRecognizedObjects.at(objectIndex)->model());
-    text += tr("\nId: %1").arg(mRecognizedObjects.at(objectIndex)->id());
+    const WbRecognizedObject *object = mRecognizedObjects.at(objectIndex);
+    QString text(object->model());
+    text += tr("\nId: %1").arg(object->id());
     text += tr("\nRelative position: %1 %2 %3")
-              .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->objectRelativePosition().x(),
-                                               WbPrecision::GUI_LOW))
-              .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->objectRelativePosition().y(),
-                                               WbPrecision::GUI_LOW))
-              .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->objectRelativePosition().z(),
-                                               WbPrecision::GUI_LOW));
-    text +=
-      tr("\nRelative orientation: %1 %2 %3 %4")
-        .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->relativeOrientation().x(), WbPrecision::GUI_LOW))
-        .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->relativeOrientation().y(), WbPrecision::GUI_LOW))
-        .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->relativeOrientation().z(), WbPrecision::GUI_LOW))
-        .arg(
-          WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->relativeOrientation().angle(), WbPrecision::GUI_LOW));
+              .arg(WbPrecision::doubleToString(object->objectRelativePosition().x(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->objectRelativePosition().y(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->objectRelativePosition().z(), WbPrecision::GUI_LOW));
+    text += tr("\nRelative orientation: %1 %2 %3 %4")
+              .arg(WbPrecision::doubleToString(object->relativeOrientation().x(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->relativeOrientation().y(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->relativeOrientation().z(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->relativeOrientation().angle(), WbPrecision::GUI_LOW));
     text += tr("\nSize: %1 %2")
-              .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->objectSize().x(), WbPrecision::GUI_LOW))
-              .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->objectSize().y(), WbPrecision::GUI_LOW));
-    text += tr("\nPosition on the image: %1 %2")
-              .arg(mRecognizedObjects.at(objectIndex)->positionOnImage().x())
-              .arg(mRecognizedObjects.at(objectIndex)->positionOnImage().y());
-    text += tr("\nSize on the image: %1 %2")
-              .arg(mRecognizedObjects.at(objectIndex)->pixelSize().x())
-              .arg(mRecognizedObjects.at(objectIndex)->pixelSize().y());
-    for (int i = 0; i < mRecognizedObjects.at(objectIndex)->colors().size(); ++i)
-      text +=
-        tr("\nColor %1: %2 %3 %4")
-          .arg(i)
-          .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->colors().at(i).red(), WbPrecision::GUI_LOW))
-          .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->colors().at(i).green(), WbPrecision::GUI_LOW))
-          .arg(WbPrecision::doubleToString(mRecognizedObjects.at(objectIndex)->colors().at(i).blue(), WbPrecision::GUI_LOW));
+              .arg(WbPrecision::doubleToString(object->objectSize().x(), WbPrecision::GUI_LOW))
+              .arg(WbPrecision::doubleToString(object->objectSize().y(), WbPrecision::GUI_LOW));
+    text += tr("\nPosition on the image: %1 %2").arg(object->positionOnImage().x()).arg(object->positionOnImage().y());
+    text += tr("\nSize on the image: %1 %2").arg(object->pixelSize().x()).arg(object->pixelSize().y());
+    for (int i = 0; i < object->colors().size(); ++i)
+      text += tr("\nColor %1: %2 %3 %4")
+                .arg(i)
+                .arg(WbPrecision::doubleToString(object->colors().at(i).red(), WbPrecision::GUI_LOW))
+                .arg(WbPrecision::doubleToString(object->colors().at(i).green(), WbPrecision::GUI_LOW))
+                .arg(WbPrecision::doubleToString(object->colors().at(i).blue(), WbPrecision::GUI_LOW));
     if (mLabelOverlay == NULL) {
       mLabelOverlay = WbWrenLabelOverlay::createOrRetrieve(WbWrenLabelOverlay::cameraCaptionOverlayId(),
                                                            WbStandardPaths::fontsPath() + "Arial.ttf");
@@ -374,14 +367,11 @@ void WbCamera::displayRecognizedObjectsInOverlay() {
     wr_texture_change_data(mRecognizedObjectsTexture, clearData, 0, 0, w, h);
 
     for (int i = 0; i < mRecognizedObjects.size(); ++i) {
-      const int x1 =
-        qMax(0, (int)(mRecognizedObjects.at(i)->positionOnImage().x() - mRecognizedObjects.at(i)->pixelSize().x() / 2 - 1));
-      const int x2 =
-        qMin(w - 1, (int)(mRecognizedObjects.at(i)->positionOnImage().x() + mRecognizedObjects.at(i)->pixelSize().x() / 2 + 1));
-      const int y1 =
-        qMax(0, (int)(mRecognizedObjects.at(i)->positionOnImage().y() - mRecognizedObjects.at(i)->pixelSize().y() / 2 - 1));
-      const int y2 =
-        qMin(h - 1, (int)(mRecognizedObjects.at(i)->positionOnImage().y() + mRecognizedObjects.at(i)->pixelSize().y() / 2 + 1));
+      const WbRecognizedObject *object = mRecognizedObjects.at(i);
+      const int x1 = qMax(0, (int)(object->positionOnImage().x() - object->pixelSize().x() / 2 - 1));
+      const int x2 = qMin(w - 1, (int)(object->positionOnImage().x() + object->pixelSize().x() / 2 + 1));
+      const int y1 = qMax(0, (int)(object->positionOnImage().y() - object->pixelSize().y() / 2 - 1));
+      const int y2 = qMin(h - 1, (int)(object->positionOnImage().y() + object->pixelSize().y() / 2 + 1));
 
       wr_texture_change_data(mRecognizedObjectsTexture, data, x1, y1, frameThickness, y2 - y1);
       wr_texture_change_data(mRecognizedObjectsTexture, data, x2 - frameThickness, y1, frameThickness, y2 - y1);
@@ -456,12 +446,13 @@ void WbCamera::updateRaysSetupIfNeeded() {
 
   // compute the camera position and rotation
   const WbVector3 cameraPosition = matrix().translation();
-  WbMatrix3 cameraRotation = rotationMatrix();
-  WbMatrix3 cameraInverseRotation = cameraRotation.transposed();
-  double horizontalFieldOfView = fieldOfView();
-  double verticalFieldOfView = WbWrenCamera::computeFieldOfViewY(horizontalFieldOfView, (double)width() / (double)height());
-  WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(cameraPosition, cameraRotation, verticalFieldOfView,
-                                                                         horizontalFieldOfView, recognition()->maxRange());
+  const WbMatrix3 cameraRotation = rotationMatrix();
+  const WbMatrix3 cameraInverseRotation = cameraRotation.transposed();
+  const double horizontalFieldOfView = fieldOfView();
+  const double verticalFieldOfView =
+    WbWrenCamera::computeFieldOfViewY(horizontalFieldOfView, (double)width() / (double)height());
+  const WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(
+    cameraPosition, cameraRotation, verticalFieldOfView, horizontalFieldOfView, recognition()->maxRange());
   foreach (WbRecognizedObject *recognizedObject, mRecognizedObjects) {
     recognizedObject->object()->updateTransformForPhysicsStep();
     bool valid =
@@ -533,10 +524,10 @@ void WbCamera::writeAnswer(QDataStream &stream) {
     if (refreshRecognitionSensorIfNeeded() || mRecognitionSensor->hasPendingValue()) {
       stream << tag();
       stream << (unsigned char)C_CAMERA_OBJECTS;
-      int numberOfObjects = mRecognizedObjects.size();
+      const int numberOfObjects = mRecognizedObjects.size();
       stream << (int)numberOfObjects;
       for (int i = 0; i < numberOfObjects; ++i) {
-        WbRecognizedObject *recognizedObject = mRecognizedObjects.at(i);
+        const WbRecognizedObject *recognizedObject = mRecognizedObjects.at(i);
         // id
         stream << (int)recognizedObject->id();
         // relative position
@@ -558,7 +549,7 @@ void WbCamera::writeAnswer(QDataStream &stream) {
         stream << (int)recognizedObject->pixelSize().x();
         stream << (int)recognizedObject->pixelSize().y();
         // colors
-        int numberOfColors = recognizedObject->colors().size();
+        const int numberOfColors = recognizedObject->colors().size();
         stream << (int)numberOfColors;
         for (int j = 0; j < numberOfColors; ++j) {
           stream << (double)recognizedObject->colors().at(j).red();
@@ -566,7 +557,7 @@ void WbCamera::writeAnswer(QDataStream &stream) {
           stream << (double)recognizedObject->colors().at(j).blue();
         }
         // model
-        QByteArray model = recognizedObject->model().toUtf8();
+        const QByteArray model = recognizedObject->model().toUtf8();
         stream.writeRawData(model.constData(), model.size() + 1);
       }
 
@@ -588,7 +579,7 @@ void WbCamera::writeAnswer(QDataStream &stream) {
         stream << (unsigned char)C_CAMERA_SEGMENTATION_SHARED_MEMORY;
         if (mSegmentationShm) {
           stream << (int)(mSegmentationShm->size());
-          QByteArray n = QFile::encodeName(mSegmentationShm->nativeKey());
+          const QByteArray n = QFile::encodeName(mSegmentationShm->nativeKey());
           stream.writeRawData(n.constData(), n.size() + 1);
         } else
           stream << (int)(0);
@@ -616,7 +607,7 @@ void WbCamera::handleMessage(QDataStream &stream) {
       double fov;
       stream >> fov;
 
-      WbZoom *z = zoom();
+      const WbZoom *z = zoom();
       if (z) {
         if (fov >= z->minFieldOfView() && fov <= z->maxFieldOfView())
           mFieldOfView->setValue(fov);
@@ -680,15 +671,15 @@ void WbCamera::handleMessage(QDataStream &stream) {
 void WbCamera::computeObjects(bool finalSetup, bool needCollisionDetection) {
   // compute the camera referential
   const WbVector3 cameraPosition = matrix().translation();
-  WbMatrix3 cameraRotation = rotationMatrix();
-  WbMatrix3 cameraInverseRotation = cameraRotation.transposed();
-  double horizontalFieldOfView = fieldOfView();
-  double verticalFieldOfView = (horizontalFieldOfView * height()) / width();
-  WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(cameraPosition, cameraRotation, verticalFieldOfView,
-                                                                         horizontalFieldOfView, recognition()->maxRange());
+  const WbMatrix3 cameraRotation = rotationMatrix();
+  const WbMatrix3 cameraInverseRotation = cameraRotation.transposed();
+  const double horizontalFieldOfView = fieldOfView();
+  const double verticalFieldOfView = (horizontalFieldOfView * height()) / width();
+  const WbAffinePlane *frustumPlanes = WbObjectDetection::computeFrustumPlanes(
+    cameraPosition, cameraRotation, verticalFieldOfView, horizontalFieldOfView, recognition()->maxRange());
 
   // loop for each possible target to check if it is visible
-  QList<WbSolid *> objects = WbWorld::instance()->cameraRecognitionObjects();
+  const QList<WbSolid *> objects = WbWorld::instance()->cameraRecognitionObjects();
   for (int i = 0; i < objects.size(); i++) {
     WbSolid *object = objects.at(i);
     if (object == this || robot() == object || robot()->solidChildren().contains(object))
@@ -701,7 +692,8 @@ void WbCamera::computeObjects(bool finalSetup, bool needCollisionDetection) {
     WbRecognizedObject *generatedObject =
       new WbRecognizedObject(this, object, needCollisionDetection, recognition()->maxRange());
     if (finalSetup) {
-      bool valid = computeObject(cameraPosition, cameraRotation, cameraInverseRotation, frustumPlanes, generatedObject, false);
+      const bool valid =
+        computeObject(cameraPosition, cameraRotation, cameraInverseRotation, frustumPlanes, generatedObject, false);
       if (!valid) {
         delete generatedObject;
         continue;
@@ -751,13 +743,13 @@ bool WbCamera::computeObject(const WbVector3 &cameraPosition, const WbMatrix3 &c
   recognizedObject->setModel(recognizedObject->object()->model());
 
   // compute position and size in the camera image
-  WbVector3 objectSize = recognizedObject->objectSize();
-  WbVector2 centerPosition = projectOnImage(recognizedObject->objectRelativePosition());
+  const WbVector3 objectSize = recognizedObject->objectSize();
+  const WbVector2 centerPosition = projectOnImage(recognizedObject->objectRelativePosition());
   double minU = centerPosition.x();
   double minV = centerPosition.y();
   double maxU = centerPosition.x();
   double maxV = centerPosition.y();
-  WbVector3 corners[8] = {
+  const WbVector3 corners[8] = {
     // corners of the bounding box of the object in the camera referential
     recognizedObject->objectRelativePosition() + 0.5 * WbVector3(objectSize.x(), objectSize.y(), objectSize.z()),
     recognizedObject->objectRelativePosition() + 0.5 * WbVector3(-objectSize.x(), objectSize.y(), objectSize.z()),
@@ -768,7 +760,7 @@ bool WbCamera::computeObject(const WbVector3 &cameraPosition, const WbMatrix3 &c
     recognizedObject->objectRelativePosition() + 0.5 * WbVector3(objectSize.x(), -objectSize.y(), -objectSize.z()),
     recognizedObject->objectRelativePosition() + 0.5 * WbVector3(-objectSize.x(), -objectSize.y(), -objectSize.z())};
   for (int i = 0; i < 8; ++i) {  // project each of the corners in the camera image
-    WbVector2 positionOnImage = projectOnImage(corners[i]);
+    const WbVector2 &positionOnImage = projectOnImage(corners[i]);
     if (positionOnImage.x() < minU)
       minU = positionOnImage.x();
     if (positionOnImage.y() < minV)
@@ -794,8 +786,7 @@ bool WbCamera::refreshRecognitionSensorIfNeeded() {
 
   if (!recognition()->occlusion())
     // no need of ODE ray collision detection
-    // rays can be created at the end of the step when all the body positions
-    // are up-to-date
+    // rays can be created at the end of the step when all the body positions are up-to-date
     computeObjects(true, false);
 
   // post process objects
@@ -806,7 +797,7 @@ bool WbCamera::refreshRecognitionSensorIfNeeded() {
   if (recognition()->maxObjects() > 0 && mRecognizedObjects.size() > recognition()->maxObjects()) {
     QMultiMap<int, WbRecognizedObject *> objectsMap;
     for (int i = 0; i < mRecognizedObjects.size(); ++i) {
-      int pixelSurface = mRecognizedObjects.at(i)->pixelSize().x() * mRecognizedObjects.at(i)->pixelSize().y();
+      const int pixelSurface = mRecognizedObjects.at(i)->pixelSize().x() * mRecognizedObjects.at(i)->pixelSize().y();
       objectsMap.insert(pixelSurface, mRecognizedObjects.at(i));
     }
     mRecognizedObjects.clear();

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -275,14 +275,11 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
     double outsidePart[4] = {0.0, 0.0, 0.0, 0.0};
     if (useBoundingSphere) {
       WbBoundingSphere *boundingSphere = rootObject->boundingSphere();
-      WbVector3 center;
-      double radius;
-      boundingSphere->computeSphereInGlobalCoordinates(center, radius);
-      objectSize.setX(2 * radius);
-      objectSize.setY(2 * radius);
-      objectSize.setZ(2 * radius);
+      const WbVector3 &scale = transform->absoluteScale();
+      const double size = 2 * boundingSphere->radius() * std::max(std::max(scale.x(), scale.y()), scale.z());
+      objectSize.setXyz(size, size, size);
       // correct the object center
-      objectPosition += center;
+      objectPosition += boundingSphere->center();
     } else {
       double height = 0;
       double radius = 0;

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -275,12 +275,14 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
     double outsidePart[4] = {0.0, 0.0, 0.0, 0.0};
     if (useBoundingSphere) {
       WbBoundingSphere *boundingSphere = rootObject->boundingSphere();
-      double radius = boundingSphere->radius();
+      WbVector3 center;
+      double radius;
+      boundingSphere->computeSphereInGlobalCoordinates(center, radius);
       objectSize.setX(2 * radius);
       objectSize.setY(2 * radius);
       objectSize.setZ(2 * radius);
       // correct the object center
-      objectPosition += boundingSphere->center();
+      objectPosition += center;
     } else {
       double height = 0;
       double radius = 0;

--- a/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
@@ -20,7 +20,16 @@
 #include "WbSphere.hpp"
 #include "WbSysInfo.hpp"
 #include "WbWorld.hpp"
+#include "WbWrenOpenGlContext.hpp"
 #include "WbWrenRenderingContext.hpp"
+#include "WbWrenShaders.hpp"
+
+#include <wren/material.h>
+#include <wren/node.h>
+#include <wren/renderable.h>
+#include <wren/scene.h>
+#include <wren/static_mesh.h>
+#include <wren/transform.h>
 
 static bool gEnabled = false;
 
@@ -32,78 +41,119 @@ WbVisualBoundingSphere *WbVisualBoundingSphere::instance() {
   return cInstance;
 }
 
+void WbVisualBoundingSphere::deleteInstance() {
+  if (!cInstance)
+    return;
+  cInstance->deleteWrenObjects();
+  delete cInstance;
+  cInstance = NULL;
+}
+
 void WbVisualBoundingSphere::enable(bool enabled, const WbBaseNode *node) {
   gEnabled = enabled;
-  instance()->show(node);
+  if (node || cInstance)
+    cInstance->show(node);
 }
 
-void WbVisualBoundingSphere::createSphere(
-  /* const Ogre::String &meshName, const float r, const int nRings, const int nSegments */) {
-  // TODO_WREN: port the functionality to WREN.
+void WbVisualBoundingSphere::createSphere(const WbVector3 &center, float radius) {
   // The visual bounding sphere can be enabled from the optional rendering if WEBOTS_DEBUG is set.
+  if (!mInitialized) {
+    mWrenNode = wr_scene_get_root(wr_scene_get_instance());
+    mWrenScaleTransform = wr_transform_new();
+    wr_transform_attach_child(mWrenNode, WR_NODE(mWrenScaleTransform));
+    mWrenRenderable = wr_renderable_new();
+    mWrenMaterial = wr_phong_material_new();
+    wr_material_set_default_program(mWrenMaterial, WbWrenShaders::lineSetShader());
+    wr_renderable_set_cast_shadows(mWrenRenderable, false);
+    wr_renderable_set_receive_shadows(mWrenRenderable, false);
+    wr_renderable_set_drawing_mode(mWrenRenderable, WR_RENDERABLE_DRAWING_MODE_LINES);
+    wr_renderable_set_material(mWrenRenderable, mWrenMaterial, NULL);
+    mWrenEncodeDepthMaterial = wr_phong_material_new();
+    wr_material_set_default_program(mWrenEncodeDepthMaterial, WbWrenShaders::encodeDepthShader());
+    wr_renderable_set_material(mWrenRenderable, mWrenEncodeDepthMaterial, "encodeDepth");
+    mWrenSegmentationMaterial = wr_phong_material_new();
+    wr_material_set_default_program(mWrenSegmentationMaterial, WbWrenShaders::segmentationShader());
+    wr_renderable_set_material(mWrenRenderable, mWrenSegmentationMaterial, "segmentation");
+    mWrenMesh = wr_static_mesh_unit_sphere_new(16, false, true);
+    wr_renderable_set_mesh(mWrenRenderable, WR_MESH(mWrenMesh));
+    wr_transform_attach_child(mWrenScaleTransform, WR_NODE(mWrenRenderable));
+    mInitialized = true;
+  }
+
+  const float scale[] = {radius, radius, radius};
+  wr_transform_set_scale(mWrenScaleTransform, scale);
+  const float position[] = {(float)center.x(), (float)center.y(), (float)center.z()};
+  wr_transform_set_position(mWrenScaleTransform, position);
 }
 
-WbVisualBoundingSphere::WbVisualBoundingSphere() : QObject() {
-  gEnabled = !WbSysInfo::environmentVariable("WEBOTS_DEBUG").isEmpty() &&
-             WbWorld::instance()->perspective()->isGlobalOptionalRenderingEnabled("BoundingSphere");
+WrMaterial *mWrenMaterial;
+WrMaterial *mWrenEncodeDepthMaterial;
+WrMaterial *mWrenSegmentationMaterial;
+WrStaticMesh *mWrenMesh;
+WrRenderable *mWrenRenderable;
+
+WbVisualBoundingSphere::WbVisualBoundingSphere() :
+  QObject(),
+  mInitialized(false),
+  mWrenNode(NULL),
+  mWrenScaleTransform(NULL),
+  mWrenMaterial(NULL),
+  mWrenEncodeDepthMaterial(NULL),
+  mWrenSegmentationMaterial(NULL),
+  mWrenMesh(NULL),
+  mWrenRenderable(NULL) {
 }
 
 WbVisualBoundingSphere::~WbVisualBoundingSphere() {
-  clear();
+  deleteWrenObjects();
 }
 
 void WbVisualBoundingSphere::show(const WbBaseNode *node) {
-  // TODO_WREN: port the functionality from Ogre to WREN.
   // The visual bounding sphere can be enabled from the optional rendering if WEBOTS_DEBUG is set.
+  if (!gEnabled) {
+    if (mInitialized)
+      deleteWrenObjects();
+    return;
+  }
 
-  // WbBoundingSphere *boundingSphere = node ? node->boundingSphere() : NULL;
-  // if (!boundingSphere || !gEnabled) {
-  //   if (mSceneNode)
-  //     clear();
-  //   return;
-  // }
+  WbBoundingSphere *boundingSphere = node ? node->boundingSphere() : NULL;
+  if (!boundingSphere) {
+    if (mInitialized)
+      wr_node_set_visible(WR_NODE(mWrenScaleTransform), false);
+    return;
+  }
 
-  // Ogre::SceneManager *sceneManager = WbWrenRenderingContext::instance()->sceneManager();
-
-  // // only one bounding sphere can be visible at a time
-  // if (!mSceneNode) {
-  //   const Ogre::String &meshName   = "mesh_debug_boundingSphere";
-  //   createSphere(meshName, 1.0, 32, 32);
-  //   assert(!mEntity);
-  //   mEntity = sceneManager->createEntity("entity_debug_boundingSphere", meshName);
-  //   mEntity->setVisibilityFlags(WbWrenRenderingContext::VF_SELECTED_OUTLINE);
-  //   mEntity->setQueryFlags(WbWrenRenderingContext::QM_NOT_QUERIABLE);
-  //   mEntity->setCastShadows(false);
-  //   mEntity->setVisible(true);
-
-  //   mSceneNode = sceneManager->getRootSceneNode()->createChildSceneNode();
-  //   mSceneNode->setInheritOrientation(false);
-  //   mSceneNode->setInheritScale(false);
-  //   mSceneNode->attachObject(mEntity);
-  // }
-
-  // assert(mSceneNode && mEntity);
-  // double radius;
-  // WbVector3 pos;
-  // boundingSphere->recomputeIfNeeded();
-  // const_cast<WbBoundingSphere *>(boundingSphere)->computeSphereInGlobalCoordinates(pos, radius);
-  // mSceneNode->setScale(radius, radius, radius);
-  // mSceneNode->setPosition(pos.x(), pos.y(), pos.z());
+  WbVector3 center;
+  double radius;
+  boundingSphere->computeSphereInGlobalCoordinates(center, radius);
+  WbWrenOpenGlContext::makeWrenCurrent();
+  createSphere(center, radius);
+  wr_renderable_set_visibility_flags(mWrenRenderable, WbWrenRenderingContext::VF_SELECTED_OUTLINE);
+  wr_node_set_visible(WR_NODE(mWrenScaleTransform), true);
+  WbWrenOpenGlContext::doneWren();
 }
 
-void WbVisualBoundingSphere::clear() {
-  // TODO_WREN: port the functionality from Ogre to WREN.
-  // The visual bounding sphere can be enabled from the optional rendering if WEBOTS_DEBUG is set.
+void WbVisualBoundingSphere::deleteWrenObjects() {
+  if (!mInitialized)
+    return;
 
-  // if (!mSceneNode)
-  //   return;
-
-  // assert(mEntity);
-  // Ogre::SceneManager *const sceneManager = WbWrenRenderingContext::instance()->sceneManager();
-  // if (mEntity->isAttached())
-  //   mSceneNode->detachObject(mEntity);
-  // sceneManager->destroyEntity(mEntity);
-  // sceneManager->destroySceneNode(mSceneNode);
-  // mEntity = NULL;
-  // mSceneNode = NULL;
+  WbWrenOpenGlContext::makeWrenCurrent();
+  wr_static_mesh_delete(mWrenMesh);
+  mWrenMesh = NULL;
+  if (mWrenRenderable) {
+    if (mWrenMaterial)
+      wr_renderable_set_material(mWrenRenderable, NULL, NULL);
+    wr_material_delete(mWrenMaterial);
+    mWrenMaterial = NULL;
+    wr_material_delete(mWrenEncodeDepthMaterial);
+    mWrenEncodeDepthMaterial = NULL;
+    wr_material_delete(mWrenSegmentationMaterial);
+    mWrenSegmentationMaterial = NULL;
+    wr_node_delete(WR_NODE(mWrenRenderable));
+    mWrenRenderable = NULL;
+  }
+  wr_node_delete(WR_NODE(mWrenScaleTransform));
+  mWrenScaleTransform = NULL;
+  WbWrenOpenGlContext::doneWren();
+  mInitialized = false;
 }

--- a/src/webots/nodes/utils/WbVisualBoundingSphere.hpp
+++ b/src/webots/nodes/utils/WbVisualBoundingSphere.hpp
@@ -21,14 +21,21 @@
 //
 
 #include "QtCore/QObject"
+#include "WbVector3.hpp"
 
 class WbBaseNode;
+
+struct WrMaterial;
+struct WrStaticMesh;
+struct WrRenderable;
+struct WrTransform;
 
 class WbVisualBoundingSphere : public QObject {
   Q_OBJECT
 
 public:
   static WbVisualBoundingSphere *instance();
+  static void deleteInstance();
 
   static void enable(bool enabled, const WbBaseNode *node = NULL);
 
@@ -37,11 +44,22 @@ public slots:
 
 private:
   static WbVisualBoundingSphere *cInstance;
-  static void createSphere(/* const Ogre::String &meshName, const float r, const int nRings = 16, const int nSegments = 16 */);
+  void createSphere(const WbVector3 &center, float radius);
 
   WbVisualBoundingSphere();
   ~WbVisualBoundingSphere();
-  void clear();
+  void deleteWrenObjects();
+
+  bool mInitialized;
+
+  // Wren
+  WrTransform *mWrenNode;
+  WrTransform *mWrenScaleTransform;
+  WrMaterial *mWrenMaterial;
+  WrMaterial *mWrenEncodeDepthMaterial;
+  WrMaterial *mWrenSegmentationMaterial;
+  WrStaticMesh *mWrenMesh;
+  WrRenderable *mWrenRenderable;
 };
 
 #endif  // WB_VISUAL_BOUNDING_SPHERE_HPP


### PR DESCRIPTION
Fix #2920: fix detected object size when using the bounding sphere that was not handling the scale.

Tasks:
* [x] fix computation of detected object size based on bounding sphere radius
* [x] port bounding sphere visualization to WREN
