### PR TITLE
Fix CameraRecognitionObject API in Python and Java

### DIFF
--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -1258,7 +1258,7 @@ Sample code showing how to use the returned segmentation image object in the dif
 The `wb_camera_recognition_save_segmentation_image` function allows the user to save the latest segmentation image.
 Further details about the arguments and the return value can be found in the description of the [`wb_camera_save_image`](#wb_camera_save_image) function.
 
-##### Camera Recognition Object
+### Camera Recognition Object
 
 A camera recognition object is defined by the following structure:
 

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,8 +13,8 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
-    - Fixed return value type of [CameraRecognitionObject.get_size](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
-    - Fixed [Camera.getRecognitionObjects](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [CameraRecognitionObject.getPositionOnImage](camera.md#camera-recognition-object) and [CameraRecognitionObject.getSizeOnImage](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
+    - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
+    - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).
     - Fixed reset of [Charger](charger.md) energy when the recharging [Robot](robot.md) battery is full ([#2879](https://github.com/cyberbotics/webots/pull/2879)).
     - Fixed [PedestrianCrossing](../guide/object-traffic.md#pedestriancrossing) PROTO model not correctly displaying the yellow stripes ([#2857](https://github.com/cyberbotics/webots/pull/2857)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,8 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed return value type of [CameraRecognitionObject.get_size](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
+    - Fixed [Camera.getRecognitionObjects](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [CameraRecognitionObject.getPositionOnImage](camera.md#camera-recognition-object) and [CameraRecognitionObject.getSizeOnImage](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).
     - Fixed reset of [Charger](charger.md) energy when the recharging [Robot](robot.md) battery is full ([#2879](https://github.com/cyberbotics/webots/pull/2879)).
     - Fixed [PedestrianCrossing](../guide/object-traffic.md#pedestriancrossing) PROTO model not correctly displaying the yellow stripes ([#2857](https://github.com/cyberbotics/webots/pull/2857)).

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -289,7 +289,7 @@ namespace webots {
     return pixelGetGray(pixel);
   }
 
-  public CameraRecognitionObject[] getCameraRecognitionObjects() {
+  public CameraRecognitionObject[] getRecognitionObjects() {
     int numberOfObjects = wrapperJNI.Camera_getRecognitionNumberOfObjects(swigCPtr, this);
     CameraRecognitionObject ret[] = new CameraRecognitionObject[numberOfObjects];
     for (int i = 0; i < numberOfObjects; ++i)

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -193,16 +193,25 @@ namespace webots {
 
 %rename WbCameraRecognitionObject CameraRecognitionObject;
 
+%javamethodmodifiers position_on_image "private"
+%javamethodmodifiers size_on_image "private"
+%javamethodmodifiers number_of_colors "private"
+
+%typemap(out) int [] {
+  $result = SWIG_JavaArrayOutInt(jenv, $1, 2);
+}
+%apply int[] {const int *};
+
 %include <webots/camera_recognition_object.h>
 
 %extend WbCameraRecognitionObject {
-  int * getPositionOnImage() {
+  const int *getPositionOnImage() const {
     return $self->position_on_image;
   }
-  int * getSizeOnImage() {
+  const int *getSizeOnImage() const {
     return $self->size_on_image;
   }
-  int getNumberOfColors() {
+  int getNumberOfColors() const {
     return $self->number_of_colors;
   }
 };

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -234,8 +234,8 @@ class AnsiCodes(object):
   PyObject *get_size() {
     const double *size = $self->size;
     PyObject *ret = PyList_New(2);
-    PyList_SetItem(ret, 0, PyInt_FromLong(size[0]));
-    PyList_SetItem(ret, 1, PyInt_FromLong(size[1]));
+    PyList_SetItem(ret, 0, PyFloat_FromDouble(size[0]));
+    PyList_SetItem(ret, 1, PyFloat_FromDouble(size[1]));
     return ret;
   }
   PyObject *get_position_on_image() {


### PR DESCRIPTION
Fix #2922: wrong return type for `CameraRecognitionObject.get_size` in Python API.
The Java API also has some issues.

Tasks:
* [x] fix `CameraRecognitionObject.get_size` return type in Python API
* [x] rename `Camera.getCameraRecognitionObjects` to `Camera.getRecognitionObjects` in Java API (name used in the documentation and in the Python API)
* [x] fix return type of `Camera.getPositionOnImage` and `Camera.getSizeOnImage` in Java API (SWIGTYPE_p_int instead of int[])
* [x] improve Camera Recognition Object section level to pass the docs tests.
       This is better than changing the test_references.py code because in general we want to skip h5 anchors but in this case.