### PR TITLE
Fix cppcheck 2.4.1 errors

### DIFF
--- a/projects/robots/epfl/lis/controllers/blimp/js.h
+++ b/projects/robots/epfl/lis/controllers/blimp/js.h
@@ -237,6 +237,8 @@ class jsJoystick {
 
       num_buttons = isp_num_needs - isp_num_axis;
       num_axes = isp_num_axis;
+      if (num_axes > _JS_MAX_AXES)
+        num_axes = _JS_MAX_AXES;
 
       for (int i = 0; i < num_axes; i++) {
         dead_band[i] = 0;

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
@@ -15,8 +15,8 @@
  */
 
 // Included libraries
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <webots/camera.h>
 #include <webots/distance_sensor.h>
 #include <webots/motor.h>

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based.c
@@ -16,6 +16,7 @@
 
 // Included libraries
 #include <stdlib.h>
+#include <assert.h>
 #include <webots/camera.h>
 #include <webots/distance_sensor.h>
 #include <webots/motor.h>
@@ -97,6 +98,7 @@ int find_middle(int tab[], int sizeTab) {
         index = j;
       }
     }
+    assert(index >= 0);
     index_bests[i] = index;
     copy[index] = 0;
   }

--- a/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based_corr.c
+++ b/projects/samples/curriculum/controllers/intermediate_behavior_based/intermediate_behavior_based_corr.c
@@ -93,6 +93,7 @@ int find_middle(int tab[], int sizeTab) {
         index = j;
       }
     }
+    assert(index >= 0);
     index_bests[i] = index;
     copy[index] = 0;
   }

--- a/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
@@ -72,10 +72,10 @@ void MotionPlayer::writeActuators() {
   foreach (Pose *pose, mMotion->poses()) {
     int poseTime = pose->time();
     if (poseTime <= currentTime) {
-      if (!beforePose || ((poseTime != currentTime && poseTime > beforePose->time()))
+      if (!beforePose || (poseTime != currentTime && poseTime > beforePose->time()))
         beforePose = pose;
     } else if (poseTime >= currentTime) {
-      if (!afterPose || ((poseTime != currentTime && poseTime > afterPose->time()))
+      if (!afterPose || (poseTime != currentTime && poseTime > afterPose->time()))
         afterPose = pose;
     }
   }

--- a/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
@@ -72,10 +72,12 @@ void MotionPlayer::writeActuators() {
   foreach (Pose *pose, mMotion->poses()) {
     int poseTime = pose->time();
     if (poseTime <= currentTime) {
-      if (!beforePose || (poseTime != currentTime && poseTime > beforePose->time()))
+      // cppcheck-suppress knownConditionTrueFalse
+      if (!beforePose || (poseTime < currentTime && poseTime > beforePose->time()))
         beforePose = pose;
     } else if (poseTime >= currentTime) {
-      if (!afterPose || (poseTime != currentTime && poseTime > afterPose->time()))
+      // cppcheck-suppress knownConditionTrueFalse
+      if (!afterPose || (poseTime > currentTime && poseTime < afterPose->time()))
         afterPose = pose;
     }
   }

--- a/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/MotionPlayer.cpp
@@ -71,21 +71,12 @@ void MotionPlayer::writeActuators() {
   Pose *afterPose = NULL;
   foreach (Pose *pose, mMotion->poses()) {
     int poseTime = pose->time();
-    // cppcheck-suppress knownConditionTrueFalse
-    if (!beforePose && poseTime <= currentTime) {
-      beforePose = pose;
-      continue;
-    } else if (!afterPose && poseTime >= currentTime) {
-      afterPose = pose;
-      continue;
-    }
-
-    if (beforePose && poseTime < currentTime && poseTime > beforePose->time()) {
-      beforePose = pose;
-      continue;
-    } else if (afterPose && poseTime > currentTime && poseTime < afterPose->time()) {
-      afterPose = pose;
-      continue;
+    if (poseTime <= currentTime) {
+      if (!beforePose || ((poseTime != currentTime && poseTime > beforePose->time()))
+        beforePose = pose;
+    } else if (poseTime >= currentTime) {
+      if (!afterPose || ((poseTime != currentTime && poseTime > afterPose->time()))
+        afterPose = pose;
     }
   }
 

--- a/resources/projects/libraries/qt_utils/motion_editor/PoseWidget.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/PoseWidget.cpp
@@ -143,7 +143,7 @@ void PoseWidget::updateStateFromModel(int index) {
     QListWidgetItem *i = mListWidget->item(index);
     i->setText(state->toString());
     setItemAppearance(i, state->status());
-    mResetButton->setEnabled(state && state->status() == MotorTargetState::MODIFIED);
+    mResetButton->setEnabled(state->status() == MotorTargetState::MODIFIED);
   } else {
     mResetButton->setEnabled(false);
   }

--- a/src/controller/c/default_robot_window.c
+++ b/src/controller/c/default_robot_window.c
@@ -206,6 +206,7 @@ static void ue_append(struct UpdateElement *ue, double update_time, const double
   if (value == NULL)
     return;
 
+  const int last_index = ue->n_values;
   ue->n_values++;
   if (ue->values == NULL)
     ue->values = (double **)malloc(sizeof(double *));
@@ -215,11 +216,11 @@ static void ue_append(struct UpdateElement *ue, double update_time, const double
     ue->times = (double *)malloc(sizeof(double));
   else
     ue->times = (double *)realloc(ue->times, ue->n_values * sizeof(double));
-  int last_index = ue->n_values - 1;
   ue->values[last_index] = malloc(ue->n_components * sizeof(double *));
   ue->times[last_index] = update_time;
   int v;
   for (v = 0; v < ue->n_components; ++v)
+    // cppcheck-suppress objectIndex
     ue->values[last_index][v] = value[v];
 }
 

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -365,6 +365,7 @@ bool WbSysInfo::isVirtualMachine() {
   unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
   __get_cpuid(0x1, &eax, &ebx, &ecx, &edx);
   // cppcheck-suppress shiftTooManyBitsSigned
+  // cppcheck-suppress integerOverflow
   if (ecx & (1 << 31)) {
     virtualMachine = 1;
     return true;

--- a/src/webots/gui/WbMultimediaStreamingLimiter.cpp
+++ b/src/webots/gui/WbMultimediaStreamingLimiter.cpp
@@ -44,8 +44,6 @@ QSize WbMultimediaStreamingLimiter::fullResolution() const {
 void WbMultimediaStreamingLimiter::recomputeStreamingLimits(int skippedImages) {
   mIsStopped = false;
   mResolutionChanged = false;
-  if (mIsStopped)
-    return;
 
   if (skippedImages > 0)
     mIncreasingSteps++;

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -144,7 +144,6 @@ protected:
 
   // other stuff
   WbSensor *mSensor;
-  short mRefreshRate;
   WbSharedMemory *mImageShm;
   unsigned char *mImageData;
   char mCharType;

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -144,6 +144,7 @@ protected:
 
   // other stuff
   WbSensor *mSensor;
+  short mRefreshRate;
   WbSharedMemory *mImageShm;
   unsigned char *mImageData;
   char mCharType;

--- a/src/webots/nodes/WbBallJoint.cpp
+++ b/src/webots/nodes/WbBallJoint.cpp
@@ -148,10 +148,10 @@ WbVector3 WbBallJoint::anchor() const {
 WbVector3 WbBallJoint::axis() const {
   const WbJointParameters *const p2 = parameters2();
   const WbJointParameters *const p3 = parameters3();
-  if (!p2 && !p3)
-    return WbVector3(1.0, 0.0, 0.0);
-  else if (p3 && !p2) {
-    if (p3->axis().cross(WbVector3(0.0, 0.0, 1.0)).isNull())
+  if (!p2) {
+    if (!p3)
+      return WbVector3(1.0, 0.0, 0.0);
+    else if (p3->axis().cross(WbVector3(0.0, 0.0, 1.0)).isNull())
       return p3->axis().cross(WbVector3(1.0, 0.0, 0.0));
     else
       return p3->axis().cross(WbVector3(0.0, 0.0, 1.0));
@@ -166,10 +166,10 @@ WbVector3 WbBallJoint::axis2() const {
 WbVector3 WbBallJoint::axis3() const {
   const WbJointParameters *const p2 = parameters2();
   const WbJointParameters *const p3 = parameters3();
-  if (!p2 && !p3)
-    return WbVector3(0.0, 0.0, 1.0);
-  else if (p2 && !p3) {
-    if (p2->axis().cross(WbVector3(1.0, 0.0, 0.0)).isNull())
+  if (!p3) {
+    if (!p2)
+      return WbVector3(0.0, 0.0, 1.0);
+    else if (p2->axis().cross(WbVector3(1.0, 0.0, 0.0)).isNull())
       return p2->axis().cross(WbVector3(0.0, 0.0, 1.0));
     else
       return p2->axis().cross(WbVector3(1.0, 0.0, 0.0));

--- a/src/webots/nodes/WbDevice.cpp
+++ b/src/webots/nodes/WbDevice.cpp
@@ -16,7 +16,6 @@
 
 void WbDevice::init() {
   mTag = UNASSIGNED;
-  mRefreshRate = 0;
   mPowerOn = true;
   mWindow = 0;
 }

--- a/src/webots/nodes/WbDevice.hpp
+++ b/src/webots/nodes/WbDevice.hpp
@@ -51,7 +51,6 @@ protected:
   WbDevice(const WbDevice &other);
 
   void *mWindow;  // robot window
-  unsigned int mRefreshRate;
 
 private:
   WbDeviceTag mTag;

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -1004,8 +1004,7 @@ void WbDisplay::imageLoad(int id, int w, int h, void *data, int format) {
     const unsigned char *dataUC = (unsigned char *)data;
     for (int i = 0; i < nbPixel; i++) {
       const int offset = 4 * i;
-      if (dataUC[offset] != 0xFF)
-        isTransparent = true;
+      isTransparent = (dataUC[offset] & 0XFF) != 0xFF;
       clippedImage[i] = (dataUC[offset] << 24) | (dataUC[offset + 1] << 16) | (dataUC[offset + 2] << 8) | dataUC[offset + 3];
     }
   } else if (format == WB_IMAGE_RGB) {
@@ -1018,16 +1017,14 @@ void WbDisplay::imageLoad(int id, int w, int h, void *data, int format) {
     const unsigned char *dataUC = (unsigned char *)data;
     for (int i = 0; i < nbPixel; i++) {
       const int offset = 4 * i;
-      if (dataUC[offset + 3] != 0xFF)
-        isTransparent = true;
+      isTransparent = (dataUC[offset + 3] & 0xFF) != 0xFF;
       clippedImage[i] = (dataUC[offset + 3] << 24) | (dataUC[offset] << 16) | (dataUC[offset + 1] << 8) | dataUC[offset + 2];
     }
   } else if (format == WB_IMAGE_ABGR) {
     const unsigned char *dataUC = (unsigned char *)data;
     for (int i = 0; i < nbPixel; i++) {
       const int offset = 4 * i;
-      if (dataUC[offset] != 0xFF)
-        isTransparent = true;
+      isTransparent = (dataUC[offset] & 0xFF) != 0xFF;
       clippedImage[i] = (dataUC[offset] << 24) | (dataUC[offset + 3] << 16) | (dataUC[offset + 2] << 8) | dataUC[offset + 1];
     }
   } else

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -107,8 +107,8 @@ void WbLed::findMaterialsAndLights(const WbGroup *group) {
 
   for (int i = 0; i < size; ++i) {
     WbBaseNode *const n = group->child(i);
-    WbLight *light = dynamic_cast<WbLight *>(n);
-    WbGroup *group = dynamic_cast<WbGroup *>(n);
+    WbLight *lightChild = dynamic_cast<WbLight *>(n);
+    WbGroup *groupChild = dynamic_cast<WbGroup *>(n);
 
     if (n->nodeType() == WB_NODE_SHAPE) {
       WbAppearance *appearance = dynamic_cast<WbShape *>(n)->appearance();
@@ -128,11 +128,11 @@ void WbLed::findMaterialsAndLights(const WbGroup *group) {
           connect(pbrAppearance->parentNode(), &WbShape::fieldChanged, this, &WbLed::updateIfNeeded, Qt::UniqueConnection);
         }
       }
-    } else if (light)
-      mLights.append(light);
-    else if (group) {
-      findMaterialsAndLights(group);
-      connect(group, &WbGroup::childrenChanged, this, &WbLed::updateChildren, Qt::UniqueConnection);
+    } else if (lightChild)
+      mLights.append(lightChild);
+    else if (groupChild) {
+      findMaterialsAndLights(groupChild);
+      connect(groupChild, &WbGroup::childrenChanged, this, &WbLed::updateChildren, Qt::UniqueConnection);
     }
   }
 

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -87,7 +87,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
   } else if (useCase) {
     if (isAValidUseableNode) {
       const WbNode::NodeUse nodeUse = node->nodeUse();
-      bool match = false;
+      bool match;
       bool typeMatch = false;
       WbBaseNode *definitionNode = NULL;
       const int ind = useNestingDegree - 1;

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -87,7 +87,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
   } else if (useCase) {
     if (isAValidUseableNode) {
       const WbNode::NodeUse nodeUse = node->nodeUse();
-      bool match;
+      bool match = false;
       bool typeMatch = false;
       WbBaseNode *definitionNode = NULL;
       const int ind = useNestingDegree - 1;

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -94,13 +94,15 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       assert(ind >= 0 && ind < mNestedDictionaries.size());
       const QList<WbNode *> &defNodes = mNestedDictionaries.at(ind).values(useName);
       const int numberOfDefs = defNodes.size();
-      for (int defIndex = 0; (!match) && defIndex < numberOfDefs; ++defIndex) {
+      for (int defIndex = 0; defIndex < numberOfDefs; ++defIndex) {
         definitionNode = static_cast<WbBaseNode *>(defNodes[defIndex]);
         QString error;
         assert(node->parentField() && node->parentNode());
         typeMatch = WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parentNode(),
                                                        error, nodeUse, QString(), QStringList(definitionNode->nodeModelName()));
         match = typeMatch && !definitionNode->isAnAncestorOf(node);
+        if (match)
+          break;
       }
 
       WbNode *matchingNode = NULL;

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -94,18 +94,18 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       assert(ind >= 0 && ind < mNestedDictionaries.size());
       const QList<WbNode *> &defNodes = mNestedDictionaries.at(ind).values(useName);
       const int numberOfDefs = defNodes.size();
-      for (int defIndex = 0; defIndex < numberOfDefs; ++defIndex) {
+      // cppcheck-suppress knownConditionTrueFalse
+      for (int defIndex = 0; !match && defIndex < numberOfDefs; ++defIndex) {
         definitionNode = static_cast<WbBaseNode *>(defNodes[defIndex]);
         QString error;
         assert(node->parentField() && node->parentNode());
         typeMatch = WbNodeUtilities::isAllowedToInsert(node->parentField(), definitionNode->nodeModelName(), node->parentNode(),
                                                        error, nodeUse, QString(), QStringList(definitionNode->nodeModelName()));
         match = typeMatch && !definitionNode->isAnAncestorOf(node);
-        if (match)
-          break;
       }
 
       WbNode *matchingNode = NULL;
+      // cppcheck-suppress knownConditionTrueFalse
       if (!match && !mNestedUseNodes.isEmpty()) {
         definitionNode = NULL;
         const WbNode *const upperUseNode = mNestedUseNodes.last();

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -764,7 +764,7 @@ void WbWrenCamera::setupSphericalSubCameras() {
 }
 
 void WbWrenCamera::setupCameraPostProcessing(int index) {
-  assert(mIsCameraActive[index] && index >= 0 && index < CAMERA_ORIENTATION_COUNT);
+  assert(index >= 0 && index < CAMERA_ORIENTATION_COUNT && mIsCameraActive[index]);
 
   if (mBloomThreshold != -1.0f && mType == 'c')
     mWrenBloom[index]->setup(mCameraViewport[index]);
@@ -870,7 +870,7 @@ void WbWrenCamera::setAspectRatio(float aspectRatio) {
 }
 
 void WbWrenCamera::updatePostProcessingParameters(int index) {
-  assert(mIsCameraActive[index] && index >= 0 && index < CAMERA_ORIENTATION_COUNT);
+  assert(index >= 0 && index < CAMERA_ORIENTATION_COUNT && mIsCameraActive[index]);
 
   if (mWrenHdr[index]->hasBeenSetup())
     mWrenHdr[index]->setExposure(mExposure);

--- a/src/wren/PbrMaterial.cpp
+++ b/src/wren/PbrMaterial.cpp
@@ -61,7 +61,8 @@ namespace wren {
     if (mTextures[0].first)
       textureId = static_cast<size_t>(mTextures[0].first->glName());
 
-    return static_cast<size_t>(mCacheData->id() << 1) | (textureId << 16) | (programId << 32) | mHasPremultipliedAlpha;
+    return static_cast<size_t>(mCacheData->id() << 1) | (textureId << 16) | (programId << 32) |
+           (mHasPremultipliedAlpha ? 1 : 0);
   }
 
   PbrMaterial *PbrMaterial::createMaterial() {

--- a/src/wren/PhongMaterial.cpp
+++ b/src/wren/PhongMaterial.cpp
@@ -46,7 +46,8 @@ namespace wren {
     if (mTextures[0].first)
       textureId = static_cast<size_t>(mTextures[0].first->glName());
 
-    return static_cast<size_t>(mCacheData->id() << 1) | (textureId << 16) | (programId << 32) | mHasPremultipliedAlpha;
+    return static_cast<size_t>(mCacheData->id() << 1) | (textureId << 16) | (programId << 32) |
+           (mHasPremultipliedAlpha ? 1 : 0);
   }
 
   PhongMaterial *PhongMaterial::createMaterial() {

--- a/src/wren/Scene.hpp
+++ b/src/wren/Scene.hpp
@@ -118,20 +118,20 @@ namespace wren {
 
     ShadowVolumeIterator partitionShadowsByVisibility(ShadowVolumeIterator first, ShadowVolumeIterator last, LightNode *light);
 
-    void sortRenderQueueByState(RenderQueueIterator first, RenderQueueIterator last);
+    static void sortRenderQueueByState(RenderQueueIterator first, RenderQueueIterator last);
     void sortRenderQueueByDistance(RenderQueueIterator first, RenderQueueIterator last);
 
-    void renderDefault(RenderQueueIterator first, RenderQueueIterator last, bool disableDepthTest = false);
-    void renderStencilPerLight(LightNode *light, RenderQueueIterator first, RenderQueueIterator firstShadwoReceiver,
+    static void renderDefault(RenderQueueIterator first, RenderQueueIterator last, bool disableDepthTest = false);
+    void renderStencilPerLight(LightNode *light, RenderQueueIterator first, RenderQueueIterator firstShadowReceiver,
                                RenderQueueIterator last);
     void renderStencilShadowVolumesDepthPass(ShadowVolumeCaster *shadowVolume, LightNode *light);
     void renderStencilShadowVolumesDepthFail(ShadowVolumeCaster *shadowVolume, LightNode *light);
-    void renderStencilAmbientEmissive(RenderQueueIterator first, RenderQueueIterator last);
-    void renderStencilDiffuseSpecular(RenderQueueIterator first, RenderQueueIterator last, LightNode *light,
-                                      bool applyShadows = true);
-    void renderStencilWithoutProgram(RenderQueueIterator first, RenderQueueIterator last);
+    static void renderStencilAmbientEmissive(RenderQueueIterator first, RenderQueueIterator last);
+    static void renderStencilDiffuseSpecular(RenderQueueIterator first, RenderQueueIterator last, LightNode *light,
+                                             bool applyShadows = true);
     void renderStencilFog(RenderQueueIterator first, RenderQueueIterator last);
-    void renderTranslucent(RenderQueueIterator first, RenderQueueIterator last, bool disableDepthTest = false);
+    static void renderStencilWithoutProgram(RenderQueueIterator first, RenderQueueIterator last);
+    static void renderTranslucent(RenderQueueIterator first, RenderQueueIterator last, bool disableDepthTest = false);
 
     static Scene *cInstance;
 

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -1982,14 +1982,14 @@ namespace wren {
     }
   }
 
-  int StaticMesh::vertexCount() {
+  int StaticMesh::vertexCount() const {
     if (mCoords.size() > 0)
       return mCoords.size();
     else
       return mCacheData->mVertexCount;
   }
 
-  int StaticMesh::indexCount() {
+  int StaticMesh::indexCount() const {
     if (mIndices.size() > 0)
       return mIndices.size();
     else

--- a/src/wren/StaticMesh.hpp
+++ b/src/wren/StaticMesh.hpp
@@ -62,8 +62,8 @@ namespace wren {
     const Mesh::Triangle &triangle(size_t index) const override { return mCacheData->mTriangles[index]; }
 
     void readData(float *coordData, float *normalData, float *texCoordData, unsigned int *indexData);
-    int vertexCount();
-    int indexCount();
+    int vertexCount() const;
+    int indexCount() const;
 
     void bind() override;
     void release() override;

--- a/tests/sources/test_cppcheck.py
+++ b/tests/sources/test_cppcheck.py
@@ -168,7 +168,7 @@ class TestCppCheck(unittest.TestCase):
         ]
         command = 'cppcheck --enable=warning,style,performance,portability --inconclusive --force -q '
         command += '--inline-suppr --suppress=invalidPointerCast --suppress=useStlAlgorithm -UKROS_COMPILATION '
-        command += '--suppress=strdupCalled '
+        command += '--suppress=strdupCalled --suppress=ctuOneDefinitionRuleViolation '
         # command += '--xml '  # Uncomment this line to get more information on the errors
         command += '--std=c++03 --output-file=\"' + self.reportFilename + '\"'
         sources = self.add_source_files(sourceDirs, skippedDirs, skippedfiles)


### PR DESCRIPTION
New cppcheck errors are thrown during the macOS sources tests where the new version 2.4.1 is used.

When checking the projects sources, many `ctuOneDefinitionRuleViolation` errors are thrown because the same class name is used in many plugins and libraries for different robots.
For example the Qt robot windows of the e-puck, RobotisOP2, automobile have classes named `Viewer`.
However given that these are different programs this doesn't cause any issues and I disabled the check.