### PR TITLE
Print generated URDF test file if test fails

### DIFF
--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -67,8 +67,7 @@ int main(int argc, char **argv) {
   FILE *f_urdf_ref = fopen(reference_filename, "r");
   int line = compare_files(f_urdf_ref, f_urdf);
 
-  
-  if (line != 0) {
+    if (line != 0) {
     int unused __attribute__((unused));
     char *file_contents;
     fseek(f_urdf, 0, SEEK_END);

--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -67,6 +67,7 @@ int main(int argc, char **argv) {
   FILE *f_urdf_ref = fopen(reference_filename, "r");
   int line = compare_files(f_urdf_ref, f_urdf);
 
+  // If the files are different then print the generated file
   if (line != 0) {
     int unused __attribute__((unused));
     char *file_contents;

--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -66,7 +66,18 @@ int main(int argc, char **argv) {
   f_urdf = fopen(generated_filename, "r");
   FILE *f_urdf_ref = fopen(reference_filename, "r");
   int line = compare_files(f_urdf_ref, f_urdf);
-  ts_assert_int_equal(line, 0, "Reference file and exported file differ at line %d", line);
+
+  
+  if (line != 0) {
+    int unused __attribute__((unused));
+    char *file_contents;
+    fseek(f_urdf, 0, SEEK_END);
+    const long input_file_size = ftell(f_urdf);
+    rewind(f_urdf);
+    file_contents = malloc(input_file_size * (sizeof(char)));
+    unused = fread(file_contents, sizeof(char), input_file_size, f_urdf);
+    ts_send_error_and_exit("Reference file and exported file differ at line %d: %s", line, file_contents);
+  }
   fclose(f_urdf);
   fclose(f_urdf_ref);
 

--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
   FILE *f_urdf_ref = fopen(reference_filename, "r");
   int line = compare_files(f_urdf_ref, f_urdf);
 
-    if (line != 0) {
+  if (line != 0) {
     int unused __attribute__((unused));
     char *file_contents;
     fseek(f_urdf, 0, SEEK_END);


### PR DESCRIPTION
We want to get more details when URDF export is broken