### PR TITLE
Enhancement defaultShader for webgl

### DIFF
--- a/resources/wren/shaders/default.frag
+++ b/resources/wren/shaders/default.frag
@@ -6,10 +6,12 @@ const int mainTextureIndex = 0;
 const int penTextureIndex = 1;
 const int backgroundTextureIndex = 2;
 
+in vec3 normalTransformed;
 in vec2 texUv;
 in vec2 penTexUv;
 
-out vec4 fragColor;
+layout(location = 0) out vec4 fragColor;
+layout(location = 1) out vec4 fragNormal;
 
 uniform sampler2D inputTextures[3];
 
@@ -25,6 +27,9 @@ material;
 
 void main() {
   fragColor = vec4(1.0);
+
+  vec3 fragmentNormal = normalize(normalTransformed);
+  fragNormal = vec4(fragmentNormal, 1.0) * 0.5 + 0.5;
 
   if (material.textureFlags.x > 0.0 || material.textureFlags.z > 0.0)
     fragColor.w = 0.0;

--- a/resources/wren/shaders/default.vert
+++ b/resources/wren/shaders/default.vert
@@ -1,9 +1,11 @@
 #version 330 core
 
 layout(location = 0) in vec3 vCoord;
+layout(location = 1) in vec3 vNormal;
 layout(location = 2) in vec2 vTexCoord;
 layout(location = 4) in vec2 vUnwrappedTexCoord;
 
+out vec3 normalTransformed;
 out vec2 texUv;
 out vec2 penTexUv;
 
@@ -30,6 +32,9 @@ material;
 
 void main() {
   gl_Position = cameraTransforms.infiniteProjection * cameraTransforms.view * modelTransform * vec4(vCoord, 1.0);
+
+  mat4 modelView = cameraTransforms.view * modelTransform;
+  normalTransformed = mat3(transpose(inverse(modelView))) * vNormal;
 
   texUv = vec2(textureTransform * vec4(vTexCoord, 0.0, 1.0));
   penTexUv = vUnwrappedTexCoord;


### PR DESCRIPTION
**Description**
We need to add a fragNormal output to the defaultShader.frag in order for it to be usable in WebGL.
I implemented the calculation of the fragNormal in the same way as it is in Phong.

defaultShader is use when there is no appearance or when there is a Phong appearance with a texture but not material.

However it does change a bit the rendering, especially when there is a texture. 
It does not really change when there is not texture :
Before:
![simple_cube_1_white](https://user-images.githubusercontent.com/25938827/114188490-7d5f6c00-9949-11eb-9ec6-89b795e02e67.png)

After:
![simple_cube_3_white](https://user-images.githubusercontent.com/25938827/114188327-4f7a2780-9949-11eb-9564-4707d5059522.png)

With a texture:
Before:
![simple_cube](https://user-images.githubusercontent.com/25938827/114188875-db8c4f00-9949-11eb-8d98-63b53462fa02.png)

After:
![simple_cube_3](https://user-images.githubusercontent.com/25938827/114188879-dc24e580-9949-11eb-8cf0-e18ea6cb9a31.png)

With a Phong materiel (so phong shaders) to compare:
![simple_cube_Phong](https://user-images.githubusercontent.com/25938827/114188886-dcbd7c00-9949-11eb-82e5-46527c668d7f.png)


