### PR TITLE
Fix variable name preventing compilation

### DIFF
--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -106,8 +106,8 @@ void WbSingleTaskApplication::convertProto() const {
 
   // Combine the user parameters with the default ones
   QVector<WbField *> fields;
-  for (WbFieldModel *model : model->fieldModels()) {
-    WbField *field = new WbField(model);
+  for (WbFieldModel *fieldModel : model->fieldModels()) {
+    WbField *field = new WbField(fieldModel);
     if (userParameters.contains(field->name())) {
       WbTokenizer tokenizer;
       tokenizer.tokenizeString(userParameters[field->name()]);


### PR DESCRIPTION
On Ubuntu 16.04, Webots doesn't compile because of this variable shadowing.
Even if we don't want to support Ubuntu 16.04, I think it is anyway good to improve the variable name so that it uses a unique name.