### PR TITLE
Fixed bug in Robot::getDevice()

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,7 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
-    - Fixed bug in the C++ API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
+    - Fixed bug in the C++, Python and Java API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed bug in the C++ API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).

--- a/src/controller/cpp/Robot.cpp
+++ b/src/controller/cpp/Robot.cpp
@@ -457,7 +457,7 @@ Device *Robot::getOrCreateDevice(int tag) {
   const int size = (int)deviceList.size();
   // if new devices have been added, then count is greater than devices.length
   // deleted devices are not removed from the C API list and don't affect the number of devices
-  if (size == count && size > 0 && tag < size)
+  if (size == count + 1 && size > 0 && tag < size)
     return deviceList[tag];
 
   // (re-)initialize deviceList

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -1108,7 +1108,7 @@ namespace webots {
     int count = getNumberOfDevices();
     // if new devices have been added, then count is greater than devices.length
     // deleted devices are not removed from the C API list and don't affect the number of devices
-    if (devices != null && devices.length == count && tag < devices.length)
+    if (devices != null && devices.length == count + 1 && tag < devices.length)
         return devices[tag];
 
     // (re-)initialize devices list

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -1135,7 +1135,7 @@ class AnsiCodes(object):
       size = len(Robot.__devices)
       # if new devices have been added, then count is greater than size
       # deleted devices are not removed from the C API list and don't affect the number of devices
-      if count == size and size > 0 and tag < size:
+      if size == count + 1 and size > 0 and tag < size:
           return Robot.__devices[tag]
 
       # (re-)initialize Robot.__devices list


### PR DESCRIPTION
The C++ API functions Robot::getDevice() and similar (Robot.getCamera(), Robot.getPositionSensor(), etc.) were behaving wrong as they were sending a new pointer each time they were called with the same device name as reported [here](https://github.com/RoboCup-Humanoid-TC/webots/issues/32).
This PR fixes this bug.