### PR TITLE
Fix Camera lens distortion

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed detection of scaled objects in the [Camera](camera.md) image using the [Recognition](recognition.md) functionality ([#2921](https://github.com/cyberbotics/webots/pull/2921)).

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -24,9 +24,9 @@ void main() {
   float d2 = 1 / (4 * radialDistortionCoeffs.x * r + 6 * radialDistortionCoeffs.y * r * r +
                   8 * tangentialDistortionCoeffs.x * relativeUv.y + 8 * tangentialDistortionCoeffs.y * relativeUv.x + 1);
   distortedUv.x = texUv.x - d2 * (d1 * relativeUv.x + 2 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y +
-                                  tangentialDistortionCoeffs.y * ( r + 2 * relativeUv.x * relativeUv.x));
+                                  tangentialDistortionCoeffs.y * (r + 2 * relativeUv.x * relativeUv.x));
   distortedUv.y = texUv.y - d2 * (d1 * relativeUv.y + 2 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y +
-                                  tangentialDistortionCoeffs.x * ( r + 2 * relativeUv.y * relativeUv.y));
+                                  tangentialDistortionCoeffs.x * (r + 2 * relativeUv.y * relativeUv.y));
 
   fragColor = texture(inputTextures[0], distortedUv);
 }

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -13,17 +13,16 @@ uniform vec2 tangentialDistortionCoeffs;
 uniform sampler2D inputTextures[1];
 
 void main() {
+  // based on "Realistic Lens Distortion Rendering", Lambers M., Sommerhoff H., Kolb A. (2018)
+  // implementing an inverted Brown's distortion model (https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction)
   vec2 distortedUv, relativeUv;
-
-  // based on Brown's distortion model (https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction)
-  float r = pow(texUv.x - center.x, 2.0) + pow(texUv.y - center.y, 2.0);
-  relativeUv = texUv - center;
-  distortedUv.x = texUv.x + relativeUv.x * (radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
-                  tangentialDistortionCoeffs.y * (r + 2.0 * relativeUv.x * relativeUv.x) +
-                  2.0 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y;
-  distortedUv.y = texUv.y + relativeUv.y * (radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
-                  tangentialDistortionCoeffs.x * (r + 2.0 * relativeUv.y * relativeUv.y) +
-                  2.0 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y;
+  relativeUv.x = texUv.x - center.x;
+  relativeUv.y = texUv.y - center.y;
+  float r = relativeUv.x * relativeUv.x + relativeUv.y * relativeUv.y;
+  float d1 = radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r;
+  float d2 = 1 / (4 * radialDistortionCoeffs.x * r + 6 * radialDistortionCoeffs.y * r * r + 8 * tangentialDistortionCoeffs.x * relativeUv.y + 8 * tangentialDistortionCoeffs.y * relativeUv.x + 1);
+  distortedUv.x = texUv.x - d2 * (d1 * relativeUv.x + 2 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y + tangentialDistortionCoeffs.y * ( r + 2 * relativeUv.x * relativeUv.x));
+  distortedUv.y = texUv.y - d2 * (d1 * relativeUv.y + 2 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y + tangentialDistortionCoeffs.x * ( r + 2 * relativeUv.y * relativeUv.y));
 
   fragColor = texture(inputTextures[0], distortedUv);
 }

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -13,16 +13,17 @@ uniform vec2 tangentialDistortionCoeffs;
 uniform sampler2D inputTextures[1];
 
 void main() {
-  vec2 distortedUv;
+  vec2 distortedUv, relativeUv;
 
   // based on Brown's distortion model (https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction)
   float r = pow(texUv.x - center.x, 2.0) + pow(texUv.y - center.y, 2.0);
-  distortedUv.x = texUv.x * (1.0 + radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
-                  tangentialDistortionCoeffs.y * (r + 2.0 * texUv.x * texUv.x) +
-                  2.0 * tangentialDistortionCoeffs.x * texUv.x * texUv.y;
-  distortedUv.y = texUv.y * (1.0 + radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
-                  tangentialDistortionCoeffs.x * (r + 2.0 * texUv.y * texUv.y) +
-                  2.0 * tangentialDistortionCoeffs.y * texUv.x * texUv.y;
+  relativeUv = texUv - center;
+  distortedUv.x = texUv.x + relativeUv.x * (radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
+                  tangentialDistortionCoeffs.y * (r + 2.0 * relativeUv.x * relativeUv.x) +
+                  2.0 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y;
+  distortedUv.y = texUv.y + relativeUv.y * (radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r) +
+                  tangentialDistortionCoeffs.x * (r + 2.0 * relativeUv.y * relativeUv.y) +
+                  2.0 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y;
 
   fragColor = texture(inputTextures[0], distortedUv);
 }

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -14,15 +14,19 @@ uniform sampler2D inputTextures[1];
 
 void main() {
   // based on "Realistic Lens Distortion Rendering", Lambers M., Sommerhoff H., Kolb A. (2018)
-  // implementing an inverted Brown's distortion model (https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction)
+  // implementing an inverted Brown's distortion model
+  // (https://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction)
   vec2 distortedUv, relativeUv;
   relativeUv.x = texUv.x - center.x;
   relativeUv.y = texUv.y - center.y;
   float r = relativeUv.x * relativeUv.x + relativeUv.y * relativeUv.y;
   float d1 = radialDistortionCoeffs.x * r + radialDistortionCoeffs.y * r * r;
-  float d2 = 1 / (4 * radialDistortionCoeffs.x * r + 6 * radialDistortionCoeffs.y * r * r + 8 * tangentialDistortionCoeffs.x * relativeUv.y + 8 * tangentialDistortionCoeffs.y * relativeUv.x + 1);
-  distortedUv.x = texUv.x - d2 * (d1 * relativeUv.x + 2 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y + tangentialDistortionCoeffs.y * ( r + 2 * relativeUv.x * relativeUv.x));
-  distortedUv.y = texUv.y - d2 * (d1 * relativeUv.y + 2 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y + tangentialDistortionCoeffs.x * ( r + 2 * relativeUv.y * relativeUv.y));
+  float d2 = 1 / (4 * radialDistortionCoeffs.x * r + 6 * radialDistortionCoeffs.y * r * r +
+                  8 * tangentialDistortionCoeffs.x * relativeUv.y + 8 * tangentialDistortionCoeffs.y * relativeUv.x + 1);
+  distortedUv.x = texUv.x - d2 * (d1 * relativeUv.x + 2 * tangentialDistortionCoeffs.x * relativeUv.x * relativeUv.y +
+                                  tangentialDistortionCoeffs.y * ( r + 2 * relativeUv.x * relativeUv.x));
+  distortedUv.y = texUv.y - d2 * (d1 * relativeUv.y + 2 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y +
+                                  tangentialDistortionCoeffs.x * ( r + 2 * relativeUv.y * relativeUv.y));
 
   fragColor = texture(inputTextures[0], distortedUv);
 }


### PR DESCRIPTION
Fix #2295 and #2934:
Camera lens distortion uses the Brown's distortion model, but there were bugs in the implementation and the center was not used for the radial and tagential components.
Additional, to apply lens distortion it is needed to apply an inverted Brown's distortion model.

Now, the distortion is correctly applied both in X and Y directions, as well as symmetrically on the right/left of the image. Here is the result using `Lens { center = [0.5, 0.5], radialCoefficients = [-0.5, 0], tangetialCoefficients = [0, 0]}`:

![lens_distortion](https://user-images.githubusercontent.com/5910449/114714022-fdaf1400-9d31-11eb-89a6-52df093f8a67.png)

