### PR TITLE
 Remove hidden parameter field connection

### DIFF
--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -330,7 +330,8 @@ void WbField::redirectTo(WbField *parameter) {
     // In some case Webots modifies the fields directly and not the proto parameters, e.g. changing "translation" or
     // "rotation" fields with the mouse. In these cases we need to propagate the change back to the proto parameters, e.g. in
     // order to update the Scene Tree
-    connect(this, &WbField::valueChanged, mParameter, &WbField::fieldChanged);
+    if (!isHidden())
+      connect(this, &WbField::valueChanged, mParameter, &WbField::fieldChanged);
   }
 
   // ODE updates


### PR DESCRIPTION
**Description**
The proposed fix removes the connection for hidden fields, which are source of overhead in the `postPhysics` step, specifically `linearVelocity` and `angularVelocity` of solids. This solution is more proper than the one considered in #2927.
The larger issue of the overhead with nested PROTO will be addressed in that PR.


As can be seen, the saving of a world mid-execution still works as intended.
```
#VRML_SIM R2021b utf8
WorldInfo {
  coordinateSystem "NUE"
}
Viewpoint {
  position 0 0 1.2232405575066063
}
TexturedBackground {
}
TexturedBackgroundLight {
}
MainProtoSimple {
  hidden linearVelocity_1 0 -3.9793883743761297e-10 0
  hidden angularVelocity_1 0 0.2 0
  condition TRUE
  pos 0.7551999999333323
  rot 0 1 0 0.7551974221411469
}
```

As for the performance impact, it was tested on the `kid.wbt` world and these are the results.
Without the fix:
```
<mode> <stepsCount> <prePhysics(ms)> <physics(ms)> <postPhysics(ms)> <mainRendering(ms)> <virtualRealityHeadsetRendering(ms)> <gpuMemoryTransfer(ms)> <trianglesCount> <mainFPS> <device:Camera(ms)> <controller:soccer(ms)>
AVG            4000            0.263        18.136             3.448              25.415                                0.000                   0.089              nan     0.000               0.213                   5.839 
TOT            4000         1050.070     72542.964         13792.519             101.658                                0.000                   0.709            0.000     0.000            3420.957               23423.677 

```
With the fix:
```
<mode> <stepsCount> <prePhysics(ms)> <physics(ms)> <postPhysics(ms)> <mainRendering(ms)> <virtualRealityHeadsetRendering(ms)> <gpuMemoryTransfer(ms)> <trianglesCount> <mainFPS> <device:Camera(ms)> <controller:soccer(ms)>
AVG            4000            0.259        18.233             3.021              26.446                                0.000                   0.085              nan     0.000               0.210                   5.828 
TOT            4000         1035.593     72932.316         12083.677             105.785                                0.000                   0.681            0.000     0.000            3368.223               23379.065 

```

Which roughly corresponds to a change in the real-time factor from 0.26x to 0.29x (on a not so strong computer). 

