### PR TITLE
Fix the saving of hidden field for BallJoint

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -48,6 +48,7 @@ Released on XX Xth, 2021.
     - Fixed the return value handling from the `webots_physics_collide` when the [Group](group.md) node is one of the colliding objects ([#2781](https://github.com/cyberbotics/webots/pull/2781)).
     - Fixed the [Pen](pen.md) ink mixed with the background and other ink when the `inkDensity` is lower than 1.0 ([#2804](https://github.com/cyberbotics/webots/pull/2804)).
     - Fixed issue where motor position limits in [Hinge2Joint](hinge2joint.md) and [BallJoint](balljoint.md) were enforced incorrectly ([#2825](https://github.com/cyberbotics/webots/pull/2825)).
+    - Fixed issue where the hidden field of a [BallJoint](balljoint.md) is not stored in the world file when saving after the simulation has run ([#2964](https://github.com/cyberbotics/webots/pull/2964)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
   - Dependency Updates

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -366,7 +366,7 @@ void WbGroup::writeParameters(WbVrmlWriter &writer) const {
           const WbVector3 *const p = it.value();
           assert(p);
           const int jointIndex = it.key();
-          for (int j = 0; j < 2; ++j) {
+          for (int j = 0; j < 3; ++j) {
             const double pj = (*p)[j];
             if (!std::isnan(pj)) {
               QString axisIndex;

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2871,7 +2871,7 @@ void WbSolid::collectHiddenKinematicParameters(HiddenKinematicParametersMap &map
   if (mSolidMerger == NULL || merger) {
     // TODO: implement an mIsVisible flag in WbNode for sake of efficiency
     WbBasicJoint *parentJoint = jointParent();
-    if (parentJoint && parentJoint->nodeType() != WB_NODE_BALL_JOINT) {
+    if (parentJoint) {
       // remove unquantified ODE effects on the endPoint Solid
       parentJoint->computeEndPointSolidPositionFromParameters(translationToBeCopied, rotationToBeCopied);
       // Note:
@@ -2909,23 +2909,24 @@ void WbSolid::collectHiddenKinematicParameters(HiddenKinematicParametersMap &map
     if (j) {
       WbVector3 v(NAN, NAN, NAN);
 
-      const WbJointParameters *const p = j->parameters();
       // TODO: implement an mIsVisible flag in WbNode for sake of efficiency
-      const bool invisible1 = p == NULL || !WbNodeUtilities::isVisible(p->findField("position"));
-      const double pos1 = j->position();
-      if (invisible1 && pos1 != j->initialPosition())
-        v[0] = pos1;
+      const WbJointParameters *const p = j->parameters();
+      if ((p == NULL || !WbNodeUtilities::isVisible(p->findField("position"))) && (j->position() != j->initialPosition()))
+        v[0] = j->position();
 
-      if (j->nodeType() == WB_NODE_HINGE_2_JOINT) {
+      if (j->nodeType() == WB_NODE_HINGE_2_JOINT || j->nodeType() == WB_NODE_BALL_JOINT) {
         const WbJointParameters *const p2 = j->parameters2();
-        // TODO: implement an mIsVisible flag in WbNode for sake of efficiency
-        const bool invisible2 = p2 == NULL || !WbNodeUtilities::isVisible(p2->findField("position"));
-        const double pos2 = j->position(2);
-        if (invisible2 && pos2 != j->initialPosition(2))
-          v[1] = pos2;
+        if ((p2 == NULL || !WbNodeUtilities::isVisible(p2->findField("position"))) && (j->position(2) != j->initialPosition(2)))
+          v[1] = j->position(2);
       }
 
-      if (!std::isnan(v[0]) || !std::isnan(v[1]))
+      if (j->nodeType() == WB_NODE_BALL_JOINT) {
+        const WbJointParameters *const p3 = j->parameters3();
+        if ((p3 == NULL || !WbNodeUtilities::isVisible(p3->findField("position"))) && (j->position(3) != j->initialPosition(3)))
+          v[2] = j->position(3);
+      }
+
+      if (!std::isnan(v[0]) || !std::isnan(v[1]) || !std::isnan(v[2]))
         positions.insert(i, new WbVector3(v));
     }
   }

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2911,7 +2911,7 @@ void WbSolid::collectHiddenKinematicParameters(HiddenKinematicParametersMap &map
 
       // TODO: implement an mIsVisible flag in WbNode for sake of efficiency
       const WbJointParameters *const p = j->parameters();
-      if ((p == NULL || !WbNodeUtilities::isVisible(p->findField("position"))) && (j->position() != j->initialPosition()))
+      if ((p == NULL || !WbNodeUtilities::isVisible(p->findField("position"))) && j->position() != j->initialPosition())
         v[0] = j->position();
 
       if (j->nodeType() == WB_NODE_HINGE_2_JOINT || j->nodeType() == WB_NODE_BALL_JOINT) {

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2922,7 +2922,7 @@ void WbSolid::collectHiddenKinematicParameters(HiddenKinematicParametersMap &map
 
       if (j->nodeType() == WB_NODE_BALL_JOINT) {
         const WbJointParameters *const p3 = j->parameters3();
-        if ((p3 == NULL || !WbNodeUtilities::isVisible(p3->findField("position"))) && (j->position(3) != j->initialPosition(3)))
+        if ((p3 == NULL || !WbNodeUtilities::isVisible(p3->findField("position"))) && j->position(3) != j->initialPosition(3))
           v[2] = j->position(3);
       }
 

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2916,7 +2916,7 @@ void WbSolid::collectHiddenKinematicParameters(HiddenKinematicParametersMap &map
 
       if (j->nodeType() == WB_NODE_HINGE_2_JOINT || j->nodeType() == WB_NODE_BALL_JOINT) {
         const WbJointParameters *const p2 = j->parameters2();
-        if ((p2 == NULL || !WbNodeUtilities::isVisible(p2->findField("position"))) && (j->position(2) != j->initialPosition(2)))
+        if ((p2 == NULL || !WbNodeUtilities::isVisible(p2->findField("position"))) && j->position(2) != j->initialPosition(2))
           v[1] = j->position(2);
       }
 


### PR DESCRIPTION
**Related Issues**
This pull-request addresses issue #2963

**Description**
It appears that indeed the saving of the hidden parameters for `BallJoint` wasn't working. 
Before the fix:
```
#VRML_SIM R2021a utf8
WorldInfo {
  coordinateSystem "NUE"
  lineScale 0.4
}
Viewpoint {
  orientation -0.36364034235430376 -0.9164891884416874 -0.16677310599116954 0.9279522774354931
  position -1.0729115992676148 0.5311913032755937 0.9792082997483017
}
TexturedBackground {
}
TexturedBackgroundLight {
}
RobotWithHinge2Joint {
  hidden position_0_0 0.12800000000000003
  hidden position2_0_0 0.25344000000000005
  hidden rotation_1 0.44864394902849164 0.8918808888552964 0.05715843852666757 0.28377458981805487
}
RobotWithBallJoint {
  hidden position_0_0 0.19199999999999998
  hidden rotation_1 -0.436450151027134 0.4018780050889322 0.8049877854316374 0.7167288954785301
  translation 0.5 0 0
}
```
After the fix:
```
#VRML_SIM R2021a utf8
WorldInfo {
  coordinateSystem "NUE"
  lineScale 0.4
}
Viewpoint {
  orientation -0.36364034235430376 -0.9164891884416874 -0.16677310599116954 0.9279522774354931
  position -1.0729115992676148 0.5311913032755937 0.9792082997483017
}
TexturedBackground {
}
TexturedBackgroundLight {
}
RobotWithHinge2Joint {
  hidden position_0_0 0.12160000000000004
  hidden position2_0_0 0.24064000000000008
  hidden rotation_1 0.4490486589044304 0.8918563250593967 0.05429178011154328 0.2694860452190886
}
RobotWithBallJoint {
  hidden position_0_0 0.18239999999999998
  hidden position2_0_0 0.35583999999999993
  hidden position3_0_0 0.52032
  hidden rotation_1 -0.44247596067295786 0.3964965005313276 0.8043665515751843 0.6785561719474464
  translation 0.5 0 0
}
```
**Test World**
World used for tests [ball_joint_save_hidden.zip](https://github.com/cyberbotics/webots/files/6297851/ball_joint_save_hidden.zip)


