### PR TITLE
Fix typo verticalfieldofview

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
     - Fixed bug in the C++, Python and Java API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).

--- a/projects/devices/hokuyo/protos/HokuyoUtm30lx.proto
+++ b/projects/devices/hokuyo/protos/HokuyoUtm30lx.proto
@@ -3880,7 +3880,7 @@ Lidar {
   }
   %{ end }%
   fieldOfView 4.71238
-  verticalFieldOfView %{= 4.18879 / fields.resolution.value }%
+  verticalFieldOfView %{= 4.71238 / fields.resolution.value }%
   horizontalResolution IS resolution
   numberOfLayers 1
   spherical TRUE


### PR DESCRIPTION
The verticalFieldOfView of the HokuyoUtm30lx was computed using a value for the fieldOfView that was corresponding to other Hokuyo lidars.

Datasheet : https://www.hokuyo-aut.jp/search/single.php?serial=169
Webots doc : https://www.cyberbotics.com/doc/guide/lidar-sensors#hokuyo-utm-30lx