### PR TITLE
Fix typo in various files

### DIFF
--- a/projects/samples/devices/controllers/gps_lat_long/gps_lat_long.c
+++ b/projects/samples/devices/controllers/gps_lat_long/gps_lat_long.c
@@ -16,7 +16,7 @@
 
 /*
  * Description:   An example of a controller using gps devices
- *                unsing latitude altitude longitude coordinates system
+ *                using latitude altitude longitude coordinates system
  */
 
 #include <stdio.h>

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -725,13 +725,13 @@ void WbLidar::updateHorizontalResolution() {
     if (isRotating()) {
       requiredResolution *= 2.0 * M_PI / actualFieldOfView();
       parsingWarn(
-        tr("Impossible to have a so small 'horizontalResolution' unsing this 'numberOfLayers' and 'verticalFieldOfView'. "
+        tr("Impossible to have a so small 'horizontalResolution' using this 'numberOfLayers' and 'verticalFieldOfView'. "
            "'horizontalResolution' should be bigger or equal to 2.0 * M_PI * numberOfLayers  / verticalFieldOfView. "
            "'horizontalResolution' set to %1.")
           .arg(requiredResolution));
     } else
       parsingWarn(
-        tr("Impossible to have a so small 'horizontalResolution' unsing this 'fieldOfView', 'numberOfLayers' and "
+        tr("Impossible to have a so small 'horizontalResolution' using this 'fieldOfView', 'numberOfLayers' and "
            "'verticalFieldOfView'. 'horizontalResolution' should be bigger or equal to numberOfLayers * fieldOfView / "
            "verticalFieldOfView. 'horizontalResolution' set to %1.")
           .arg(requiredResolution));
@@ -753,13 +753,13 @@ void WbLidar::updateVerticalFieldOfView() {
     double requiredVerticalFieldOfView = (actualNumberOfLayers() * actualFieldOfView()) / width();
     if (isRotating())
       parsingWarn(
-        tr("Impossible to have a so small 'verticalFieldOfView' unsing this 'numberOfLayers' and 'horizontalResolution'. "
+        tr("Impossible to have a so small 'verticalFieldOfView' using this 'numberOfLayers' and 'horizontalResolution'. "
            "'verticalFieldOfView' should be bigger or equal to 2.0 * M_PI * numberOfLayers / horizontalResolution. "
            "'verticalFieldOfView' set to %1.")
           .arg(requiredVerticalFieldOfView));
     else
       parsingWarn(
-        tr("Impossible to have a so small 'verticalFieldOfView' unsing this 'fieldOfView', 'numberOfLayers' and "
+        tr("Impossible to have a so small 'verticalFieldOfView' using this 'fieldOfView', 'numberOfLayers' and "
            "'horizontalResolution'. 'verticalFieldOfView' should be bigger or equal to numberOfLayers * fieldOfView / "
            "horizontalResolution. 'verticalFieldOfView' set to %1.")
           .arg(requiredVerticalFieldOfView));
@@ -782,12 +782,12 @@ void WbLidar::updateNumberOfLayers() {
     int requiredNumberOfLayers = height();
     if (isRotating())
       parsingWarn(
-        tr("Impossible to have a so big 'numberOfLayers' unsing this 'verticalFieldOfView' and 'horizontalResolution'. "
+        tr("Impossible to have a so big 'numberOfLayers' using this 'verticalFieldOfView' and 'horizontalResolution'. "
            "'numberOfLayers' should be smaller or equal to verticalFieldOfView * actualHorizontalResolution() / (2.0 * "
            "M_PI). 'numberOfLayers' set to %1.")
           .arg(requiredNumberOfLayers));
     else
-      parsingWarn(tr("Impossible to have a so big 'numberOfLayers' unsing this 'fieldOfView', 'verticalFieldOfView' and "
+      parsingWarn(tr("Impossible to have a so big 'numberOfLayers' using this 'fieldOfView', 'verticalFieldOfView' and "
                      "'horizontalResolution'. 'numberOfLayers' should be smaller or equal to verticalFieldOfView * "
                      "horizontalResolution / fieldOfView. 'numberOfLayers' set to %1.")
                     .arg(requiredNumberOfLayers));

--- a/src/webots/nodes/utils/WbBoundingSphere.hpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.hpp
@@ -27,7 +27,7 @@
 //              or WbGeometry instance have a bounding sphere including bounding
 //              objects.
 //
-//              The WbBoundingSphere is also included in a tree of WbBounsingSphere
+//              The WbBoundingSphere is also included in a tree of WbBoundingSphere
 //              instances using the 'parent' and 'subBoundingSphere' concepts.
 //              But the sphere's radius and center are expressed in the owner node
 //              coordinate system.

--- a/tests/api/controllers/joint_end_point_collision/joint_end_point_collision.c
+++ b/tests/api/controllers/joint_end_point_collision/joint_end_point_collision.c
@@ -3,7 +3,7 @@
  *               This controller handles both "obstacle" and "sensor" robot,
  *               and tests:
  *               - initial computation of bounding sphere for end point solid
- *               - update of bounsing sphere when joint moves
+ *               - update of bounding sphere when joint moves
  */
 
 #include <webots/distance_sensor.h>


### PR DESCRIPTION
A users reported a typo in the Lidar warning messages.
Same typo is found in a couple of other files.