### PR TITLE
Fix updating Lidar.type during simulation run

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed bug in the C++, Python and Java API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,7 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
-    - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
+    - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
     - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).
     - Fixed bug in the C++, Python and Java API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -76,6 +76,7 @@ void WbLidar::init() {
   mActualHorizontalResolution = mHorizontalResolution->value();
   mActualVerticalFieldOfView = mVerticalFieldOfView->value();
   mActualFieldOfView = mFieldOfView->value();
+  mActualType = mType->value();
 }
 
 WbLidar::WbLidar(WbTokenizer *tokenizer) : WbAbstractCamera("Lidar", tokenizer) {
@@ -384,6 +385,7 @@ void WbLidar::createWrenCamera() {
   mActualHorizontalResolution = mHorizontalResolution->value();
   mActualVerticalFieldOfView = mVerticalFieldOfView->value();
   mActualFieldOfView = mFieldOfView->value();
+  mActualType = mType->value();
 
   WbAbstractCamera::createWrenCamera();
   applyMaxRangeToWren();
@@ -679,7 +681,10 @@ void WbLidar::updateType() {
     parsingWarn(tr("'type' should either be 'fixed' or 'rotating', reset to 'fixed'"));
     mType->setValue("fixed");
   }
-  if (areWrenObjectsInitialized())
+  if (hasBeenSetup())
+    warn(tr("'type' has been modified. This modification will be taken into account after saving and reloading "
+            "the world."));
+  else if (areWrenObjectsInitialized())
     applyFrustumToWren();
 }
 

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -682,8 +682,7 @@ void WbLidar::updateType() {
     mType->setValue("fixed");
   }
   if (hasBeenSetup())
-    warn(tr("'type' has been modified. This modification will be taken into account after saving and reloading "
-            "the world."));
+    warn(tr("'type' has been modified. This modification will be taken into account after saving and reloading the world."));
   else if (areWrenObjectsInitialized())
     applyFrustumToWren();
 }

--- a/src/webots/nodes/WbLidar.hpp
+++ b/src/webots/nodes/WbLidar.hpp
@@ -103,6 +103,7 @@ private:
   int mActualHorizontalResolution;
   double mActualVerticalFieldOfView;
   double mActualFieldOfView;
+  QString mActualType;
 
   WrRenderable *mFrustumRenderable;
   WrMaterial *mFrustumMaterial;
@@ -132,7 +133,7 @@ private:
     return (sizeof(float) + sizeof(WbLidarPoint)) * actualHorizontalResolution() * actualNumberOfLayers();
   }
   double minRange() const override { return mMinRange->value(); }
-  bool isRotating() const { return mType->value().startsWith('r', Qt::CaseInsensitive); }
+  bool isRotating() const { return mActualType.startsWith('r', Qt::CaseInsensitive); }
   double verticalFieldOfView() const { return actualFieldOfView() * ((double)height() / (double)width()); }
 
   WbLidarPoint *pointArray() { return (WbLidarPoint *)(lidarImage() + actualHorizontalResolution() * actualNumberOfLayers()); }


### PR DESCRIPTION
Many internal structures (WREN camera, image arrays, etc.) depends on the `Lidar.type` value but the size of these structure was not updated when then `Lidar.type` was changed causing some issues in particular when switching from "rotating" to "fixed" (height and width of the lidar is bigger for the "fixed" type).
Here are some of the issues:
- crash #2982 when executing the `memset` instruction in the `WbLidar::reset` method
- wrong graphical point cloud representation

There are already a number of fields for Camera (width, height) and Lidar (fieldOfView, verticalFieldOfView, horizontalResolution, numberOfLayers) nodes whose modification is only applied after saving and reloading the world.
So the best and more consistent fix is to require saving and reloading the world also to change the Lidar type.

