### PR TITLE
Add namespace to model_name topic for ROS controller

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -159,7 +159,7 @@ void Ros::launchRos(int argc, char **argv) {
   mNodeHandle = new ros::NodeHandle;
   ROS_INFO("The controller is now connected to the ROS master.");
 
-  mNamePublisher = mNodeHandle->advertise<std_msgs::String>("model_name", 1, true);
+  mNamePublisher = mNodeHandle->advertise<std_msgs::String>(mRobotName + "/model_name", 1, true);
   robotName.data = mRobotName;
   mNamePublisher.publish(robotName);
 


### PR DESCRIPTION
**Description**

For multiple robots with ROS controllers, it's necessary to have a namespace for the `model_name` topic name so they don't collide with each other.

**Tasks**

  - [x] Add namespace to topic name
  - [x] [Make sure other parts of the repo are not using it](https://github.com/cyberbotics/webots/search?q=model_name&type=code)

