### PR TITLE
Improve wb_supervisor_node_reset_physics

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also moved with the [Supervisor]((supervisor.md) ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
     - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
     - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,7 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
-    - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also moved with the [Supervisor](supervisor.md) ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
+    - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also artificially moved with the [Supervisor](supervisor.md) API ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
     - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
     - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,7 +13,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
-    - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also moved with the [Supervisor]((supervisor.md) ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
+    - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also moved with the [Supervisor](supervisor.md) ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
     - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
     - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).

--- a/src/webots/nodes/WbMatter.hpp
+++ b/src/webots/nodes/WbMatter.hpp
@@ -64,7 +64,7 @@ public:
 
   // for wb_supervisor_simulation_reset_physics()
   virtual void resetPhysics() {}
-  virtual void pausePhysics() {}
+  virtual void pausePhysics(bool resumeAutomatically = false) {}
   virtual void resumePhysics() {}
 
   // handle artifical moves triggered by the user or a Supervisor

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -157,7 +157,7 @@ public:
 
   void resetPhysics() override;
   // pause/resume physics computation on the current solid and its descandants
-  void pausePhysics() override;
+  void pausePhysics(bool resumeAutomatically = false) override;
   void resumePhysics() override;
 
   // handle artifical moves triggered by the user or a Supervisor
@@ -339,7 +339,8 @@ private:
 
   // ODE
   dJointID mJoint;
-  bool mUpdatedInStep;  // used to update Transform coordinated to setup ray collisions (based on pre-physics step values)
+  bool mUpdatedInStep;       // used to update Transform coordinated to setup ray collisions (based on pre-physics step values)
+  bool mResetPhysicsInStep;  // used to completely reset physics when the solid is also moved in the same step
   void setGeomAndBodyPositions();
   void applyPhysicsTransform();
   void computePlaneParams(WbTransform *transform, WbVector3 &n, double &d) const;

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -329,7 +329,7 @@ WbSimulationState::Mode WbSupervisorUtilities::convertSimulationMode(int supervi
 }
 
 void WbSupervisorUtilities::processImmediateMessages(bool blockRegeneration) {
-  int n = mFieldSetRequests.size();
+  const int n = mFieldSetRequests.size();
   if (n == 0)
     return;
   WbTemplateManager::instance()->blockRegeneration(true);
@@ -807,9 +807,10 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
 
       WbNode *const node = getProtoParameterNodeInstance(WbNode::findNode(id));
       WbSolid *const solid = dynamic_cast<WbSolid *>(node);
-      if (solid)
+      if (solid) {
         solid->resetPhysics();
-      else
+        solid->pausePhysics(true);
+      } else
         mRobot->warn(tr("wb_supervisor_node_reset_physics() can exclusively be used with a Solid"));
       return;
     }

--- a/tests/api/controllers/supervisor_set_position_of_dynamic_object/supervisor_set_position_of_dynamic_object.c
+++ b/tests/api/controllers/supervisor_set_position_of_dynamic_object/supervisor_set_position_of_dynamic_object.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
   wb_supervisor_node_reset_physics(robot_node);
 
   wb_robot_step(TIME_STEP);  // Apply the reset
-  wb_robot_step(TIME_STEP);  // Let one step the stabilize the robot.
+  wb_robot_step(2 * TIME_STEP);  // Run some steps to the stabilize the robot.
 
   // Check GPS feedback is correct.
   const double *body_position = wb_gps_get_values(body_gps);

--- a/tests/api/controllers/supervisor_set_position_of_dynamic_object/supervisor_set_position_of_dynamic_object.c
+++ b/tests/api/controllers/supervisor_set_position_of_dynamic_object/supervisor_set_position_of_dynamic_object.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
   wb_supervisor_field_set_sf_rotation(rotation_field, rotation);
   wb_supervisor_node_reset_physics(robot_node);
 
-  wb_robot_step(TIME_STEP);  // Apply the reset
+  wb_robot_step(TIME_STEP);      // Apply the reset
   wb_robot_step(2 * TIME_STEP);  // Run some steps to the stabilize the robot.
 
   // Check GPS feedback is correct.


### PR DESCRIPTION
Fix #2899:
Independently if the node physics is reset before or after moving it artificially with the supervisor, during the physics step ODE handles the jerk and overwrites the linear/angular velocities, etc.
The only alternative to run a simulation step between the artificial move and the physics reset, is to reset the node physics again after the ODE step computations.


Additionally I also found that the ball joint was not handled in the ODE joint physics reset.