### PR TITLE
Remove blank line proto info

### DIFF
--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -56,6 +56,7 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
           !info.at(i).startsWith("documentation url:"))
         mInfo += info.at(i) + "\n";
     }
+    mInfo.chop(1);
   }
   mTags = tokenizer->tags();
   mLicense = tokenizer->license();


### PR DESCRIPTION
Remove the blank line appearing for PROTO nodes in the small info window that appears on hover. This is done by removing the last character which is in this case always '\n' in non-empty strings.

![before](https://user-images.githubusercontent.com/38250944/115574890-55192b00-a2c2-11eb-8dee-6499332d505a.png)
![after](https://user-images.githubusercontent.com/38250944/115574899-56e2ee80-a2c2-11eb-89c6-c9b23f2d078c.png)

