### PR TITLE
Add loading time and average real time factor to performance log

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -34,6 +34,7 @@ Released on June, Xth, 2021.
     - Added conversion from PROTO to URDF from the Webots command line ([#2885](https://github.com/cyberbotics/webots/pull/2885)).
     - Added flag to [RobotisOp2](../guide/robotis-op2.md) that enables the modeling of backlash in the robot ([#2881](https://github.com/cyberbotics/webots/pull/2881)).
     - Added the `wb_supervisor_node_get_pose` function that retrieves an absolute or relative pose. Relative pose is expressed in the coordinate system of another node specified as an argument ([#2932](https://github.com/cyberbotics/webots/pull/2932)).
+    - Added measurement of the load time and average speed factor when using the `--log-performance` command ([#3002](https://github.com/cyberbotics/webots/pull/3002)).
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added HingeJointWithBacklash proto that extends [HingeJoint](hingejoint.md) to model the effect of backlash and a corresponding sample world ([#2786](https://github.com/cyberbotics/webots/pull/2786)).

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -172,15 +172,14 @@ WbSimulationWorld::~WbSimulationWorld() {
 
 void WbSimulationWorld::step() {
   WbPerformanceLog *log = WbPerformanceLog::instance();
-  if (log) {
+  if (log)
     log->stepChanged();
-    log->lapTime(WbPerformanceLog::SPEED_FACTOR);
-  }
 
   const double timeStep = basicTimeStep();
 
   if (WbSimulationState::instance()->isRealTime()) {
     const int elapsed = mRealTimeTimer.restart();
+
     // computing the mean of an history of several elapsedTime
     // improves significantly the stability of the algorithm
     // in case of simulations where elapsedTime oscillates often
@@ -304,7 +303,7 @@ void WbSimulationWorld::modeChanged() {
       WbSoundEngine::setPause(true);
       WbSoundEngine::setMute(WbPreferences::instance()->value("Sound/mute").toBool());
       if (log)
-        log->invalidateMeasure(WbPerformanceLog::SPEED_FACTOR);
+        log->stopMeasure(WbPerformanceLog::SPEED_FACTOR);
       break;
     case WbSimulationState::STEP:
       WbSoundEngine::setMute(WbPreferences::instance()->value("Sound/mute").toBool());

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -105,9 +105,6 @@ WbSimulationWorld::WbSimulationWorld(WbProtoList *protos, WbTokenizer *tokenizer
   finalize();
   setIsLoading(false);
 
-  if (log)
-    log->stopMeasure(WbPerformanceLog::LOADING);
-
   if (mWorldLoadingCanceled)
     return;
 
@@ -126,6 +123,9 @@ WbSimulationWorld::WbSimulationWorld(WbProtoList *protos, WbTokenizer *tokenizer
   WbRadio::createAndSetupPluginObjects();
 
   WbSoundEngine::setWorld(this);
+
+  if (log)
+    log->stopMeasure(WbPerformanceLog::LOADING);
 
   connect(mTimer, &QTimer::timeout, this, &WbSimulationWorld::triggerStepFromTimer);
   const WbSimulationState *const s = WbSimulationState::instance();
@@ -179,9 +179,6 @@ void WbSimulationWorld::step() {
 
   if (WbSimulationState::instance()->isRealTime()) {
     const int elapsed = mRealTimeTimer.restart();
-
-    if (log)
-      log->relayStepDuration(elapsed);
 
     // computing the mean of an history of several elapsedTime
     // improves significantly the stability of the algorithm

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -172,14 +172,15 @@ WbSimulationWorld::~WbSimulationWorld() {
 
 void WbSimulationWorld::step() {
   WbPerformanceLog *log = WbPerformanceLog::instance();
-  if (log)
+  if (log) {
     log->stepChanged();
+    log->lapTime(WbPerformanceLog::SPEED_FACTOR);
+  }
 
   const double timeStep = basicTimeStep();
 
   if (WbSimulationState::instance()->isRealTime()) {
     const int elapsed = mRealTimeTimer.restart();
-
     // computing the mean of an history of several elapsedTime
     // improves significantly the stability of the algorithm
     // in case of simulations where elapsedTime oscillates often
@@ -294,12 +295,16 @@ void WbSimulationWorld::restartStepTimer() {
 }
 
 void WbSimulationWorld::modeChanged() {
+  WbPerformanceLog *log = WbPerformanceLog::instance();
+
   const WbSimulationState::Mode mode = WbSimulationState::instance()->mode();
   switch (mode) {
     case WbSimulationState::PAUSE:
       mTimer->stop();
       WbSoundEngine::setPause(true);
       WbSoundEngine::setMute(WbPreferences::instance()->value("Sound/mute").toBool());
+      if (log)
+        log->invalidateMeasure(WbPerformanceLog::SPEED_FACTOR);
       break;
     case WbSimulationState::STEP:
       WbSoundEngine::setMute(WbPreferences::instance()->value("Sound/mute").toBool());

--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -72,6 +72,10 @@ WbSimulationWorld::WbSimulationWorld(WbProtoList *protos, WbTokenizer *tokenizer
 
   mSleepRealTime = basicTimeStep();
 
+  WbPerformanceLog *log = WbPerformanceLog::instance();
+  if (log)
+    log->setTimeStep(basicTimeStep());
+
   WbSimulationState::instance()->resetTime();
   // Reset random seed to ensure reproducible simulations.
   updateRandomSeed();
@@ -100,6 +104,9 @@ WbSimulationWorld::WbSimulationWorld(WbProtoList *protos, WbTokenizer *tokenizer
   root()->finalize();
   finalize();
   setIsLoading(false);
+
+  if (log)
+    log->stopMeasure(WbPerformanceLog::LOADING);
 
   if (mWorldLoadingCanceled)
     return;
@@ -172,6 +179,9 @@ void WbSimulationWorld::step() {
 
   if (WbSimulationState::instance()->isRealTime()) {
     const int elapsed = mRealTimeTimer.restart();
+
+    if (log)
+      log->relayStepDuration(elapsed);
 
     // computing the mean of an history of several elapsedTime
     // improves significantly the stability of the algorithm

--- a/src/webots/gui/WbSimulationStateIndicator.cpp
+++ b/src/webots/gui/WbSimulationStateIndicator.cpp
@@ -16,7 +16,6 @@
 
 #include "WbApplication.hpp"
 #include "WbGuiRefreshOracle.hpp"
-#include "WbPerformanceLog.hpp"
 #include "WbSimulationState.hpp"
 
 #include <QtWidgets/QHBoxLayout>
@@ -96,11 +95,6 @@ void WbSimulationStateIndicator::update() {
       // update speed indicator
       int elapsed = WbGuiRefreshOracle::instance()->elapsed();
       double speed = (time - mLastSpeedIndicatorTime) / elapsed;
-
-      WbPerformanceLog *log = WbPerformanceLog::instance();
-      if (log && (WbSimulationState::instance()->isFast() || WbSimulationState::instance()->isRealTime())) {
-        log->relaySpeedFactor(speed);
-      }
 
       // If the speed < 10, we want two decimal places i.e 0.00 - 9.99
       // Following this, remove a decimal place as we climb an order of magnitude

--- a/src/webots/gui/WbSimulationStateIndicator.cpp
+++ b/src/webots/gui/WbSimulationStateIndicator.cpp
@@ -16,6 +16,7 @@
 
 #include "WbApplication.hpp"
 #include "WbGuiRefreshOracle.hpp"
+#include "WbPerformanceLog.hpp"
 #include "WbSimulationState.hpp"
 
 #include <QtWidgets/QHBoxLayout>
@@ -95,6 +96,11 @@ void WbSimulationStateIndicator::update() {
       // update speed indicator
       int elapsed = WbGuiRefreshOracle::instance()->elapsed();
       double speed = (time - mLastSpeedIndicatorTime) / elapsed;
+
+      WbPerformanceLog *log = WbPerformanceLog::instance();
+      if (log && (WbSimulationState::instance()->isFast() || WbSimulationState::instance()->isRealTime())) {
+        log->relaySpeedFactor(speed);
+      }
 
       // If the speed < 10, we want two decimal places i.e 0.00 - 9.99
       // Following this, remove a decimal place as we climb an order of magnitude

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -36,6 +36,7 @@
 #include "WbNodeUtilities.hpp"
 #include "WbOdeContact.hpp"
 #include "WbPbrAppearance.hpp"
+#include "WbPerformanceLog.hpp"
 #include "WbPerspective.hpp"
 #include "WbPreferences.hpp"
 #include "WbProject.hpp"
@@ -99,6 +100,10 @@ WbWorld::WbWorld(WbProtoList *protos, WbTokenizer *tokenizer) :
   WbNode::setGlobalParentNode(mRoot);
   mRadarTargets.clear();
   mCameraRecognitionObjects.clear();
+
+  WbPerformanceLog *log = WbPerformanceLog::instance();
+  if (log)
+    log->startMeasure(WbPerformanceLog::LOADING);
 
   if (tokenizer) {
     mFileName = tokenizer->fileName();

--- a/src/webots/util/WbPerformanceLog.cpp
+++ b/src/webots/util/WbPerformanceLog.cpp
@@ -245,6 +245,14 @@ void WbPerformanceLog::stepChanged() {
     mIsLogCompleted = true;
   else
     mStepsCount++;
+
+  if (mValuesCount[SPEED_FACTOR] == 0 && !mTimers[SPEED_FACTOR]->isValid()) {
+    startMeasure(SPEED_FACTOR);
+    return;
+  }
+
+  stopMeasure(SPEED_FACTOR);
+  startMeasure(SPEED_FACTOR);
 }
 
 void WbPerformanceLog::startMeasure(InfoType type, const QString &object) {
@@ -289,26 +297,6 @@ void WbPerformanceLog::stopMeasure(InfoType type, const QString &object) {
     mValuesCount[type] += 1;
     mTimers[type]->invalidate();
   }
-}
-
-void WbPerformanceLog::lapTime(InfoType type) {
-  if (mIsLogCompleted) {
-    mTimers[type]->invalidate();
-    return;
-  }
-
-  if (mValuesCount[type] == 0 && !mTimers[type]->isValid()) {
-    startMeasure(type);
-    return;
-  }
-
-  stopMeasure(type);
-  startMeasure(type);
-}
-
-void WbPerformanceLog::invalidateMeasure(InfoType type) {
-  if (mTimers[type]->isValid())
-    mTimers[type]->invalidate();
 }
 
 void WbPerformanceLog::reportStepRenderingStats(int trianglesCount) {

--- a/src/webots/util/WbPerformanceLog.cpp
+++ b/src/webots/util/WbPerformanceLog.cpp
@@ -105,6 +105,7 @@ WbPerformanceLog::WbPerformanceLog(const QString &fileName, int stepsCount) :
   mValuesCount(INFO_COUNT, 0),
   mTimers(INFO_COUNT),
   mAverageFPS(0.0),
+  mTimeStep(0),
   mIsLogCompleted(false) {
   mFile = new QFile(mFileName);
   for (int i = 0; i < INFO_COUNT; ++i)
@@ -149,6 +150,7 @@ void WbPerformanceLog::worldClosed(const QString &worldName, const QString &worl
   // reset values
   mIsLogCompleted = false;
   mStepsCount = 0;
+  mTimeStep = 0;
   for (int i = 0; i < INFO_COUNT; ++i) {
     mValues[i] = 0;
     mValuesCount[i] = 0;

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -34,7 +34,7 @@ class Measurement;
 class WbPerformanceLog {
 public:
   enum InfoType {
-    LOADING,
+    LOADING = 0,
     PRE_PHYSICS_STEP,
     PHYSICS_STEP,
     POST_PHYSICS_STEP,
@@ -45,6 +45,7 @@ public:
     DEVICE_RENDERING,
     DEVICE_WINDOW_RENDERING,
     CONTROLLER,
+    SPEED_FACTOR,
     INFO_COUNT
   };
 
@@ -58,9 +59,10 @@ public:
   void stepChanged();
   void startMeasure(InfoType type, const QString &object = QString());
   void stopMeasure(InfoType type, const QString &object = QString());
+  void lapTime(InfoType type);
+  void invalidateMeasure(InfoType type);
   void startControllerMeasure(const QString &controllerName);
   void stopControllerMeasure(const QString &controllerName);
-  void relaySpeedFactor(double speed);
   void setTimeStep(double value) { mTimeStep = value; }
   void setAvgFPS(double value) { mAverageFPS = value; }
 
@@ -86,7 +88,6 @@ private:
   QVector<QElapsedTimer *> mTimers;
   QTextStream mOutStream;
   double mAverageFPS;
-  double mAverageSpeed;
   double mTimeStep;
   bool mIsLogCompleted;
 

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -59,8 +59,6 @@ public:
   void stepChanged();
   void startMeasure(InfoType type, const QString &object = QString());
   void stopMeasure(InfoType type, const QString &object = QString());
-  void lapTime(InfoType type);
-  void invalidateMeasure(InfoType type);
   void startControllerMeasure(const QString &controllerName);
   void stopControllerMeasure(const QString &controllerName);
   void setTimeStep(double value) { mTimeStep = value; }

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -34,7 +34,8 @@ class Measurement;
 class WbPerformanceLog {
 public:
   enum InfoType {
-    PRE_PHYSICS_STEP = 0,
+    LOADING,
+    PRE_PHYSICS_STEP,
     PHYSICS_STEP,
     POST_PHYSICS_STEP,
     MAIN_RENDERING,
@@ -59,7 +60,8 @@ public:
   void stopMeasure(InfoType type, const QString &object = QString());
   void startControllerMeasure(const QString &controllerName);
   void stopControllerMeasure(const QString &controllerName);
-
+  void relayStepDuration(double elapsed);
+  void setTimeStep(double value) { mTimeStep = value; }
   void setAvgFPS(double value) { mAverageFPS = value; }
 
   void reportStepRenderingStats(int trianglesCount);
@@ -84,6 +86,8 @@ private:
   QVector<QElapsedTimer *> mTimers;
   QTextStream mOutStream;
   double mAverageFPS;
+  double mRealtimeFactor;
+  double mTimeStep;
   bool mIsLogCompleted;
 
   QHash<QString, Measurement *> mRenderingDevicesValues;

--- a/src/webots/util/WbPerformanceLog.hpp
+++ b/src/webots/util/WbPerformanceLog.hpp
@@ -60,7 +60,7 @@ public:
   void stopMeasure(InfoType type, const QString &object = QString());
   void startControllerMeasure(const QString &controllerName);
   void stopControllerMeasure(const QString &controllerName);
-  void relayStepDuration(double elapsed);
+  void relaySpeedFactor(double speed);
   void setTimeStep(double value) { mTimeStep = value; }
   void setAvgFPS(double value) { mAverageFPS = value; }
 
@@ -86,7 +86,7 @@ private:
   QVector<QElapsedTimer *> mTimers;
   QTextStream mOutStream;
   double mAverageFPS;
-  double mRealtimeFactor;
+  double mAverageSpeed;
   double mTimeStep;
   bool mIsLogCompleted;
 


### PR DESCRIPTION
**Description**
This PR adds additional info to the performance log.

Loading time options:
1. Measure time only for node structure creation
2. Entire load process (basically from [here](https://github.com/cyberbotics/webots/blob/1367ab2560688c435afa50b8713522b9897afe7c/src/webots/nodes/utils/WbWorld.cpp#L102) to [here](https://github.com/cyberbotics/webots/blob/1367ab2560688c435afa50b8713522b9897afe7c/src/webots/engine/WbSimulationWorld.cpp#L106)) including things like `handleInitialCollisions`, loading plugins, etc

The current solution corresponds to option (2)  for loading timing. 