### PR TITLE
Support for label in animation

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -34,6 +34,7 @@ Released on June, Xth, 2021.
     - Added conversion from PROTO to URDF from the Webots command line ([#2885](https://github.com/cyberbotics/webots/pull/2885)).
     - Added flag to [RobotisOp2](../guide/robotis-op2.md) that enables the modeling of backlash in the robot ([#2881](https://github.com/cyberbotics/webots/pull/2881)).
     - Added the `wb_supervisor_node_get_pose` function that retrieves an absolute or relative pose. Relative pose is expressed in the coordinate system of another node specified as an argument ([#2932](https://github.com/cyberbotics/webots/pull/2932)).
+    - Support labels in animations ([#3003](https://github.com/cyberbotics/webots/pull/3003)).
   - New Samples:
     - Added a simple room with a Nao robot ([#2701](https://github.com/cyberbotics/webots/pull/2701)).
     - Added HingeJointWithBacklash proto that extends [HingeJoint](hingejoint.md) to model the effect of backlash and a corresponding sample world ([#2786](https://github.com/cyberbotics/webots/pull/2786)).

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -157,6 +157,13 @@ export default class Animation {
       for (let p = 0; p < poses.length; p++)
         appliedIds[poses[p].id] = this.scene.applyPose(poses[p], this.data.frames[this.step].time);
     }
+
+    if (this.data.frames[this.step].hasOwnProperty('labels')) {
+      let labels = this.data.frames[this.step].labels;
+      for (let i = 0; i < labels.length; i++)
+        this.scene.applyLabel(labels[i], this.view);
+    }
+
     const x3dScene = this.view.x3dScene;
     // lookback mechanism: search in history
     if (this.step !== this.previousStep + 1) {

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -32,6 +32,7 @@ export default class Animation {
     this.data = data;
     // extract animated node ids: remove empty items and convert to integer
     this.allIds = this.data.ids.split(';').filter(Boolean).map(s => parseInt(s));
+    this.labelsIds = [];
 
     const canvas = document.getElementById('canvas');
     canvas.insertAdjacentHTML('afterend', "<div id='playBar'></div>");
@@ -152,6 +153,7 @@ export default class Animation {
     this.step = requestedStep;
 
     const appliedIds = [];
+    const appliedLabelsIds = [];
     if (this.data.frames[this.step].hasOwnProperty('poses')) {
       const poses = this.data.frames[this.step].poses;
       for (let p = 0; p < poses.length; p++)
@@ -160,8 +162,12 @@ export default class Animation {
 
     if (this.data.frames[this.step].hasOwnProperty('labels')) {
       let labels = this.data.frames[this.step].labels;
-      for (let i = 0; i < labels.length; i++)
+      for (let i = 0; i < labels.length; i++) {
+        if (!this.labelsIds.includes(labels[i].id))
+          this.labelsIds.push(labels[i].id);
         this.scene.applyLabel(labels[i], this.view);
+        appliedLabelsIds.push(labels[i].id);
+      }
     }
 
     const x3dScene = this.view.x3dScene;
@@ -181,6 +187,20 @@ export default class Animation {
             for (let p = 0; p < this.data.frames[f].poses.length; p++) {
               if (this.data.frames[f].poses[p].id === id)
                 appliedFields = this.scene.applyPose(this.data.frames[f].poses[p], this.data.frames[f].time, appliedFields);
+            }
+          }
+        }
+      }
+      for (let id of this.labelsIds) {
+        for (let f = this.step - 1; f >= previousPoseStep; f--) {
+          if (this.data.frames[f].labels) {
+            for (let p = 0; p < this.data.frames[f].labels.length; p++) {
+              if (this.data.frames[f].labels[p].id === id) {
+                if (!appliedLabelsIds.includes(id)) {
+                  this.scene.applyLabel(this.data.frames[f].labels[p], this.view);
+                  appliedLabelsIds.push(id);
+                }
+              }
             }
           }
         }

--- a/resources/web/wwi/Webots.js
+++ b/resources/web/wwi/Webots.js
@@ -277,7 +277,7 @@ webots.View = class View {
       this.x3dDiv.appendChild(labelElement);
     }
     labelElement.style.fontFamily = properties.font;
-    labelElement.style.color = properties.color;
+    labelElement.style.color = 'rgba(' + properties.color + ')';
     labelElement.style.fontSize = $(this.x3dDiv).height() * properties.size / 2.25 + 'px'; // 2.25 is an empirical value to match with Webots appearance
     labelElement.style.left = $(this.x3dDiv).width() * properties.x + 'px';
     labelElement.style.top = $(this.x3dDiv).height() * properties.y + 'px';

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -186,8 +186,19 @@ export default class X3dScene {
       WbWorld.instance.viewpoint.updateFollowUp(time);
   }
 
+  applyLabel(label, view) {
+    view.setLabel({
+      id: label.id,
+      text: label.text,
+      font: label.font,
+      color: label.rgba,
+      size: label.size,
+      x: label.x,
+      y: label.y
+    });
+  }
+
   processServerMessage(data, view) {
-    console.log(data);
     if (data.startsWith('application/json:')) {
       if (typeof view.time !== 'undefined') { // otherwise ignore late updates until the scene loading is completed
         data = data.substring(data.indexOf(':') + 1);
@@ -201,6 +212,11 @@ export default class X3dScene {
         if (frame.hasOwnProperty('poses')) {
           for (let i = 0; i < frame.poses.length; i++)
             this.applyPose(frame.poses[i]);
+        }
+
+        if (frame.hasOwnProperty('labels')) {
+          for (let i = 0; i < frame.labels.length; i++)
+            this.applyLabel(frame.labels[i], view);
         }
 
         this.render();
@@ -224,25 +240,6 @@ export default class X3dScene {
         return true;
       view.stream.socket.send('pause');
       this.loadObject(data, 0, view.onready);
-    } else if (data.startsWith('label')) {
-      let semiColon = data.indexOf(';');
-      const id = data.substring(data.indexOf(':'), semiColon);
-      let previousSemiColon;
-      const labelProperties = []; // ['font', 'color', 'size', 'x', 'y', 'text']
-      for (let i = 0; i < 5; i++) {
-        previousSemiColon = semiColon + 1;
-        semiColon = data.indexOf(';', previousSemiColon);
-        labelProperties.push(data.substring(previousSemiColon, semiColon));
-      }
-      view.setLabel({
-        id: id,
-        text: data.substring(semiColon + 1, data.length),
-        font: labelProperties[0],
-        color: labelProperties[1],
-        size: labelProperties[2],
-        x: labelProperties[3],
-        y: labelProperties[4]
-      });
     } else
       return false;
     return true;

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -187,6 +187,7 @@ export default class X3dScene {
   }
 
   processServerMessage(data, view) {
+    console.log(data);
     if (data.startsWith('application/json:')) {
       if (typeof view.time !== 'undefined') { // otherwise ignore late updates until the scene loading is completed
         data = data.substring(data.indexOf(':') + 1);

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -28,7 +28,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 #include <QtCore/QMutableListIterator>
-
+#include <iostream>
 // this function is used to round the transform position coordinates
 #define ROUND(x, precision) (roundf((x) / precision) * precision)
 
@@ -334,12 +334,21 @@ QString WbAnimationRecorder::computeUpdateData(bool force) {
 
   out << ",\"labels\":[";
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();
+  bool needComma = false;
   foreach (const WbRobot *robot, robots) {
     if (robot->supervisor()) {
       foreach (const QString &label, robot->supervisorUtilities()->labelsState()) {
-        out << "{";
+        if (needComma) {
+          out << ", {";
+          needComma = false;
+        } else
+          out << "{";
         out << label;
-        out << "}";
+        if (label == robot->supervisorUtilities()->labelsState().last()) {
+          out << "}";
+          needComma = true;
+        } else
+          out << "},";
       }
     }
   }

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -354,9 +354,10 @@ QString WbAnimationRecorder::computeUpdateData(bool force) {
       else
         out << "},";
     }
+    out << "]";
   }
 
-  out << "]}";
+  out << "}";
 
   mChangedCommands.clear();
   mChangedLabels.clear();

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -221,9 +221,13 @@ void WbAnimationRecorder::populateCommands() {
 
     const QList<WbRobot *> &robots = WbWorld::instance()->robots();
     foreach (WbRobot *const robot, robots)
-      if (robot->supervisor())
+      if (robot->supervisor()) {
+        foreach (QString label, robot->supervisorUtilities()->labelsState())
+          addChangedLabelToList(label);
+
         connect(robot->supervisorUtilities(), &WbSupervisorUtilities::labelChanged, this,
                 &WbAnimationRecorder::addChangedLabelToList);
+      }
   }
 
   foreach (WbAnimationCommand *command, mCommands) {

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -17,8 +17,10 @@
 #include "WbField.hpp"
 #include "WbGroup.hpp"
 #include "WbLog.hpp"
+#include "WbRobot.hpp"
 #include "WbSFRotation.hpp"
 #include "WbSimulationState.hpp"
+#include "WbSupervisorUtilities.hpp"
 #include "WbViewpoint.hpp"
 #include "WbWorld.hpp"
 
@@ -328,7 +330,21 @@ QString WbAnimationRecorder::computeUpdateData(bool force) {
       out << "},";
     command->resetChanges();
   }
+  out << "]";
+
+  out << ",\"labels\":[";
+  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
+  foreach (const WbRobot *robot, robots) {
+    if (robot->supervisor()) {
+      foreach (const QString &label, robot->supervisorUtilities()->labelsState()) {
+        out << "{";
+        out << label;
+        out << "}";
+      }
+    }
+  }
   out << "]}";
+
   mChangedCommands.clear();
   foreach (WbAnimationCommand *command, mArtificialCommands)
     delete command;

--- a/src/webots/engine/WbAnimationRecorder.hpp
+++ b/src/webots/engine/WbAnimationRecorder.hpp
@@ -92,6 +92,7 @@ private slots:
   void update();
   void updateCommandsAfterNodeDeletion(QObject *);
   void addChangedCommandToList(WbAnimationCommand *command);
+  void addChangedLabelToList(QString label);
   void handleNodeVisibilityChange(WbNode *node, bool visibility);
 
 private:
@@ -121,6 +122,7 @@ private:
   QList<WbAnimationCommand *> mCommands;
   QList<WbAnimationCommand *> mChangedCommands;
   QList<WbAnimationCommand *> mArtificialCommands;
+  QList<QString> mChangedLabels;
 };
 
 #endif

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -162,14 +162,6 @@ void WbX3dStreamingServer::deleteWorld() {
   WbStreamingServer::deleteWorld();
 }
 
-void WbX3dStreamingServer::connectNewRobot(const WbRobot *robot) {
-  WbStreamingServer::connectNewRobot(robot);
-
-  if (robot->supervisor())
-    connect(robot->supervisorUtilities(), &WbSupervisorUtilities::labelChanged, this, &WbX3dStreamingServer::sendLabelUpdate,
-            Qt::UniqueConnection);
-}
-
 void WbX3dStreamingServer::propagateNodeAddition(WbNode *node) {
   if (!isActive() || WbWorld::instance() == NULL)
     return;
@@ -231,21 +223,9 @@ void WbX3dStreamingServer::sendWorldToClient(QWebSocket *client) {
   if (!state.isEmpty())
     sendWorldStateToClient(client, state);
 
-  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
-  foreach (const WbRobot *robot, robots) {
-    if (robot->supervisor()) {
-      foreach (const QString &label, robot->supervisorUtilities()->labelsState())
-        client->sendTextMessage(label);
-    }
-  }
-
   WbStreamingServer::sendWorldToClient(client);
 }
 
 void WbX3dStreamingServer::sendWorldStateToClient(QWebSocket *client, const QString &state) const {
   client->sendTextMessage(QString("application/json:") + state);
-}
-
-void WbX3dStreamingServer::sendLabelUpdate(const QString &labelDescription) {
-  sendToClients(labelDescription);
 }

--- a/src/webots/gui/WbX3dStreamingServer.hpp
+++ b/src/webots/gui/WbX3dStreamingServer.hpp
@@ -34,12 +34,10 @@ private slots:
   void processTextMessage(QString) override;
 
   void propagateNodeDeletion(WbNode *node);
-  void sendLabelUpdate(const QString &labelDescription);
 
 private:
   void create(int port) override;
   void sendTcpRequestReply(const QString &requestedUrl, const QString &etag, QTcpSocket *socket) override;
-  void connectNewRobot(const WbRobot *robot) override;
   bool prepareWorld() override;
   void deleteWorld() override;
   void sendWorldToClient(QWebSocket *client) override;

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1876,7 +1876,7 @@ QString WbSupervisorUtilities::createLabelUpdateString(const WbWrenLabelOverlay 
   int r, g, b;
   labelOverlay->position(x, y);
   labelOverlay->color(r, g, b, alpha);
-  return QString("label:%1;%2;rgba(%3,%4,%5,%6);%7;%8;%9;%10")
+  return QString("\"id\":%1,\"font\":\"%2\",\"rgba\":\"%3,%4,%5,%6\",\"size\":%7,\"x\":%8,\"y\":%9,\"text\":\"%10\"")
     .arg(labelOverlay->id())
     .arg(labelOverlay->font())
     .arg(r)

--- a/src/webots/nodes/utils/WbSupervisorUtilities.hpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.hpp
@@ -54,7 +54,7 @@ public:
 signals:
   void worldModified();
   void changeSimulationModeRequested(int newMode);
-  void labelChanged(const QString &labelDescription);  // i.e. "label:<id>;<font>;<color>;<size>;<x>;<y>;<text>"
+  void labelChanged(QString labelDescription);  // i.e. json format
 
 private slots:
   void animationStartStatusChanged(int status);


### PR DESCRIPTION
**Description**
Currently the labels are not recorded in animation, the PR aims to change that.

For animations to be able to read and update correctly the labels, we need to change the way they are transmitted to webots.js. An update of label will be transmitted along the updates of other objects, with a timestamp, instead of alone without timestamp

**Tasks**
  - [x] Modify how webots send the labels
  - [x] Modify X3dScene.js to read the new format of labels 
  - [x] Support for multiple labels
  - [x] Modify WbAnimationRecorder to take labels into account
  - [x] Send labels only when they are updated
  - [x] Remove the old way of sending labels