### PR TITLE
Allows failed controller to reconnect to a robot

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -18,6 +18,7 @@ Released on XX Xth, 2021.
     - Fixed [Supervisor](supervisor.md) API operations on nodes defined in multiple nested PROTO fields ([#3036](https://github.com/cyberbotics/webots/pull/3036)).
     - Fixed crash applying [`wb_supervisor_node_add_force`](supervisor.md#wb_supervisor_node_add_force) on kinematic objects ([#3036](https://github.com/cyberbotics/webots/pull/3036)).
     - Fixed mecanum wheels [ContactProperties](contactproperties.md) in [YouBot](../guide/youbot.md) worlds ([#3025](https://github.com/cyberbotics/webots/pull/3025)).
+    - Fixed various issues when an extern [Robot](robot.md) controller exits without disconnecting and reconnects to the same [Robot](robot.md) ([#3005](https://github.com/cyberbotics/webots/pull/3005)).
     - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also artificially moved with the [Supervisor](supervisor.md) API ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
     - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -300,7 +300,7 @@ void WbControlledWorld::reset(bool restartControllers) {
 }
 
 void WbControlledWorld::checkIfReadRequestCompleted() {
-  assert(!mControllers.isEmpty());
+  //assert(!mControllers.isEmpty());
   if (!needToWait()) {
     WbSimulationState *state = WbSimulationState::instance();
     emit state->controllerReadRequestsCompleted();

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -219,9 +219,22 @@ void WbControlledWorld::addControllerConnection() {
       robotName = buffer;
       delete[] buffer;
     }
+    int nbExternalController = 0;
     foreach (WbRobot *const robot, robots()) {
-      if (robot->isControllerStarted())
-        continue;
+      if (robot->controllerName() == "<extern>")
+	    nbExternalController++;
+    }
+    foreach (WbRobot *const robot, robots()) {
+      if (robot->isControllerStarted()) {
+        // if a specific robot have been targeted by giving a name, or only one external controller is in the scene (hence it's the target)
+        if (robot->controllerName() == "<extern>" && (robotName == robot->name() || nbExternalController == 1)) {
+          // automatically disconnect from previous extern controller that may have failed, the slot could be immediately used to restart
+          WbLog::info(tr("Closing extern controller connection for robot \"%1\".").arg(robot->name()));
+          updateRobotController(robot);
+        }
+        else // this controller seems to be in active use, ignore it
+          continue;
+      }
       if ((robotName == robot->name() || robotName.isEmpty()) && robot->controllerName() == "<extern>") {
         WbLog::info(tr("Starting extern controller for robot \"%1\".").arg(robot->name()));
         mRobotsWaitingExternController.append(robot);

--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -60,7 +60,7 @@ private:
   void startControllerFromSocket(WbRobot *robot, QLocalSocket *socket);
   void updateRobotController(WbRobot *robot);
   void handleRobotRemoval(WbBaseNode *node);
-
+  WbRobot *findRobotToReconnect(QString robotName);
   QLocalServer *mServer;
   QList<WbController *> mControllers;
   QList<WbController *> mWaitingControllers;  // controllers inserted in previous step and waiting to be started in current step


### PR DESCRIPTION
If the controller died, it can't call the cleanup function, and when I restart it, I get a error message from webots because he think that the controller is still running, so he can't find a spot for the new incoming connection.

It simply remove the dead controller connection as usual, then recreate a new one. (a bit of code duplication from the line above, my bad... It might be possible to avoid that).
The trick is to use the name of the robot to know which dead controller should be kill. (which is fine for me). Otherwise, if no name is provided, the code execute as usual (scanning for free spot).

Maybe a more elegant solution is possible, by reassigning a socket id, for instance, but I'm first trying to get it working. I've noticed the robot_id, which maybe could be used for that, but I've not investigated in that direction.
It's have not been tested in every way possible, but I'm not seeing major issues coming.
The main thing to check would be leak of memory, unclosed socket and so on, because I'm not sure how is it performed.

I'm open to any advice,  it's my first PR here ! :)
This PR close #3000
It might close #1903 
#2152 is also about it, however having built from origin/master don't seems to solve the issue

PS : I'm not sure about merging to master. Is it on develop ?