### PR TITLE
Add two missing package to build on Debian 11

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -6,7 +6,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev zip unzip
+apt install --yes git lsb-release cmake swig python2.7-dev python3-dev libusb-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev zip unzip
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "16.04"  || $UBUNTU_VERSION == "18.04" ]]; then


### PR DESCRIPTION
Building on Debian miss some instructions.
I've built Webots from source on a clean install of Debian 11, and I needed to issue some additionnal commands.

**Solution**
Got the followings messages during make :

`/usr/bin/ld: cannot find -lusb`
solution : 
`sudo apt install libusb-dev`

`Can't find Python.h`
solution : 
`sudo apt install python3-dev`

I suggest adding both those packages in `sudo scripts/install/linux_compilation_dependencies.sh`

`can't find execstack`
solution:
didn't need to make anything, it seems to be working fine without it. Any idea ?