### PR TITLE
Avoid duplicate device names in the exported URDF

### DIFF
--- a/src/webots/nodes/WbSolidDevice.cpp
+++ b/src/webots/nodes/WbSolidDevice.cpp
@@ -58,7 +58,3 @@ QString WbSolidDevice::computeShortUniqueName() const {
     return QString("%1:%2").arg(robot->computeUniqueName()).arg(WbSolid::name());
   return computeUniqueName();
 }
-
-const QString WbSolidDevice::urdfName() const {
-  return getUrdfPrefix() + name();
-}

--- a/src/webots/nodes/WbSolidDevice.hpp
+++ b/src/webots/nodes/WbSolidDevice.hpp
@@ -47,8 +47,6 @@ protected:
   void subscribeToRaysUpdate(dGeomID ray);
   virtual void updateRaysSetupIfNeeded() {}
 
-  const QString urdfName() const override;
-
 private:
   static QList<QPair<WbSolidDevice *, dGeomID>> cDirtySensors;
 };


### PR DESCRIPTION
**Description**
In case there was a device and solid with the same name there used to be a conflict in the generated URDF. In general, we should make sure there is no device and solid with the same name, but this PR makes the URDF exporter more robust to these cases.