### PR TITLE
Fix crash Matlab controller

### DIFF
--- a/resources/projects/plugins/robot_windows/generic/Makefile
+++ b/resources/projects/plugins/robot_windows/generic/Makefile
@@ -23,8 +23,8 @@ LIBRARIES = -lgeneric_robot_window
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
-
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
+
 ifeq ($(OSTYPE),linux)
  LIBRARIES += -Wl,-rpath,$(WEBOTS_HOME_PATH)/lib/controller
 endif

--- a/resources/projects/plugins/robot_windows/generic/Makefile
+++ b/resources/projects/plugins/robot_windows/generic/Makefile
@@ -24,3 +24,7 @@ null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.include
+
+ifeq ($(OSTYPE),linux)
+ LIBRARIES += -Wl,-rpath,$(WEBOTS_HOME_PATH)/lib/controller
+endif

--- a/resources/projects/plugins/robot_windows/generic/Makefile
+++ b/resources/projects/plugins/robot_windows/generic/Makefile
@@ -23,8 +23,10 @@ LIBRARIES = -lgeneric_robot_window
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
-include $(WEBOTS_HOME_PATH)/resources/Makefile.include
 
+include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 ifeq ($(OSTYPE),linux)
  LIBRARIES += -Wl,-rpath,$(WEBOTS_HOME_PATH)/lib/controller
 endif
+
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include


### PR DESCRIPTION
**Description**
The MATLAB controllers crash in the _develop_ branch, because they fail to load `lib/controller/libgeneric_robot_window.so`  from `resources/projects/plugins/robot_windows/generic/libgeneric.so`.

**Related Issues**
This pull-request fixes issue #2996.

**Tasks**

- [x] Compatibility MacOS
- [x] Compatibility Windows

**Additional context**
This has been solved by adding `lib/controller` in the rpath of `libgeneric.so`.