### PR TITLE
Improve Linux installation instructions

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -14,7 +14,7 @@ if [[ $UBUNTU_VERSION == "16.04"  || $UBUNTU_VERSION == "18.04" ]]; then
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
        apt install --yes libzip5 python-pip-whl
 else
-       echo "Unsupported Linux version."
+       echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
 fi
 
 script_full_path=$(dirname "$0")

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -9,7 +9,7 @@ fi
 apt install --yes software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt update
-apt install --yes lsb-release curl python3.6-dev python3.7-dev python3.8-dev python3.9-dev dirmngr
+apt install --yes lsb-release curl python3.6-dev python3.7-dev python3.8-dev python3.9-dev dirmngr execstack
 curl -sL https://deb.nodesource.com/setup_15.x | bash -
 apt install --yes nodejs
 
@@ -21,7 +21,7 @@ elif [[ $UBUNTU_VERSION == "18.04" ]]; then
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
        apt install --yes openjdk-14-jdk
 else
-       echo "Unsupported Linux version."
+       echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
 fi
 
 script_full_path=$(dirname "$0")

--- a/scripts/install/linux_runtime_dependencies.sh
+++ b/scripts/install/linux_runtime_dependencies.sh
@@ -6,7 +6,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes lsb-release g++ make libavcodec-extra libglu1-mesa libxkbcommon-x11-dev execstack libusb-dev libxcb-keysyms1 libxcb-image0 libxcb-icccm4 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcomposite-dev libxtst6 libnss3
+apt install --yes lsb-release g++ make libavcodec-extra libglu1-mesa libxkbcommon-x11-dev libusb-dev libxcb-keysyms1 libxcb-image0 libxcb-icccm4 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcomposite-dev libxtst6 libnss3
 if [[ -z "$DISPLAY" ]]; then
        apt install --yes xvfb
 fi
@@ -19,5 +19,5 @@ elif [[ $UBUNTU_VERSION == "18.04" ]]; then
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
        apt install --yes ffmpeg
 else
-       echo "Unsupported Linux version."
+       echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
 fi

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -13,7 +13,7 @@ elif [[ $UBUNTU_VERSION == "18.04" ]]; then
 elif [[ $UBUNTU_VERSION == "20.04" ]]; then
        export ROS_DISTRO=noetic
 else
-       echo "Unsupported Linux version."
+       echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
 fi
 
 sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -25,4 +25,3 @@ if [[ $1 != "--norecurse" ]]; then
 	script_full_path=$(dirname "$0")
 	$script_full_path/linux_runtime_dependencies.sh
 fi
-

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -97,6 +97,9 @@ TARGET          = $(PYOUT) $(LIBOUT)
 ifeq (, $(shell which $(PYTHON_COMMAND) 2> /dev/null))
 release debug profile:
 	@echo -e "# \033[0;33m$(PYTHON_COMMAND) not installed, skipping Python API\033[0m"
+else ifeq (, $(shell which $(PYTHON_COMMAND)-config 2> /dev/null))
+release debug profile:
+	@echo -e "# \033[0;33m$(PYTHON_COMMAND)-dev not installed, skipping Python API\033[0m"
 else ifeq ($(SWIG_EXISTS),)
 release debug profile:
 	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"


### PR DESCRIPTION
Following the feedback in #3006, I tried to improve the Linux installation instructions:
* [x] improve the wiki page:
    * clearly state that automatic scripts only fully works on Ubuntu LTS
    * clearly state that the `.bash` configuration should be adapted to the user system
    * clearly state that on other Linux distribution python-dev package 
    https://github.com/cyberbotics/webots/wiki/Linux-installation/_compare/ac6b97088b70a397ad9f1ebcd0ff0c1265c1eb54...3e45f2826bcb70df7025a7c6d75f44e30bad6d34
* [x] improve "Unsupported Linux version" message
* [x] `execstack` library is not available on some Linux distribution (e.g., Debian 11) and could be needed for e-puck cross compilation but seems safe to move it from `compilation` to  `optional` dependency
* [x] add python-dev availability check in Python API Makefile