### PR TITLE
Fix initial labels in streaming viewer mode

### DIFF
--- a/resources/web/templates/x3d_playback.html
+++ b/resources/web/templates/x3d_playback.html
@@ -20,7 +20,7 @@
     <script src="https://www.cyberbotics.com/jquery-ui/1.11.4/jquery-ui.min.js"></script>
     <script src="https://www.cyberbotics.com/jquery-dialogextend/2.0.4/jquery.dialogextend.min.js"></script>
     <script src="https://www.cyberbotics.com/ace/1.2.0/ace.js"></script>
-    <script src="https://www.cyberbotics.com/wwi/R2021b/webotslabel.min.js"></script>
+    <script src="https://www.cyberbotics.com/wwi/R2021b/webots.min.js"></script>
     <script>
       function init() {
           var view = new webots.View(document.getElementById("view3d"));

--- a/resources/web/wwi/x3d_scene.js
+++ b/resources/web/wwi/x3d_scene.js
@@ -481,6 +481,13 @@ class X3dScene { // eslint-disable-line no-unused-vars
         if (this.viewpoint.updateViewpointPosition(null, view.time))
           this.viewpoint.notifyCameraParametersChanged(false);
         this.onSceneUpdate();
+      } else { // parse the labels even so the scene loading is not completed
+        data = data.substring(data.indexOf(':') + 1);
+        let frame = JSON.parse(data);
+        if (frame.hasOwnProperty('labels')) {
+          for (let i = 0; i < frame.labels.length; i++)
+            this.applyLabel(frame.labels[i], view);
+        }
       }
     } else if (data.startsWith('node:')) {
       data = data.substring(data.indexOf(':') + 1);


### PR DESCRIPTION
**Description**
The labels are now send along the updates of positions/rotations/...

The labels that are set before the connection with the streaming viewer are sent with the first update.

However, it happens that this first update is droped by the streaming viewer because the scene is not fully loaded.

As labels are HTML elements, it is not a problem if some nodes or textures are not loaded, we can already draw them.

**Fix**
Instead of fully dropping an update if the scene is still loading, we drop everything but the labels.

Additionally, we restore the correct link in the animation template (the file will be changed on the server when merging) 

