### PR TITLE
Fix crash solidReference

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -53,6 +53,7 @@ Released on XX Xth, 2021.
     - Fixed the [Pen](pen.md) ink mixed with the background and other ink when the `inkDensity` is lower than 1.0 ([#2804](https://github.com/cyberbotics/webots/pull/2804)).
     - Fixed issue where motor position limits in [Hinge2Joint](hinge2joint.md) and [BallJoint](balljoint.md) were enforced incorrectly ([#2825](https://github.com/cyberbotics/webots/pull/2825)).
     - Fixed issue where the hidden field of a [BallJoint](balljoint.md) is not stored in the world file when saving after the simulation has run ([#2964](https://github.com/cyberbotics/webots/pull/2964)).
+    - Fixed crash when the top node of a solidReference was a transform or a group ([#3039](https://github.com/cyberbotics/webots/pull/3039)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
   - Dependency Updates

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -53,7 +53,7 @@ Released on XX Xth, 2021.
     - Fixed the [Pen](pen.md) ink mixed with the background and other ink when the `inkDensity` is lower than 1.0 ([#2804](https://github.com/cyberbotics/webots/pull/2804)).
     - Fixed issue where motor position limits in [Hinge2Joint](hinge2joint.md) and [BallJoint](balljoint.md) were enforced incorrectly ([#2825](https://github.com/cyberbotics/webots/pull/2825)).
     - Fixed issue where the hidden field of a [BallJoint](balljoint.md) is not stored in the world file when saving after the simulation has run ([#2964](https://github.com/cyberbotics/webots/pull/2964)).
-    - Fixed crash when the top node of a solidReference was a transform or a group ([#3039](https://github.com/cyberbotics/webots/pull/3039)).
+    - Fixed crash when the top node of a SolidReference was a transform or a group ([#3039](https://github.com/cyberbotics/webots/pull/3039)).
   - Cleanup
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
   - Dependency Updates

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -663,7 +663,24 @@ WbMatter *WbNodeUtilities::findUppermostMatter(WbNode *node) {
 }
 
 WbSolid *WbNodeUtilities::findTopSolid(const WbNode *node) {
-  return dynamic_cast<WbSolid *>(const_cast<WbNode *>(findTopNode(node)));
+  if (node == NULL || node->isWorldRoot())
+    return NULL;
+
+  const WbNode *n = node;
+  const WbNode *parent = n->parentNode();
+  WbSolid *topSolid = NULL;
+  WbSolid *currentNode;
+  while (parent) {
+    currentNode = dynamic_cast<WbSolid *>(const_cast<WbNode *>(n));
+    if (currentNode)
+      topSolid = currentNode;
+    if (parent->isWorldRoot())
+      return topSolid;
+
+    n = parent;
+    parent = n->parentNode();
+  }
+  return NULL;
 }
 
 WbTransform *WbNodeUtilities::findUpperTransform(const WbNode *node) {

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -663,24 +663,23 @@ WbMatter *WbNodeUtilities::findUppermostMatter(WbNode *node) {
 }
 
 WbSolid *WbNodeUtilities::findTopSolid(const WbNode *node) {
-  if (node == NULL || node->isWorldRoot())
+  if (node == NULL)
     return NULL;
 
   const WbNode *n = node;
   const WbNode *parent = n->parentNode();
   WbSolid *topSolid = NULL;
-  WbSolid *currentNode;
   while (parent) {
-    currentNode = dynamic_cast<WbSolid *>(const_cast<WbNode *>(n));
-    if (currentNode)
-      topSolid = currentNode;
+    WbSolid *currentSolid = dynamic_cast<WbSolid *>(const_cast<WbNode *>(n));
+    if (currentSolid)
+      topSolid = currentSolid;
     if (parent->isWorldRoot())
-      return topSolid;
+      break;
 
     n = parent;
     parent = n->parentNode();
   }
-  return NULL;
+  return topSolid;
 }
 
 WbTransform *WbNodeUtilities::findUpperTransform(const WbNode *node) {

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -673,8 +673,6 @@ WbSolid *WbNodeUtilities::findTopSolid(const WbNode *node) {
     WbSolid *currentSolid = dynamic_cast<WbSolid *>(const_cast<WbNode *>(n));
     if (currentSolid)
       topSolid = currentSolid;
-    if (parent->isWorldRoot())
-      break;
 
     n = parent;
     parent = n->parentNode();


### PR DESCRIPTION
**Description**
Webots crashed when we were inserting a solidReference and the top node of this solidReference was a transform or a group.
For example: Transform->Solid->HingeJoint->SolidReference.

With the introduction in developp of the possibility to introduce robots in transform, Webots would crash if we inserted the Shrimp robot in a transform.

CAUSE: to get the top solid, Webots was retrieving the top node and casting it to solid. But in the case of a group or transform as the top node, it would fail.

FIX: instead of retrieving the top node, we retrieve the uppest solid.

**Related Issues**
This pull-request fixes issue #3037 

