### PR TITLE
Added mStep increment in ros.cpp

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -112,6 +112,8 @@ void Ros::launchRos(int argc, char **argv) {
   fixName();
   bool rosMasterUriSet = false;
 
+  mStepSize = mRobot->getBasicTimeStep();
+
   for (int i = 1; i < argc; ++i) {
     const char masterUri[] = "--ROS_MASTER_URI=";
     const char name[] = "--name=";
@@ -447,7 +449,7 @@ void Ros::run(int argc, char **argv) {
     ros::spinOnce();
     publishClockIfNeeded();
     for (unsigned int i = 0; i < mSensorList.size(); i++)
-      mSensorList[i]->publishValues(mStep * mRobot->getBasicTimeStep());
+      mSensorList[i]->publishValues(mStep * mStepSize);
 
     if (!mUseWebotsSimTime && (mStep != 0 || mIsSynchronized)) {
       int oldStep = mStep;

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -447,7 +447,7 @@ void Ros::run(int argc, char **argv) {
     ros::spinOnce();
     publishClockIfNeeded();
     for (unsigned int i = 0; i < mSensorList.size(); i++)
-      mSensorList[i]->publishValues(mStep * mStepSize);
+      mSensorList[i]->publishValues(mStep * mRobot->getBasicTimeStep());
 
     if (!mUseWebotsSimTime && (mStep != 0 || mIsSynchronized)) {
       int oldStep = mStep;
@@ -458,6 +458,8 @@ void Ros::run(int argc, char **argv) {
       }
     } else if (step(mRobot->getBasicTimeStep()) == -1)
       mEnd = true;
+
+    mStep++;
   }
 }
 


### PR DESCRIPTION
**Description**
Fixing a bug which affects sampling period of sensors enabled from a ROS service. Sensors enabled from ROS are publishing values based on the basic time step of the world and not on the given value when enabling the sensor. mStep was not increased in ROS::run method. Additionaly I changed mStepSize by mRobot->getBasicTimeStep() in ROS::run, when passing the elapsed time to the publishValues method. mStepSize seems to be always equal to 1, even if the basic time step is bigger than 1ms.

**Related Issues**
None (Discord discussion)

**Tasks**
Add the list of tasks of this PR.
  - [ ] Task 1
  - [ ] Task 2

**Documentation**
None

**Screenshots**
None

**Additional context**
Bug was discovered while creating a VIO module using ROS environment.
