### PR TITLE
Fix path to the e-puck remote_controls sample

### DIFF
--- a/docs/guide/controller-plugin.md
+++ b/docs/guide/controller-plugin.md
@@ -157,4 +157,4 @@ For example, if you want to be able to use the distance sensor of the real robot
 
 A complete sample (communicating with the e-puck robot using bluetooth) can be found in this directory:
 
-`WEBOTS_HOME/projects/robots/e-puck/plugins/remote_controls/e-puck_bluetooth`
+`WEBOTS_HOME/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth`


### PR DESCRIPTION
**Description**
The path to the e-puck sample in the "Controller Plugins" section of the user guide is incorrect

**Documentation**
https://www.cyberbotics.com/doc/guide/controller-plugin?version=master
