### PR TITLE
Fix crash after camera spherical change

### DIFF
--- a/src/webots/nodes/WbRenderingDevice.cpp
+++ b/src/webots/nodes/WbRenderingDevice.cpp
@@ -104,6 +104,8 @@ int WbRenderingDevice::height() const {
 }
 
 void WbRenderingDevice::setup() {
+  if (mHasBeenSetup)
+    return;  
   if (mWidth)
     mSetupWidth = mWidth->value();
   if (mHeight)

--- a/src/webots/nodes/WbRenderingDevice.cpp
+++ b/src/webots/nodes/WbRenderingDevice.cpp
@@ -105,7 +105,7 @@ int WbRenderingDevice::height() const {
 
 void WbRenderingDevice::setup() {
   if (mHasBeenSetup)
-    return;  
+    return;
   if (mWidth)
     mSetupWidth = mWidth->value();
   if (mHeight)


### PR DESCRIPTION
Fixes the mentioned in the https://github.com/cyberbotics/webots/pull/3032#pullrequestreview-657983394 comment. Probably the Camera was affected as well.

**Steps to reproduce**
Compared to the steps explained in the comment we should be more aggressive to reproduce the crash almost every time:
  - open `range_finder.wbt`
  - start the simulation
  - change the RangeFinder image width and height to 1000
  - change the RangeFinder.spherical value to TRUE

**Additional context**
The `WbRenderingDevice` doesn't support changing the camera resolution at runtime. However, changing the `spherical` parameter fires an event that setups the `WbRenderingDevice` again. Setting up the `WbRenderingDevice` with the new resolution during the runtime crashes the simulation.

I am not sure whether the bug is present in the master branch.