### PR TITLE
Fixed Windows packaging

### DIFF
--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -44,7 +44,7 @@
 /mingw64/bin/libwoff2common.dll
 /mingw64/bin/libwoff2dec.dll
 /mingw64/bin/libxml2-2.dll
-/mingw64/bin/libzzip-0-13.dll
+/mingw64/bin/libzzip-0.dll
 /mingw64/bin/libopenal-1.dll
 /mingw64/bin/libassimp.dll
 /mingw64/bin/libssl-1_1-x64.dll


### PR DESCRIPTION
The nightly builds were failing at creating the Windows packages because libzzip was recently renamed after a MSYS2 update.