### PR TITLE
Allow tuning red color sensitivity of infra-red distance sensor

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -8,7 +8,9 @@ Released on June, Xth, 2021.
     - Added the `wb_supervisor_node_export_string` function which returns a string from which the node is constructed ([#2743](https://github.com/cyberbotics/webots/pull/2743)).
     - Added the `wb_supervisor_node_save/load_state` functions that allow partial world reverting to a saved state ([#2740](https://github.com/cyberbotics/webots/pull/2740)).
     - Added coupled motors feature which allows to control multiple logically linked [Motors](motor.md) at once ([#2939](https://github.com/cyberbotics/webots/pull/2939)).
-    - Changed the rendering engine of the streaming viewer and of the animations for WREN ([#2769](https://github.com/cyberbotics/webots/pull/2769)).
+    - Changed the rendering engine of the streaming viewer and of the animations for WREN ([#2769](https://
+    github.com/cyberbotics/webots/pull/2769)).
+    - Added the `redColorSensitivity` field to [DistanceSensor](distancesensor.md) that allows tuning (or even disabling) of the red color sensitivity for an infra-red distance sensor type ([#3077](https://github.com/cyberbotics/webots/pull/3077)).
   - Enhancements
     - Significantly improved the performance of the `wb_camera_get_image`, `wb_range_finder_get_range_image`, and `wb_lidar_get_range_image` functions ([#3032](https://github.com/cyberbotics/webots/pull/3032)).
     - Added a `stadium_dry` [background](../guide/object-backgrounds.md) with dry grass to allow Robocup players to distinguish the soccer field from the background ([#2874](https://github.com/cyberbotics/webots/pull/2874)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -8,9 +8,8 @@ Released on June, Xth, 2021.
     - Added the `wb_supervisor_node_export_string` function which returns a string from which the node is constructed ([#2743](https://github.com/cyberbotics/webots/pull/2743)).
     - Added the `wb_supervisor_node_save/load_state` functions that allow partial world reverting to a saved state ([#2740](https://github.com/cyberbotics/webots/pull/2740)).
     - Added coupled motors feature which allows to control multiple logically linked [Motors](motor.md) at once ([#2939](https://github.com/cyberbotics/webots/pull/2939)).
-    - Changed the rendering engine of the streaming viewer and of the animations for WREN ([#2769](https://
-    github.com/cyberbotics/webots/pull/2769)).
-    - Added the `redColorSensitivity` field to [DistanceSensor](distancesensor.md) that allows tuning (or even disabling) of the red color sensitivity for an infra-red distance sensor type ([#3077](https://github.com/cyberbotics/webots/pull/3077)).
+    - Changed the rendering engine of the streaming viewer and of the animations for WREN ([#2769](https://github.com/cyberbotics/webots/pull/2769)).
+    - Added the `redColorSensitivity` field to [DistanceSensor](distancesensor.md) that allows tuning (or even disabling) of the red color sensitivity for an infra-red distance sensor ([#3077](https://github.com/cyberbotics/webots/pull/3077)).
   - Enhancements
     - Significantly improved the performance of the `wb_camera_get_image`, `wb_range_finder_get_range_image`, and `wb_lidar_get_range_image` functions ([#3032](https://github.com/cyberbotics/webots/pull/3032)).
     - Added a `stadium_dry` [background](../guide/object-backgrounds.md) with dry grass to allow Robocup players to distinguish the soccer field from the background ([#2874](https://github.com/cyberbotics/webots/pull/2874)).

--- a/docs/reference/distancesensor.md
+++ b/docs/reference/distancesensor.md
@@ -10,7 +10,7 @@ DistanceSensor {
   SFFloat  aperture                 1.5708                # [0, 2*pi]
   SFFloat  gaussianWidth            1                     # [0, inf)
   SFFloat  resolution               -1                    # {-1, [0, inf)}
-  SFFloat  redColorSensitivity      1                     # [0, 1]
+  SFFloat  redColorSensitivity      1                     # [0, inf)
 }
 ```
 
@@ -79,9 +79,9 @@ This field accepts any value in the interval (0.0, inf).
 
 - `redColorSensitivity`: red color sensitivity factor.
 This allows to tune (or even disable) red color sensitivity for infra-red distance sensor type.
-Value of 1 means ordinary Webots behavior.
+A value of 1 corresponds to the default behavior.
 Values greater that 1 increase the red color sensitivity and values lower than 1 decrease it.
-Value of 0 disables the red color sensitivity completely.
+A value of 0 disables the effect of the red color completely.
 See details [below](#infra-red-sensors).
 
 ### Lookup Table

--- a/docs/reference/distancesensor.md
+++ b/docs/reference/distancesensor.md
@@ -4,12 +4,13 @@ Derived from [Device](device.md) and [Solid](solid.md).
 
 ```
 DistanceSensor {
-  MFVec3f  lookupTable   [ 0 0 0, 0.1 1000 0 ] # lookup table
-  SFString type          "generic"             # {"generic", "infra-red", "sonar", "laser"}
-  SFInt32  numberOfRays  1                     # [1, inf)
-  SFFloat  aperture      1.5708                # [0, 2*pi]
-  SFFloat  gaussianWidth 1                     # [0, inf)
-  SFFloat  resolution    -1                    # {-1, [0, inf)}
+  MFVec3f  lookupTable              [ 0 0 0, 0.1 1000 0 ] # lookup table
+  SFString type                     "generic"             # {"generic", "infra-red", "sonar", "laser"}
+  SFInt32  numberOfRays             1                     # [1, inf)
+  SFFloat  aperture                 1.5708                # [0, 2*pi]
+  SFFloat  gaussianWidth            1                     # [0, inf)
+  SFFloat  resolution               -1                    # {-1, [0, inf)}
+  SFFloat  redColorSensitivity      1                     # [0, 1]
 }
 ```
 
@@ -27,7 +28,7 @@ The red/green transition on the rays indicates the points of intersection with t
 - `lookupTable`: a table used for specifying the desired response curve and noise of the device (see [below](#lookup-table) for more details).
 
 - `type`: one of "generic" (the default), "infra-red", "sonar" or "laser".
-Sensors of type "infra-red" are sensitive to the objects' colors; light and red (RGB) obstacles have a higher response than dark and non-red obstacles (see below for more details).
+Sensors of type "infra-red" can be sensitive to the objects' colors; light and red (RGB) obstacles have a higher response than dark and non-red obstacles (see below for more details).
 Sensors of type "sonar" and "laser" return the distance to the nearest object while "generic" and "infa-red" computes the average distance of all rays.
 Note however that sensors of type "sonar" will return the sonar range for each ray whose angle of incidence is greater than &pi;/8 radians (see below for more details).
 Sensors of type "laser" can have only one ray and they have the particularity to draw a red spot at the point where this ray hits an obstacle. This red spot is visible on the camera images. If the red spot disappears due to depth fighting, then it could help increasing the `lineScale` value in [WorldInfo](worldinfo.md) node that is used for computing its position offset.
@@ -140,12 +141,12 @@ Two different methods are used for calculating the distance from an object.
 
 ### Infra-Red Sensors
 
-In the case of an "infra-red" sensor, the value returned by the lookup table is modified by a reflection factor depending on the color, roughness and occlusion properties of the object hit by the sensor ray.
+In the case of an "infra-red" sensor, the value returned by the lookup table is modified by a reflection factor depending on the color, roughness and occlusion properties of the object hit by the sensor ray. The red color sensitivity property of the distance sensor also applies and can be used to tune this sensitivity. Value of 0 will completely disable red color sensitivity.
 The reflection factor is computed as follows: *f = 0.2 + 0.8 * red\_level * (1 - 0.5 * roughness) * (1 - 0.5 * occlusion)* where *red\_level* is the level of red color of the object hit by the sensor ray.
 This level is evaluated combining the `diffuseColor` (in case of [Appearance](appearance.md)), `baseColor` (in case of [PBRAppearance](pbrappearance.md)) and `transparency` values of the object, the pixel value of the image texture and the paint color applied on the object with the [Pen](pen.md) device.
 The *roughness* is evaluated (only in case of [PBRAppearance](pbrappearance.md), otherwise roughness is 0) using the `roughness` value and the pixel value of the `roughnessMap` image texture.
 The *occlusion* is evaluated (only in case of [PBRAppearance](pbrappearance.md), otherwise occlusion is 0) using the pixel value of the `occlusionMap` image texture.
-Then, the distance value computed by the simulator is divided by the reflection factor before the lookup table is used to compute the output value.
+Then, the distance value computed by the simulator is multiplied by the red color sensitivity factor and divided by the reflection factor before the lookup table is used to compute the output value.
 
 > **Note**: Unlike other distance sensor rays, "infra-red" rays can detect solid parts of the robot itself.
 It is thus important to ensure that no solid geometries interpose between the sensor and the area to inspect.

--- a/docs/reference/distancesensor.md
+++ b/docs/reference/distancesensor.md
@@ -77,6 +77,13 @@ This field is ignored for the "sonar" and "laser" DistanceSensor types.
 Setting this field to -1 (default) means that the sensor has an 'infinite' resolution (it can measure any infinitesimal change).
 This field accepts any value in the interval (0.0, inf).
 
+- `redColorSensitivity`: red color sensitivity factor.
+This allows to tune (or even disable) red color sensitivity for infra-red distance sensor type.
+Value of 1 means ordinary Webots behavior.
+Values greater that 1 increase the red color sensitivity and values lower than 1 decrease it.
+Value of 0 disables the red color sensitivity completely.
+See details [below](#infra-red-sensors).
+
 ### Lookup Table
 
 A lookup table indicates how the value measured by Webots must be mapped to response values returned by the sensor (the distance returned by the `wb_distance_sensor_get_value` function in case of [DistanceSensor](#distancesensor)).
@@ -141,12 +148,13 @@ Two different methods are used for calculating the distance from an object.
 
 ### Infra-Red Sensors
 
-In the case of an "infra-red" sensor, the value returned by the lookup table is modified by a reflection factor depending on the color, roughness and occlusion properties of the object hit by the sensor ray. The red color sensitivity property of the distance sensor also applies and can be used to tune this sensitivity. Value of 0 will completely disable red color sensitivity.
+In the case of an "infra-red" sensor, the value returned by the lookup table is modified by a reflection factor depending on the color, roughness and occlusion properties of the object hit by the sensor ray.
+The `redColorSensitivity` field also applies and can be used to tune this functionality. Value of 0 will completely disable red color sensitivity.
 The reflection factor is computed as follows: *f = 0.2 + 0.8 * red\_level * (1 - 0.5 * roughness) * (1 - 0.5 * occlusion)* where *red\_level* is the level of red color of the object hit by the sensor ray.
 This level is evaluated combining the `diffuseColor` (in case of [Appearance](appearance.md)), `baseColor` (in case of [PBRAppearance](pbrappearance.md)) and `transparency` values of the object, the pixel value of the image texture and the paint color applied on the object with the [Pen](pen.md) device.
 The *roughness* is evaluated (only in case of [PBRAppearance](pbrappearance.md), otherwise roughness is 0) using the `roughness` value and the pixel value of the `roughnessMap` image texture.
 The *occlusion* is evaluated (only in case of [PBRAppearance](pbrappearance.md), otherwise occlusion is 0) using the pixel value of the `occlusionMap` image texture.
-Then, the distance value computed by the simulator is multiplied by the red color sensitivity factor and divided by the reflection factor before the lookup table is used to compute the output value.
+Then, the distance value computed by the simulator is multiplied by the `redColorSensitivity` field value and divided by the reflection factor before the lookup table is used to compute the output value.
 
 > **Note**: Unlike other distance sensor rays, "infra-red" rays can detect solid parts of the robot itself.
 It is thus important to ensure that no solid geometries interpose between the sensor and the area to inspect.

--- a/resources/nodes/DistanceSensor.wrl
+++ b/resources/nodes/DistanceSensor.wrl
@@ -27,7 +27,7 @@ DistanceSensor {
   field     SFFloat                                             aperture             1.5708                 # aperture angle
   field     SFFloat                                             gaussianWidth        1                      # gaussian distribution width
   field     SFFloat                                             resolution          -1                      # resolution
-  field     SFFloat                                             redColorSensitivity  1                      # red color sensitivity (0..1) for infra-red distance sensor
+  field     SFFloat                                             redColorSensitivity  1                      # red color sensitivity for infra-red distance sensor
 
   # hidden fields
   hiddenField SFVec3f linearVelocity  0 0 0   # (m/s) Solid's initial linear velocity

--- a/resources/nodes/DistanceSensor.wrl
+++ b/resources/nodes/DistanceSensor.wrl
@@ -21,12 +21,13 @@ DistanceSensor {
   field     SFFloat    radarCrossSection   0.0               # radar cross section of this solid
   field     MFColor    recognitionColors   []                # colors returned for this Solid by Cameras with a Recognition node
   #fields specific to the DistanceSensor node:
-  field     MFVec3f                                             lookupTable     [ 0 0 0, 0.1 1000 0 ]  # return values are computed by extrapoling this table (measure in m., returned value integer, associated noise)
-  field     SFString{"generic", "infra-red" "sonar", "laser"}   type            "generic"              # distance sensor type
-  field     SFInt32                                             numberOfRays    1                      # number of rays
-  field     SFFloat                                             aperture        1.5708                 # aperture angle
-  field     SFFloat                                             gaussianWidth   1                      # gaussian distribution width
-  field     SFFloat                                             resolution     -1                      # resolution
+  field     MFVec3f                                             lookupTable          [ 0 0 0, 0.1 1000 0 ]  # return values are computed by extrapoling this table (measure in m., returned value integer, associated noise)
+  field     SFString{"generic", "infra-red" "sonar", "laser"}   type                 "generic"              # distance sensor type
+  field     SFInt32                                             numberOfRays         1                      # number of rays
+  field     SFFloat                                             aperture             1.5708                 # aperture angle
+  field     SFFloat                                             gaussianWidth        1                      # gaussian distribution width
+  field     SFFloat                                             resolution          -1                      # resolution
+  field     SFFloat                                             redColorSensitivity  1                      # red color sensitivity (0..1) for infra-red distance sensor
 
   # hidden fields
   hiddenField SFVec3f linearVelocity  0 0 0   # (m/s) Solid's initial linear velocity

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -183,6 +183,7 @@ void WbDistanceSensor::init() {
   mNumberOfRays = findSFInt("numberOfRays");
   mGaussianWidth = findSFDouble("gaussianWidth");
   mResolution = findSFDouble("resolution");
+  mRedColorSensitivity = findSFDouble("redColorSensitivity");
 
   mTransform = NULL;
   mMesh = NULL;
@@ -247,6 +248,7 @@ void WbDistanceSensor::postFinalize() {
   connect(mNumberOfRays, &WbSFInt::changed, this, &WbDistanceSensor::updateRaySetup);
   connect(mGaussianWidth, &WbSFDouble::changed, this, &WbDistanceSensor::updateRaySetup);
   connect(mResolution, &WbSFDouble::changed, this, &WbDistanceSensor::updateRaySetup);
+  connect(mRedColorSensitivity, &WbSFDouble::changed, this, &WbDistanceSensor::updateRaySetup);
 }
 
 void WbDistanceSensor::updateRaySetup() {
@@ -269,6 +271,8 @@ void WbDistanceSensor::updateRaySetup() {
   if (WbFieldChecker::resetDoubleIfNonPositive(this, mGaussianWidth, 1.0))
     return;  // in order to avoiding passing twice in this function
   if (WbFieldChecker::resetDoubleIfNonPositiveAndNotDisabled(this, mResolution, -1, -1))
+    return;  // in order to avoiding passing twice in this function
+  if (WbFieldChecker::resetDoubleIfNegative(this, mRedColorSensitivity, -mRedColorSensitivity->value()))
     return;  // in order to avoiding passing twice in this function
   if (mRayType == LASER && mNumberOfRays->value() > 1) {
     parsingWarn(tr("'type' \"laser\" must have one single ray."));
@@ -530,8 +534,8 @@ void WbDistanceSensor::computeValue() {
       mDistance += distance * mRays[i].weight();
     }
 
-    // apply infrared reflection factor
-    mDistance = mDistance / averageInfraRedFactor;
+    // apply infrared reflection factor and red color sensitivity
+    mDistance = mDistance * (mRedColorSensitivity->value() / averageInfraRedFactor);
   } else if (mRayType == SONAR) {
     // use only the nearest ray collision, ignore ray weight
     mDistance = lutMaxRange;
@@ -619,6 +623,7 @@ void WbDistanceSensor::addConfigure(QDataStream &stream) {
   stream << (double)mLut->minValue();
   stream << (double)mLut->maxValue();
   stream << (double)mAperture->value();
+  stream << (double)mRedColorSensitivity->value();
   stream << (int)mLookupTable->size();
   for (int i = 0; i < mLookupTable->size(); i++) {
     stream << (double)mLookupTable->item(i).x();

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -535,7 +535,8 @@ void WbDistanceSensor::computeValue() {
     }
 
     // apply infrared reflection factor and red color sensitivity
-    mDistance = mDistance * (mRedColorSensitivity->value() / averageInfraRedFactor);
+    // before adding of red color sensitivity factor it was calculated with mDistance = mDistance / averageInfraRedFactor
+    mDistance = mDistance + (mDistance / averageInfraRedFactor - mDistance) * mRedColorSensitivity->value();
   } else if (mRayType == SONAR) {
     // use only the nearest ray collision, ignore ray weight
     mDistance = lutMaxRange;

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -623,7 +623,6 @@ void WbDistanceSensor::addConfigure(QDataStream &stream) {
   stream << (double)mLut->minValue();
   stream << (double)mLut->maxValue();
   stream << (double)mAperture->value();
-  stream << (double)mRedColorSensitivity->value();
   stream << (int)mLookupTable->size();
   for (int i = 0; i < mLookupTable->size(); i++) {
     stream << (double)mLookupTable->item(i).x();

--- a/src/webots/nodes/WbDistanceSensor.hpp
+++ b/src/webots/nodes/WbDistanceSensor.hpp
@@ -94,6 +94,7 @@ private:
   WbSFInt *mNumberOfRays;
   WbSFDouble *mGaussianWidth;
   WbSFDouble *mResolution;
+  WbSFDouble *mRedColorSensitivity;
 
   // other fields
   WbLookupTable *mLut;


### PR DESCRIPTION
**Description**
Allows tuning of red color sensitivity of infra-red distance sensor with a new property `redColorSensitivity`. It's a floating point number, with default value 1 it will behave like before, with value 0 the red color sensitivity will be completely disabled.

**Tasks**
  - [x] Add to changelog
  - [x] Add entry to field summary documentation

**Documentation**
https://cyberbotics.com/doc/reference/distancesensor?version=develop

**Additional context**
This is my first PR to Webots and I may not know all the things that have to be done.
Should I update the changelog file?
Should I include controller method to get the new property (`wb_distance_sensor_get_red_color_sensitivity`)?
