### PR TITLE
Increase default mass for intemediary solids in `HingeJointWithBacklash` and `Hinge2JointWithBacklash`

### DIFF
--- a/docs/guide/hinge-2-joint-with-backlash.md
+++ b/docs/guide/hinge-2-joint-with-backlash.md
@@ -16,8 +16,8 @@ Hinge2JointWithBacklash [
   SFNode       jointParameters2    JointParameters {}
   SFFloat      backlash            0.01        # [0, inf)
   SFFloat      backlash2           0.01        # [0, inf)
-  SFFloat      gearMass            0.01        # (0, inf)
-  SFFloat      gearMass2           0.01        # (0, inf)
+  SFFloat      gearMass            0.1         # (0, inf)
+  SFFloat      gearMass2           0.1         # (0, inf)
   MFNode       device              [ ]         # {RotationalMotor, PositionSensor, Brake}
   MFNode       device2             [ ]         # {RotationalMotor, PositionSensor, Brake}
   MFNode       outputSensor        [ ]         # {PositionSensor}

--- a/docs/guide/hinge-joint-with-backlash.md
+++ b/docs/guide/hinge-joint-with-backlash.md
@@ -12,9 +12,9 @@ Derived from [HingeJoint](../reference/hingejoint.md).
 
 ```
 HingeJointWithBacklash [
-  SFNode       jointParameters   HingeJointParameters {} 
+  SFNode       jointParameters   HingeJointParameters {}
   SFFloat      backlash          0.01   # (0, inf)
-  SFFloat      gearMass          0.01   # [0, inf)
+  SFFloat      gearMass          0.1    # [0, inf)
   MFNode       device            [ ]    # {RotationalMotor, PositionSensor, Brake}
   MFNode       outputSensor      [ ]    # {PositionSensor}
   MFNode       startPoint        NULL   # {Group, Transform, or Shape}

--- a/projects/joints/protos/Hinge2JointWithBacklash.proto
+++ b/projects/joints/protos/Hinge2JointWithBacklash.proto
@@ -8,8 +8,8 @@ PROTO Hinge2JointWithBacklash [
   field SFNode                                 jointParameters2  JointParameters {}
   field SFFloat                                backlash          0.01   # Defines the gear clearence for axis, [0, inf).
   field SFFloat                                backlash2         0.01   # Defines the gear clearence for axis2, [0, inf).
-  field SFFloat                                gearMass          0.01   # Defines the gear mass for axis, [0, inf).
-  field SFFloat                                gearMass2         0.01   # Defines the gear mass for axis2, [0, inf).
+  field SFFloat                                gearMass          0.1    # Defines the gear mass for axis, [0, inf).
+  field SFFloat                                gearMass2         0.1    # Defines the gear mass for axis2, [0, inf).
   field MFNode                                 device            [ ]    # {RotationalMotor, PositionSensor, Brake}.
   field MFNode                                 device2           [ ]    # {RotationalMotor, PositionSensor, Brake}.
   field MFNode{PositionSensor{}}               outputSensor      [ ]    # {PositionSensor}.
@@ -95,7 +95,7 @@ PROTO Hinge2JointWithBacklash [
             }
           ]
           physics Physics {
-            inertiaMatrix [ 4e-9 4e-9 4e-9, 0.0 0.0 0.0 ] # sphere of radius 0.001
+            inertiaMatrix [ 4e-8 4e-8 4e-8, 0.0 0.0 0.0 ] # sphere of radius 0.01
             centerOfMass %{= anchor.x }% %{= anchor.y }% %{= anchor.z }%
             density -1
             mass IS gearMass2
@@ -146,7 +146,7 @@ PROTO Hinge2JointWithBacklash [
                   }
                 ]
                 physics Physics {
-                  inertiaMatrix [ 4e-9 4e-9 4e-9, 0.0 0.0 0.0 ] # sphere of radius 0.001
+                  inertiaMatrix [ 4e-8 4e-8 4e-8, 0.0 0.0 0.0 ] # sphere of radius 0.01
                   centerOfMass %{= anchor.x }% %{= anchor.y }% %{= anchor.z }%
                   density -1
                   mass IS gearMass2
@@ -156,7 +156,7 @@ PROTO Hinge2JointWithBacklash [
           }
         ]
         physics Physics {
-          inertiaMatrix [ 4e-9 4e-9 4e-9, 0.0 0.0 0.0 ] # sphere of radius 0.001
+          inertiaMatrix [ 4e-8 4e-8 4e-8, 0.0 0.0 0.0 ] # sphere of radius 0.01
           centerOfMass %{= anchor.x }% %{= anchor.y }% %{= anchor.z }%
           density -1
           mass IS gearMass

--- a/projects/joints/protos/HingeJointWithBacklash.proto
+++ b/projects/joints/protos/HingeJointWithBacklash.proto
@@ -6,7 +6,7 @@
 PROTO HingeJointWithBacklash [
   field SFNode                                 jointParameters   HingeJointParameters {}
   field SFFloat                                backlash          0.01   # Defines the gear clearence, [0, inf).
-  field SFFloat                                gearMass          0.01   # Defines the gear mass, [0, inf).
+  field SFFloat                                gearMass          0.1    # Defines the gear mass, [0, inf).
   field MFNode                                 device            [ ]    # {RotationalMotor, PositionSensor, Brake}.
   field MFNode{PositionSensor{}}               outputSensor      [ ]    # {PositionSensor}.
   field MFNode{Group{}, Transform{}, Shape{}}  startPoint        NULL   # {Group, Transform, or Shape}.
@@ -62,7 +62,7 @@ PROTO HingeJointWithBacklash [
           }
         ]
         physics Physics {
-          inertiaMatrix [ 4e-9 4e-9 4e-9, 0.0 0.0 0.0 ] # sphere of radius 0.001
+          inertiaMatrix [ 4e-8 4e-8 4e-8, 0.0 0.0 0.0 ] # sphere of radius 0.01
           centerOfMass %{= anchor.x}% %{= anchor.y}% %{= anchor.z}%
           density -1
           mass IS gearMass


### PR DESCRIPTION
**Description**
As reported by a Robocup user (Uli), the default mass used in the intermediary solids of the `HingeJointWithBacklash` and `Hinge2JointWithBacklash` might be too small for most use-cases and could lead to instabilities.
