### PR TITLE
Fixed compilation problem in WbPrecision.hpp

### DIFF
--- a/src/webots/maths/WbPrecision.hpp
+++ b/src/webots/maths/WbPrecision.hpp
@@ -17,6 +17,7 @@
 
 #include <math.h>
 #include <QtCore/QString>
+#include <limits>
 
 namespace WbPrecision {
 


### PR DESCRIPTION
See https://github.com/RoboCup-Humanoid-TC/webots/pull/112
Apparently this include is needed on some systems.