### PR TITLE
Fix potential crash on Windows

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1723,6 +1723,7 @@ void WbMainWindow::show3DForceInfo() {
       break;
     case WbSysInfo::WIN32_PLATFORM:
       info = infoWindows;
+      break;
     default:
       assert(false);
   }


### PR DESCRIPTION
Add a missing break statement.
Otherwise on Windows displaying we run the default statement, which raise an assert.