### PR TITLE
Run Webots step() in ROS controller by default

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -451,7 +451,7 @@ void Ros::run(int argc, char **argv) {
     for (unsigned int i = 0; i < mSensorList.size(); i++)
       mSensorList[i]->publishValues(mStep * mStepSize);
 
-    if (!mUseWebotsSimTime && (mStep != 0 || mIsSynchronized)) {
+    if (!mUseWebotsSimTime && mIsSynchronized) {
       int oldStep = mStep;
       while (mStep == oldStep && !mEnd && ros::ok()) {
         ros::spinOnce();


### PR DESCRIPTION
Incrementing `mStep` in the #3040 made the `ros` controller wait for the `time_step` service by default instead of running normally. This PR reverts the behavior, but I am not sure what was the purpose of the `mStep != 0` in the first place.