### PR TITLE
Fix triangle count

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -14,6 +14,7 @@ Released on XX Xth, 2021.
     - Added a nice looking FIFA soccer ball proto ([#2782](https://github.com/cyberbotics/webots/pull/2782)).
     - Added an `allowedChannels` field in the [Emitter](emitter.md) and [Receiver](receiver.md) nodes to restrict the channel usage ([#2849](https://github.com/cyberbotics/webots/pull/2849)).
   - Bug fixes
+    - Fixed triangle count for [Mesh](mesh.md) and [IndexedFaceSet](indexedfaceset.md) when there is a lot of triangles ([#3086](https://github.com/cyberbotics/webots/pull/3086)).
     - Fixed [Supervisor](supervisor.md) API operations on nodes defined in multiple nested PROTO fields ([#3036](https://github.com/cyberbotics/webots/pull/3036)).
     - Fixed crash applying [`wb_supervisor_node_add_force`](supervisor.md#wb_supervisor_node_add_force) on kinematic objects ([#3036](https://github.com/cyberbotics/webots/pull/3036)).
     - Fixed mecanum wheels [ContactProperties](contactproperties.md) in [YouBot](../guide/youbot.md) worlds ([#3025](https://github.com/cyberbotics/webots/pull/3025)).

--- a/include/wren/static_mesh.h
+++ b/include/wren/static_mesh.h
@@ -46,7 +46,6 @@ void wr_static_mesh_get_bounding_sphere(WrStaticMesh *mesh, float *sphere);
    This function should be avoided in performance sensitive code as it involves heavy memory operations. */
 void wr_static_mesh_read_data(WrStaticMesh *mesh, float *coord_data, float *normal_data, float *tex_coord_data,
                               unsigned int *index_data);
-int wr_static_mesh_get_triangle_count(WrStaticMesh *mesh);
 int wr_static_mesh_get_vertex_count(WrStaticMesh *mesh);
 int wr_static_mesh_get_index_count(WrStaticMesh *mesh);
 

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -44,7 +44,7 @@
 // Constant used to scale down the line scale property
 const float WbGeometry::LINE_SCALE_FACTOR = 250.0f;
 
-const int gMaxIndexNumberToCastShadows = (2 << 14) - 1;  // 2^15 - 1 (16-bit resolution)
+const int gMaxIndexNumberToCastShadows = (2 << 15) - 1;  // 2^16 - 1 (16-bit resolution)
 
 int WbGeometry::maxIndexNumberToCastShadows() {
   return gMaxIndexNumberToCastShadows;
@@ -559,7 +559,7 @@ bool WbGeometry::isAValidBoundingObject(bool checkOde, bool warning) const {
 
 int WbGeometry::triangleCount() const {
   if (areWrenObjectsInitialized() && this->wrenMesh())
-    return wr_static_mesh_get_triangle_count(this->wrenMesh());
+    return wr_static_mesh_get_index_count(this->wrenMesh()) / 3;
   else
     return 0;
 }

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -44,7 +44,7 @@
 // Constant used to scale down the line scale property
 const float WbGeometry::LINE_SCALE_FACTOR = 250.0f;
 
-const int gMaxIndexNumberToCastShadows = (2 << 15) - 1;  // 2^16 - 1 (16-bit resolution)
+const int gMaxIndexNumberToCastShadows = (1 << 16) - 1;  // 2^16 - 1 (16-bit resolution)
 
 int WbGeometry::maxIndexNumberToCastShadows() {
   return gMaxIndexNumberToCastShadows;

--- a/src/webots/scene_tree/WbNodeEditor.cpp
+++ b/src/webots/scene_tree/WbNodeEditor.cpp
@@ -146,9 +146,14 @@ void WbNodeEditor::update() {
     mStackedWidget->setCurrentIndex(EMPTY_PANE);
 
   const WbGeometry *node = dynamic_cast<WbGeometry *>(mNode);
-  if (node && !node->isUseNode())
-    mNbTriangles->setText(tr("Triangle count: %1").arg(node->triangleCount()));
-  else
+  if (node && !node->isUseNode()) {
+    const int maxTriangleNumberToCastShadows = node->maxIndexNumberToCastShadows() / 3;
+    int triangleCount = node->triangleCount();
+    if (triangleCount > maxTriangleNumberToCastShadows) {
+      mNbTriangles->setText(tr("Triangle count: %1 (no shadow)").arg(triangleCount));
+    } else
+      mNbTriangles->setText(tr("Triangle count: %1").arg(triangleCount));
+  } else
     mNbTriangles->clear();
 }
 

--- a/src/webots/scene_tree/WbNodeEditor.cpp
+++ b/src/webots/scene_tree/WbNodeEditor.cpp
@@ -149,9 +149,9 @@ void WbNodeEditor::update() {
   if (node && !node->isUseNode()) {
     const int maxTriangleNumberToCastShadows = node->maxIndexNumberToCastShadows() / 3;
     int triangleCount = node->triangleCount();
-    if (triangleCount > maxTriangleNumberToCastShadows) {
+    if (triangleCount > maxTriangleNumberToCastShadows)
       mNbTriangles->setText(tr("Triangle count: %1 (no shadow)").arg(triangleCount));
-    } else
+    else
       mNbTriangles->setText(tr("Triangle count: %1").arg(triangleCount));
   } else
     mNbTriangles->clear();

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -2070,10 +2070,6 @@ void wr_static_mesh_read_data(WrStaticMesh *mesh, float *coord_data, float *norm
   reinterpret_cast<wren::StaticMesh *>(mesh)->readData(coord_data, normal_data, tex_coord_data, index_data);
 }
 
-int wr_static_mesh_get_triangle_count(WrStaticMesh *mesh) {
-  return reinterpret_cast<wren::StaticMesh *>(mesh)->triangles().size();
-}
-
 int wr_static_mesh_get_vertex_count(WrStaticMesh *mesh) {
   return reinterpret_cast<wren::StaticMesh *>(mesh)->vertexCount();
 }


### PR DESCRIPTION
**Description**
The triangle count for `Mesh`/`IndexedFaceSet` shows `0` when there is too many triangles. 

![noshadow](https://user-images.githubusercontent.com/38250944/119150747-055b8a00-ba4f-11eb-9449-1add1d1d153b.png)

This is because the count function relies on the size of the `triangles` vector from the `wren`. However, the renderer currently does not  display shadows  for meshes with more than (2^16-1)/3 triangles, to avoid an overflow of the index. Thus the `triangles` vector is empty.

This PR instead directly use the `indexCount` (divided by 3) to get the number of triangles. Also, it displays `(no shadow)` next to the number of triangles if it is beyond the limit for which Webots casts shadows.

![corrected](https://user-images.githubusercontent.com/38250944/119151726-f5907580-ba4f-11eb-8dd6-8dcff4253aea.png)

**Linked PR**
[Enhancement display triangles geometry node](https://github.com/cyberbotics/webots/pull/1456)
