### PR TITLE
Fix mismatch between slugify function in documentation test

### DIFF
--- a/docs/guide/robotis-op2.md
+++ b/docs/guide/robotis-op2.md
@@ -616,7 +616,7 @@ Webots will also stop the auto start of the demo program at the startup of the r
 Then the controller code itself is sent to the robot.
 The whole controller directory is sent to the robot, so please put all the files needed by your controller in the same directory.
 The controller itself is then compiled for the robot and you can see the compilation in the `Robot console`.
-If the compilation succeeds and the robot is close to the [start position](#start-position-of-the-robot-the-robot-is-sitting-down) the controller will be initialized (head and eyes [LED](../reference/led.md) in red) and then started (head and eyes [LED](../reference/led.md) in green).
+If the compilation succeeds and the robot is close to the [start position](#start-position-of-the-robot-the-robot-is-sitting-down-same-start-position-as-in-simulation) the controller will be initialized (head and eyes [LED](../reference/led.md) in red) and then started (head and eyes [LED](../reference/led.md) in green).
 
 %figure "Start position of the robot. The robot is sitting down (same start position as in simulation)"
 
@@ -686,7 +686,7 @@ Moreover, the remote control mode allows you to visualize the state of the senso
 #### Using Remote Control from Robot Window
 
 To use remote control, open the robot window, go to the `Transfer` tab, as for remote compilation you have to set the connection settings (see [previous chapter](#settings) for more information).
-To start the remote control, stop and revert your simulation, put your robot in the [stable position](#start-position-of-the-robot-the-robot-is-sitting-down).
+To start the remote control, stop and revert your simulation, put your robot in the [stable position](#start-position-of-the-robot-the-robot-is-sitting-down-same-start-position-as-in-simulation).
 Then press the following button:
 
 %figure "Remote control button"
@@ -784,7 +784,7 @@ The controller is a very simple soccer player.
 It relies on most of the tools used in previous examples.
 We recommend you to study it by yourself and of course to improve it.
 
-To extend this controller you can add new files to the project, but do not forget to also add them to the makefile (add the cpp files to the `CXX_SOURCES` section).
+To extend this controller you can add new files to the project, but do not forget to also add them to the Makefile (add the cpp files to the `CXX_SOURCES` section).
 This example is also a good starting point for developing a more complicated controller.
 
 This example works in remote compilation.

--- a/docs/guide/robotis-op3.md
+++ b/docs/guide/robotis-op3.md
@@ -49,7 +49,7 @@ RobotisOp3 {
 
 > **File location**: "WEBOTS\_HOME/projects/robots/robotis/darwin-op/protos/RobotisOp3.proto"
 
-#### RobotisOp2 Field Summary
+#### RobotisOp3 Field Summary
 
 - `cameraWidth`: Defines the `width` field of the [Camera](../reference/camera.md).
 
@@ -82,7 +82,7 @@ The simulation model is mounted with the following sensors and actuators:
 #### Motion Manager
 
 The ROBOTIS OP3 can use the MotionManager.
-Please refer to [this documenation](robotis-op2.md#motion-manager).
+Please refer to [this documentation](robotis-op2.md#motion-manager).
 
 ### Samples
 

--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -2,7 +2,7 @@
 
 This tutorial aims at creating your first robot from scratch.
 The robot will consist of a body, four wheels, and two distance sensors.
-The result is depicted on [this figure](#3d-view-of-the-4-wheels-robot-note-that-the-coordinate-system-representations-of-the-robot-body-and-of-its-wheels-are-oriented-the-same-way-their-px-vector-defines-the-left-of-the-robot-their-py-vector-defines-the-top-of-the-robot-and-their-pz-vector-defines-the-front-of-the-robot-the-distance-sensors-are-oriented-in-a-different-way-their-px-vector-indicates-the-direction-of-the-sensor).
+The result is depicted on [this figure](#3d-view-of-the-4-wheels-robot-note-that-the-coordinate-system-representations-of-the-robot-body-and-of-its-wheels-are-oriented-the-same-way-their-px-vector-in-red-defines-the-left-of-the-robot-their-py-vector-in-green-defines-the-top-of-the-robot-and-their-pz-vector-in-blue-defines-the-front-of-the-robot-the-distance-sensors-are-oriented-in-a-different-way-their-px-vector-indicates-the-direction-of-the-sensor).
 The [next figure](#top-view-of-the-4-wheeled-robot-the-grid-behind-the-robot-has-a-dimension-of-0-2-x-0-3-meters-the-text-labels-correspond-to-the-name-of-the-device) shows the robot from a top view.
 
 %figure "3D view of the 4 wheels robot. Note that the coordinate system representations of the robot body and of its wheels are oriented the same way. Their +x-vector (in red) defines the left of the robot, their +y-vector (in green) defines the top of the robot, and their +z-vector (in blue) defines the front of the robot. The distance sensors are oriented in a different way, their +x-vector indicates the direction of the sensor."

--- a/docs/js/showdown-extensions.js
+++ b/docs/js/showdown-extensions.js
@@ -17,7 +17,7 @@ function wbSlugify(obj) {
     .replace(/[-]+/g, '-')
     .replace(/^-*/, '')
     .replace(/-*$/, '')
-    .replace('/\+/g', 'p')
+    .replace(/\+/g, 'p')
     .replace(/[^\w-]+/g, '');
 }
 

--- a/docs/js/showdown-extensions.js
+++ b/docs/js/showdown-extensions.js
@@ -17,7 +17,7 @@ function wbSlugify(obj) {
     .replace(/[-]+/g, '-')
     .replace(/^-*/, '')
     .replace(/-*$/, '')
-    .replace('+', 'p')
+    .replace('/\+/g', 'p')
     .replace(/[^\w-]+/g, '');
 }
 

--- a/docs/reference/connector.md
+++ b/docs/reference/connector.md
@@ -91,11 +91,11 @@ The distance is measured between the origins of the coordinate systems of the co
 - `axisTolerance`: the maximum angle [in radians] between the *z*-axes of two connectors at which they may successfully lock.
 Two [Connector](#connector) nodes can lock when their *z*-axes are parallel (within tolerance), but pointed in opposite directions.
 
-- `rotationTolerance`: the tolerated angle difference with respect to each of the allowed docking rotations (see [this figure](#example-of-rotational-alignment)).
+- `rotationTolerance`: the tolerated angle difference with respect to each of the allowed docking rotations (see [this figure](#example-of-rotational-alignment-numberofrotations4-and-rotationaltolerance22-5-deg)).
 
 - `numberOfRotations`: specifies how many different docking rotations are allowed in a full 360 degree rotation around the [Connector](#connector)'s z-axis.
 For example, modular robots' connectors are often 1-, 2- or 4-way dockable depending on mechanical and electrical interfaces.
-As illustrated in [this figure](#example-of-rotational-alignment), if `numberOfRotations` is 4 then there will be 4 different docking positions (one every 90 degrees).
+As illustrated in [this figure](#example-of-rotational-alignment-numberofrotations4-and-rotationaltolerance22-5-deg), if `numberOfRotations` is 4 then there will be 4 different docking positions (one every 90 degrees).
 If you don't wish to check the rotational alignment criterion this field should be set to zero.
 
 %figure "Example of rotational alignment (numberOfRotations=4 and rotationalTolerance=22.5 deg)"

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -263,9 +263,9 @@ Before the first call to the `wb_display_set_alpha` function, the default value 
 
 The `wb_display_set_opacity` function defines with which opacity the new pixels will replace the old ones for the following drawing instructions.
 It is expressed as a floating point value between 0.0 and 1.0; while 0 means that the new pixel has no effect over the old one and 1 means that the new pixel replaces entirely the old one.
-Only the color channel is affected by the `opacity` according to the [blending](#blending-formula-used-to-compute-the-new-the-color-channels-of-a-pixel-from-the-old-color-channels-of-the-background-pixel-and-from-the-opacity) formula.
+Only the color channel is affected by the `opacity` according to the [blending](#blending-formula-used-to-compute-the-new-color-channels-cn-of-a-pixel-from-the-old-color-channels-co-of-the-background-pixel-and-from-the-opacity) formula.
 
-%figure "Blending formula used to compute the new the color channels (Cn) of a pixel from the old color channels (Co) of the background pixel and from the opacity."
+%figure "Blending formula used to compute the new color channels (Cn) of a pixel from the old color channels (Co) of the background pixel and from the opacity."
 
 ![display_opacity.png](images/display_opacity.png)
 
@@ -720,7 +720,7 @@ The copied sub-image is defined by its top left coordinate (`x`,`y`) and its dim
 
 The `wb_display_image_paste` function pastes a clipboard image referred to by the `ir` parameter to the main display image.
 The (`x`,`y`) coordinates define the top left point of the pasted image.
-If the `blend` parameter is true, the resulting pixels displayed in the main display image are computed using a blending operation (similar to the one defined in the [blending](#blending-formula-used-to-compute-the-new-the-color-channels-of-a-pixel-from-the-old-color-channels-of-the-background-pixel-and-from-the-opacity) formula but involving the alpha channels of the old and new pixels instead of the opacity).
+If the `blend` parameter is true, the resulting pixels displayed in the main display image are computed using a blending operation (similar to the one defined in the [blending](#blending-formula-used-to-compute-the-new-color-channels-cn-of-a-pixel-from-the-old-color-channels-co-of-the-background-pixel-and-from-the-opacity) formula but involving the alpha channels of the old and new pixels instead of the opacity).
 In the `blend` parameter is set to false, the resulting pixels are simply copied from the clipboard image.
 The paste operation is much faster if `blend` is set to false.
 

--- a/docs/reference/lightsensor.md
+++ b/docs/reference/lightsensor.md
@@ -85,7 +85,7 @@ Finally, *spot[i]* is a factor used only in case of a [SpotLight](spotlight.md),
 
 %end
 
-The value *I[i]* corresponds to the *intensity* field of light *i*, and *N* is the normal axis (x-axis) of the sensor (see [this figure](#the-irradiance-depends-on-the-angle-between-the-n-and-l-vectors)).
+The value *I[i]* corresponds to the *intensity* field of light *i*, and *N* is the normal axis (x-axis) of the sensor (see [this figure](#the-irradiance-e-depends-on-the-angle-phi-between-the-n-and-l-vectors)).
 In the case of a [PointLight](pointlight.md), *L* is the sensor-to-light-source vector.
 In the case of a [DirectionalLight](directionallight.md), *L* corresponds to the negative of the light's `direction` field.
 The * operation is a modified dot product: if dot < 0, then 0, otherwise, dot product.

--- a/docs/tests/test_references.py
+++ b/docs/tests/test_references.py
@@ -10,7 +10,7 @@ import sys
 def slugify(txt):
     """Slugify function."""
     output = txt.lower()
-    output = re.sub(r'\([^)]*\)', '', output)  # remove the content of parenthesis
+    output = re.sub(r'\]\([^)]*\)', ']', output)  # remove the content of parenthesis if reference
     output = re.sub(r'<[^>]+>', '', output)
     output = output.replace('+', 'p')
     output = re.sub(r"[\(\):`']", '', output)

--- a/docs/tests/test_references.py
+++ b/docs/tests/test_references.py
@@ -13,7 +13,7 @@ def slugify(txt):
     output = re.sub(r'\]\([^)]*\)', ']', output)  # remove the content of parenthesis if reference
     output = re.sub(r'<[^>]+>', '', output)
     output = output.replace('+', 'p')
-    output = re.sub(r"[\(\):`']", '', output)
+    output = re.sub(r"[\(\):`'=]", '', output)
     output = re.sub(r'\\_', '_', output)
     output = re.sub(r'[\W-]+', '-', output)
     output = re.sub(r'^-*', '', output)


### PR DESCRIPTION
The `slugify` function used in `showdown-extension-js` to create the documentation HTML code doesn't match the one used in the documentation tests.
As a result wrong anchors that won't work in the documentation are passing the tests instead of the correct ones.
In particular there are issues with text in parenthesis.

Also `showdown-extensions.js` doesn't properly convert the `+` symbols in its slugify function but just the first occurrence.