### PR TITLE
Feature api webcomponent

### DIFF
--- a/resources/web/wwi/WebotsStreaming.js
+++ b/resources/web/wwi/WebotsStreaming.js
@@ -75,13 +75,19 @@ export default class WebotsStreaming extends HTMLElement {
       this._disconnectCallback();
   }
 
-  toggleToolbar() {
+  hideToolbar() {
     let toolbar = document.getElementById('toolBar');
     if (toolbar) {
-      if (toolbar.style.display === 'none')
-        toolbar.style.display = 'block';
-      else
+      if (toolbar.style.display !== 'none')
         toolbar.style.display = 'none';
+    }
+  }
+
+  showToolbar() {
+    let toolbar = document.getElementById('toolBar');
+    if (toolbar) {
+      if (toolbar.style.display !== 'block')
+        toolbar.style.display = 'block';
     }
   }
 

--- a/resources/web/wwi/WebotsStreaming.js
+++ b/resources/web/wwi/WebotsStreaming.js
@@ -75,6 +75,21 @@ export default class WebotsStreaming extends HTMLElement {
       this._disconnectCallback();
   }
 
+  toggleToolbar() {
+    let toolbar = document.getElementById('toolBar');
+    if (toolbar) {
+      if (toolbar.style.display === 'none')
+        toolbar.style.display = 'block';
+      else
+        toolbar.style.display = 'none';
+    }
+  }
+
+  sendMessage(message) {
+    if (typeof this._view !== 'undefined' && this._view.stream.socket.readyState === 1)
+      this._view.stream.socket.send(message);
+  }
+
   _load(scriptUrl) {
     return new Promise(function(resolve, reject) {
       let script = document.createElement('script');

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -280,9 +280,11 @@ void WbStreamingServer::processTextMessage(QString message) {
     if (realTime) {
       printf("real-time\n");
       WbSimulationState::instance()->setMode(WbSimulationState::REALTIME);
+      client->sendTextMessage("real-time");
     } else {
       printf("fast\n");
       WbSimulationState::instance()->setMode(WbSimulationState::FAST);
+      client->sendTextMessage("fast");
     }
     connect(WbSimulationState::instance(), &WbSimulationState::modeChanged, this,
             &WbStreamingServer::propagateSimulationStateChange);


### PR DESCRIPTION
Add the following API functions to the WebotsStreaming webcomponent:

- HideToolbar
- ShowToolbar
- SendMessage: allow the user to send message through the websocket, to play, pause, change the controller,...

An example of usage is present here:  https://cyberbotics1.epfl.ch/open-roberta
with the configuration file here : https://cyberbotics1.epfl.ch/open-roberta/setup_viewer.js