### PR TITLE
Fix CentOS compilation

### DIFF
--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -132,7 +132,7 @@ ifeq ($(MAKECMDGOALS), profile)
 LIB_ODE = ../ode/libode.a
 LIBS += $(LIB_ODE) -lpthread
 else
-LIBS += -lode
+LIBS += -lode -lpthread
 endif
 
 else ifeq ($(OSTYPE),windows)


### PR DESCRIPTION
I am getting the following error on CentOS 7:
```
# linking  ../../bin/webots-bin
/lukic1/webots/lib/webots/libode.so: error: undefined reference to 'pthread_mutex_trylock'
/lukic1/webots/lib/webots/libode.so: error: undefined reference to 'pthread_create'
/lukic1/webots/lib/webots/libode.so: error: undefined reference to 'pthread_spin_init'
collect2: error: ld returned 1 exit status
make[1]: *** [../../bin/webots-bin] Error 1
make: *** [webots_target] Error 2
```

I know we don't support CentOS, but it shouldn't affect the other platforms