### PR TITLE
Fixes Windows nightly builds

### DIFF
--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -44,7 +44,7 @@
 /mingw64/bin/libwoff2common.dll
 /mingw64/bin/libwoff2dec.dll
 /mingw64/bin/libxml2-2.dll
-/mingw64/bin/libzzip-0.dll
+/mingw64/bin/libzzip.dll
 /mingw64/bin/libopenal-1.dll
 /mingw64/bin/libassimp.dll
 /mingw64/bin/libssl-1_1-x64.dll


### PR DESCRIPTION
It seems the libzzip DLL was renamed (again) breaking the distribution (nightly builds) on Windows:
```
Error on line 21620 in D:\a\webots\webots\scripts\packaging\webots.iss: Source file "D:\a\_temp\msys\msys64\mingw64\bin\libzzip-0.dll" does not exist.
```
This PR fixes the problem.