### PR TITLE
Enhancement guided tour

### DIFF
--- a/projects/guided_tour.txt
+++ b/projects/guided_tour.txt
@@ -20,7 +20,7 @@ projects/robots/clearpath/pr2/worlds/pr2.wbt 38
 projects/robots/irobot/create/worlds/create.wbt 30
 projects/robots/adept/pioneer3/worlds/pioneer3at.wbt 14
 projects/robots/robotis/darwin-op/worlds/soccer.wbt 12
-projects/robots/softbank/nao/worlds/nao_demo.wbt 20
+projects/robots/softbank/nao/worlds/nao_room.wbt 20
 projects/robots/fujitsu/hoap2/worlds/hoap2_walk.wbt 30
 projects/robots/micromagic/mantis/worlds/mantis.wbt 30
 projects/robots/gctronic/e-puck/worlds/e-puck_line_demo.wbt 30

--- a/projects/robots/robotis/darwin-op/worlds/soccer.wbt
+++ b/projects/robots/robotis/darwin-op/worlds/soccer.wbt
@@ -13,11 +13,11 @@ Viewpoint {
   follow "ROBOTIS OP2"
 }
 TexturedBackground {
-  texture "stadium_dry"
+  texture "noon_cloudy_countryside"
   luminosity 1.5
 }
 TexturedBackgroundLight {
-  texture "stadium_dry"
+  texture "noon_cloudy_countryside"
   luminosity 0.5
 }
 DEF BALL Ball {

--- a/projects/robots/robotis/darwin-op/worlds/soccer.wbt
+++ b/projects/robots/robotis/darwin-op/worlds/soccer.wbt
@@ -13,20 +13,15 @@ Viewpoint {
   follow "ROBOTIS OP2"
 }
 TexturedBackground {
-  texture "noon_cloudy_countryside"
+  texture "stadium_dry"
   luminosity 1.5
 }
 TexturedBackgroundLight {
-  texture "noon_cloudy_countryside"
+  texture "stadium_dry"
   luminosity 0.5
 }
-RobotstadiumSoccerField {
-  rotation 1 0 0 1.5707963267948966
-  frame1Color 0.9 0.8 0.2
-  frame2Color 0.2 0.4 0.8
-}
 DEF BALL Ball {
-  translation 0 0.0325 0.03
+  translation 0 0 0.03
   rotation 1 0 0 1.5707963267948966
 }
 DEF ROBOTISOP2 RobotisOp2 {
@@ -35,4 +30,8 @@ DEF ROBOTISOP2 RobotisOp2 {
   controller "soccer"
   jersey RobotisJersey {
   }
+}
+RobocupSoccerField {
+  size "kid"
+  turfPhysics FALSE
 }

--- a/projects/robots/softbank/nao/worlds/nao_room.wbt
+++ b/projects/robots/softbank/nao/worlds/nao_room.wbt
@@ -1,7 +1,10 @@
 #VRML_SIM R2021b utf8
 WorldInfo {
   info [
-    "A NAO robot in a living room"
+    "An Aldebaran's Nao H25 V5.0 robot in a living room"
+    "NAO is a programmable, 57-cm tall humanoid robot."
+    "The body has 25 degrees of freedom (DOF)."
+    "The sensors include 2 cameras, 4 microphones, sonar rangefinder, 2 IR emitters and receivers, 1 inertial board, and 8 pressure sensors."
   ]
   title "NAO room"
   basicTimeStep 10


### PR DESCRIPTION
I propose to improve the guided tour by :

- Replacing the nao_demo.wbt by nao_room.wbt. They have both a nao with the same controller, but the room world is nicer than a simple floor.
- Modernizing the soccer.wbt by changing the field for the new one made for robocup.

Old:
<img src=https://user-images.githubusercontent.com/25938827/120346288-86dad400-c2fb-11eb-8473-6321f18af7f4.png width=50%>
New:
<img src=https://user-images.githubusercontent.com/25938827/120346297-893d2e00-c2fb-11eb-8262-88344c607fdb.png width=50%>
Old:
<img src=https://user-images.githubusercontent.com/25938827/120346921-1bddcd00-c2fc-11eb-853e-28086db8aff1.png width=50%>
New:
<img src=https://user-images.githubusercontent.com/25938827/120346915-1aaca000-c2fc-11eb-8cbb-ef5f97d6d478.png width=50%>


