### PR TITLE
Removed use of undefined variable

### DIFF
--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -541,7 +541,7 @@ $(BUILD_GOAL_DIR)/%.o:%.c++
 
 EMCC_FILE = $(BUILD_GOAL_DIR_EMCC)/$(notdir $@)
 $(BUILD_GOAL_DIR)/%.o:%.cpp
-	@echo "# compiling $(var)" $(notdir $<)
+	@echo "# compiling" $(notdir $<)
 	$(SILENT)$(CXX) -c $(WBCFLAGS) $(CFLAGS) $(CXXFLAGS) $(INCLUDE) $< -o $@
 ifdef WREN
 	$(SILENT)emcc -O3 -c $(WBCFLAGS) $(CFLAGS) $(CXXFLAGS) $(INCLUDE) $< -o $(EMCC_FILE)


### PR DESCRIPTION
This `$(var)` variable is not defined and seems useless.