### PR TITLE
Fix world update error Mir100

### DIFF
--- a/projects/robots/mir/mir100/protos/Mir100.proto
+++ b/projects/robots/mir/mir100/protos/Mir100.proto
@@ -3,7 +3,7 @@
 # license url: https://cyberbotics.com/webots_assets_license
 # documentation url: https://www.cyberbotics.com/doc/guide/mir100
 # Designed by Mobile Industrial Robotics (MIR), MiR100 is a six-wheeled robot (4 caster wheels and 2 regular ones at the
-# center. Used in industrial environments, it can carry a payload of up to 100kg.
+# center). Used in industrial environments, it can carry a payload of up to 100kg.
 
 PROTO Mir100 [
   field  SFVec3f     translation      0 0 0               # Is `Transform.translation`.

--- a/projects/robots/mir/mir100/worlds/mir100.wbt
+++ b/projects/robots/mir/mir100/worlds/mir100.wbt
@@ -28,7 +28,6 @@ TexturedBackground {
 }
 Mir100 {
   translation -6.23612 -0.936359 0
-  controller "keyboard_control"
   frontLidarSlot [
     SickS300 {
       name "front_lidar"


### PR DESCRIPTION
**Description**
World-update test fails on develop because the `keybody_controller` is already the default controller in the PROTO so no need to have it in the world as well.
