### PR TITLE
fix matlab makefile

### DIFF
--- a/src/controller/matlab/Makefile
+++ b/src/controller/matlab/Makefile
@@ -26,7 +26,7 @@ PYTHON_OK := $(shell which python3)
 release debug profile:
 	@echo "# generating matlab"
 ifeq ('$(PYTHON_OK)','')
-	@echo "# \033[0;33mUnable to find python, skipping matlab API\033[0m"
+	@echo "# \033[0;33mUnable to find python3, skipping matlab API\033[0m"
 else
 	$(shell python3 mgenerate.py;)
 endif 

--- a/src/controller/matlab/Makefile
+++ b/src/controller/matlab/Makefile
@@ -22,7 +22,7 @@ endif
 
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
-PYTHON_OK := $(shell which python)
+PYTHON_OK := $(shell which python3)
 release debug profile:
 	@echo "# generating matlab"
 ifeq ('$(PYTHON_OK)','')

--- a/src/controller/matlab/Makefile
+++ b/src/controller/matlab/Makefile
@@ -28,7 +28,7 @@ release debug profile:
 ifeq ('$(PYTHON_OK)','')
 	@echo "# \033[0;33mUnable to find python, skipping matlab API\033[0m"
 else
-	$(shell python mgenerate.py;)
+	$(shell python3 mgenerate.py;)
 endif 
 
 clean:


### PR DESCRIPTION
**Description**
It seems that `which python` is not available by default on ubuntu 20.
We should use `which python3` instead, moreover it is more pertinent as the mgenerate.py script is not compatible with python 2.7.
