### PR TITLE
Added Viewpoint in world converter scripts

### DIFF
--- a/docs/reference/viewpoint.md
+++ b/docs/reference/viewpoint.md
@@ -4,7 +4,7 @@
 Viewpoint {
   SFFloat    fieldOfView             0.785398         # [0, pi]
   SFRotation orientation             0 0 1 0          # unit axis, (-inf, inf) angle
-  SFVec3f    position                0 0 0            # any vector
+  SFVec3f    position                0 0 10           # any vector
   SFString   description             ""               # any string
   SFFloat    near                    0.05             # [0, far]
   SFFloat    far                     0.0              # [near, inf)

--- a/scripts/converter/convert_eun_to_nue.py
+++ b/scripts/converter/convert_eun_to_nue.py
@@ -58,7 +58,7 @@ def convert_to_nue(filename):
                     field['value'] = rotation(field['value'], [0, 1, 0, 0.5 * math.pi])
                 elif field['name'] in ['position']:
                     field['value'] = [field['value'][2], field['value'][1], str(-float(field['value'][0]))]
-        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
+        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight', 'PointLight']:
             print('Rotating', node['name'])
             rotation_found = False
             for field in node['fields']:

--- a/scripts/converter/convert_eun_to_nue.py
+++ b/scripts/converter/convert_eun_to_nue.py
@@ -53,23 +53,11 @@ def convert_to_nue(filename):
                                        'type': 'SFString'})
         elif node['name'] == 'Viewpoint':
             print('Rotating', node['name'])
-            orientation_found = False
-            position_found = False
             for field in node['fields']:
                 if field['name'] in ['orientation']:
-                    orientation_found = True
                     field['value'] = rotation(field['value'], [0, 1, 0, 0.5 * math.pi])
                 elif field['name'] in ['position']:
-                    position_found = True
                     field['value'] = [field['value'][2], field['value'][1], str(-float(field['value'][0]))]
-            if not orientation_found:
-                node['fields'].append({'name': 'orientation',
-                                       'value': ['0', '1', '0', str(0.5 * math.pi)],
-                                       'type': 'SFRotation'})
-            if not position_found:
-                node['fields'].append({'name': 'position',
-                                       'value': ['10', '0', '0'],
-                                       'type': 'SFVec3f'})
         elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
             print('Rotating', node['name'])
             rotation_found = False

--- a/scripts/converter/convert_eun_to_nue.py
+++ b/scripts/converter/convert_eun_to_nue.py
@@ -53,12 +53,23 @@ def convert_to_nue(filename):
                                        'type': 'SFString'})
         elif node['name'] == 'Viewpoint':
             print('Rotating', node['name'])
+            orientation_found = False
+            position_found = False
             for field in node['fields']:
                 if field['name'] in ['orientation']:
-                    rotation_found = True
+                    orientation_found = True
                     field['value'] = rotation(field['value'], [0, 1, 0, 0.5 * math.pi])
                 elif field['name'] in ['position']:
+                    position_found = True
                     field['value'] = [field['value'][2], field['value'][1], str(-float(field['value'][0]))]
+            if not orientation_found:
+                node['fields'].append({'name': 'orientation',
+                                       'value': ['0', '1', '0', str(0.5 * math.pi)],
+                                       'type': 'SFRotation'})
+            if not position_found:
+                node['fields'].append({'name': 'position',
+                                       'value': ['10', '0', '0'],
+                                       'type': 'SFVec3f'})
         elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
             print('Rotating', node['name'])
             rotation_found = False

--- a/scripts/converter/convert_eun_to_nue.py
+++ b/scripts/converter/convert_eun_to_nue.py
@@ -51,7 +51,15 @@ def convert_to_nue(filename):
                 node['fields'].append({'name': 'coordinateSystem',
                                        'value': 'NUE',
                                        'type': 'SFString'})
-        elif node['name'] not in ['Viewpoint', 'TexturedBackground', 'TexturedBackgroundLight']:
+        elif node['name'] == 'Viewpoint':
+            print('Rotating', node['name'])
+            for field in node['fields']:
+                if field['name'] in ['orientation']:
+                    rotation_found = True
+                    field['value'] = rotation(field['value'], [0, 1, 0, 0.5 * math.pi])
+                elif field['name'] in ['position']:
+                    field['value'] = [field['value'][2], field['value'][1], str(-float(field['value'][0]))]
+        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
             print('Rotating', node['name'])
             rotation_found = False
             for field in node['fields']:

--- a/scripts/converter/convert_nue_to_enu.py
+++ b/scripts/converter/convert_nue_to_enu.py
@@ -44,12 +44,23 @@ def convert_to_enu(filename):
                     del node['fields'][node['fields'].index(field)]
         elif node['name'] == 'Viewpoint':
             print('Rotating', node['name'])
+            orientation_found = False
+            position_found = False
             for field in node['fields']:
                 if field['name'] in ['orientation']:
-                    rotation_found = True
+                    orientation_found = True
                     field['value'] = rotation(field['value'], [1, 0, 0, 0.5 * math.pi])
                 elif field['name'] in ['position']:
+                    position_found = True
                     field['value'] = [field['value'][0], str(-float(field['value'][2])), field['value'][1]]
+            if not orientation_found:
+                node['fields'].append({'name': 'orientation',
+                                       'value': ['1', '0', '0', str(0.5 * math.pi)],
+                                       'type': 'SFRotation'})
+            if not position_found:
+                node['fields'].append({'name': 'position',
+                                       'value': ['0', '-10', '0'],
+                                       'type': 'SFVec3f'})
         elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
             print('Rotating', node['name'])
             rotation_found = False
@@ -63,7 +74,6 @@ def convert_to_enu(filename):
                 node['fields'].append({'name': 'rotation',
                                        'value': ['1', '0', '0', str(0.5 * math.pi)],
                                        'type': 'SFRotation'})
-       
     world.save(filename)
 
 

--- a/scripts/converter/convert_nue_to_enu.py
+++ b/scripts/converter/convert_nue_to_enu.py
@@ -61,7 +61,7 @@ def convert_to_enu(filename):
                 node['fields'].append({'name': 'position',
                                        'value': ['0', '-10', '0'],
                                        'type': 'SFVec3f'})
-        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
+        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight', 'PointLight']:
             print('Rotating', node['name'])
             rotation_found = False
             for field in node['fields']:

--- a/scripts/converter/convert_nue_to_enu.py
+++ b/scripts/converter/convert_nue_to_enu.py
@@ -42,7 +42,15 @@ def convert_to_enu(filename):
                 if field['name'] == 'coordinateSystem':
                     # remove the 'coordinateSystem ENU'
                     del node['fields'][node['fields'].index(field)]
-        elif node['name'] not in ['Viewpoint', 'TexturedBackground', 'TexturedBackgroundLight', 'PointLight']:
+        elif node['name'] == 'Viewpoint':
+            print('Rotating', node['name'])
+            for field in node['fields']:
+                if field['name'] in ['orientation']:
+                    rotation_found = True
+                    field['value'] = rotation(field['value'], [1, 0, 0, 0.5 * math.pi])
+                elif field['name'] in ['position']:
+                    field['value'] = [field['value'][0], str(-float(field['value'][2])), field['value'][1]]
+        elif node['name'] not in ['TexturedBackground', 'TexturedBackgroundLight']:
             print('Rotating', node['name'])
             rotation_found = False
             for field in node['fields']:
@@ -55,6 +63,7 @@ def convert_to_enu(filename):
                 node['fields'].append({'name': 'rotation',
                                        'value': ['1', '0', '0', str(0.5 * math.pi)],
                                        'type': 'SFRotation'})
+       
     world.save(filename)
 
 


### PR DESCRIPTION
**Description**
Added the conversion of the `Viewpoint` in the scripts to convert the `coordinateSystem` of a world.

**Tasks**

- [x] Viewpoint
- [x] Correct doc of viewpoint.md (default `position` field) to match reality

Note: if no `orientation`/`position` are given, it will adopt the `Viewpoint` as seen from a `NUE` world with the default Webots parameters. So for EUN-->NUE nothing is done, and for NUE-->ENU the default Viewpoint is adapted.
