### PR TITLE
Fix size animation web component

### DIFF
--- a/resources/web/templates/x3d_playback.html
+++ b/resources/web/templates/x3d_playback.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <h1 style="height:5%">%title%</h1>
-    <webots-animation style="height:80%"></webots-animation>
+    <webots-animation style="height:80%; display:block;"></webots-animation>
     <p style="height:5%">If the animation is not loading correctly, please refer to the <a style='color: #5DADE2;' target:'_blank' href='https://cyberbotics.com/doc/guide/web-scene#remarks-on-the-used-technologies-and-their-limitations'>User Guide</a>
       it could be that your browser prevents local files CORS requests.</p>
     <p style="height:5%">%description%</p>

--- a/resources/web/wwi/WebotsAnimation.js
+++ b/resources/web/wwi/WebotsAnimation.js
@@ -2,7 +2,7 @@ const template = document.createElement('template');
 
 template.innerHTML = `
 <link type="text/css" href="https://cyberbotics.com/wwi/R2021b/css/animation.css" rel="stylesheet"/>
-<div id="view3d" style="height:80%"></div>
+<div id="view3d" style="height:100%; width:100%"></div>
 `;
 
 export default class WebotsAnimation extends HTMLElement {


### PR DESCRIPTION
**Description**
Fix the size of the animation to 100% of the web-component. 

It was necessary to also set the width to 100% to allow both `flex` and `block` display to work.

The user can know determine the size of the web-component by changing it in the .html.

Fix #3159.
