### PR TITLE
Fix export of & in x3d

### DIFF
--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -3064,7 +3064,10 @@ void WbSolid::exportNodeFooter(WbVrmlWriter &writer) const {
   WbMatter::exportNodeFooter(writer);
 }
 
-QString WbSolid::sanitizedName() const {
+const QString WbSolid::sanitizedName() const {
   QString name_dirty = name();
+  name_dirty.replace("\"", "&quot;", Qt::CaseInsensitive);
+  name_dirty.replace(">", "&gt;", Qt::CaseInsensitive);
+  name_dirty.replace("<", "&lt;", Qt::CaseInsensitive);
   return name_dirty.replace("&", "&amp;", Qt::CaseInsensitive);
 }

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -3041,7 +3041,7 @@ void WbSolid::exportNodeFields(WbVrmlWriter &writer) const {
   WbMatter::exportNodeFields(writer);
   if (writer.isX3d()) {
     if (!name().isEmpty())
-      writer << " name='" << name() << "'";
+      writer << " name='" << sanitizedName() << "'";
     writer << " solid='true'";
   }
 }
@@ -3062,4 +3062,9 @@ void WbSolid::exportNodeFooter(WbVrmlWriter &writer) const {
   }
 
   WbMatter::exportNodeFooter(writer);
+}
+
+QString WbSolid::sanitizedName() const {
+  QString name_dirty = name();
+  return name_dirty.replace("&", "&amp;", Qt::CaseInsensitive);
 }

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -3066,6 +3066,7 @@ void WbSolid::exportNodeFooter(WbVrmlWriter &writer) const {
 
 const QString WbSolid::sanitizedName() const {
   QString name_dirty = name();
+  name_dirty.replace("\'", "&apos;", Qt::CaseInsensitive);
   name_dirty.replace("\"", "&quot;", Qt::CaseInsensitive);
   name_dirty.replace(">", "&gt;", Qt::CaseInsensitive);
   name_dirty.replace("<", "&lt;", Qt::CaseInsensitive);

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -288,8 +288,7 @@ protected:
   bool exportNodeHeader(WbVrmlWriter &writer) const override;
   void exportNodeFields(WbVrmlWriter &writer) const override;
   void exportNodeFooter(WbVrmlWriter &writer) const override;
-  // If there is a & in the name, change it to &amp; so that it can be parsed by XML.
-  QString sanitizedName() const;
+  const QString sanitizedName() const;
 
 protected slots:
   void updateTranslation() override;

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -288,6 +288,8 @@ protected:
   bool exportNodeHeader(WbVrmlWriter &writer) const override;
   void exportNodeFields(WbVrmlWriter &writer) const override;
   void exportNodeFooter(WbVrmlWriter &writer) const override;
+  // If there is a & in the name, change it to &amp; so that it can be parsed by XML.
+  QString sanitizedName() const;
 
 protected slots:
   void updateTranslation() override;


### PR DESCRIPTION
The `&` was not sanitized correctly in solid names when exported in x3d and causes XML parsing errors.

It aims to fix https://github.com/RoboCup-Humanoid-TC/webots/issues/200.