### PR TITLE
Fix Context Menu Refresh

### DIFF
--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -218,6 +218,7 @@ void WbSceneTree::setWorld(WbWorld *world) {
   connect(mTreeView, &WbTreeView::collapsed, this, &WbSceneTree::stopWatching);
   connect(mModel, &WbSceneTreeModel::itemInserted, mTreeView, &WbTreeView::itemInserted);
   connect(mModel, &WbSceneTreeModel::rowsAboutToBeRemovedSoon, this, &WbSceneTree::handleRowRemoval);
+  connect(mTreeView, &WbTreeView::beforeContextMenuShowed, this, &WbSceneTree::updateSelection);
 
   connect(mTreeView, &WbTreeView::selectionHasChanged, this, &WbSceneTree::updateSelection);
   connect(WbSelection::instance(), &WbSelection::selectionChangedFromSceneTree, this, &WbSceneTree::updateSelection);

--- a/src/webots/scene_tree/WbTreeView.cpp
+++ b/src/webots/scene_tree/WbTreeView.cpp
@@ -120,6 +120,7 @@ void WbTreeView::itemInserted(const QModelIndex &index) {
 }
 
 void WbTreeView::showMenu(const QPoint &position) {
+  emit beforeContextMenuShowed();
   const QModelIndexList indexes = selectionModel()->selectedIndexes();
   if (indexes.isEmpty())
     return;

--- a/src/webots/scene_tree/WbTreeView.hpp
+++ b/src/webots/scene_tree/WbTreeView.hpp
@@ -53,6 +53,7 @@ signals:
   void selectionHasChanged();
   void focusIn();
   void refreshRequested();
+  void beforeContextMenuShowed();
 
 protected:
   void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;


### PR DESCRIPTION
Fixes #3169. Webots now updates the context menu before it is shown in the scene tree.