### PR TITLE
Publish libcontroller from master branch

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -56,12 +56,12 @@ jobs:
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
     - name: Prepare Webots Controller Deployment
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' && matrix.os == 'ubuntu-18.04' }}
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' && matrix.os == 'ubuntu-18.04' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -62,7 +62,7 @@ jobs:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
       if: ${{ github.event_name == 'schedule' }}
-      run: scripts/packaging/sync_controller_lib.sh    
+      run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       run: |

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -57,11 +57,11 @@ jobs:
         xvfb-run --auto-servernum make distrib -j4
     - name: Prepare Webots Controller Deployment
       # if: ${{ github.event_name == 'schedule' }}
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      if: ${{ github.event_name == 'schedule' }}
+      # if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -55,6 +55,14 @@ jobs:
         export LIBGL_ALWAYS_SOFTWARE=true
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
+    - name: Prepare Webots Controller Deployment
+      # if: ${{ github.event_name == 'schedule' }}
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
+    - name: Deploy Webots Controller
+      if: ${{ github.event_name == 'schedule' }}
+      run: scripts/packaging/sync_controller_lib.sh    
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       run: |

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -53,11 +53,11 @@ jobs:
         xvfb-run --auto-servernum make distrib -j4
     - name: Prepare Webots Controller Deployment
       # if: ${{ github.event_name == 'schedule' }}
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      if: ${{ github.event_name == 'schedule' }}
+      # if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -51,6 +51,14 @@ jobs:
         export LIBGL_ALWAYS_SOFTWARE=true
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
+    - name: Prepare Webots Controller Deployment
+      # if: ${{ github.event_name == 'schedule' }}
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
+    - name: Deploy Webots Controller
+      if: ${{ github.event_name == 'schedule' }}
+      run: scripts/packaging/sync_controller_lib.sh     
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       run: |

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -52,12 +52,12 @@ jobs:
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
     - name: Prepare Webots Controller Deployment
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' && matrix.os == 'ubuntu-18.04' }}
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' && matrix.os == 'ubuntu-18.04' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -58,7 +58,7 @@ jobs:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
       if: ${{ github.event_name == 'schedule' }}
-      run: scripts/packaging/sync_controller_lib.sh     
+      run: scripts/packaging/sync_controller_lib.sh
     - name: Rename Webots Tarball Package
       if: ${{ matrix.os == 'ubuntu-18.04' }}
       run: |

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -52,12 +52,12 @@ jobs:
         export PATH=/Library/Frameworks/Python.framework/Versions/3.9/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Library/Frameworks/Python.framework/Versions/3.7/bin:/usr/local/bin/:$PATH
         make distrib -j4
     - name: Prepare Webots Controller Deployment
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -53,11 +53,11 @@ jobs:
         make distrib -j4
     - name: Prepare Webots Controller Deployment
       # if: ${{ github.event_name == 'schedule' }}
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      if: ${{ github.event_name == 'schedule' }}
+      # if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -51,6 +51,14 @@ jobs:
         export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
         export PATH=/Library/Frameworks/Python.framework/Versions/3.9/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Library/Frameworks/Python.framework/Versions/3.7/bin:/usr/local/bin/:$PATH
         make distrib -j4
+    - name: Prepare Webots Controller Deployment
+      # if: ${{ github.event_name == 'schedule' }}
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
+    - name: Deploy Webots Controller
+      if: ${{ github.event_name == 'schedule' }}
+      run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -49,11 +49,11 @@ jobs:
         make distrib -j4
     - name: Prepare Webots Controller Deployment
       # if: ${{ github.event_name == 'schedule' }}
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      if: ${{ github.event_name == 'schedule' }}
+      # if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -48,12 +48,12 @@ jobs:
         export PATH=/Library/Frameworks/Python.framework/Versions/3.9/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Library/Frameworks/Python.framework/Versions/3.7/bin:/usr/local/bin/:$PATH
         make distrib -j4
     - name: Prepare Webots Controller Deployment
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -47,6 +47,14 @@ jobs:
         export JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
         export PATH=/Library/Frameworks/Python.framework/Versions/3.9/bin:/Library/Frameworks/Python.framework/Versions/3.8/bin:/Library/Frameworks/Python.framework/Versions/3.7/bin:/usr/local/bin/:$PATH
         make distrib -j4
+    - name: Prepare Webots Controller Deployment
+      # if: ${{ github.event_name == 'schedule' }}
+      uses: webfactory/ssh-agent@v0.5.2
+      with:
+        ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
+    - name: Deploy Webots Controller
+      if: ${{ github.event_name == 'schedule' }}
+      run: scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -64,6 +64,16 @@ jobs:
       run: |
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
+    - name: Deploy Webots Controller
+      # if: ${{ github.event_name == 'schedule' }}
+      run: |
+        pacman -S --noconfirm git openssh
+        export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+        mkdir ~/.ssh
+        ssh-keyscan -H github.com > ~/.ssh/known_hosts
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}"
+        scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -65,7 +65,7 @@ jobs:
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       run: |
         pacman -S --noconfirm git openssh
         export SSH_AUTH_SOCK=/tmp/ssh_agent.sock

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -60,7 +60,7 @@ jobs:
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller
-      # if: ${{ github.event_name == 'schedule' }}
+      if: ${{ github.event_name == 'schedule' }}
       run: |
         pacman -S --noconfirm git openssh
         export SSH_AUTH_SOCK=/tmp/ssh_agent.sock

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -59,6 +59,16 @@ jobs:
       run: |
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
+    - name: Deploy Webots Controller
+      # if: ${{ github.event_name == 'schedule' }}
+      run: |
+        pacman -S --noconfirm git openssh
+        export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+        mkdir ~/.ssh
+        ssh-keyscan -H github.com > ~/.ssh/known_hosts
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-add - <<< "${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}"
+        scripts/packaging/sync_controller_lib.sh
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |

--- a/scripts/packaging/sync_controller_lib.sh
+++ b/scripts/packaging/sync_controller_lib.sh
@@ -38,7 +38,9 @@ rm -rf include
 mkdir -p include
 
 # Copy files
-cp -r ${WEBOTS_HOME}/include/controller/* include
+if [ "${OSTYPE}" != "msys" ]; then
+    cp -r ${WEBOTS_HOME}/include/controller/* include
+fi
 for filename in $DYNAMIC_LIBS
 do
     echo $filename

--- a/scripts/packaging/sync_controller_lib.sh
+++ b/scripts/packaging/sync_controller_lib.sh
@@ -23,9 +23,7 @@ if [ ! -d /tmp/webots-controller ]; then
 fi
 cd /tmp/webots-controller
 
-git show-branch ${VERSION} &> /dev/null
-BRANCH_MISSING=$?
-if [ ${BRANCH_MISSING} -eq 0 ]; then
+if [ ! -z $(git branch -a | egrep "/${VERSION}$") ]; then
     echo "Checkout to the existing branch ${VERSION}"
     git checkout ${VERSION}
 else

--- a/scripts/packaging/sync_controller_lib.sh
+++ b/scripts/packaging/sync_controller_lib.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -
+
+# WEBOTS_HOME has to be specified
+if [ -z "${WEBOTS_HOME}" ]; then
+    WEBOTS_HOME=$(pwd)
+fi
+
+VERSION=$(cat ${WEBOTS_HOME}/scripts/packaging/webots_version.txt | sed 's/ /-/g')
+
+# Dynamic libraries to be copied
+DYNAMIC_LIBS="Controller CppController car CppCar driver CppDriver"
+
+# Get the repo
+rm -rf /tmp/webots-controller || true
+if [ ! -z "${GITHUB_ACTOR}" ]; then
+    git config --global user.name ${GITHUB_ACTOR}
+    git config --global user.email ${GITHUB_ACTOR}@github.com
+fi
+git clone git@github.com:cyberbotics/webots-libcontroller.git /tmp/webots-controller
+if [ ! -d /tmp/webots-controller ]; then
+    echo 'The repository is not properly cloned'
+    exit 1
+fi
+cd /tmp/webots-controller
+
+git show-branch ${VERSION} &> /dev/null
+BRANCH_MISSING=$?
+if [ ${BRANCH_MISSING} -eq 0 ]; then
+    echo "Checkout to the existing branch ${VERSION}"
+    git checkout ${VERSION}
+else
+    echo "Create a new branch ${VERSION}"
+    git checkout -b ${VERSION}
+fi
+
+# Prepare the structure
+rm -rf lib/${OSTYPE}
+mkdir -p lib/${OSTYPE}
+rm -rf include
+mkdir -p include
+
+# Copy files
+cp -r ${WEBOTS_HOME}/include/controller/* include
+for filename in $DYNAMIC_LIBS
+do
+    echo $filename
+    find ${WEBOTS_HOME}/lib/controller -maxdepth 1 -name "*${filename}*" | xargs -I{} cp {} lib/${OSTYPE}
+done
+
+# Push
+git add -A
+git commit -m "Automatic update"
+git push origin ${VERSION}


### PR DESCRIPTION
We need this one #3079 on the master as well, at least until the new release.

In addition:
- it doesn't upload Windows header files (since there are already managed by Linux and macOS and it seems Windows has different line endings)
- it creates a branch if it doesn't exist
- it uploads Linux shared libraries only from Ubuntu 18.04 (shared libraries from Ubuntu 18.04 and 20.04 are not binary the same, so the script generates a diff otherwise)