### PR TITLE
Fix windows nightly build

### DIFF
--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -251,8 +251,9 @@ resources/lua/modules/webots/*.lua
 resources/lua/liluat/license.txt
 resources/lua/liluat/*.lua
 resources/javascript/
-resources/javascript/modules
 resources/javascript/jsTemplate.js
+resources/javascript/modules/
+resources/javascript/modules/*.js
 resources/Makefile.include
 resources/Makefile.java.include
 resources/Makefile.os.include

--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -253,7 +253,8 @@ resources/lua/liluat/*.lua
 resources/javascript/
 resources/javascript/jsTemplate.js
 resources/javascript/modules/
-resources/javascript/modules/*.js
+resources/javascript/modules/webots/
+resources/javascript/modules/webots/*.js
 resources/Makefile.include
 resources/Makefile.java.include
 resources/Makefile.os.include


### PR DESCRIPTION
**Description**
Addresses issue #3179.
It appears that for windows it's necessary to be verbose and include all folders.
