### PR TITLE
Removed obsolete Python 2.7 tests

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2019]
-        python: [2.7, 3.9]
+        python: 3.9
         include:
           - os: ubuntu-18.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10 cppcheck"
@@ -47,9 +47,6 @@ jobs:
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
           - os: windows-2019
             DEPENDENCIES_INSTALLATION: "choco install cppcheck --version 2.2; choco install llvm --version 11.0.0; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
-        exclude:
-          - os: windows-2019
-            python: 2.7
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, windows-2019]
-        python: 3.9
+        python: [3.9]
         include:
           - os: ubuntu-18.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install clang-format-10 cppcheck"


### PR DESCRIPTION
These tests were causing PEP8 failures with python 3 code, such as some f-strings.
Since Python 2.7 is deprecated since January 2021, we should get rid of it.