### PR TITLE
Fix reconnecting extern controllers

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -58,6 +58,7 @@ Released on June, Xth, 2021.
     - Added a version of the [RobotisOp2](../guide/robotis-op2.md) modeled using [Hinge2Joint](hinge2joint.md) on the ankles, hips, and neck ([#2861](https://github.com/cyberbotics/webots/pull/2861)).
     - Made the `static` behavior the default for PROTO files and removal of the tag. Non static cases must be labeled as such using the `nonDeterministic` tag instead ([#2903](https://github.com/cyberbotics/webots/pull/2903)).
   - Bug fixes:
+    - Fixed various issues when an extern [Robot](robot.md) controller exits without disconnecting and reconnects to the same [Robot](robot.md) ([#3189](https://github.com/cyberbotics/webots/pull/3189)).
     - Fixed wrong computation of the asymmetric friction force direction for [Cylinder](cylinder.md) and [Box](box.md) ([#3150](https://github.com/cyberbotics/webots/pull/3150)).
     - Fixed broken multithreading in Python controllers due to Python GIL ([#3104](https://github.com/cyberbotics/webots/pull/3104)).
     - Fixed crash visualizing node properties in Node Editor for nodes in deeply nested PROTO structures ([#3109](https://github.com/cyberbotics/webots/pull/30109)).

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -219,9 +219,30 @@ void WbControlledWorld::addControllerConnection() {
       robotName = buffer;
       delete[] buffer;
     }
-    foreach (WbRobot *const robot, robots()) {
-      if (robot->isControllerStarted())
-        continue;
+
+    QListIterator<WbRobot *> robotsIt(robots());
+    // count number of external controllers
+    int nbExternalController = 0;
+    while (robotsIt.hasNext()) {
+      if (robotsIt.next()->controllerName() == "<extern>")
+        nbExternalController++;
+    }
+
+    robotsIt.toFront();
+    while (robotsIt.hasNext()) {
+      WbRobot *const robot = robotsIt.next();
+      if (robot->isControllerStarted()) {
+        // if a specific robot have been targeted by giving a name, or only one external controller is in the scene (hence it's
+        // the target)
+        if (robot->controllerName() == "<extern>" &&
+            (robotName == robot->name() || (robotName.isEmpty() && nbExternalController == 1))) {
+          // automatically disconnect from previous extern controller that may have failed, the slot could be immediately used
+          // to restart
+          WbLog::info(tr("Closing extern controller connection for robot \"%1\".").arg(robot->name()));
+          updateRobotController(robot);
+        } else  // this controller seems to be in active use, ignore it
+          continue;
+      }
       if ((robotName == robot->name() || robotName.isEmpty()) && robot->controllerName() == "<extern>") {
         WbLog::info(tr("Starting extern controller for robot \"%1\".").arg(robot->name()));
         mRobotsWaitingExternController.append(robot);


### PR DESCRIPTION
Replaces #3005.
Fixes: #3000 and #1903

> If the controller died, it can't call the cleanup function, and when I restart it, I get a error message from webots because he think that the controller is still running, so he can't find a spot for the new incoming connection.

> It simply remove the dead controller connection as usual, then recreate a new one.
The trick is to use the name of the robot to know which dead controller should be kill.
Otherwise, if no name is provided, the code execute as usual (scanning for free spot).

In case a single extern controller is defined, then the robot name is not needed and the currently connected controller is terminated and reconnected.