### PR TITLE
Don't fire tests on ready_for_review event

### DIFF
--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -2,7 +2,7 @@ name: Test Doc
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron:  '0 22 * * *'
 

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -2,7 +2,7 @@ name: Test Sources
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches-ignore:
       - 'released'
   schedule:


### PR DESCRIPTION
I don't understand the need for launching the sources and doc tests on the `ready_for_review` event, given that there is no code modification at this point and tests are run on each commit (`synchronize` event). We would save time by disabling this.