### PR TITLE
Fix border color for lens distortion

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -96,7 +96,7 @@ Released on XX Xth, 2021.
     - Fixed [`wb_supervisor_node_reset_physics`](supervisor.md#wb_supervisor_node_reset_physics) not working if during the same step the node is also artificially moved with the [Supervisor](supervisor.md) API ([#2991](https://github.com/cyberbotics/webots/pull/2991)).
     - Fixed crash changing the [`Lidar.type`](lidar.md) field during the simulation run by requiring to save and reload the world ([#2983](https://github.com/cyberbotics/webots/pull/2983)).
     - Fixed value of the `verticalFieldOfView` for the [Hokuyo UTM-30LX](../guide/lidar-sensors.md#hokuyo-utm-30lx) ([#2972](https://github.com/cyberbotics/webots/pull/2972)).
-    - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961)).
+    - Fixed [Lens](lens.md) distortion ([#2961](https://github.com/cyberbotics/webots/pull/2961), [#3191](https://github.com/cyberbotics/webots/pull/3191)).
     - Fixed bug in the C++, Python and Java API where the [Robot.getDevice()](robot.md#wb_robot_get_device) methods were returning different objects when passing the same string argument for the device name ([#2957](https://github.com/cyberbotics/webots/pull/2957)).
     - Fixed return value type of [`CameraRecognitionObject.get_size`](camera.md#camera-recognition-object) Python function ([#2923](https://github.com/cyberbotics/webots/pull/2923)).
     - Fixed [`Camera.getRecognitionObjects`](camera.md#wb_camera_recognition_get_objects) function not available and the return value of [`CameraRecognitionObject.getPositionOnImage`](camera.md#camera-recognition-object) and [`CameraRecognitionObject.getSizeOnImage`](camera.md#camera-recognition-object) in Java API ([#2923](https://github.com/cyberbotics/webots/pull/2923)).

--- a/resources/wren/shaders/lens_distortion.frag
+++ b/resources/wren/shaders/lens_distortion.frag
@@ -28,5 +28,8 @@ void main() {
   distortedUv.y = texUv.y - d2 * (d1 * relativeUv.y + 2 * tangentialDistortionCoeffs.y * relativeUv.x * relativeUv.y +
                                   tangentialDistortionCoeffs.x * (r + 2 * relativeUv.y * relativeUv.y));
 
-  fragColor = texture(inputTextures[0], distortedUv);
+  if (distortedUv.x < 0.0 || distortedUv.x > 1.0 || distortedUv.y < 0.0 || distortedUv.y > 1.0)
+    fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+  else
+    fragColor = texture(inputTextures[0], distortedUv);
 }


### PR DESCRIPTION
Fix #3068: show black pixels instead of repeating closest visible pixel colour when applying lens distortion.

Example with FOV 1.05, radialCoefficients [-0.26, -0.26]. 
Previous:
![camera_previous](https://user-images.githubusercontent.com/5910449/122370273-39976d00-cf5f-11eb-8c18-42494a0c0f11.png)

Now:
![camera_now](https://user-images.githubusercontent.com/5910449/122370284-3c925d80-cf5f-11eb-8475-baa7d6773f3f.png)

