### PR TITLE
Add the name of a solid next to it in tree

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -30,6 +30,7 @@ Released on June, Xth, 2021.
     - Changed the rendering engine of the streaming viewer and of the animations for WREN ([#2769](https://github.com/cyberbotics/webots/pull/2769)).
     - Added JavaScript scripting support for [Procedural Proto Nodes](procedural-proto-nodes.md) ([#3087](https://github.com/cyberbotics/webots/pull/3087)).
   - Enhancements
+    - Ensure that any node "name" is displayed in the tree to help navigation ([#3198](https://github.com/cyberbotics/webots/pull/3198)).
     - Altered the collision detection logic for [Robot.selfCollision](robot.md) to ignore chains of joints if the intermediary joints all share the same `anchor` point ([#2868](https://github.com/cyberbotics/webots/pull/2868)).
     - Allow the [Robot](robot.md) node to be added inside the [Group](group.md) node and other nodes derived from the Group node like [Transform](transform.md) and [Solid](solid.md) ([#2732](https://github.com/cyberbotics/webots/pull/2732)).
     - Make the external controller check more frequently (and indefinitely) for the simulation ([#2442](https://github.com/cyberbotics/webots/pull/2442)).

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -128,13 +128,9 @@ QString WbTreeItem::data() const {
   switch (mType) {
     case NODE: {
       QString fullName = mNode->fullName();
-      if (!fullName.startsWith("DEF ") && !fullName.startsWith("USE ")) {
-        if (mNode->nodeModelName() == "Solid" || WbNodeUtilities::isDeviceTypeName(mNode->nodeModelName())) {
-          WbSFString *name = mNode->findSFString("name");
-          if (name)
-            fullName += " \"" + name->value() + "\"";
-        }
-      }
+      WbSFString *name = mNode->findSFString("name");
+      if (name)
+        fullName += " \"" + name->value() + "\"";
       return fullName;
     }
     case FIELD: {

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -128,9 +128,11 @@ QString WbTreeItem::data() const {
   switch (mType) {
     case NODE: {
       QString fullName = mNode->fullName();
-      WbSFString *name = mNode->findSFString("name");
-      if (name)
-        fullName += " \"" + name->value() + "\"";
+      if (!fullName.startsWith("DEF ") && !fullName.startsWith("USE ")) {
+        WbSFString *name = mNode->findSFString("name");
+        if (name)
+          fullName += " \"" + name->value() + "\"";
+      }
       return fullName;
     }
     case FIELD: {

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -129,7 +129,7 @@ QString WbTreeItem::data() const {
     case NODE: {
       QString fullName = mNode->fullName();
       if (!fullName.startsWith("DEF ") && !fullName.startsWith("USE ")) {
-        if (WbNodeUtilities::isDeviceTypeName(mNode->nodeModelName())) {
+        if (mNode->nodeModelName() == "Solid" || WbNodeUtilities::isDeviceTypeName(mNode->nodeModelName())) {
           WbSFString *name = mNode->findSFString("name");
           if (name)
             fullName += " \"" + name->value() + "\"";

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -129,7 +129,7 @@ QString WbTreeItem::data() const {
     case NODE: {
       QString fullName = mNode->fullName();
       if (!fullName.startsWith("DEF ") && !fullName.startsWith("USE ")) {
-        WbSFString *name = mNode->findSFString("name");
+        const WbSFString *name = mNode->findSFString("name");
         if (name)
           fullName += " \"" + name->value() + "\"";
       }


### PR DESCRIPTION
Fix https://github.com/cyberbotics/webots/issues/3157

However, the fix is not the right way to do it, but I don't which one is the good one : 
- add "Solid" in either WbNodeUtilities::isDeviceTypeName or WbNodeUtilities::isSolidDeviceTypeName
- or remove the condition that this PR modify. In fact I don't understand why should we limit the display of the name to certains types. As long as the node have a "name" field, we should be good to display it.
