### PR TITLE
Fix field/context conversion from JavaScript to Lua

### DIFF
--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -62,25 +62,25 @@ bool WbProtoTemplateEngine::generate(const QString &logHeaderName, const QVector
   tags["fields"].chop(2);  // remove the last ",\n" if any
 
 #ifdef _WIN32
-  tags["context"] = QString("os: \"windows\", ");
+  tags["context"] = QString("os: 'windows', ");
 #endif
 #ifdef __linux__
-  tags["context"] = QString("os: \"linux\", ");
+  tags["context"] = QString("os: 'linux', ");
 #endif
 #ifdef __APPLE__
-  tags["context"] = QString("os: \"mac\", ");
+  tags["context"] = QString("os: 'mac', ");
 #endif
-  tags["context"] += QString("world: \"%1\", ").arg(worldPath);
-  tags["context"] += QString("proto: \"%1\", ").arg(protoPath);
-  tags["context"] += QString("webots_home: \"%1\", ").arg(WbStandardPaths::webotsHomePath());
-  tags["context"] += QString("project_path: \"%1\", ").arg(WbProject::current()->path());
-  tags["context"] += QString("temporary_files_path: \"%1\", ").arg(WbStandardPaths::webotsTmpPath());
-  tags["context"] += QString("id: \"%1\", ").arg(id);
-  tags["context"] += QString("coordinate_system: \"%1\", ").arg(gCoordinateSystem);
+  tags["context"] += QString("world: '%1', ").arg(worldPath);
+  tags["context"] += QString("proto: '%1', ").arg(protoPath);
+  tags["context"] += QString("webots_home: '%1', ").arg(WbStandardPaths::webotsHomePath());
+  tags["context"] += QString("project_path: '%1', ").arg(WbProject::current()->path());
+  tags["context"] += QString("temporary_files_path: '%1', ").arg(WbStandardPaths::webotsTmpPath());
+  tags["context"] += QString("id: '%1', ").arg(id);
+  tags["context"] += QString("coordinate_system: '%1', ").arg(gCoordinateSystem);
   WbVersion version = WbApplicationInfo::version();
   // for example major = R2018a and revision = 0
   tags["context"] +=
-    QString("webots_version: {major: \"%1\", revision: \"%2\"}").arg(version.toString(false)).arg(version.revisionNumber());
+    QString("webots_version: {major: '%1', revision: '%2'}").arg(version.toString(false)).arg(version.revisionNumber());
 
   if (templateLanguage == "lua") {
     tags["fields"] = convertStatementFromJavaScriptToLua(tags["fields"]);
@@ -226,7 +226,7 @@ QString WbProtoTemplateEngine::convertStatementFromJavaScriptToLua(QString &stat
 
   statement = statement.replace("value: undefined", "value = nil");
   statement = statement.replace("defaultValue: undefined", "defaultValue = nil");
-  statement = statement.replace(":", " =");
+  statement = statement.replace(": ", " = ");
   statement = statement.replace("'", "\"");
 
   return statement;


### PR DESCRIPTION
**Addresses**
Fixes #3199.

**Description**
While Lua support is maintained, the formatting of fields and context has to be converted from JavaScript statements to Lua-friendly ones. Objects `{key: value}` are translated to tables `{key = value}`. If however the colon appears inside the value, it would also get replaced.

The proper way to handle it might be to use a regular expression like: `/(?<=\\w):\\s+(?=[['{\\d\\w-])/g` so that only the colons after the keys are replaced. 

The expression would specify a colon preceded by:

- word

followed by a space and:

- `[` : if value is a MFField
- `{`: if value is a Vector2/Vector3/SFNode
- `\\d`: if value is a SFFloat/SFInt
- `'`: if value is a string
- `-` if value is a negative SFFloat/SFInt.
- `\\w` if value is a word (true, false, undefined)

It works, but it almost feels overkill. The workaround of replacing `.replace(":", " =")` to `.replace(": ", " = ")` works so well that I'm tempted to just leave it like that.

Also, I took the opportunity to clean up how the the context strings are encoded, using `'` for string instead of `"`.


