### PR TITLE
Export urls in animation

### DIFF
--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -394,6 +394,14 @@ void WbWorldInfo::exportNodeFields(WbVrmlWriter &writer) const {
     writer << " basicTimeStep=\'" << mBasicTimeStep->value() << "\'";
     writer << " coordinateSystem=\'" << mCoordinateSystem->value() << "\'";
 
+    QString versionString = WbApplicationInfo::branch();
+    if (versionString.isEmpty()) {
+      versionString = WbApplicationInfo::version().toString();
+      versionString.replace(" revision ", "-rev");
+    }
+
+    writer << " version=\'" << versionString << "\'";
+
     if (!findField("window")->isDefault())
       writer << " window='" << mWindow->value() << "'";
   } else


### PR DESCRIPTION
**Description**
Do not export the textures files in animation if they are specified with a `webots://` URL, meaning they are hosted on github
**Tasks**
  - [ ] Change the export of WbImageTexture.cpp
  - [ ] Change the export of WbBackground.cpp
  - [x] Add the export of the version/branch to WbWorldInfo.cpp
  - [ ] Add the export of the repo to WbWorldInfo.cpp to support fork.
  - [ ] Modify parser.js to support `webots://` URL.
  - [ ] Modify the robocup field and background with `webots://` URL.