### PR TITLE
Fix crash due to invalid SFColor value

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -80,6 +80,7 @@ Released on June, Xth, 2021.
     - Fixed in the interaction between [IndexedFaceSets](indexedfaceset.md) and distance sensor rays that resulted in the wrong contact point being considered for collision ([#2610](https://github.com/cyberbotics/webots/pull/2610)), affecting TexturedBoxes.
     - Fixed crash visualizing node properties in Node Editor for nodes in deeply nested PROTO structures ([#3109](https://github.com/cyberbotics/webots/pull/30109)).
     - Fixed crash when selecting velocities relative to kinematic ancestor [Solid](solid.md) node in Node Editor ([#3098](https://github.com/cyberbotics/webots/pull/3098)).
+    - Fixed crash due to invalid SFColor values in PROTO fields by clamping the value and printing a warning in the Webots console ([#3218](https://github.com/cyberbotics/webots/pull/3218)).
     - Fixed the wireframe rendering badly affected by lighting ([#2806](https://github.com/cyberbotics/webots/pull/2806)).
     - Fixed external force/torque logic such that the closest dynamic [Solid](solid.md) ancestor is picked if the selected one lacks it ([#2635](https://github.com/cyberbotics/webots/pull/2635)).
     - Fixed a strategy used to find a MATLAB executable in the `PATH` environment variable ([#2624](https://github.com/cyberbotics/webots/pull/2624)).

--- a/projects/robots/softbank/nao/protos/Nao.proto
+++ b/projects/robots/softbank/nao/protos/Nao.proto
@@ -9,7 +9,7 @@ PROTO Nao [
   field SFString                     name                  "NAO"                 # Is `Solid.name`.
   field SFString{"3.3","4.0", "5.0"} version               "5.0"                 # Defines the Nao version; either "3.3","4.0" or "5.0".
   field SFInt32{21, 25}              degreeOfFreedom       25                    # Defines the number of degrees of freedom; either "21" (fixed fingers) or "25" (articulated fingers).
-  field SFColor                      color                 -1 -1 -1              # Defines the diffuseColor of the secondary `Material`.
+  field SFColor                      color                 0.878 0 0.204         # Defines the diffuseColor of the secondary `Material`.
   field SFString                     controller            "nao_demo"            # Is `Robot.controller`.
   field MFString                     controllerArgs        []                    # Is `Robot.controllerArgs`.
   field SFString                     customData            ""                    # Is `Robot.customData`.
@@ -42,15 +42,6 @@ PROTO Nao [
     -- version check
     local version = fields.version.value
     local color = fields.color.value
-    if color.r == -1 and color.g == -1 and color.b == -1 then
-      if version == "3.3" then
-        color = { r = 0.8, g = 0.8, b = 0.8 }
-      elseif version == "4.0" then
-        color = { r = 0.94, g = 0.41, b = 0.01 }
-      else
-        color = { r = 0.878, g = 0, b = 0.204 }
-      end
-    end
 
     -- degreeOfFreedom check
     local realistic_hands = true

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -103,8 +103,8 @@ void WbCharger::updateMaterialsAndLights(double batteryRatio) {
     WbMaterial *material = dynamic_cast<WbMaterial *>(visualElement->node);
     WbPbrAppearance *appearance = dynamic_cast<WbPbrAppearance *>(visualElement->node);
     WbLight *light = dynamic_cast<WbLight *>(visualElement->node);
-    WbRgb color(cr, cg, cb);
-    assert(!color.clampValuesIfNeeded());
+    const WbRgb color(cr, cg, cb);
+    assert(!WbRgb(cr, cg, cb).clampValuesIfNeeded());
     if (material)
       material->setEmissiveColor(color);
     else if (appearance)

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -103,12 +103,14 @@ void WbCharger::updateMaterialsAndLights(double batteryRatio) {
     WbMaterial *material = dynamic_cast<WbMaterial *>(visualElement->node);
     WbPbrAppearance *appearance = dynamic_cast<WbPbrAppearance *>(visualElement->node);
     WbLight *light = dynamic_cast<WbLight *>(visualElement->node);
+    WbRgb color(cr, cg, cb);
+    assert(!color.clampValuesIfNeeded());
     if (material)
-      material->setEmissiveColor(WbRgb(cr, cg, cb));
+      material->setEmissiveColor(color);
     else if (appearance)
-      appearance->setEmissiveColor(WbRgb(cr, cg, cb));
+      appearance->setEmissiveColor(color);
     else if (light)
-      light->setColor(WbRgb(cr, cg, cb));
+      light->setColor(color);
   }
 }
 

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -208,18 +208,21 @@ void WbLed::setMaterialsAndLightsColor() {
     }
   }
 
+  WbRgb color(r, g, b);
+  assert(!color.clampValuesIfNeeded());
+
   // update every material
   foreach (WbMaterial *material, mMaterials)
-    material->setEmissiveColor(WbRgb(r, g, b));
+    material->setEmissiveColor(color);
 
   // same for PbrAppearances
   foreach (WbPbrAppearance *pbrAppearance, mPbrAppearances)
-    pbrAppearance->setEmissiveColor(WbRgb(r, g, b));
+    pbrAppearance->setEmissiveColor(color);
 
   // update every lights
-  bool on = mValue != 0;
+  const bool on = mValue != 0;
   foreach (WbLight *light, mLights) {
-    light->setColor(WbRgb(r, g, b));
+    light->setColor(color);
     // disable WREN lights if not on
     light->toggleOn(on);
   }

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -208,8 +208,8 @@ void WbLed::setMaterialsAndLightsColor() {
     }
   }
 
-  WbRgb color(r, g, b);
-  assert(!color.clampValuesIfNeeded());
+  const WbRgb color(r, g, b);
+  assert(!WbRgb(r, g, b).clampValuesIfNeeded());
 
   // update every material
   foreach (WbMaterial *material, mMaterials)

--- a/src/webots/nodes/utils/WbFieldChecker.cpp
+++ b/src/webots/nodes/utils/WbFieldChecker.cpp
@@ -288,7 +288,7 @@ bool WbFieldChecker::resetVector3IfNonPositive(const WbBaseNode *node, WbSFVecto
 
 bool WbFieldChecker::resetColorIfInvalid(const WbBaseNode *node, WbSFColor *value) {
   WbRgb rgb = value->value();
-  if (clampRgb(rgb)) {
+  if (rgb.clampValuesIfNeeded()) {
     const WbField *field = findField(node, value);
     node->parsingWarn(tr("Invalid '%1' changed to %2.").arg(field->name()).arg(rgb.toString(WbPrecision::GUI_MEDIUM)));
     value->setValue(rgb);
@@ -303,7 +303,7 @@ bool WbFieldChecker::resetMultipleColorIfInvalid(const WbBaseNode *node, WbMFCol
   const WbField *field = findField(node, value);
   for (int i = 0; i < size; i++) {
     WbRgb rgb = value->item(i);
-    if (clampRgb(rgb)) {
+    if (rgb.clampValuesIfNeeded()) {
       node->parsingWarn(
         tr("Invalid item %1 of '%2' changed to %3.").arg(i).arg(field->name()).arg(rgb.toString(WbPrecision::GUI_MEDIUM)));
       value->setItem(i, rgb);
@@ -318,34 +318,4 @@ const WbField *WbFieldChecker::findField(const WbBaseNode *node, WbValue *value)
     if (field->value() == value)
       return field;
   return NULL;
-}
-
-bool WbFieldChecker::clampRgb(WbRgb &rgb) {
-  bool changed = false;
-
-  if (rgb.red() < 0.0) {
-    rgb.setRed(0.0);
-    changed = true;
-  } else if (rgb.red() > 1.0) {
-    rgb.setRed(1.0);
-    changed = true;
-  }
-
-  if (rgb.green() < 0.0) {
-    rgb.setGreen(0.0);
-    changed = true;
-  } else if (rgb.green() > 1.0) {
-    rgb.setGreen(1.0);
-    changed = true;
-  }
-
-  if (rgb.blue() < 0.0) {
-    rgb.setBlue(0.0);
-    changed = true;
-  } else if (rgb.blue() > 1.0) {
-    rgb.setBlue(1.0);
-    changed = true;
-  }
-
-  return changed;
 }

--- a/src/webots/vrml/WbMFColor.cpp
+++ b/src/webots/vrml/WbMFColor.cpp
@@ -23,10 +23,11 @@ void WbMFColor::readAndAddItem(WbTokenizer *tokenizer, const QString &worldPath)
   WbRgb color(r, g, b);
   if (color.clampValuesIfNeeded())
     tokenizer->reportError(
-      tr("Expected positive color values in range [0.0, 1.0], found [%1 %2 %3]. MFColor field item reset to [%4 %5 %6]")
+      tr("Expected positive color values in range [0.0, 1.0], found [%1 %2 %3]. MFColor field item %4 reset to [%5 %6 %7]")
         .arg(r)
         .arg(g)
         .arg(b)
+        .arg(mVector.size())
         .arg(color.red())
         .arg(color.green())
         .arg(color.blue()));

--- a/src/webots/vrml/WbMFColor.cpp
+++ b/src/webots/vrml/WbMFColor.cpp
@@ -20,7 +20,17 @@ void WbMFColor::readAndAddItem(WbTokenizer *tokenizer, const QString &worldPath)
   const double r = tokenizer->nextToken()->toDouble();
   const double g = tokenizer->nextToken()->toDouble();
   const double b = tokenizer->nextToken()->toDouble();
-  mVector.append(WbRgb(r, g, b));
+  WbRgb color(r, g, b);
+  if (color.clampValuesIfNeeded())
+    tokenizer->reportError(
+      tr("Expected positive color values in range [0.0, 1.0], found [%1 %2 %3]. MFColor field item reset to [%4 %5 %6]")
+        .arg(r)
+        .arg(g)
+        .arg(b)
+        .arg(color.red())
+        .arg(color.green())
+        .arg(color.blue()));
+  mVector.append(color);
 }
 
 void WbMFColor::clear() {

--- a/src/webots/vrml/WbRgb.hpp
+++ b/src/webots/vrml/WbRgb.hpp
@@ -86,7 +86,7 @@ public:
 private:
   double mRed, mGreen, mBlue;
 
-  bool clampValue(double &value) {
+  static bool clampValue(double &value) {
     if (value < 0.0)
       value = 0.0;
     else if (value > 1.0)

--- a/src/webots/vrml/WbRgb.hpp
+++ b/src/webots/vrml/WbRgb.hpp
@@ -75,8 +75,26 @@ public:
   }
   friend QTextStream &operator<<(QTextStream &stream, const WbRgb &c);
 
+  // clamp RGB values in range [0.0, 1.0]
+  bool clampValuesIfNeeded() {
+    const bool redReset = clampValue(mRed);
+    const bool greenReset = clampValue(mGreen);
+    const bool blueReset = clampValue(mBlue);
+    return redReset || greenReset || blueReset;
+  }
+
 private:
   double mRed, mGreen, mBlue;
+
+  bool clampValue(double &value) {
+    if (value < 0.0)
+      value = 0.0;
+    else if (value > 1.0)
+      value = 1.0;
+    else
+      return false;
+    return true;
+  }
 };
 
 inline QTextStream &operator<<(QTextStream &stream, const WbRgb &c) {

--- a/src/webots/vrml/WbSFColor.cpp
+++ b/src/webots/vrml/WbSFColor.cpp
@@ -43,7 +43,6 @@ void WbSFColor::setValue(const WbRgb &c) {
     return;
 
   mValue = c;
-  assert(!mValue.clampValuesIfNeeded());
   emit changed();
 }
 
@@ -52,7 +51,6 @@ void WbSFColor::setValue(uint8_t r, uint8_t g, uint8_t b) {
     return;
 
   mValue.setValue(r, g, b);
-  assert(!mValue.clampValuesIfNeeded());
   emit changed();
 }
 

--- a/src/webots/vrml/WbSFColor.cpp
+++ b/src/webots/vrml/WbSFColor.cpp
@@ -47,15 +47,6 @@ void WbSFColor::setValue(const WbRgb &c) {
   emit changed();
 }
 
-void WbSFColor::setValue(double r, double g, double b) {
-  if (mValue == WbRgb(r, g, b))
-    return;
-
-  mValue.setValue(r, g, b);
-  assert(!mValue.clampValuesIfNeeded());
-  emit changed();
-}
-
 void WbSFColor::setValue(uint8_t r, uint8_t g, uint8_t b) {
   if (mValue == WbRgb(r, g, b))
     return;

--- a/src/webots/vrml/WbSFColor.cpp
+++ b/src/webots/vrml/WbSFColor.cpp
@@ -46,6 +46,14 @@ void WbSFColor::setValue(const WbRgb &c) {
   emit changed();
 }
 
+void WbSFColor::setValue(double r, double g, double b) {
+  if (mValue == WbRgb(r, g, b))
+    return;
+
+  mValue.setValue(r, g, b);
+  emit changed();
+}
+
 void WbSFColor::setValue(uint8_t r, uint8_t g, uint8_t b) {
   if (mValue == WbRgb(r, g, b))
     return;

--- a/src/webots/vrml/WbSFColor.cpp
+++ b/src/webots/vrml/WbSFColor.cpp
@@ -22,6 +22,15 @@ void WbSFColor::readSFColor(WbTokenizer *tokenizer, const QString &worldPath) {
     const double g = tokenizer->nextToken()->toDouble();
     const double b = tokenizer->nextToken()->toDouble();
     mValue.setValue(r, g, b);
+    if (mValue.clampValuesIfNeeded())
+      tokenizer->reportError(
+        tr("Expected positive color values in range [0.0, 1.0], found [%1 %2 %3]. SFColor field reset to [%4 %5 %6]")
+          .arg(r)
+          .arg(g)
+          .arg(b)
+          .arg(mValue.red())
+          .arg(mValue.green())
+          .arg(mValue.blue()));
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());
     tokenizer->ungetToken();  // unexpected token: keep the tokenizer coherent
@@ -34,6 +43,7 @@ void WbSFColor::setValue(const WbRgb &c) {
     return;
 
   mValue = c;
+  assert(!mValue.clampValuesIfNeeded());
   emit changed();
 }
 
@@ -42,6 +52,7 @@ void WbSFColor::setValue(double r, double g, double b) {
     return;
 
   mValue.setValue(r, g, b);
+  assert(!mValue.clampValuesIfNeeded());
   emit changed();
 }
 
@@ -50,6 +61,7 @@ void WbSFColor::setValue(uint8_t r, uint8_t g, uint8_t b) {
     return;
 
   mValue.setValue(r, g, b);
+  assert(!mValue.clampValuesIfNeeded());
   emit changed();
 }
 

--- a/src/webots/vrml/WbSFColor.hpp
+++ b/src/webots/vrml/WbSFColor.hpp
@@ -44,6 +44,7 @@ public:
   double green() const { return mValue.green(); }
   double blue() const { return mValue.blue(); }
   void setValue(const WbRgb &c);
+  void setValue(double r, double g, double b);     // values between 0.0 and 1.0
   void setValue(uint8_t r, uint8_t g, uint8_t b);  // values between 0 and 255
   WbSFColor &operator=(const WbSFColor &other);
   bool operator==(const WbSFColor &other) const { return mValue == other.mValue; }

--- a/src/webots/vrml/WbSFColor.hpp
+++ b/src/webots/vrml/WbSFColor.hpp
@@ -44,7 +44,6 @@ public:
   double green() const { return mValue.green(); }
   double blue() const { return mValue.blue(); }
   void setValue(const WbRgb &c);
-  void setValue(double r, double g, double b);     // values between 0.0 and 1.0
   void setValue(uint8_t r, uint8_t g, uint8_t b);  // values between 0 and 255
   WbSFColor &operator=(const WbSFColor &other);
   bool operator==(const WbSFColor &other) const { return mValue == other.mValue; }


### PR DESCRIPTION
Fix #3183:
do not allow use of invalid SFColor values in PROTO parameters.
If invalid values are defined, they are clamped to the valid range [0.0, 1.0] and an error is printed in the console.