### PR TITLE
Fix kinematic simulation triggering a field regeneration which leads to a crash

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -131,6 +131,7 @@ Released on June, Xth, 2021.
     - Fixed [RandomBuilding](../guide/object-buildings.md#randombuilding) PROTO where different instances generated the same building ([#2897](https://github.com/cyberbotics/webots/pull/2897)).
     - Fixed [PedestrianCrossing](../guide/object-traffic.md#pedestriancrossing) PROTO model not correctly displaying the yellow stripes ([#2857](https://github.com/cyberbotics/webots/pull/2857)).
     - Fixed incorrect position retrieval immediately after resetting nested [Transform](transform.md) nodes ([#3051](https://github.com/cyberbotics/webots/issues/3051)).
+    - Fixed crash triggered by a kinematic simulation involving a PROTO with template regenerable fields ([#3227](https://github.com/cyberbotics/webots/pull/3227)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -189,9 +189,9 @@ void WbTemplateManager::regenerateNodeFromParameterChange(WbField *field) {
 // Note: The security is probably overkill there, but its also safer for the first versions of the template mechanism
 void WbTemplateManager::regenerateNodeFromField(WbNode *templateNode, WbField *field, bool isParameter) {
   // 1. retrieve upper template node where the modification appeared in a template regenerator field
-  templateNode = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, templateNode);
+  WbNode *upperTemplateNode = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, templateNode);
 
-  if (!templateNode)
+  if (!upperTemplateNode)
     return;
 
   // 2. check it's not a parameter managed by ODE
@@ -202,7 +202,7 @@ void WbTemplateManager::regenerateNodeFromField(WbNode *templateNode, WbField *f
     return;
 
   // 3. regenerate template where the modification appeared in a template regenerator field
-  regenerateNode(templateNode);
+  regenerateNode(upperTemplateNode);
 }
 
 void WbTemplateManager::regenerateNode(WbNode *node, bool restarted) {


### PR DESCRIPTION
**Description**
test world: [bug_crash_kinetic_regeneration.zip](https://github.com/cyberbotics/webots/files/6711975/bug_crash_kinetic_regeneration.zip)

If the world file includes a PROTO  like the following:

```
#VRML_SIM R2021b utf8

PROTO MyHingeJoint
[
  field SFNode                                 jointParameters   NULL
  field MFNode                                 device            [ ]
  field SFNode                                 endPoint          NULL
]
{
  %{
    local a = fields.endPoint.value;
  }%
  HingeJoint {
    jointParameters IS jointParameters
    device IS device
    endPoint IS endPoint
  }
}
``` 
where a field is a template regenerator (specifically of type Solid like the `endPoint` of a `HingeJoint`). If this PROTO is used in kinematic mode (i.e the `Solid` lacks a `Physics` node), when the kinematic `updatePosition` step occurs [here](https://github.com/cyberbotics/webots/blob/868b331bb7d29cc2ceed96233dd35c2752f1c84a/src/webots/nodes/WbHingeJoint.cpp#L384-L401), the call of [setTranslationAndRotation](https://github.com/cyberbotics/webots/blob/868b331bb7d29cc2ceed96233dd35c2752f1c84a/src/webots/nodes/WbHingeJoint.cpp#L397) triggers the emission of a `fieldChange` which in turn provokes a regeneration. In theory, this regeneration would potentially occur at every timestep, but in practice it makes webots crash (probably because the regeneration happens mid-physics step, after `setTranslationAndRotation` a function `resetPhysics` is called which likely references a node that is no longer valid).

During the execution of the simulation step I don't think regenerations should even occur, even less so considering field changes of type `translation`, `rotation` and `position` are excluded [here](https://github.com/cyberbotics/webots/blob/868b331bb7d29cc2ceed96233dd35c2752f1c84a/src/webots/nodes/utils/WbTemplateManager.cpp#L197-L202).

The reason it bypasses this restriction is because the test of whether it's a `Solid` or not is done on the uppermost regenerable node (which in this case is of type `HingeJoint` hence passes through) instead of the node itself that triggered it.

**Fix**
Essentially there's two ways of fixing it, but I'm not 100% convinced which of the two is best:
- Option 1: proposed solution. Since the field that triggered the regeneration belongs to node `templateNode`, it seems to me more reasonable to use this same node when checking if it is of type `Solid` (and therefore if the field is one of these excluded cases). If regeneration has to occur, then of course what is regenerated has to be the uppermost `templateNode`
- Option 2: find the uppermost `templateNode` that can be regenerated (as it already does) and replace the current condition `dynamic_cast<const WbSolid *>(templateNode)` with  `dynamic_cast<const WbSolid *>(templateNode) || WbNodeUtilities::hasASolidDescendant(templateNode)`

To me option 1 appears to be the more reasonable one and the one less prone to undesired side-effects.