### PR TITLE
Add acknowledgements to r2021b-blog

### DIFF
--- a/docs/blog/Webots-2021-b-release.md
+++ b/docs/blog/Webots-2021-b-release.md
@@ -133,3 +133,10 @@ A new [Billboard](../reference/billboard.md) node has been introduced to display
 We added [JavaScript scripting support](../reference/javascript-procedural-proto.md) for procedural PROTO nodes in addition to LUA.
 
 **Go and [download](https://cyberbotics.com/#download) Webots R2021b today, so you don't miss out on all these great new features!**
+
+---
+
+## Acknowledgements
+
+The current release includes contributions from [Adman](https://github.com/Adman), [Aethor](https://github.com/Aethor), [AleBurzio11](https://github.com/AleBurzio11), [aykborstelmann](https://github.com/aykborstelmann), [angel-ayala](https://github.com/angel-ayala), [ar0usel](https://github.com/ar0usel), [bkpcoding](https://github.com/bkpcoding), [Behrouz-m](https://github.com/Behrouz-m), [BruceXSK](https://github.com/BruceXSK), [correll](https://github.com/correll), [DavidMansolino](https://github.com/DavidMansolino), [doggo4242](https://github.com/doggo4242), [Dorteel](https://github.com/Dorteel), [fmrico](https://github.com/fmrico), [it14149](https://github.com/it14149), [jmarsik](https://github.com/jmarsik), [kyax32](https://github.com/kyax32), [medrimonia](https://github.com/medrimonia), [NicolasGuy97](https://github.com/NicolasGuy97), [renan028](https://github.com/renan028), [ShuffleWire](https://github.com/ShuffleWire), [sigmunau](https://github.com/sigmunau), [Simon-Steinmann](https://github.com/Simon-Steinmann) and [WasabiFan](https://github.com/WasabiFan).
+Special thanks go to these contributors and the many other members of our community that have contributed by reporting issues, bugs or provided support and moderation in our [Discord](https://discord.com/invite/nTWbN9m) channel.


### PR DESCRIPTION
**Description**
https://www.cyberbotics.com/doc/blog/Webots-2021-b-release?version=documentation-acknowledgements

Added a section for acknowledgements. Don't know where is the best place to put it, if before or after the extra goodies.

The names are contributions (big or small) which have been successfully merged since the previous release (for repo webots, webots-ros, webots-ros2). Any other I should include?

If @sishamilton manages to conclude the altimeter feature before the release it might be nice to mention it as well.
