### PR TITLE
Fix `wb_supervisor_node_get_contact_points` caching

### DIFF
--- a/docs/reference/changelog-r2020.md
+++ b/docs/reference/changelog-r2020.md
@@ -236,7 +236,7 @@ Released on December 18th, 2019.
     - Fixed determinism in camera rendering order.
     - Fixed missing `WB_NODE_MUSCLE` and `WB_NODE_PROPELLER` types in [`wb_node_get_name()`](supervisor.md#wb_supervisor_node_get_type) function.
     - Fixed missing `WB_NODE_NORMAL` node type in MATLAB API.
-    - Fixed arguments of [`wb_supervisor_node_get_number_of_contacts_points()`](supervisor.md#wb_supervisor_node_get_number_of_contact_points) function in MATLAB API.
+    - Fixed arguments of `wb_supervisor_node_get_number_of_contacts_points()` function in MATLAB API.
     - Fixed missing [`wb_robot_set_mode()`](robot.md#wb_robot_set_mode) function in MATLAB API.
     - Fixed `simulation_server.py` script to work with Python3.
     - Fixed `simulation_server.py` script overwriting the DISPLAY environment variable.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -135,7 +135,7 @@ Released on June, Xth, 2021.
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).
-    - Deprecated [`wb_supervisor_node_get_contact_point`](supervisor.md#wb_supervisor_node_get_contact_point), [`wb_supervisor_node_get_contact_point_node`](supervisor.md#wb_supervisor_node_get_contact_point_node), and [`wb_supervisor_node_get_number_of_contact_points`](supervisor.md#wb_supervisor_node_get_number_of_contact_points) functions in favor of [`wb_supervisor_node_get_contact_points`](supervisor.md#wb_supervisor_node_get_contact_points) ([#3162](https://github.com/cyberbotics/webots/pull/3162)).
+    - Deprecated `wb_supervisor_node_get_contact_point`, `wb_supervisor_node_get_contact_point_node`, and `wb_supervisor_node_get_number_of_contact_points` functions in favor of [`wb_supervisor_node_get_contact_points`](supervisor.md#wb_supervisor_node_get_contact_points) ([#3162](https://github.com/cyberbotics/webots/pull/3162)).
     - Remove the viewpoint_control benchmark that was not working in Webots ([#3192](https://github.com/cyberbotics/webots/pull/3192)).
   - Dependency Updates
     - Upgraded to Qt 5.15.2 on macOS ([#2721](https://github.com/cyberbotics/webots/pull/2721)).
@@ -150,8 +150,8 @@ Released on December 15th, 2020.
     - Added the `wb_connector_is_locked` function to returns the current *isLocked* state of a [Connector](connector.md) ([#2087](https://github.com/cyberbotics/webots/pull/2087)).
     - Added the possibility to use an EUN (East-Up-North) coordinate system in the `coordinateSystem` field of the [WorldInfo](worldinfo.md) node ([#2228](https://github.com/cyberbotics/webots/pull/2228)).
     - Added the possibility to disable rendering in the `realtime` mode ([#2286](https://github.com/cyberbotics/webots/pull/2286)).
-    - **Added a new argument to the [Supervisor](supervisor.md) [`wb_supervisor_node_get_number_of_contact_points`](supervisor.md#wb_supervisor_node_get_number_of_contact_points) API function to retrieve the number of contact points including those of the desendant nodes ([#2228](https://github.com/cyberbotics/webots/pull/2228)).**
-    - Added a new [`wb_supervisor_node_get_contact_point_node`](supervisor.md#wb_supervisor_node_get_contact_point_node) [Supervisor](supervisor.md) API function to get the node reference associated to a given contact point ([#2228](https://github.com/cyberbotics/webots/pull/2228)).
+    - **Added a new argument to the [Supervisor](supervisor.md) `wb_supervisor_node_get_number_of_contact_points` API function to retrieve the number of contact points including those of the desendant nodes ([#2228](https://github.com/cyberbotics/webots/pull/2228)).**
+    - Added a new `wb_supervisor_node_get_contact_point_node` [Supervisor](supervisor.md) API function to get the node reference associated to a given contact point ([#2228](https://github.com/cyberbotics/webots/pull/2228)).
     - Added two new functions to the [Camera](camera.md) API called [`wb_camera_get_exposure`](camera.md#wb_camera_get_exposure) and [`wb_camera_set_exposure`](camera.md#wb_camera_set_exposure) to retrieve and change the [Camera](camera.md) exposure ([#2363](https://github.com/cyberbotics/webots/pull/2363)).
     - Added a new functionality in the [Recognition](recognition.md) node and [Camera](camera.md) API for generating segmented ground truth images ([#2199](https://github.com/cyberbotics/webots/pull/2199)).
     - Added options to enable and disable recognition and segmentation functionalities in the [Camera](camera.md) tab of the default robot window ([#2431](https://github.com/cyberbotics/webots/pull/2431)).

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1041,10 +1041,6 @@ The "[WEBOTS\_HOME/projects/samples/howto/center\_of\_mass/worlds/center\_of\_ma
 #### `wb_supervisor_node_enable_contact_point_tracking`
 #### `wb_supervisor_node_disable_contact_point_tracking`
 
-#### `wb_supervisor_node_get_contact_point`
-#### `wb_supervisor_node_get_contact_point_node`
-#### `wb_supervisor_node_get_number_of_contact_points`
-
 
 %tab-component "language"
 
@@ -1056,10 +1052,6 @@ The "[WEBOTS\_HOME/projects/samples/howto/center\_of\_mass/worlds/center\_of\_ma
 WbContactPoint *wb_supervisor_node_get_contact_points(WbNodeRef node, bool include_descendants, int *size);
 wb_supervisor_node_enable_contact_point_tracking(WbNodeRef node, int sampling_period, bool include_descendants);
 wb_supervisor_node_disable_contact_point_tracking(WbNodeRef node, bool include_descendants);
-
-const double *wb_supervisor_node_get_contact_point(WbNodeRef node, int index);
-WbNodeRef wb_supervisor_node_get_contact_point_node(WbNodeRef node, int index);
-int wb_supervisor_node_get_number_of_contact_points(WbNodeRef node, bool include_descendants);
 ```
 
 %tab-end
@@ -1074,10 +1066,6 @@ namespace webots {
     ContactPoint *getContactPoints(bool includeDescendants, int *size) const;
     void enableContactPointsTracking(int samplingPeriod, bool includeDescendants = false) const;
     void disableContactPointsTracking(bool includeDescendants = false) const;
-
-    const double *getContactPoint(int index) const;
-    Node *getContactPointNode(int index) const;
-    int getNumberOfContactPoints(bool includeDescendants = false) const;
     // ...
   }
 }
@@ -1094,10 +1082,6 @@ class Node:
     def getContactPoints(includeDescendants=False):
     def enableContactPointsTracking(samplingPeriod, includeDescendants=False):
     def disableContactPointsTracking(includeDescendants=False):
-
-    def getContactPoint(self, index):
-    def getContactPointNode(self, index):
-    def getNumberOfContactPoints(self, includeDescendants=False):
     # ...
 ```
 
@@ -1112,10 +1096,6 @@ public class Node {
   public ContactPoint[] getContactPoints(boolean includeDescendants);
   public enableContactPointsTracking(int samplingPeriod, boolean includeDescendants = false);
   public disableContactPointsTracking(boolean includeDescendants = false);
-
-  public double[] getContactPoint(int index);
-  public Node getContactPointNode(int index);
-  public int getNumberOfContactPoints(boolean includeDescendants);
   // ...
 }
 ```
@@ -1128,10 +1108,6 @@ public class Node {
 contact_point = wb_supervisor_node_get_contact_points(include_descendants):
 wb_supervisor_node_enable_contact_point_tracking(sampling_period, include_descendants):
 wb_supervisor_node_disable_contact_point_tracking(include_descendants):
-
-contact_point = wb_supervisor_node_get_contact_point(node, index)
-node = wb_supervisor_node_get_contact_point_node(node, index);
-number_of_contacts = wb_supervisor_node_get_number_of_contact_points(node, include_descendants)
 ```
 
 %tab-end
@@ -1143,9 +1119,6 @@ number_of_contacts = wb_supervisor_node_get_number_of_contact_points(node, inclu
 | `/supervisor/node/get_contact_points` | `service` | `webots_ros::node_get_contact_points` | `uint64 node`<br/>`---`<br/>[`webots_ros/ContactPoint[]`](supervisor.md#contact-point) contact_points |
 | `/supervisor/node/enable_contact_point_tracking` | `service` | `webots_ros::enable_contact_point_tracking` | `uint64 node`<br/>`int32 sampling_period`<br/>`bool include_descendants`<br/>`---`<br/>`int32 success` |
 | `/supervisor/node/disable_contact_points_tracking` | `service` | `webots_ros::disable_contact_points_tracking` | `uint64 node`<br/>`bool include_descendants`<br/>`---`<br/>`int32 success` |
-| `/supervisor/node/get_number_of_contact_points` | `service` | `webots_ros::node_get_number_of_contact_points` | `uint64 node`<br/>`bool includeDescendants`<br/>`---`<br/>`int32 numberOfContactPoints` |
-| `/supervisor/node/get_contact_point` | `service` | `webots_ros::node_get_contact_point` | `uint64 node`<br/>`int32 index`<br/>`---`<br/>[`geometry_msgs/Point`](http://docs.ros.org/api/geometry_msgs/html/msg/Point.html) point |
-| `/supervisor/node/get_contact_point_node` | `service` | `webots_ros::node_get_contact_point_node` | `uint64 node`<br/>`int32 index`<br/>`---`<br/>`uint64 node` |
 
 %tab-end
 
@@ -1153,32 +1126,17 @@ number_of_contacts = wb_supervisor_node_get_number_of_contact_points(node, inclu
 
 ##### Description
 
-*get the contact point with given index in the contact point list of the given solid.*
-
-The `wb_supervisor_node_get_contact_points` function returns a list of contact points.
+The `wb_supervisor_node_get_contact_points` function returns a list of contact points of the given `Solid`.
+Contact points are expressed in the global (world) coordinate system.
+The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent.
+The `include_descendants` argument defines whether the descendant nodes should also generate contact points or not.
+The descendant nodes are the nodes included within the node given as an argument.
 
 The `wb_supervisor_node_enable_contact_point_tracking` function forces Webots to stream contact point data to the controller.
 It improves the performance as the controller by default uses a request-response pattern to get data from the field.
 The `sampling_period` argument determines how often the contact point data should be sent to the controller.
 
 The `wb_supervisor_node_disable_contact_point_tracking` function disables contact point data tracking.
-
-The `wb_supervisor_node_get_contact_point` function returns the contact point with given index in the contact point list of the given `Solid`.
-**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
-
-The `wb_supervisor_node_get_number_of_contact_points` function allows you to retrieve the length of this list.
-Contact points are expressed in the global (world) coordinate system.
-If the index is less than the number of contact points, then the x (resp. y, z) coordinate (expressed in the global (world) coordinate system) of the *index*th contact point is the element number *0* (resp. *1, 2*) in the returned array.
-Otherwise the function returns a `NaN` (Not a Number) value for each of these numbers.
-The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `NaN` values on the first 3 array components.
-**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
-
-The `wb_supervisor_node_get_contact_point_node` function allows you to retrieve the node associated to a contact point. This is useful when contact points of the descendants are included, to know which part the contact belongs to.
-**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
-
-The `wb_supervisor_node_get_number_of_contact_points` function returns the number of contact points of the given `Solid`.
-The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.
-The `include_descendants` argument defines whether the descendant nodes should also generate contact points or not. The descendant nodes are the nodes included within the node given as an argument.
 
 The "[WEBOTS\_HOME/projects/samples/howto/cylinder\_stack/worlds/cylinder\_stack.wbt]({{ url.github_tree }}/projects/samples/howto/cylinder_stack/worlds/cylinder_stack.wbt)" project shows how to use this function.
 

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1164,13 +1164,17 @@ The `sampling_period` argument determines how often the contact point data shoul
 The `wb_supervisor_node_disable_contact_point_tracking` function disables contact point data tracking.
 
 The `wb_supervisor_node_get_contact_point` function returns the contact point with given index in the contact point list of the given `Solid`.
+**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
+
 The `wb_supervisor_node_get_number_of_contact_points` function allows you to retrieve the length of this list.
 Contact points are expressed in the global (world) coordinate system.
 If the index is less than the number of contact points, then the x (resp. y, z) coordinate (expressed in the global (world) coordinate system) of the *index*th contact point is the element number *0* (resp. *1, 2*) in the returned array.
 Otherwise the function returns a `NaN` (Not a Number) value for each of these numbers.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `NaN` values on the first 3 array components.
+**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
 
 The `wb_supervisor_node_get_contact_point_node` function allows you to retrieve the node associated to a contact point. This is useful when contact points of the descendants are included, to know which part the contact belongs to.
+**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
 
 The `wb_supervisor_node_get_number_of_contact_points` function returns the number of contact points of the given `Solid`.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1131,6 +1131,7 @@ Contact points are expressed in the global (world) coordinate system.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent.
 The `include_descendants` argument defines whether the descendant nodes should also generate contact points or not.
 The descendant nodes are the nodes included within the node given as an argument.
+The `size` argument is an output argument and it returns a number of contact points in the list.
 
 The `wb_supervisor_node_enable_contact_point_tracking` function forces Webots to stream contact point data to the controller.
 It improves the performance as the controller by default uses a request-response pattern to get data from the field.

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1164,17 +1164,17 @@ The `sampling_period` argument determines how often the contact point data shoul
 The `wb_supervisor_node_disable_contact_point_tracking` function disables contact point data tracking.
 
 The `wb_supervisor_node_get_contact_point` function returns the contact point with given index in the contact point list of the given `Solid`.
-**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
+**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_number_of_contact_points` function allows you to retrieve the length of this list.
 Contact points are expressed in the global (world) coordinate system.
 If the index is less than the number of contact points, then the x (resp. y, z) coordinate (expressed in the global (world) coordinate system) of the *index*th contact point is the element number *0* (resp. *1, 2*) in the returned array.
 Otherwise the function returns a `NaN` (Not a Number) value for each of these numbers.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `NaN` values on the first 3 array components.
-**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
+**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_contact_point_node` function allows you to retrieve the node associated to a contact point. This is useful when contact points of the descendants are included, to know which part the contact belongs to.
-**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
+**Deprecation warning:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_number_of_contact_points` function returns the number of contact points of the given `Solid`.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1164,17 +1164,17 @@ The `sampling_period` argument determines how often the contact point data shoul
 The `wb_supervisor_node_disable_contact_point_tracking` function disables contact point data tracking.
 
 The `wb_supervisor_node_get_contact_point` function returns the contact point with given index in the contact point list of the given `Solid`.
-**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
+**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_number_of_contact_points` function allows you to retrieve the length of this list.
 Contact points are expressed in the global (world) coordinate system.
 If the index is less than the number of contact points, then the x (resp. y, z) coordinate (expressed in the global (world) coordinate system) of the *index*th contact point is the element number *0* (resp. *1, 2*) in the returned array.
 Otherwise the function returns a `NaN` (Not a Number) value for each of these numbers.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `NaN` values on the first 3 array components.
-**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
+**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_contact_point_node` function allows you to retrieve the node associated to a contact point. This is useful when contact points of the descendants are included, to know which part the contact belongs to.
-**This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.**
+**Note:** This function is deprecated and the `wb_supervisor_node_get_contact_points` function should be used instead.
 
 The `wb_supervisor_node_get_number_of_contact_points` function returns the number of contact points of the given `Solid`.
 The `node` argument must be a [Solid](solid.md) node (or a derived node), which moreover has no `Solid` parent, otherwise the function will print a warning message and return `-1`.

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -1156,7 +1156,7 @@ static void supervisor_read_answer(WbDevice *d, WbRequest *r) {
           points[i].node_id = request_read_int32(r);
         }
       }
-      contact_point_node->contact_points->last_update = wb_robot_get_time();
+      contact_point_node->contact_points[include_descendants].last_update = wb_robot_get_time();
       break;
     }
     case C_SUPERVISOR_NODE_GET_STATIC_BALANCE:
@@ -2201,7 +2201,7 @@ WbContactPoint *wb_supervisor_node_get_contact_points(WbNodeRef node, bool inclu
   const double t = wb_robot_get_time();
   const int descendants = include_descendants ? 1 : 0;
 
-  if (t <= node->contact_points[descendants].last_update) {
+  if (t == node->contact_points[descendants].last_update) {
     *size = node->contact_points[descendants].n;
     return node->contact_points[descendants].points;
   }


### PR DESCRIPTION
The `contact_points[descendants].last_update` was initialized to a random value, sometimes higher than 0, making the caching mechanism break.

Also, delete deprecated documentation:
https://www.cyberbotics.com/doc/reference/supervisor?version=fix-get-contact-points#wb_supervisor_node_get_contact_points