### PR TITLE
Drop Python 2.7

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -42,12 +42,10 @@ jobs:
     - name: Install Webots Compilation Dependencies
       run: |
         export PYTHON_INSTALLATION_FOLDER=/C/hostedtoolcache/windows/Python/
-        export PYTHON27_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^2\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON37_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON38_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.8\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON39_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.9\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         echo 'export JAVA_HOME=/C/Program\ Files/Java/jdk1.8.0_211' >> ~/.bash_profile
-        echo 'export PYTHON27_HOME='$PYTHON_INSTALLATION_FOLDER'2.7.'$PYTHON27_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON37_HOME='$PYTHON_INSTALLATION_FOLDER'3.7.'$PYTHON37_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME='$PYTHON_INSTALLATION_FOLDER'3.8.'$PYTHON38_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON39_HOME='$PYTHON_INSTALLATION_FOLDER'3.9.'$PYTHON39_REVISION'/x64' >> ~/.bash_profile

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -38,12 +38,10 @@ jobs:
     - name: Install Webots Compilation Dependencies
       run: |
         export PYTHON_INSTALLATION_FOLDER=/C/hostedtoolcache/windows/Python/
-        export PYTHON27_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^2\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON37_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON38_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.8\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON39_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.9\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         echo 'export JAVA_HOME=/C/Program\ Files/Java/jdk1.8.0_211' >> ~/.bash_profile
-        echo 'export PYTHON27_HOME='$PYTHON_INSTALLATION_FOLDER'2.7.'$PYTHON27_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON37_HOME='$PYTHON_INSTALLATION_FOLDER'3.7.'$PYTHON37_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME='$PYTHON_INSTALLATION_FOLDER'3.8.'$PYTHON38_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON39_HOME='$PYTHON_INSTALLATION_FOLDER'3.9.'$PYTHON39_REVISION'/x64' >> ~/.bash_profile

--- a/docs/guide/controller-programming.md
+++ b/docs/guide/controller-programming.md
@@ -1511,11 +1511,11 @@ For example:
 ; runtime.ini for a Python controller on macOS
 
 [python]
-COMMAND = /opt/local/bin/python2.7
+COMMAND = /opt/local/bin/python3.8
 OPTIONS = -m package.name.given
 ```
 
-In the example above, the resulting command issued by Webots will be: `/opt/local/bin/python2.7 -m package.name.given my_controller.py` possibly followed by the value of the `controllerArgs` field of the corresponding [Robot](../reference/robot.md) node.
+In the example above, the resulting command issued by Webots will be: `/opt/local/bin/python3.8 -m package.name.given my_controller.py` possibly followed by the value of the `controllerArgs` field of the corresponding [Robot](../reference/robot.md) node.
 
 ```ini
 ; runtime.ini for a Java controller on Windows

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -76,7 +76,6 @@ No specific setup is needed.
 %tab "Python"
 | Version               | Environment Variable     | Typical Value                                     |
 |--------------         |--------------------------|---------------------------------------------------|
-| Python 2.7            | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python27`      |
 | Python 3.X            | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python3X`      |
 | Python Homebrew 3.X   | PYTHONPATH               | add `${WEBOTS_HOME}/lib/controller/python3X_brew` |
 | all                   | PYTHONIOENCODING         | `UTF-8`                                           |

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -8,9 +8,8 @@ The Python API is currently composed of a set of about 25 classes having about 2
 The classes are either representations of a node of the scene tree (such as Robot, LED, etc.) or utility classes (such as Motion, ImageRef, etc.).
 A complete description of these functions can be found in the reference guide while the instructions about the common way to program a Python controller can be found in [this chapter](programming-fundamentals.md).
 
-The Python API of Webots supports Python versions 2.7, 3.7, 3.8 and 3.9.
-Please note that Python 2.7 is deprecated since January 1st, 2020 and should be avoided.
-On Ubuntu it also supports Python versions 3.5 and 3.6.
+The Python API of Webots supports Python versions 3.7, 3.8 and 3.9.
+On Ubuntu 18.04 it also supports Python version 3.6.
 
 Alternatively to the Webots built-in editor, [PyCharm](https://www.jetbrains.com/pycharm) can be used to edit and launch Python controllers, see the [Using PyCharm with Webots](using-your-ide.md#pycharm) chapter for a step-by-step procedure.
 
@@ -21,7 +20,7 @@ As a consequence, it executes the first `python` binary found in the current `PA
 If you want to use a different version of Python, please install it if needed and configure your environment so that it becomes the default `python` version when called from the command line in a terminal.
 Alternatively, you can change the default Python command from the Webots Preferences in the General tab.
 If you set it for example to `python3.8` instead of `python`, this version of Python will be used by default, if available from the command line.
-It is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.8` or `python2.7`, etc.
+It is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.9` or `python3.8`, etc.
 If specified in the `runtime.ini` file of a controller, this Python command will be executed instead of the default one to launch this controller.
 On Linux and macOS, it is also possible to override this value by setting a standard Python shebang header line in your main python controller file, for example:
 
@@ -34,20 +33,19 @@ However, it is parsed and a warning is displayed in case of mismatch, e.g., if t
 
 #### Linux Installation
 
-Most of the Linux distributions have Python 2.7 and 3.x already installed.
-To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python2.7 --version`, `python3 --version`, etc.
+Most of the Linux distributions have Python 3 already installed.
+To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python3 --version`, etc.
 
 #### macOS Installation
 
-Python 2.7 installed by default.
 You can install Python 3.7, 3.8 or 3.9 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
-To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python2.7 --version`, `python3 --version`, etc.
+To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python3 --version`, etc.
 
 > **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (e.g. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
 
 #### Windows Installation
 
-You should install the latest version of Python 3.7 (64 bit), 3.8 (64 bit), 3.9 (64 bit) or 2.7 (64 bit) from the official [Python website](https://www.python.org).
+You should install the latest 64-bit version of Python 3.9, 3.8 or 3.7 from the official [Python website](https://www.python.org).
 Then, you have to modify your `PATH` environment variable to add the path to the `python.exe` binary which is located in the main installation folder.
 To check this was done properly, you can open a DOS console (`CMD.EXE`) and type `python --version`.
 If it displays the correct Python version, then, everything is setup properly and you should be able to run the Python example provided with Webots in the `WEBOTS_HOME/projects/languages/python/worlds/example.wbt` world file.
@@ -86,7 +84,7 @@ Where `PYTHON_PATH` is the path to the Python installation directory, for exampl
 
 ### Use an Alternative Python Version
 
-As explained above, the Python libraries for Webots are precompiled for the standard versions of Python 2.7, 3.7, 3.8, 3.9 and on Ubuntu for the default Python 3 version provided with the system.
+As explained above, the Python libraries for Webots are precompiled for the standard versions of Python 3.7, 3.8, 3.9 and on Ubuntu for the default Python 3 version provided with the system.
 It is possible however to use another Python version, like Anaconda Python, by recompiling the Webots Python libraries.
 Such a task requires some knowledge in software installation, compilation from sources and Makefile.
 

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -61,8 +61,8 @@ Using Python *pip*, the *NumPy* package is automatically installed with *opencv-
 Use the `pip` command to install OpenCV:
 
 ```sh
-sudo apt-get install python-pip
-sudo pip install opencv-python
+sudo apt-get install python3-pip
+sudo pip3 install opencv-python
 ```
 
 #### macOS Libraries

--- a/lib/controller/.gitignore
+++ b/lib/controller/.gitignore
@@ -1,5 +1,4 @@
 /java
-/python27
 /python34
 /python35
 /python36

--- a/projects/default/libraries/vehicle/Makefile
+++ b/projects/default/libraries/vehicle/Makefile
@@ -27,12 +27,6 @@ java: cpp/driver cpp/car
 
 python: cpp/driver cpp/car
 ifeq ($(OSTYPE),linux)
-	@echo "# make" $@ python2.7;
-	+PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
-ifeq ($(UBUNTU_VERSION), 16.04)
-	@echo "# make" $@ python3.5;
-	+PYTHON_COMMAND=python3.5 make -s -C python $(MAKECMDGOALS)
-endif
 	@echo "# make" $@ python3.6;
 	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
@@ -49,12 +43,8 @@ ifeq ($(OSTYPE),windows)
 	+PATH="$(PYTHON38_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PATH="$(PYTHON37_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
-	@echo "# make" $@ python2.7;
-	+PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
 endif
 ifeq ($(OSTYPE),darwin)
-	@echo "# make" $@ python2.7;
-	+make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.8;

--- a/projects/robots/robotis/darwin-op/libraries/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/Makefile
@@ -19,16 +19,9 @@ include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
 TARGETS=robotis-op2.Makefile managers.Makefile python.Makefile
 
-ifeq ($(OSTYPE),windows)
-PYTHON_MAKE = PATH="$(PYTHON27_HOME):$(PATH)" make
-else
-PYTHON_MAKE = make
-endif
-
 .PHONY: release debug profile clean
 
 release debug profile: $(TARGETS)
-	cp python27/*managers.* python || true # kept for backward compatibility with < R2019b
 
 clean: $(TARGETS)
 	# Remove python/*managers.* except python/managers.i
@@ -42,12 +35,6 @@ managers.Makefile robotis-op2.Makefile:
 
 python.Makefile: managers.Makefile
 ifeq ($(OSTYPE),linux)
-	@echo "# make" $@ python2.7;
-	+PYTHON_COMMAND=python2.7 make -s -C python $(MAKECMDGOALS)
-ifeq ($(UBUNTU_VERSION), 16.04)
-	@echo "# make" $@ python3.5;
-	+PYTHON_COMMAND=python3.5 make -s -C python $(MAKECMDGOALS)
-endif
 	@echo "# make" $@ python3.6;
 	+PYTHON_COMMAND=python3.6 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
@@ -64,12 +51,8 @@ ifeq ($(OSTYPE),windows)
 	+PATH="$(PYTHON38_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PATH="$(PYTHON37_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
-	@echo "# make" $@ python2.7;
-	+PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $(MAKECMDGOALS)
 endif
 ifeq ($(OSTYPE),darwin)
-	@echo "# make" $@ python2.7;
-	+make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.7;
 	+PYTHON_COMMAND=python3.7 make -s -C python $(MAKECMDGOALS)
 	@echo "# make" $@ python3.8;

--- a/scripts/install/bash_profile.windows
+++ b/scripts/install/bash_profile.windows
@@ -3,7 +3,6 @@
 #####################################################################################################
 
 # export JAVA_HOME=/C/Program\ Files/Java/jdk1.8.0_192                             # Optionally defines the path to Java home.
-# export PYTHON27_HOME=/C/Python27                                                 # Optionally defines the path to Python 2.7 home.
 # export PYTHON37_HOME=/C/Program\ Files/Python37                                  # Optionally defines the path to Python 3.7 home.
 # export PYTHON38_HOME=/C/Program\ Files/Python38                                  # Optionally defines the path to Python 3.8 home.
 # export PYTHON39_HOME=/C/Program\ Files/Python39                                  # Optionally defines the path to Python 3.9 home.

--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -6,13 +6,11 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes git lsb-release cmake swig python2.7-dev libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev zip unzip
+apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage-dev libfreetype6-dev libxml2-dev libzzip-0-13 libboost-dev libgd3 libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget libssl-dev zip unzip
 
 UBUNTU_VERSION=$(lsb_release -rs)
-if [[ $UBUNTU_VERSION == "16.04"  || $UBUNTU_VERSION == "18.04" ]]; then
-       apt install --yes python-pip
-elif [[ $UBUNTU_VERSION == "20.04" ]]; then
-       apt install --yes libzip5 python-pip-whl
+if [[ $UBUNTU_VERSION == "20.04" ]]; then
+       apt install --yes libzip5
 else
        echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
 fi

--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -99,11 +99,6 @@ lib/controller/driver.lib [windows]
 
 lib/controller/generic_robot_window [dll]
 
-lib/controller/python27/
-lib/controller/python27/*.py
-lib/controller/python27/_*.so [linux,mac]
-lib/controller/python27/_*.pyd [windows]
-
 lib/controller/python36/ [linux]
 lib/controller/python36/*.py [linux]
 lib/controller/python36/_*.so [linux]

--- a/src/controller/Makefile
+++ b/src/controller/Makefile
@@ -34,16 +34,6 @@ release debug profile clean:
 	@+make -s -C matlab $@
 ifeq ($(OSTYPE),linux)
 	@echo "#"
-	@echo "# Python 2.7 controller library ("$@")"
-	@echo "#"
-	@+PYTHON_COMMAND=python2.7 make -s -C python $@
-ifeq ($(UBUNTU_VERSION), 16.04)
-	@echo "#"
-	@echo "# Python 3.5 controller library ("$@")"
-	@echo "#"
-	@+PYTHON_COMMAND=python3.5 make -s -C python $@
-endif
-	@echo "#"
 	@echo "# Python 3.6 controller library ("$@")"
 	@echo "#"
 	@+PYTHON_COMMAND=python3.6 make -s -C python $@
@@ -62,27 +52,19 @@ endif
 endif
 ifeq ($(OSTYPE),windows)
 	@echo "#"
-	@echo "# Python 3.9 controller library ("$@")"
+	@echo "# Python 3.7 controller library ("$@")"
 	@echo "#"
-	@+PATH="$(PYTHON39_HOME):$(PATH)" make -s -C python $@
+	@+PATH="$(PYTHON37_HOME):$(PATH)" make -s -C python $@
 	@echo "#"
 	@echo "# Python 3.8 controller library ("$@")"
 	@echo "#"
 	@+PATH="$(PYTHON38_HOME):$(PATH)" make -s -C python $@
 	@echo "#"
-	@echo "# Python 3.7 controller library ("$@")"
+	@echo "# Python 3.9 controller library ("$@")"
 	@echo "#"
-	@+PATH="$(PYTHON37_HOME):$(PATH)" make -s -C python $@
-	@echo "#"
-	@echo "# Python 2.7 controller library ("$@")"
-	@echo "#"
-	@+PATH="$(PYTHON27_HOME):$(PATH)" make -s -C python $@
+	@+PATH="$(PYTHON39_HOME):$(PATH)" make -s -C python $@
 endif
 ifeq ($(OSTYPE),darwin)
-	@echo "#"
-	@echo "# Python 2.7 controller library ("$@")"
-	@echo "#"
-	@+PYTHON_COMMAND=/usr/bin/python2.7 make -s -C python $@
 	@echo "#"
 	@echo "# Python 3.7 controller library ("$@")"
 	@echo "#"

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -61,7 +61,7 @@ endif
 
 ifeq ($(OSTYPE),darwin)
 PYTHON_PATH = $(shell $(PYTHON_COMMAND) -u -c "import sys; print(sys.exec_prefix)")
-SKIP_PYTHON_PYMALLOC := 27 38 39
+SKIP_PYTHON_PYMALLOC := 38 39
 ifeq ($(filter $(PYTHON_SHORT_VERSION),$(SKIP_PYTHON_PYMALLOC)),)
 PYTHON_PYMALLOC = m
 endif

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -64,13 +64,13 @@ const QStringList WbLanguageTools::javaArguments() {
 QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &command, QProcessEnvironment &env) {
   QString pythonCommand = command;
   const QString advice =
-    QObject::tr("Webots requires Python version 3."
+    QObject::tr("Webots requires Python version 3.9, 3.8"
 #ifdef __linux__
-                "x"  // we support 3.6 on ubuntu 18.04 and 3.5 and 3.6 on ubuntu 16.04
+                ", 3.7 or 3.6"  // we also support 3.6 on ubuntu 18.04
 #else
-                "9, 3.8, 3.7"
+                " or 3.7"
 #endif
-                " or 2.7 (64 bit) from python.org in your current PATH.\n"
+                " from python.org in your current PATH.\n"
                 "To fix the problem, you should:\n"
                 "1. Check the Python command set in the Webots preferences.\n"
                 "2. Check the COMMAND set in the [python] section of the runtime.ini file of your controller program if any.\n"
@@ -88,8 +88,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   const QString output = process.readAll();
   // "3.6.3 (v3.6.3:2c5fed8, Oct  3 2017, 18:11:49) [MSC v.1900 64 bit (AMD64)]\nTrue\n" or the like
   const QStringList version = output.split("\n");
-  if (!version[0].startsWith("3.9.") && !version[0].startsWith("3.8.") && !version[0].startsWith("3.7.") &&
-      !version[0].startsWith("2.7.")) {
+  if (!version[0].startsWith("3.9.") && !version[0].startsWith("3.8.") && !version[0].startsWith("3.7.")) {
     WbLog::warning(QObject::tr("\"%1\" was not found.\n").arg(pythonCommand) + advice);
     pythonCommand = "!";
   } else if (version.size() > 1 && version[1].startsWith("False")) {
@@ -104,9 +103,9 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
                                              << "import sys;print(sys.version);");
   process.waitForFinished();
   const QString output = process.readAll();
-  // "2.7.6 (default, Nov 23 2017, 15:49:48) \n[GCC 4.8.4]\n" or the like
+  // "3.8.10 (tags/v3.8.10:3d8993a, May  3 2021, 11:48:03) [MSC v.1928 64 bit (AMD64)]" or the like
   const QStringList version = output.split(" ");
-  if (!version[0].startsWith("3.") && !version[0].startsWith("2.7.")) {
+  if (!version[0].startsWith("3.")) {
     WbLog::warning(QObject::tr("\"%1\" was not found.\n").arg(pythonCommand) + advice);
     pythonCommand = "!";
   } else


### PR DESCRIPTION
Python 2.7 has been deprecated for long now. We should get rid of it.
Fixes #3310.