### PR TITLE
Recommend for all users installation on Windows

### DIFF
--- a/scripts/packaging/webots_distro.c
+++ b/scripts/packaging/webots_distro.c
@@ -565,9 +565,9 @@ static void create_file(const char *name, int m) {
               "DefaultDirName={autopf}\\%s\n"
               "DefaultGroupName=Cyberbotics\n"
               "UninstallDisplayIcon={app}\\msys64\\mingw64\\bin\\webots-bin.exe\n"
-              "PrivilegesRequired=lowest\n"
+              "PrivilegesRequired=admin\n"
               "UsePreviousPrivileges=no\n"
-              "PrivilegesRequiredOverridesAllowed=dialog\n",
+              "PrivilegesRequiredOverridesAllowed=dialog commandline\n",
               application_name, version, application_name, version, year, application_name);
       fprintf(fd, "OutputBaseFileName=%s-%s_setup\n", application_name_lowercase_and_dashes, package_version);
       fprintf(fd,


### PR DESCRIPTION
It is usually better to install Webots for all users (if the user has administrator privileges):
![image](https://user-images.githubusercontent.com/1264964/124292192-985f0800-db55-11eb-8da0-4fe6cfaa9b5c.png)

Moreover, this PR allows users to specify the type of installation also on the command line.