### PR TITLE
Fix shapely module error in `highway_driving_benchmark.wbt`

### DIFF
--- a/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
+++ b/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
@@ -1,12 +1,17 @@
 """Controller program to manage the benchmark."""
-from controller import Supervisor
-from shapely.geometry import Point
-from shapely.geometry import LineString
-
 import os
 import random
 import socket
 import sys
+
+from controller import Supervisor
+try:
+    from shapely.geometry import Point
+    from shapely.geometry import LineString
+except ImportError:
+    sys.stderr.write("Error: 'shapely' module not found.\n")
+    sys.exit(0)
+
 
 VEHICLE_DEF_NAME = 'WEBOTS_VEHICLE0'
 SUMO_PORTS_RANGE = [1024, 1998]

--- a/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
+++ b/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
@@ -12,7 +12,6 @@ except ImportError:
     sys.stderr.write("Error: 'shapely' module not found.\n")
     sys.exit(0)
 
-
 VEHICLE_DEF_NAME = 'WEBOTS_VEHICLE0'
 SUMO_PORTS_RANGE = [1024, 1998]
 MAX_TIME = 60.0


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3293. Give a proper warning concerning the missing module.