### PR TITLE
Replace default controller for `thymio2_pen.wbt` and `thymio2_ball.wbt`

### DIFF
--- a/projects/robots/mobsya/thymio/worlds/thymio2_ball.wbt
+++ b/projects/robots/mobsya/thymio/worlds/thymio2_ball.wbt
@@ -24,6 +24,7 @@ CircleArena {
 }
 Thymio2 {
   translation 0 1 0
+  controller "thymio2_demo"
   window "thymio2"
 }
 Thymio2Ball {

--- a/projects/robots/mobsya/thymio/worlds/thymio2_pen.wbt
+++ b/projects/robots/mobsya/thymio/worlds/thymio2_pen.wbt
@@ -33,6 +33,7 @@ RectangleArena {
   }
 }
 Thymio2 {
+  controller "thymio2_demo"
   window "thymio2"
   bodySlot [
     Thymio2Pen {


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3311.

The default controller `thymio2_aseba` is not integrated with the robot window therefore these two worlds cannot be played without external software. It is too premature to remove this external dependency altogether but this change at least makes the worlds playable.

The world `thymio2.wbt` already uses this controller.
