### PR TITLE
Fix pointlight reset

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -141,6 +141,7 @@ Released on July, 5th, 2021.
     - Fixed [PedestrianCrossing](../guide/object-traffic.md#pedestriancrossing) PROTO model not correctly displaying the yellow stripes ([#2857](https://github.com/cyberbotics/webots/pull/2857)).
     - **Changed ROS message type published by the [Camera Recognition Objects](camera.md#wb_camera_recognition_get_objects) node that now sends a single message including all the recognized objects ([#3234](https://github.com/cyberbotics/webots/pull/3234))**.
     - **Changed ROS data type of [`/supervisor/node/get_type_name`](supervisor.md#wb_supervisor_node_get_type_name) service that now uses `webots_ros::node_get_name` instead of `webots_ros::node_get_type_name` ([#3202](https://github.com/cyberbotics/webots/pull/3202))**.
+    - Fixed incorrect resetting of [PointLight](pointlight.md) nodes ([#3345](https://github.com/cyberbotics/webots/pull/3345)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/nodes/WbPointLight.cpp
+++ b/src/webots/nodes/WbPointLight.cpp
@@ -72,6 +72,11 @@ void WbPointLight::reset(const QString &id) {
   mLocation->setValue(mSavedLocation[id]);
 }
 
+void WbPointLight::save(const QString &id) {
+  WbLight::save(id);
+  mSavedLocation[stateId()] = mLocation->value();
+}
+
 void WbPointLight::preFinalize() {
   WbLight::preFinalize();
 

--- a/src/webots/nodes/WbPointLight.cpp
+++ b/src/webots/nodes/WbPointLight.cpp
@@ -74,7 +74,7 @@ void WbPointLight::reset(const QString &id) {
 
 void WbPointLight::save(const QString &id) {
   WbLight::save(id);
-  mSavedLocation[stateId()] = mLocation->value();
+  mSavedLocation[id] = mLocation->value();
 }
 
 void WbPointLight::preFinalize() {

--- a/src/webots/nodes/WbPointLight.cpp
+++ b/src/webots/nodes/WbPointLight.cpp
@@ -39,6 +39,8 @@ void WbPointLight::init() {
   mAttenuation = findSFVector3("attenuation");
   mLocation = findSFVector3("location");
   mRadius = findSFDouble("radius");
+
+  mSavedLocation[stateId()] = mLocation->value();
 }
 
 WbPointLight::WbPointLight(WbTokenizer *tokenizer) : WbLight("PointLight", tokenizer) {
@@ -63,6 +65,11 @@ WbPointLight::~WbPointLight() {
     wr_node_delete(WR_NODE(mWrenLight));
     delete mLightRepresentation;
   }
+}
+
+void WbPointLight::reset(const QString &id) {
+  WbLight::reset(id);
+  mLocation->setValue(mSavedLocation[id]);
 }
 
 void WbPointLight::preFinalize() {

--- a/src/webots/nodes/WbPointLight.hpp
+++ b/src/webots/nodes/WbPointLight.hpp
@@ -38,6 +38,7 @@ public:
   void preFinalize() override;
   void postFinalize() override;
   void reset(const QString &id) override;
+  void save(const QString &id) override;
 
   // specific functions
   double computeAttenuation(double distance) const;

--- a/src/webots/nodes/WbPointLight.hpp
+++ b/src/webots/nodes/WbPointLight.hpp
@@ -37,6 +37,7 @@ public:
   void createWrenObjects() override;
   void preFinalize() override;
   void postFinalize() override;
+  void reset(const QString &id) override;
 
   // specific functions
   double computeAttenuation(double distance) const;
@@ -55,6 +56,8 @@ private:
   WbSFDouble *mRadius;
 
   WrPointLight *mWrenLight;
+
+  QMap<QString, WbVector3> mSavedLocation;
 
   // optional rendering
   WbLightRepresentation *mLightRepresentation;


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3302.

Contrary to other light nodes, the PointLight has a `location` field which isn't otherwise reset. I believe during a reset it is desirable for the light to return to whatever state it was previously set to (be it at `__init__` or another `stateid`).
