### PR TITLE
Fix javascript construct

### DIFF
--- a/projects/samples/robotbenchmark/highway_driving/plugins/robot_windows/highway_driving/highway_driving.html
+++ b/projects/samples/robotbenchmark/highway_driving/plugins/robot_windows/highway_driving/highway_driving.html
@@ -69,9 +69,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/humanoid_marathon/plugins/robot_windows/humanoid_marathon/humanoid_marathon.html
+++ b/projects/samples/robotbenchmark/humanoid_marathon/plugins/robot_windows/humanoid_marathon/humanoid_marathon.html
@@ -64,9 +64,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/humanoid_sprint/plugins/robot_windows/humanoid_sprint/humanoid_sprint.html
+++ b/projects/samples/robotbenchmark/humanoid_sprint/plugins/robot_windows/humanoid_sprint/humanoid_sprint.html
@@ -84,9 +84,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/inverted_pendulum/plugins/robot_windows/inverted_pendulum/inverted_pendulum.html
+++ b/projects/samples/robotbenchmark/inverted_pendulum/plugins/robot_windows/inverted_pendulum/inverted_pendulum.html
@@ -78,9 +78,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/maze_runner/plugins/robot_windows/maze_runner/maze_runner.html
+++ b/projects/samples/robotbenchmark/maze_runner/plugins/robot_windows/maze_runner/maze_runner.html
@@ -62,9 +62,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/obstacle_avoidance/plugins/robot_windows/obstacle_avoidance/obstacle_avoidance.html
+++ b/projects/samples/robotbenchmark/obstacle_avoidance/plugins/robot_windows/obstacle_avoidance/obstacle_avoidance.html
@@ -69,9 +69,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/pick_and_place/plugins/robot_windows/pick_and_place/pick_and_place.html
+++ b/projects/samples/robotbenchmark/pick_and_place/plugins/robot_windows/pick_and_place/pick_and_place.html
@@ -80,9 +80,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/pit_escape/plugins/robot_windows/pit_escape/pit_escape.html
+++ b/projects/samples/robotbenchmark/pit_escape/plugins/robot_windows/pit_escape/pit_escape.html
@@ -74,9 +74,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/robot_programming/plugins/robot_windows/robot_programming/robot_programming.html
+++ b/projects/samples/robotbenchmark/robot_programming/plugins/robot_windows/robot_programming/robot_programming.html
@@ -82,9 +82,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/square_path/plugins/robot_windows/square_path/square_path.html
+++ b/projects/samples/robotbenchmark/square_path/plugins/robot_windows/square_path/square_path.html
@@ -92,7 +92,7 @@
           </p>
         </div>
         <input class="radio" id="real-robot" name="group" type="radio">
-        <label class="tab" for="real-robot">Real Robot</label>        
+        <label class="tab" for="real-robot">Real Robot</label>
         <div class="panel">
           <p>
             <h2>How to perform the benchmark with a real robot?</h2>
@@ -144,9 +144,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/visual_tracking/plugins/robot_windows/pan_tilt_camera_view/pan_tilt_camera_view.html
+++ b/projects/samples/robotbenchmark/visual_tracking/plugins/robot_windows/pan_tilt_camera_view/pan_tilt_camera_view.html
@@ -37,9 +37,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/visual_tracking/plugins/robot_windows/visual_tracking/visual_tracking.html
+++ b/projects/samples/robotbenchmark/visual_tracking/plugins/robot_windows/visual_tracking/visual_tracking.html
@@ -147,9 +147,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();

--- a/projects/samples/robotbenchmark/wall_following/plugins/robot_windows/wall_following/wall_following.html
+++ b/projects/samples/robotbenchmark/wall_following/plugins/robot_windows/wall_following/wall_following.html
@@ -95,9 +95,9 @@
           return;
         height = newHeight;
         let panels = document.getElementsByClassName('panel');
-        for (panel of panels) {
+        Array.from(panels).forEach((panel) => {
           panel.style.top = height + 'px';
-        };
+        });
       }
       window.addEventListener('resize', adaptPositionOfText);
       adaptPositionOfText();


### PR DESCRIPTION
The JavaScript "for of" construct doesn't work on Windows where the JS engine is older than the one on Linux and macOS. Therefore, we have to revert to an older construct to iterate on items.