### PR TITLE
Improve Urls handling

### DIFF
--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -398,7 +398,8 @@ void WbSimulationWorld::reset(bool restartControllers) {
     }
   }
   updateRandomSeed();
-  WbSimulationState::instance()->resumeSimulation();
+  if (WbDownloader::progress() == 100)
+    WbSimulationState::instance()->resumeSimulation();
   if (mPhysicsPlugin)
     mPhysicsPlugin->init();
   storeLastSaveTime();

--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -16,6 +16,7 @@
 
 #include "WbApplication.hpp"
 #include "WbNetwork.hpp"
+#include "WbSimulationState.hpp"
 
 #include <QtCore/QDir>
 #include <QtCore/QTimer>
@@ -60,6 +61,8 @@ QIODevice *WbDownloader::device() const {
 }
 
 void WbDownloader::download(const QUrl &url) {
+  WbSimulationState::instance()->pauseSimulation();
+
   mUrl = url;
 
   if (gUrlCache.contains(mUrl) && !mIsBackground &&
@@ -124,16 +127,17 @@ void WbDownloader::finished() {
   }
 
   gComplete++;
+  mFinished = true;
+  emit complete();
+
   if (gComplete == gCount) {
     gDownloading = false;
     gDisplayPopUp = false;
     gUrlCache.clear();
     emit WbApplication::instance()->deleteWorldLoadingProgressDialog();
+    WbSimulationState::instance()->resumeSimulation();
   } else if (gDisplayPopUp)
     emit WbApplication::instance()->setWorldLoadingProgress(progress());
-
-  mFinished = true;
-  emit complete();
 }
 
 void WbDownloader::displayPopUp() {

--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -118,7 +118,12 @@ void WbDownloader::finished() {
     }
 
     QNetworkCacheMetaData metaData = WbNetwork::instance()->networkAccessManager()->cache()->metaData(mUrl);
-    // if expirationDate is in UTC format it means that it is the expirationDate sent by raw.githubusercontent.
+    // We need to replace the expiration date only the first time the asset is downloaded and when it has been refreshed by the
+    // cache. The QNetworkRequest::SourceIsFromCacheAttribute attribute present in the reply is not enough because the image is
+    // still loaded from the cache when the expiration date is just refreshed.
+    // The hack we use to detect if the expiration date of an asset is the one set by webots or is the automatic one works as
+    // follows: The automatic expiration date is an <http-date> and thus is in UTC format. The expiration date set by webots is
+    // in local format. So we just need to check the format of the expiration date to know if it needs to be updated or not.
     if (metaData.expirationDate().toUTC().toString() == metaData.expirationDate().toString()) {
       // increase expiration date to one day
       metaData.setExpirationDate(QDateTime::currentDateTime().addDays(1));


### PR DESCRIPTION
**Description**
Several improvements to webots when worlds use URLs

**Tasks**
  - [x] Pause the simulation until all the textures are ready (on reset for example), fix #3283 
  - [x] Change the default cache policy from `prefer network` to `prefer cache`.
  - [x] Modify the expiration date to be one day. (default = 5min). 
