### PR TITLE
Fix cabinet `primaryAppearance`

### DIFF
--- a/projects/objects/cabinet/protos/Cabinet.proto
+++ b/projects/objects/cabinet/protos/Cabinet.proto
@@ -206,7 +206,9 @@ PROTO Cabinet [
                   %< } >%
                   thickness IS innerThickness
                   handle IS handle
-                  primaryAppearance IS primaryAppearance
+                  %< if (data[0] === 'Drawer') { >%
+                    primaryAppearance IS primaryAppearance
+                  %< } >%
                   secondaryAppearance IS secondaryAppearance
                 }
             %< } else if (data[0] === 'Shelf') { >%

--- a/projects/objects/cabinet/protos/CabinetDoor.proto
+++ b/projects/objects/cabinet/protos/CabinetDoor.proto
@@ -13,7 +13,6 @@ PROTO CabinetDoor [
   field SFFloat  thickness           0.03              # Defines the thickness of the door.
   field SFFloat  mass                1.5               # Defines the mass of the door.
   field SFNode   handle              CabinetHandle {}  # Defines door handle.
-  field SFNode   primaryAppearance   NULL              # Defines the primary appearance (this field is not used but is required for compatibilty reason with the other cabinet modules).
   field SFNode   secondaryAppearance NULL              # Defines the secondary appearance.
 ]
 {

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -378,6 +378,7 @@ bool WbAddNodeDialog::doFieldRestrictionsAllowNode(const QString &nodeName) cons
 }
 
 void WbAddNodeDialog::buildTree() {
+  printf("buildTree\n");
   mTree->clear();
   mUsesItem = NULL;
   mDefNodes.clear();
@@ -403,9 +404,12 @@ void WbAddNodeDialog::buildTree() {
   foreach (const QString &basicNodeName, basicNodes) {
     QFileInfo fileInfo(basicNodeName);
     QString errorMessage;
+    // printf("checking %s / %s / %s \n", mField->name().toUtf8().constData(), fileInfo.baseName().toUtf8().constData(),
+    //       mCurrentNode->usefulName().toUtf8().constData());
     if (fileInfo.baseName().contains(QRegExp(mFindLineEdit->text(), Qt::CaseInsensitive, QRegExp::Wildcard)) &&
         WbNodeUtilities::isAllowedToInsert(mField, fileInfo.baseName(), mCurrentNode, errorMessage, nodeUse, QString(),
                                            QStringList(fileInfo.baseName()))) {
+      // printf("> %s is allowed in %s\n", basicNodeName.toUtf8().constData(), mField->name().toUtf8().constData());
       item = new QTreeWidgetItem(nodesItem, QStringList(fileInfo.baseName()));
       item->setIcon(0, QIcon("enabledIcons:node.png"));
       nodesItem->addChild(item);

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -378,7 +378,6 @@ bool WbAddNodeDialog::doFieldRestrictionsAllowNode(const QString &nodeName) cons
 }
 
 void WbAddNodeDialog::buildTree() {
-  printf("buildTree\n");
   mTree->clear();
   mUsesItem = NULL;
   mDefNodes.clear();
@@ -404,12 +403,9 @@ void WbAddNodeDialog::buildTree() {
   foreach (const QString &basicNodeName, basicNodes) {
     QFileInfo fileInfo(basicNodeName);
     QString errorMessage;
-    // printf("checking %s / %s / %s \n", mField->name().toUtf8().constData(), fileInfo.baseName().toUtf8().constData(),
-    //       mCurrentNode->usefulName().toUtf8().constData());
     if (fileInfo.baseName().contains(QRegExp(mFindLineEdit->text(), Qt::CaseInsensitive, QRegExp::Wildcard)) &&
         WbNodeUtilities::isAllowedToInsert(mField, fileInfo.baseName(), mCurrentNode, errorMessage, nodeUse, QString(),
                                            QStringList(fileInfo.baseName()))) {
-      // printf("> %s is allowed in %s\n", basicNodeName.toUtf8().constData(), mField->name().toUtf8().constData());
       item = new QTreeWidgetItem(nodesItem, QStringList(fileInfo.baseName()));
       item->setIcon(0, QIcon("enabledIcons:node.png"));
       nodesItem->addChild(item);


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3337.

The MRE of this bug is this PROTO
```
PROTO Cabinet [
  field SFNode   primaryAppearance   PaintedWood {}    # Defines the primary appearance.
  field SFNode   secondaryAppearance PaintedWood {}    # Defines the secondary appearance.
]
{
  Solid {
    children [
      CabinetDrawer{
         primaryAppearance IS primaryAppearance
         secondaryAppearance IS secondaryAppearance
      }
      CabinetDoor {
         primaryAppearance IS primaryAppearance
         secondaryAppearance IS secondaryAppearance
      }
    ]
  }
}
```
The reason for the bug is that although `CabinetDoor` has a `primaryAppearance` parameter, this is not used anywhere in the body of the PROTO. As such, when removing the default node and attempting to add a new one (in the parent PROTO `Cabinet`), the candidates must satisfy both the constraints imposed by `CabinerDrawer` (which uses this field) and `CabinetDoor` (which doesn't) and the result is that no node satisfies both.

The simplest solution is to remove this unnecessary field from `CabinetDoor`. No update to the documentation is necessary since this PROTO is hidden.

PS: At some point we should look into the `isAllowedToInsert` function, trying to debug this from the webots side was a nightmare. There has to be a cleaner way of checking node compatibility.