### PR TITLE
"Fix" floor distorsion

### DIFF
--- a/projects/samples/howto/inverted_pendulum/worlds/inverted_pendulum.wbt
+++ b/projects/samples/howto/inverted_pendulum/worlds/inverted_pendulum.wbt
@@ -23,7 +23,7 @@ Viewpoint {
 TexturedBackground {
 }
 Floor {
-  size 2 10000
+  size 2 1000
   appearance PBRAppearance {
     baseColorMap ImageTexture {
       url [


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3331.

Not exactly a fix, but I've noticed that choosing a size of 1000 or less and the issue virtually disappears. For the purpose of this world, even 100 would've largely sufficed.

The problem appears to be only affect `IndexedFaceSets` which are defined as a single quad (or 2 triangles) which are very long. I don't think it's very common to have a single 10 km-sided triangle. The only case I can think of is a 10 km straight `Road`. However after testing one, the issue doesn't show up at all even for a length of 100 km. Roads however are built as 8 triangles though, so even this case doesn't really fit the bill.

I've resized the floor so that the distortion doesn't appear, but I'm not sure whether it's practically useful to investigate it further given how niche a case it appears to be. I've put a `wontfix` label, but feel free to remove it.


https://user-images.githubusercontent.com/44834743/124601739-7b357c80-de68-11eb-8b29-66283f444043.mp4


