### PR TITLE
Fix Cabinet doors and drawers physics

### DIFF
--- a/projects/objects/cabinet/protos/CabinetDoor.proto
+++ b/projects/objects/cabinet/protos/CabinetDoor.proto
@@ -92,17 +92,5 @@ PROTO CabinetDoor [
     ]
     name IS name
     model "cabinet door"
-    physics Physics {
-      density -1
-      mass 0.01
-    }
-    boundingObject Transform {
-      translation 0 0 %<= - size.z >%
-      children [
-        Sphere {
-          radius 0.01
-        }
-      ]
-    }
   }
 }

--- a/projects/objects/cabinet/protos/CabinetDrawer.proto
+++ b/projects/objects/cabinet/protos/CabinetDrawer.proto
@@ -117,17 +117,5 @@ PROTO CabinetDrawer [
     ]
     name IS name
     model "cabinet drawer"
-    physics Physics {
-      density -1
-      mass 0.01
-    }
-    boundingObject Transform {
-      translation 0 0 %<= - size.z >%
-      children [
-        Sphere {
-          radius 0.01
-        }
-      ]
-    }
   }
 }

--- a/projects/robots/softbank/nao/worlds/nao_room.wbt
+++ b/projects/robots/softbank/nao/worlds/nao_room.wbt
@@ -139,7 +139,6 @@ WoodenChair {
 Nao {
   translation 0.997971 0.34 -1.74563
   rotation 0.57735126918836 0.57735126918836 0.5773482691869614 -2.094395307179586
-  controller "nao_demo"
   cameraWidth 320
   cameraHeight 240
 }


### PR DESCRIPTION
Fixes #3354
Removed the `Physics` of the node before the HingeJoint to which the door / drawer is attached to.