### PR TITLE
Cleanup useless/broken jquery includes

### DIFF
--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -107,8 +107,7 @@ void WbRobotWindow::setupPage() {
   if (htmlFile.open(QFile::ReadOnly | QFile::Text)) {
     QTextStream htmlInput(&htmlFile);
 
-    QString prependToHead = linkTag(WbStandardPaths::resourcesPath() + "web/local/webots.css") +
-                            linkTag(WbStandardPaths::localDocPath() + "dependencies/jqueryui/1.11.4/jquery-ui.min.css");
+    QString prependToHead = linkTag(WbStandardPaths::resourcesPath() + "web/local/webots.css");
 #ifdef __APPLE__
     // Chromium bug on macOS:
     // - warnings like the following one are displayed in the console: "2018-05-08 11:17:37.496
@@ -120,9 +119,7 @@ void WbRobotWindow::setupPage() {
 #ifndef _WIN32
       scriptTag(WbStandardPaths::resourcesPath() + "web/local/qwebchannel.js") +
 #endif
-      scriptTag(WbStandardPaths::resourcesPath() + "web/local/webots.js") +
-      scriptTag(WbStandardPaths::localDocPath() + "dependencies/jquery/1.11.3/jquery.min.js") +
-      scriptTag(WbStandardPaths::localDocPath() + "dependencies/jqueryui/1.11.4/jquery-ui.min.js");
+      scriptTag(WbStandardPaths::resourcesPath() + "web/local/webots.js");
     QString content;
     const QRegularExpression script("<script[^>]*src=[\"']([^\"'>]*)[\"']");
     const QRegularExpression link("<link[^>]*href=[\"']([^\"'>]*)[\"']");


### PR DESCRIPTION
These jquery include files are not distributed any more, so including them from Webots was wrong.
Since they were not included in the distribution, removing them shouldn't break anything.
