### PR TITLE
Reset scroll when changing tab in Robot Window

### DIFF
--- a/resources/projects/plugins/robot_windows/generic/window_manager.js
+++ b/resources/projects/plugins/robot_windows/generic/window_manager.js
@@ -37,6 +37,7 @@ function menuTabCallback(deviceType) {
   // Plots will be refreshed when the animation is over
   const canvas = new Canvas();
   canvas.clearCanvas();
+  window.scrollTo(0, 0);
 }
 
 function refreshSelectedTab() {

--- a/resources/projects/plugins/robot_windows/generic/window_manager.js
+++ b/resources/projects/plugins/robot_windows/generic/window_manager.js
@@ -37,6 +37,7 @@ function menuTabCallback(deviceType) {
   // Plots will be refreshed when the animation is over
   const canvas = new Canvas();
   canvas.clearCanvas();
+  
   window.scrollTo(0, 0);
 }
 


### PR DESCRIPTION
**Description**
Fixes #3358 
Reset the scroll position to zero when changing tab in Robot Window.
