### PR TITLE
Add instructions for force3d_sensor.wbt

### DIFF
--- a/projects/samples/devices/controllers/force3d_sensor/force3d_sensor.c
+++ b/projects/samples/devices/controllers/force3d_sensor/force3d_sensor.c
@@ -22,7 +22,7 @@ Instructions:
 This demo is intentionally very simple:
 The transparent box is a "force-3d" TouchSensor. The opaque box in the
 center of the transparent one is a Robot node. The TouchSensor is the
-child of the Robot node (Scene tree). This simple setup allow to measure
+child of the Robot node (Scene tree). This simple setup allows to measure
 the force on all (six) sides of the TouchSensor.
 
 To do:

--- a/projects/samples/devices/worlds/force3d_sensor.wbt
+++ b/projects/samples/devices/worlds/force3d_sensor.wbt
@@ -2,7 +2,7 @@
 WorldInfo {
   info [
     "Example use of a \"force-3d\" TouchSensor."
-    "The transparent box is a TouchSensor and the opaque box inside is a Robot node."
+    "The transparent box is a "force-3d" TouchSensor and the opaque box inside is a Robot node."
     "The TouchSensor is the child of the Robot node. This simple setup allows to measure the force on all (six) sides of the TouchSensor."
     "Rotate the transparent box to see how the measured force vector changes."
     "More information is available in the controller file."

--- a/projects/samples/devices/worlds/force3d_sensor.wbt
+++ b/projects/samples/devices/worlds/force3d_sensor.wbt
@@ -2,7 +2,7 @@
 WorldInfo {
   info [
     "Example use of a \"force-3d\" TouchSensor."
-    "The transparent box is a "force-3d" TouchSensor and the opaque box inside is a Robot node."
+    "The transparent box is a \"force-3d\" TouchSensor and the opaque box inside is a Robot node."
     "The TouchSensor is the child of the Robot node. This simple setup allows to measure the force on all (six) sides of the TouchSensor."
     "Rotate the transparent box to see how the measured force vector changes."
     "More information is available in the controller file."

--- a/projects/samples/devices/worlds/force3d_sensor.wbt
+++ b/projects/samples/devices/worlds/force3d_sensor.wbt
@@ -2,6 +2,10 @@
 WorldInfo {
   info [
     "Example use of a \"force-3d\" TouchSensor."
+    "The transparent box is a TouchSensor and the opaque box inside is a Robot node."
+    "The TouchSensor is the child of the Robot node. This simple setup allows to measure the force on all (six) sides of the TouchSensor."
+    "Rotate the transparent box to see how the measured force vector changes."
+    "More information is available in the controller file."
   ]
   title "Force-3D TouchSensor"
   basicTimeStep 8


### PR DESCRIPTION
**Description**
Fixes #3300 
In `force3d_sensor.wbt`, added information in the `info` field of the `WorldInfo` node, so that they are displayed in the Webots Guided Tour interface.
