### PR TITLE
Fix relocation of Skins

### DIFF
--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -312,6 +312,7 @@ int WbProjectRelocationDialog::copyProject() {
   //    controllers folder at the same level as the protos folder of the PROTO robot
   // 5) possibly the current controller file (even if corresponding to a PROTO robot)
   // 6) project libraries if a project controller or plugin is copied
+  // 7) copy skins folder if it exists
 
   const WbWorld *world = WbWorld::instance();
   const QString &worldFileBaseName = QFileInfo(world->fileName()).baseName();
@@ -406,6 +407,10 @@ int WbProjectRelocationDialog::copyProject() {
 
   if (copyLibraries && !projectLibrariesCopied)
     result += WbFileUtil::copyDir(mProject->path() + "libraries", mTargetPath + "/libraries", true, false, true);
+
+  const QString skinsPath = WbProject::current()->path() + "skins/";
+  if (QDir(skinsPath).exists())
+    result += WbFileUtil::copyDir(skinsPath, mTargetPath + "/skins", true, true, true);
 
   return result;
 }


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3292

Based on what I understood, `copyExternalProject` comes [into play](https://github.com/cyberbotics/webots/blob/8eeccb12a698624634b877da7d0d0c0c4e1df5f9/src/webots/editor/WbProjectRelocationDialog.cpp#L211-L212) only if `mExternalProjectPath` is defined, hence if [this](https://github.com/cyberbotics/webots/blob/8eeccb12a698624634b877da7d0d0c0c4e1df5f9/src/webots/editor/WbProjectRelocationDialog.cpp#L446-L454) point is reached. This is the case only if the skins folder would be inside the `protos` folder but according to `WbSkin`, the skins folder must be at the [root](https://github.com/cyberbotics/webots/blob/8eeccb12a698624634b877da7d0d0c0c4e1df5f9/src/webots/nodes/WbSkin.cpp#L405) (same level as worlds) hence it will never be the case.
As such, unless I misunderstood, it's sufficient to relocate this skins folder only in `copyProject` and not in `copyExternalProject`.