### PR TITLE
Fixed deletion of robot window on reset (Linux and macOS)

### DIFF
--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -71,6 +71,7 @@ WbRobotWindow::WbRobotWindow(WbRobot *robot, QWidget *parent) :
 }
 
 WbRobotWindow::~WbRobotWindow() {
+  qDebug() << "deleting RobotWindow";
   if (mWebView)
     delete mWebView->page();
   delete mWebView;
@@ -80,10 +81,8 @@ void WbRobotWindow::setupPage() {
   assert(mWebView);
   mLoaded = false;
 
-#ifdef _WIN32
   if (mWebView->page())
     delete mWebView->page();
-#endif
 
   mWebView->setPage(new WbWebPage());
 

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -71,7 +71,6 @@ WbRobotWindow::WbRobotWindow(WbRobot *robot, QWidget *parent) :
 }
 
 WbRobotWindow::~WbRobotWindow() {
-  qDebug() << "deleting RobotWindow";
   if (mWebView)
     delete mWebView->page();
   delete mWebView;


### PR DESCRIPTION
This fixes a wrong behavior of the robot window on Linux when resetting the `custom_robot_window_simple.wbt`: the series of numbers was wrong after the reset.
It also fixes the following warning occurring when resetting a simulation while a robot window is open on Linux and macOS:
```
Warning: Release of profile requested but WebEnginePage still not deleted. Expect troubles !
```