### PR TITLE
Fix disabled proto test

### DIFF
--- a/tests/protos/controllers/derived_proto_automatic_IS_redirection/derived_proto_automatic_IS_redirection.c
+++ b/tests/protos/controllers/derived_proto_automatic_IS_redirection/derived_proto_automatic_IS_redirection.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, TIME_STEP);

--- a/tests/protos/controllers/mixed_template_derived_proto/mixed_template_derived_proto.c
+++ b/tests/protos/controllers/mixed_template_derived_proto/mixed_template_derived_proto.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag cameraX = wb_robot_get_device("cameraX");
   WbDeviceTag cameraY = wb_robot_get_device("cameraY");

--- a/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
+++ b/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
@@ -10,7 +10,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag ds = wb_robot_get_device("ds");
   wb_distance_sensor_enable(ds, TIME_STEP);
@@ -20,27 +20,8 @@ int main(int argc, char **argv) {
   WbFieldRef urlField = wb_supervisor_node_get_field(node, "url");
   const char *url = wb_supervisor_field_get_mf_string(urlField, 0);
   const double ds_value_grey = wb_distance_sensor_get_value(ds);
-  char path[1024];
-  getcwd(path, sizeof(path));
-  int len = strlen(path);
-#ifdef _WIN32
-  for (int i = len - 1; i >= 0; i--)
-    if (path[i] == '\\')
-      path[i] = '/';
-#endif
-  int count = 0;
-  for (int i = len - 1; i >= 0; i--) {
-    if (path[i] == '/' && ++count == 2) {
-      path[i] = '\0';
-      break;
-    }
-  }
-  strncat(path, "/protos/", sizeof(path) - 8);
-  strncat(path, url, sizeof(path) - strlen(url));
-  ts_assert_int_equal(access(path, R_OK), 0, "File \"%s\" is not readable.", path);
-  ts_assert_double_in_delta(ds_value_grey, 277, 0.000000001,
-                            "Wrong distance sensor value with \"%s\" texture: expecting 277, received %g. WEBOTS_HOME=%s", path,
-                            ds_value_grey, getenv("WEBOTS_HOME"));
+  ts_assert_double_in_delta(ds_value_grey, 277, 20.0,
+                            "Wrong distance sensor value with \"%s\" texture: expecting 277, received %g.", url, ds_value_grey);
   wb_supervisor_field_set_mf_string(urlField, 0, "textures/green.jpg");
 
   wb_robot_step(TIME_STEP);

--- a/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
+++ b/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
@@ -15,11 +15,12 @@ int main(int argc, char **argv) {
   wb_distance_sensor_enable(ds, TIME_STEP);
 
   wb_robot_step(TIME_STEP);
-
+  WbNodeRef n = wb_supervisor_node_get_from_def("TEST_NODE");
+  WbFieldRef field = wb_supervisor_node_get_field(n, "url");
+  const char *url = wb_supervisor_field_get_mf_string(field, 0);
   const double ds_value_grey = wb_distance_sensor_get_value(ds);
   ts_assert_double_in_delta(ds_value_grey, 277, 20.0,
-                            "Wrong distance sensor value with grey texture: expecting 277, received %g.", ds_value_grey);
-
+                            "Wrong distance sensor value with \"%s\" texture: expecting 277, received %g.", url, ds_value_grey);
   WbNodeRef node = wb_supervisor_node_get_from_def("TEST_NODE");
   WbFieldRef urlField = wb_supervisor_node_get_field(node, "url");
   wb_supervisor_field_set_mf_string(urlField, 0, "textures/green.jpg");

--- a/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
+++ b/tests/protos/controllers/modify_proto_template_field/modify_proto_template_field.c
@@ -17,8 +17,7 @@ int main(int argc, char **argv) {
   wb_robot_step(TIME_STEP);
 
   const double ds_value_grey = wb_distance_sensor_get_value(ds);
-  ts_assert_double_in_delta(ds_value_grey, 277,
-                            1000.0,  // FIXME: the tolerance was originally 20, but something is going wrong on the CI machine
+  ts_assert_double_in_delta(ds_value_grey, 277, 20.0,
                             "Wrong distance sensor value with grey texture: expecting 277, received %g.", ds_value_grey);
 
   WbNodeRef node = wb_supervisor_node_get_from_def("TEST_NODE");
@@ -29,9 +28,9 @@ int main(int argc, char **argv) {
 
   // test appearance after regeneration
   const double ds_value_green = wb_distance_sensor_get_value(ds);
-  ts_assert_double_in_delta(
-    ds_value_green, 381, 1000.0,  // FIXME: the tolerance was originally 20, but something is going wrong on the CI machine
-    "Wrong distance sensor value with green texture after regeneration: expecting 381, received %g.", ds_value_green);
+  ts_assert_double_in_delta(ds_value_green, 381, 20.0,
+                            "Wrong distance sensor value with green texture after regeneration: expecting 381, received %g.",
+                            ds_value_green);
 
   wb_robot_step(TIME_STEP);
 

--- a/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
+++ b/tests/protos/controllers/nested_mixed_template_proto/nested_mixed_template_proto.c
@@ -20,7 +20,7 @@ static void check_object_status(WbDeviceTag camera, bool visible, const char *me
 }
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag cameraX = wb_robot_get_device("cameraX");
   WbDeviceTag cameraY = wb_robot_get_device("cameraY");
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 
   wb_robot_step(TIME_STEP);
 
-  if (strcmp(argv[1], "nested_mixed_template_proto") == 0) {
+  if (strncmp(argv[1], "nested_mixed_template_proto", 27) == 0) {
     check_object_status(cameraX, false, "Unexpected cameraX color. The box should not be visible.");
     check_object_status(cameraY, false, "Unexpected cameraY color. The box should not be visible.");
     wb_supervisor_field_set_sf_float(xField, 0.5);

--- a/tests/protos/controllers/proto_nested_parameter/proto_nested_parameter.c
+++ b/tests/protos/controllers/proto_nested_parameter/proto_nested_parameter.c
@@ -12,7 +12,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag camera = wb_robot_get_device("camera");
   wb_camera_enable(camera, TIME_STEP);

--- a/tests/protos/controllers/proto_regeneration_multiple_instances/proto_regeneration_multiple_instances.c
+++ b/tests/protos/controllers/proto_regeneration_multiple_instances/proto_regeneration_multiple_instances.c
@@ -9,7 +9,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbNodeRef protoNode = wb_supervisor_node_get_from_def("TEST_NODE");
   WbFieldRef sizeField = wb_supervisor_node_get_field(protoNode, "size");

--- a/tests/protos/controllers/template_deterministic/template_deterministic.c
+++ b/tests/protos/controllers/template_deterministic/template_deterministic.c
@@ -7,7 +7,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);
+  ts_setup(argv[1]);
 
   // get and enable the acc
   WbDeviceTag ds_deterministic1 = wb_robot_get_device("deterministic 1");

--- a/tests/protos/controllers/template_nested_slot_container/template_nested_slot_container.c
+++ b/tests/protos/controllers/template_nested_slot_container/template_nested_slot_container.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   int time_step = wb_robot_get_basic_time_step();
 

--- a/tests/protos/controllers/template_node_id/template_node_id.c
+++ b/tests/protos/controllers/template_node_id/template_node_id.c
@@ -7,7 +7,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   // let the time for the robot controller to copy the args in customData field
   wb_robot_step(5 * TIME_STEP);

--- a/tests/protos/controllers/template_parameter_toggle_from_supervisor/template_parameter_toggle_from_supervisor.c
+++ b/tests/protos/controllers/template_parameter_toggle_from_supervisor/template_parameter_toggle_from_supervisor.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);
+  ts_setup(argv[1]);
 
   WbNodeRef template = wb_supervisor_node_get_from_def("TEMPLATE");
   ts_assert_pointer_not_null(template, "Unable to retrieve template node");

--- a/tests/protos/controllers/template_proto_follow_solid/template_proto_follow_solid.c
+++ b/tests/protos/controllers/template_proto_follow_solid/template_proto_follow_solid.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbDeviceTag motor = wb_robot_get_device("linear motor");
   wb_motor_set_position(motor, INFINITY);

--- a/tests/protos/controllers/template_robot_regenerated/template_robot_regenerated.c
+++ b/tests/protos/controllers/template_robot_regenerated/template_robot_regenerated.c
@@ -9,7 +9,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   wb_robot_step(TIME_STEP);
 

--- a/tests/protos/controllers/template_viewpoint_proto/template_viewpoint_proto.c
+++ b/tests/protos/controllers/template_viewpoint_proto/template_viewpoint_proto.c
@@ -8,7 +8,7 @@
 #define TIME_STEP 32
 
 int main(int argc, char **argv) {
-  ts_setup(argv[0]);  // give the controller args
+  ts_setup(argv[1]);  // give the controller args
 
   WbNodeRef solid_node = wb_supervisor_node_get_from_def("SOLID");
   WbNodeRef viewpoint_node = wb_supervisor_node_get_from_def("VIEWPOINT");

--- a/tests/protos/worlds/derived_proto_automatic_IS_redirection_lua.wbt
+++ b/tests/protos/worlds/derived_proto_automatic_IS_redirection_lua.wbt
@@ -30,7 +30,7 @@ Robot {
   ]
   controller "derived_proto_automatic_IS_redirection"
   controllerArgs [
-    "derived_proto_automatic_IS_redirection"
+    "derived_proto_automatic_IS_redirection (lua)"
   ]
   supervisor TRUE
 }

--- a/tests/protos/worlds/mixed_template_derived_proto.wbt
+++ b/tests/protos/worlds/mixed_template_derived_proto.wbt
@@ -37,6 +37,9 @@ Robot {
     }
   ]
   controller "mixed_template_derived_proto"
+  controllerArgs [
+    "mixed_template_derived_proto"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/mixed_template_derived_proto_lua.wbt
+++ b/tests/protos/worlds/mixed_template_derived_proto_lua.wbt
@@ -37,6 +37,9 @@ Robot {
     }
   ]
   controller "mixed_template_derived_proto"
+  controllerArgs [
+    "mixed_template_derived_proto (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/modify_proto_template_field_lua.wbt
+++ b/tests/protos/worlds/modify_proto_template_field_lua.wbt
@@ -47,7 +47,7 @@ Robot {
   ]
   controller "modify_proto_template_field"
   controllerArgs [
-    "modify_proto_template_field"
+    "modify_proto_template_field (lua)"
   ]
   supervisor TRUE
 }

--- a/tests/protos/worlds/modify_proto_template_field_lua.wbt
+++ b/tests/protos/worlds/modify_proto_template_field_lua.wbt
@@ -19,7 +19,7 @@ TestRectangleArenaLua {
   floorAppearance PBRAppearance {
     baseColorMap DEF TEST_NODE ImageTexture {
       url [
-        "textures/asphalt.jpg"
+        "textures/grey.jpg"
       ]
       repeatS FALSE
       repeatT FALSE

--- a/tests/protos/worlds/nested_mixed_template_proto_lua.wbt
+++ b/tests/protos/worlds/nested_mixed_template_proto_lua.wbt
@@ -42,7 +42,7 @@ Robot {
   ]
   controller "nested_mixed_template_proto"
   controllerArgs [
-    "nested_mixed_template_proto"
+    "nested_mixed_template_proto (lua)"
   ]
   supervisor TRUE
 }

--- a/tests/protos/worlds/proto_nested_parameter.wbt
+++ b/tests/protos/worlds/proto_nested_parameter.wbt
@@ -34,6 +34,9 @@ Robot {
     }
   ]
   controller "proto_nested_parameter"
+  controllerArgs [
+    "proto_nested_parameter"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_nested_parameter_lua.wbt
+++ b/tests/protos/worlds/proto_nested_parameter_lua.wbt
@@ -34,6 +34,9 @@ Robot {
     }
   ]
   controller "proto_nested_parameter"
+  controllerArgs [
+    "proto_nested_parameter (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_regeneration_multiple_instances.wbt
+++ b/tests/protos/worlds/proto_regeneration_multiple_instances.wbt
@@ -49,6 +49,9 @@ Robot {
     }
   ]
   controller "proto_regeneration_multiple_instances"
+  controllerArgs [
+    "proto_regeneration_multiple_instances"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/proto_regeneration_multiple_instances_lua.wbt
+++ b/tests/protos/worlds/proto_regeneration_multiple_instances_lua.wbt
@@ -49,6 +49,9 @@ Robot {
     }
   ]
   controller "proto_regeneration_multiple_instances"
+  controllerArgs [
+    "proto_regeneration_multiple_instances (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_deterministic.wbt
+++ b/tests/protos/worlds/template_deterministic.wbt
@@ -66,6 +66,9 @@ Robot {
     }
   ]
   controller "template_deterministic"
+  controllerArgs [
+    "template_deterministic"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_deterministic_lua.wbt
+++ b/tests/protos/worlds/template_deterministic_lua.wbt
@@ -66,6 +66,9 @@ Robot {
     }
   ]
   controller "template_deterministic"
+  controllerArgs [
+    "template_deterministic (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_direct_nested_lua.wbt
+++ b/tests/protos/worlds/template_direct_nested_lua.wbt
@@ -40,7 +40,7 @@ Robot {
   ]
   controller "nested"
   controllerArgs [
-    "template_direct_nested"
+    "template_direct_nested (lua)"
   ]
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_nested_slot_container.wbt
+++ b/tests/protos/worlds/template_nested_slot_container.wbt
@@ -31,6 +31,9 @@ Robot {
   ]
   name "supervisor"
   controller "template_nested_slot_container"
+  controllerArgs [
+    "template_nested_slot_container"
+  ]
   supervisor TRUE
 }
 DEF TEST_PROTO TemplateNestedSlotContainer {

--- a/tests/protos/worlds/template_nested_slot_container_lua.wbt
+++ b/tests/protos/worlds/template_nested_slot_container_lua.wbt
@@ -31,6 +31,9 @@ Robot {
   ]
   name "supervisor"
   controller "template_nested_slot_container"
+  controllerArgs [
+    "template_nested_slot_container (lua)"
+  ]
   supervisor TRUE
 }
 DEF TEST_PROTO TemplateNestedSlotContainerLua {

--- a/tests/protos/worlds/template_node_id.wbt
+++ b/tests/protos/worlds/template_node_id.wbt
@@ -41,6 +41,9 @@ Robot {
   ]
   name "supervisor"
   controller "template_node_id"
+  controllerArgs [
+    "template_node_id"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_node_id_lua.wbt
+++ b/tests/protos/worlds/template_node_id_lua.wbt
@@ -41,6 +41,9 @@ Robot {
   ]
   name "supervisor"
   controller "template_node_id"
+  controllerArgs [
+    "template_node_id (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_parameter_toggle_from_supervisor.wbt
+++ b/tests/protos/worlds/template_parameter_toggle_from_supervisor.wbt
@@ -34,6 +34,9 @@ Robot {
     }
   ]
   controller "template_parameter_toggle_from_supervisor"
+  controllerArgs [
+    "template_parameter_toggle_from_supervisor"
+  ]
   supervisor TRUE
 }
 DEF TEMPLATE TemplateSimpleSolidWithPhysicsToggle {

--- a/tests/protos/worlds/template_parameter_toggle_from_supervisor_lua.wbt
+++ b/tests/protos/worlds/template_parameter_toggle_from_supervisor_lua.wbt
@@ -34,6 +34,9 @@ Robot {
     }
   ]
   controller "template_parameter_toggle_from_supervisor"
+  controllerArgs [
+    "template_parameter_toggle_from_supervisor (lua)"
+  ]
   supervisor TRUE
 }
 DEF TEMPLATE TemplateSimpleSolidWithPhysicsToggleLua {

--- a/tests/protos/worlds/template_proto_follow_solid.wbt
+++ b/tests/protos/worlds/template_proto_follow_solid.wbt
@@ -61,6 +61,9 @@ TemplateRobotSlotContainer {
     }
   ]
   controller "template_proto_follow_solid"
+  controllerArgs [
+    "template_proto_follow_solid"
+  ]
 }
 TestSuiteSupervisor {
 }

--- a/tests/protos/worlds/template_proto_follow_solid_lua.wbt
+++ b/tests/protos/worlds/template_proto_follow_solid_lua.wbt
@@ -61,6 +61,9 @@ TemplateRobotSlotContainerLUA {
     }
   ]
   controller "template_proto_follow_solid"
+  controllerArgs [
+    "template_proto_follow_solid (lua)"
+  ]
 }
 TestSuiteSupervisor {
 }

--- a/tests/protos/worlds/template_proto_with_nested_template_parameter_1_lua.wbt
+++ b/tests/protos/worlds/template_proto_with_nested_template_parameter_1_lua.wbt
@@ -49,7 +49,7 @@ Robot {
   ]
   controller "test_cylinder_size_and_resizing"
   controllerArgs [
-    "template_proto_with_nested_template_parameter_1"
+    "template_proto_with_nested_template_parameter_1 (lua)"
     "template_regeneration"
   ]
   supervisor TRUE

--- a/tests/protos/worlds/template_proto_with_nested_template_parameter_2_lua.wbt
+++ b/tests/protos/worlds/template_proto_with_nested_template_parameter_2_lua.wbt
@@ -48,7 +48,7 @@ Robot {
   ]
   controller "test_cylinder_size_and_resizing"
   controllerArgs [
-    "template_proto_with_nested_template_parameter_2"
+    "template_proto_with_nested_template_parameter_2 (lua)"
     "template_regeneration_disabled"
   ]
   supervisor TRUE

--- a/tests/protos/worlds/template_proto_with_nested_template_parameter_3_lua.wbt
+++ b/tests/protos/worlds/template_proto_with_nested_template_parameter_3_lua.wbt
@@ -40,7 +40,7 @@ Robot {
   ]
   controller "test_cylinder_size_and_resizing"
   controllerArgs [
-    "template_proto_with_nested_template_parameter_3"
+    "template_proto_with_nested_template_parameter_3 (lua)"
     "template_regeneration_disabled"
   ]
   supervisor TRUE

--- a/tests/protos/worlds/template_proto_with_template_parameter_1_lua.wbt
+++ b/tests/protos/worlds/template_proto_with_template_parameter_1_lua.wbt
@@ -32,7 +32,7 @@ Robot {
   ]
   controller "test_cylinder_size_and_resizing"
   controllerArgs [
-    "template_proto_with_template_parameter_1"
+    "template_proto_with_template_parameter_1 (lua)"
   ]
   supervisor TRUE
 }

--- a/tests/protos/worlds/template_proto_with_template_parameter_2_lua.wbt
+++ b/tests/protos/worlds/template_proto_with_template_parameter_2_lua.wbt
@@ -32,7 +32,7 @@ Robot {
   ]
   controller "test_cylinder_size_and_resizing"
   controllerArgs [
-    "template_proto_with_template_parameter_2"
+    "template_proto_with_template_parameter_2 (lua)"
   ]
   supervisor TRUE
 }

--- a/tests/protos/worlds/template_robot_regenerated.wbt
+++ b/tests/protos/worlds/template_robot_regenerated.wbt
@@ -21,6 +21,9 @@ Robot {
     }
   ]
   controller "template_robot_regenerated"
+  controllerArgs [
+    "template_robot_regenerated"
+  ]
   supervisor TRUE
 }
 DEF ROBOT TemplateRobot {

--- a/tests/protos/worlds/template_robot_regenerated_lua.wbt
+++ b/tests/protos/worlds/template_robot_regenerated_lua.wbt
@@ -21,6 +21,9 @@ Robot {
     }
   ]
   controller "template_robot_regenerated"
+  controllerArgs [
+    "template_robot_regenerated (lua)"
+  ]
   supervisor TRUE
 }
 DEF ROBOT TemplateRobotLua {

--- a/tests/protos/worlds/template_viewpoint_proto.wbt
+++ b/tests/protos/worlds/template_viewpoint_proto.wbt
@@ -38,6 +38,9 @@ Robot {
     }
   ]
   controller "template_viewpoint_proto"
+  controllerArgs [
+    "template_viewpoint_proto"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {

--- a/tests/protos/worlds/template_viewpoint_proto_lua.wbt
+++ b/tests/protos/worlds/template_viewpoint_proto_lua.wbt
@@ -38,6 +38,9 @@ Robot {
     }
   ]
   controller "template_viewpoint_proto"
+  controllerArgs [
+    "template_viewpoint_proto (lua)"
+  ]
   supervisor TRUE
 }
 TestSuiteSupervisor {


### PR DESCRIPTION
Fixes #3243.
In addition to fixing #3243, this PR also displays the correct test name in the log. This will facilitate tests debugging in the future.