### PR TITLE
Improved test suite scripts

### DIFF
--- a/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
+++ b/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
@@ -202,7 +202,7 @@ class TestSuite (Supervisor):
             if not success:
                 self.outputFileManager.write(
                     'FAILURE with ' + self.currentSimulationFilename +
-                    ': Expected message not found\n'
+                    ': Expected message not found \"' + self.expectedString + '\"\n'
                 )
         else:
             success = self.stderrFileManager.isEmpty()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -51,6 +51,9 @@ if len(sys.argv) > 1:
 
 testGroups = ['api', 'other_api', 'physics', 'protos', 'parser', 'rendering']
 
+if sys.platform == 'win32':
+    testGroups.remove('parser')  # this one doesn't work on Windows
+
 # global files
 testsFolderPath = os.path.dirname(os.path.abspath(__file__)) + os.sep
 outputFilename = testsFolderPath + 'output.txt'
@@ -313,8 +316,8 @@ for groupName in testGroups:
             for line in f:
                 appendToOutputFile(line)
                 if '(core dumped)' in line:
-                    l = line[0:line.find(' Segmentation fault')]
-                    pid = int(l[l.rfind(' ') + 1:])
+                    seg_fault_line = line[0:line.find(' Segmentation fault')]
+                    pid = int(seg_fault_line[seg_fault_line.rfind(' ') + 1:])
                     core_dump_file = '/tmp/core_webots-bin.' + str(pid)
                     if os.path.exists(core_dump_file):
                         appendToOutputFile(subprocess.check_output([


### PR DESCRIPTION
This PR:
- improves the error reporting of the test suite.
- fixes PEP8 issues in python script
- disables the parser tests on Windows which were never working because the stderr and stdout redirection doesn't work.