### PR TITLE
Improve python example

### DIFF
--- a/projects/languages/python/controllers/driver/common.py
+++ b/projects/languages/python/controllers/driver/common.py
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def common_print(caller):
     print('This module is common to both driver and slave controllers (called from ' + caller + ').')

--- a/projects/languages/python/controllers/driver/common.py
+++ b/projects/languages/python/controllers/driver/common.py
@@ -1,0 +1,2 @@
+def common_print(caller):
+    print(caller + ': this module is common to both driver and slave controllers.')

--- a/projects/languages/python/controllers/driver/common.py
+++ b/projects/languages/python/controllers/driver/common.py
@@ -1,2 +1,2 @@
 def common_print(caller):
-    print(caller + ': this module is common to both driver and slave controllers.')
+    print('This module is common to both driver and slave controllers (called from ' + caller + ').')

--- a/projects/languages/python/controllers/driver/common.py
+++ b/projects/languages/python/controllers/driver/common.py
@@ -1,2 +1,16 @@
+# Copyright 1996-2021 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 def common_print(caller):
     print('This module is common to both driver and slave controllers (called from ' + caller + ').')

--- a/projects/languages/python/controllers/driver/driver.py
+++ b/projects/languages/python/controllers/driver/driver.py
@@ -19,6 +19,7 @@ message through an emitter or handle the position of Robot1.
 """
 
 from controller import Supervisor
+from common import common_print
 
 
 class Driver (Supervisor):
@@ -86,4 +87,5 @@ class Driver (Supervisor):
 
 
 controller = Driver()
+common_print('driver')
 controller.run()

--- a/projects/languages/python/controllers/slave/runtime.ini
+++ b/projects/languages/python/controllers/slave/runtime.ini
@@ -1,0 +1,3 @@
+[environment variables with paths]
+PYTHONPATH=$(PYTHONPATH):$(WEBOTS_HOME)/projects/languages/python/controllers/driver/
+PYTHONPATH2=$(WEBOTS_HOME)/projects/languages/python/controllers/driver/

--- a/projects/languages/python/controllers/slave/runtime.ini
+++ b/projects/languages/python/controllers/slave/runtime.ini
@@ -1,3 +1,2 @@
 [environment variables with paths]
-PYTHONPATH=$(PYTHONPATH):$(WEBOTS_HOME)/projects/languages/python/controllers/driver/
-PYTHONPATH2=$(WEBOTS_HOME)/projects/languages/python/controllers/driver/
+PYTHONPATH=$(WEBOTS_HOME)/projects/languages/python/controllers/driver/

--- a/projects/languages/python/controllers/slave/slave.py
+++ b/projects/languages/python/controllers/slave/slave.py
@@ -18,8 +18,6 @@ According to the messages it receives, the robot change its
 behavior.
 """
 
-import os
-
 from controller import AnsiCodes
 from controller import Robot
 from common import common_print
@@ -98,6 +96,5 @@ class Slave (Robot):
 
 
 controller = Slave()
-print(os.environ['PYTHONPATH'])
 common_print('slave')
 controller.run()

--- a/projects/languages/python/controllers/slave/slave.py
+++ b/projects/languages/python/controllers/slave/slave.py
@@ -18,8 +18,11 @@ According to the messages it receives, the robot change its
 behavior.
 """
 
+import os
+
 from controller import AnsiCodes
 from controller import Robot
+from common import common_print
 
 
 class Enumerate(object):
@@ -95,4 +98,6 @@ class Slave (Robot):
 
 
 controller = Slave()
+print(os.environ['PYTHONPATH'])
+common_print('slave')
 controller.run()


### PR DESCRIPTION
Fixes #3011.
Actually, I cannot reproduce #3011 on Linux any more. Everything works as expected.
I believe the original issue description was wrong, mentioning the deprecated `[environment variable with relative paths]` instead of `[environment variables with paths]`.
I modified the python example to illustrate how to use `PYTHONPATH` in a `runtime.ini` file which is a common problem that Python controller developers are facing.