### PR TITLE
Disable building of packages on develop

### DIFF
--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite Linux (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * *'
+    - cron:  '0 23 * * 2100'
 
 defaults:
   run:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite Linux (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * 2100'
+    - cron:  '0 23 * 12 *'
 
 defaults:
   run:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite macOS (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * 2100'
+    - cron:  '0 23 * 12 *'
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite macOS (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * *'
+    - cron:  '0 23 * * 2100'
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite Windows (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * *'
+    - cron:  '0 23 * * 2100'
 
 defaults:
   run:

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -2,7 +2,7 @@ name: Test Suite Windows (develop)
 
 on:
   schedule:
-    - cron:  '0 23 * * 2100'
+    - cron:  '0 23 * 12 *'
 
 defaults:
   run:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -67,6 +67,6 @@ jobs:
     - name: Test Workflows Synchronization
       if: needs.job-skipper.outputs.should_skip != 'true' && (matrix.os == 'ubuntu-18.04' && matrix.python == '3.9')
       run: |
-        if [[ "$(diff .github/workflows/test_suite_linux.yml .github/workflows/test_suite_linux_develop.yml | grep -c -e '^<' -e '^>')" -ne "13" ]]; then echo Linux Workflows not synchronized; exit -1; fi
-        if [[ "$(diff .github/workflows/test_suite_mac.yml .github/workflows/test_suite_mac_develop.yml | grep -c -e '^<' -e '^>')" -ne "10" ]]; then echo macOS Workflows not synchronized; exit -1; fi
-        if [[ "$(diff .github/workflows/test_suite_windows.yml .github/workflows/test_suite_windows_develop.yml | grep -c -e '^<' -e '^>')" -ne "8" ]]; then echo Windows Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_linux.yml .github/workflows/test_suite_linux_develop.yml | grep -c -e '^<' -e '^>')" -ne "14" ]]; then echo Linux Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_mac.yml .github/workflows/test_suite_mac_develop.yml | grep -c -e '^<' -e '^>')" -ne "11" ]]; then echo macOS Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_windows.yml .github/workflows/test_suite_windows_develop.yml | grep -c -e '^<' -e '^>')" -ne "9" ]]; then echo Windows Workflows not synchronized; exit -1; fi

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -67,6 +67,6 @@ jobs:
     - name: Test Workflows Synchronization
       if: needs.job-skipper.outputs.should_skip != 'true' && (matrix.os == 'ubuntu-18.04' && matrix.python == '3.9')
       run: |
-        if [[ "$(diff .github/workflows/test_suite_linux.yml .github/workflows/test_suite_linux_develop.yml | grep -c -e '^<' -e '^>')" -ne "14" ]]; then echo Linux Workflows not synchronized; exit -1; fi
-        if [[ "$(diff .github/workflows/test_suite_mac.yml .github/workflows/test_suite_mac_develop.yml | grep -c -e '^<' -e '^>')" -ne "11" ]]; then echo macOS Workflows not synchronized; exit -1; fi
-        if [[ "$(diff .github/workflows/test_suite_windows.yml .github/workflows/test_suite_windows_develop.yml | grep -c -e '^<' -e '^>')" -ne "9" ]]; then echo Windows Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_linux.yml .github/workflows/test_suite_linux_develop.yml | grep -c -e '^<' -e '^>')" -ne "15" ]]; then echo Linux Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_mac.yml .github/workflows/test_suite_mac_develop.yml | grep -c -e '^<' -e '^>')" -ne "12" ]]; then echo macOS Workflows not synchronized; exit -1; fi
+        if [[ "$(diff .github/workflows/test_suite_windows.yml .github/workflows/test_suite_windows_develop.yml | grep -c -e '^<' -e '^>')" -ne "10" ]]; then echo Windows Workflows not synchronized; exit -1; fi


### PR DESCRIPTION
**Description**
As develop and master have the same version name (R2021b) and we do not plan to add modification on develop until the end of FLU conversion, we can turn off the building of packages on develop.

Moreover having master and develop with the same version name is a bad idea as it causes conflict between the packages build on develop and those build on master during the upload to the release.
