### PR TITLE
Acquire the python GIL for all functions except Robot.step()

### DIFF
--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -83,6 +83,9 @@ using namespace std;
 //  Miscellaneous - controller module's level
 //----------------------------------------------------------------------------------------------
 
+%thread webots::Robot::step(int duration);
+%nothreadblock;
+
 //handling std::string
 %include "std_string.i"
 %include "typemaps.i"


### PR DESCRIPTION
Fixes #3158 and replaces #3176.

It seems to be a cleaner path than #3176.