### PR TITLE
Fix bug sumo

### DIFF
--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -73,9 +73,9 @@ void WbDownloader::download(const QUrl &url) {
     if (!(mOffline == true && mCopy == false)) {
       mCopy = true;
       QNetworkReply *reply = gUrlCache[mUrl];
-      if (reply && !reply->isFinished()) {
+      if (reply && !reply->isFinished())
         connect(reply, &QNetworkReply::finished, this, &WbDownloader::finished, Qt::UniqueConnection);
-      } else
+      else
         finished();
       return;
     }

--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -52,8 +52,11 @@ WbDownloader::WbDownloader(QObject *parent) :
 }
 
 WbDownloader::~WbDownloader() {
-  if (mNetworkReply != NULL)
+  if (mNetworkReply != NULL) {
     mNetworkReply->deleteLater();
+    if (gUrlCache.contains(mUrl))
+      gUrlCache.remove(mUrl);
+  }
 }
 
 QIODevice *WbDownloader::device() const {
@@ -70,11 +73,8 @@ void WbDownloader::download(const QUrl &url) {
     if (!(mOffline == true && mCopy == false)) {
       mCopy = true;
       QNetworkReply *reply = gUrlCache[mUrl];
-      if (reply) {
-        if (reply->isFinished())
-          finished();
-        else
-          connect(reply, &QNetworkReply::finished, this, &WbDownloader::finished, Qt::UniqueConnection);
+      if (reply && !reply->isFinished()) {
+        connect(reply, &QNetworkReply::finished, this, &WbDownloader::finished, Qt::UniqueConnection);
       } else
         finished();
       return;


### PR DESCRIPTION
**Description**
Webots was crashing when trying to play the world with SUMO (like `highway overtake`).

The cause was that some `QNetworkReplys` where deleted locally but there entry was not removed/set to null in the intermediary cache.