### PR TITLE
Enhancement project relocation

### DIFF
--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -320,7 +320,7 @@ void WbBuildEditor::make(const QString &target) {
     return;
 
   // update path of modified files from external project
-  const QString &oldProjectPath = WbProjectRelocationDialog::relocatedExternalProjectPath();
+  const QString &oldProjectPath = WbProjectRelocationDialog::relocatedExternalProtoProjectPath();
   if (!oldProjectPath.isEmpty())
     updateProjectPath(oldProjectPath, WbProject::current()->path());
 

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -499,13 +499,11 @@ bool WbProjectRelocationDialog::validateLocation(QWidget *parent, QString &filen
 
   // change filename parameter: get relative filename with respect to previous project path
   QString absolutePath;
-  if (mExternalProtoProjectPath.isEmpty()) {
-    filename = QDir(current->path()).relativeFilePath(filename);
+  if (mExternalProtoProjectPath.isEmpty())
     absolutePath = current->path();
-  } else {
-    filename = QDir(mExternalProtoProjectPath).relativeFilePath(filename);
+  else
     absolutePath = mExternalProtoProjectPath;
-  }
+  filename = QDir(absolutePath).relativeFilePath(filename);
 
   // relocate dialog
   WbProjectRelocationDialog dialog(current, filename, absolutePath, parent);

--- a/src/webots/editor/WbProjectRelocationDialog.hpp
+++ b/src/webots/editor/WbProjectRelocationDialog.hpp
@@ -41,7 +41,7 @@ public:
 
   // return the path of a modified external default PROTO project
   // return empty string if no external PROTO project was modified
-  static const QString &relocatedExternalProjectPath() { return mExternalProjectPath; }
+  static const QString &relocatedExternalProtoProjectPath() { return mExternalProtoProjectPath; }
 
 private slots:
   void selectDirectory();
@@ -62,7 +62,8 @@ private:
   bool mIsProtoModified;
   bool mIsCompleteRelocation;
 
-  static QString mExternalProjectPath;
+  // path to the projects folder of the modified PROTO resource located outside the current project path
+  static QString mExternalProtoProjectPath;
 
   // create project relocation dialog
   explicit WbProjectRelocationDialog(WbProject *project, const QString &relativeFilename, const QString &absoluteFilePath,
@@ -75,7 +76,7 @@ private:
   // user's chosen target directory
   const QString &targetPath() const { return mTargetPath; }
   int copyProject();
-  int copyExternalProject();
+  int copyExternalProtoProject();
 
   void setStatus(const QString &text, bool ok = true);
 };

--- a/src/webots/editor/WbProjectRelocationDialog.hpp
+++ b/src/webots/editor/WbProjectRelocationDialog.hpp
@@ -75,8 +75,8 @@ private:
 
   // user's chosen target directory
   const QString &targetPath() const { return mTargetPath; }
-  int copyProject();
-  int copyExternalProtoProject();
+  int copyProject(const QString &projectPath, bool copyProtoProject);
+  int copyWorldFiles();
 
   void setStatus(const QString &text, bool ok = true);
 };


### PR DESCRIPTION
Follow up #3368:
* [x]  add more comments regarding the project files copy needed to relocate a default simulation
* [x] copy skins folder also for PROTO projects

It seems also possible to merge the `copyProjects` and `copyExternalProjects` functions.
* [x] merge copyProjects` and `copyExternalProjects` functions