### PR TITLE
Fix mac pythonpath

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -146,7 +146,7 @@ Released on July, 5th, 2021.
     - Fixed incorrect resetting of [PointLight](pointlight.md) nodes ([#3345](https://github.com/cyberbotics/webots/pull/3345)).
     - Fixed incorrect cleaning of [Light](light.md) node ([3374](https://github.com/cyberbotics/webots/pull/3374)).
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
-    - Fixed the path to the python command on MacOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
+    - Fixed the path to the python command on macOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -146,6 +146,7 @@ Released on July, 5th, 2021.
     - Fixed incorrect resetting of [PointLight](pointlight.md) nodes ([#3345](https://github.com/cyberbotics/webots/pull/3345)).
     - Fixed incorrect cleaning of [Light](light.md) node ([3374](https://github.com/cyberbotics/webots/pull/3374)).
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
+    - Fixed the path to the python command on MacOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -141,6 +141,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   return pythonCommand;
 }
 
+#if defined __APPLE__ || defined __linux__
 const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log) {
   QString shortVersion;
   QProcess process;
@@ -159,6 +160,7 @@ const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCo
     shortVersion = QString(version[0][0]) + version[0][2];
   return shortVersion;
 }
+#endif
 
 #ifdef __APPLE__
 QString WbLanguageTools::findWorkingPythonPath(const QString &pythonVersion, QProcessEnvironment &env, bool log) {

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -64,6 +64,10 @@ const QStringList WbLanguageTools::javaArguments() {
 QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &command, QProcessEnvironment &env) {
   QString pythonCommand = command;
   QString advice =
+#ifdef __APPLE__
+    "To fix the problem, you could try to insert the full path of your python distribution in "
+    "Webots->preferences->python command.\n";
+#else
     QObject::tr("Webots requires Python version 3.9, 3.8"
 #ifdef __linux__
                 ", 3.7 or 3.6"  // we also support 3.6 on ubuntu 18.04
@@ -76,6 +80,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
                 "2. Check the COMMAND set in the [python] section of the runtime.ini file of your controller program if any.\n"
                 "3. Fix your PATH environment variable to use the required Python 64 bit version (if available).\n"
                 "4. Install the required Python 64 bit version and ensure your PATH environment variable points to it.\n");
+#endif
 #ifdef _WIN32
   if (!command.endsWith(".exe", Qt::CaseInsensitive))
     pythonCommand += ".exe";
@@ -97,9 +102,6 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
-  // cppcheck-suppress redundantInitialization
-  advice = "To fix the problem, you could try to insert the full path of your python distribution in "
-           "Webots->preferences->python command.\n";
   if (pythonCommand == "python" || pythonCommand == "python3") {
     pythonCommand = findWorkingPath("3.8", env, false);
     shortVersion = "38";
@@ -129,7 +131,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // Linux
-  shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
+    shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -63,7 +63,7 @@ const QStringList WbLanguageTools::javaArguments() {
 
 QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &command, QProcessEnvironment &env) {
   QString pythonCommand = command;
-  QString advice =
+  const QString advice =
 #ifdef __APPLE__
     "To fix the problem, you should set the full path of your python command in "
     "Webots->preferences->python command.\n";

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -103,24 +103,24 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
   if (pythonCommand == "python" || pythonCommand == "python3") {
-    pythonCommand = findWorkingPath("3.8", env, false);
+    pythonCommand = findWorkingPythonPath("3.8", env, false);
     shortVersion = "38";
     if (pythonCommand == "!") {
-      pythonCommand = findWorkingPath("3.9", env, false);
+      pythonCommand = findWorkingPythonPath("3.9", env, false);
       shortVersion = "39";
       if (pythonCommand == "!") {
-        pythonCommand = findWorkingPath("3.7", env, true);
+        pythonCommand = findWorkingPythonPath("3.7", env, true);
         shortVersion = "37";
       }
     }
   } else if (pythonCommand == "python3.7") {
-    pythonCommand = findWorkingPath("3.7", env, true);
+    pythonCommand = findWorkingPythonPath("3.7", env, true);
     shortVersion = "37";
   } else if (pythonCommand == "python3.8") {
-    pythonCommand = findWorkingPath("3.8", env, true);
+    pythonCommand = findWorkingPythonPath("3.8", env, true);
     shortVersion = "38";
   } else if (pythonCommand == "python3.9") {
-    pythonCommand = findWorkingPath("3.9", env, true);
+    pythonCommand = findWorkingPythonPath("3.9", env, true);
     shortVersion = "39";
   } else {
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
@@ -160,7 +160,8 @@ const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCo
   return shortVersion;
 }
 
-QString WbLanguageTools::findWorkingPath(const QString &pythonVersion, QProcessEnvironment &env, bool log) {
+#ifdef __APPLE__
+QString WbLanguageTools::findWorkingPythonPath(const QString &pythonVersion, QProcessEnvironment &env, bool log) {
   QString shortVersion;
 
   // look for python from python.org
@@ -181,6 +182,7 @@ QString WbLanguageTools::findWorkingPath(const QString &pythonVersion, QProcessE
 
   return pythonCommand;
 }
+#endif
 
 const QStringList WbLanguageTools::pythonArguments() {
   return QStringList("-u");

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -97,14 +97,15 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
-  advice = "To fix the problem, you could try to insert the full path of your python distribution in Webots->preferences->python command.\n";
+  advice = "To fix the problem, you could try to insert the full path of your python distribution in "
+           "Webots->preferences->python command.\n";
   if (pythonCommand == "python" || pythonCommand == "python3") {
     pythonCommand = findRightPath("3.8", env, false);
     shortVersion = "38";
-    if (pythonCommand == "!"){
+    if (pythonCommand == "!") {
       pythonCommand = findRightPath("3.9", env, false);
       shortVersion = "39";
-      if (pythonCommand == "!"){
+      if (pythonCommand == "!") {
         pythonCommand = findRightPath("3.7", env, true);
         shortVersion = "37";
       }
@@ -126,10 +127,12 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
 
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
-#else // Linux
-    shortVersion = pythonCommandFound(pythonCommand, env, true);
-    if (shortVersion.isEmpty())
-      pythonCommand = "!";
+#else  // Linux
+  shortVersion = pythonCommandFound(pythonCommand, env, true);
+  if (shortVersion.isEmpty()) {
+    pythonCommand = "!";
+    WbLog::warning(QObject::tr("Python was not found.\n") + advice);
+  }
 
 #endif
   return pythonCommand;
@@ -158,14 +161,14 @@ QString WbLanguageTools::findRightPath(const QString &pythonVersion, QProcessEnv
   QString shortVersion;
   QString pythonCommand = "/Library/Frameworks/Python.framework/Versions/" + pythonVersion + "/bin/python" + pythonVersion;
 
-  //look for python from python.org
+  // look for python from python.org
   shortVersion = pythonCommandFound(pythonCommand, env, false);
   if (shortVersion.isEmpty()) {
-    //look first possible path for python from homebrew
+    // look first possible path for python from homebrew
     pythonCommand = "/usr/local/opt/python@" + pythonVersion + " /bin/python" + pythonVersion;
     shortVersion = pythonCommandFound(pythonCommand, env, false);
     if (shortVersion.isEmpty()) {
-      //look a second possible path for python from homebrew
+      // look a second possible path for python from homebrew
       pythonCommand = "/usr/local/bin/python" + pythonVersion;
       shortVersion = pythonCommandFound(pythonCommand, env, log);
       if (shortVersion.isEmpty())

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -97,6 +97,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
+  // cppcheck-suppress redundantInitialization
   advice = "To fix the problem, you could try to insert the full path of your python distribution in "
            "Webots->preferences->python command.\n";
   if (pythonCommand == "python" || pythonCommand == "python3") {

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -65,7 +65,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   QString pythonCommand = command;
   QString advice =
 #ifdef __APPLE__
-    "To fix the problem, you could try to insert the full path of your python distribution in "
+    "To fix the problem, you should set the full path of your python command in "
     "Webots->preferences->python command.\n";
 #else
     QObject::tr("Webots requires Python version 3.9, 3.8"

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -63,7 +63,7 @@ const QStringList WbLanguageTools::javaArguments() {
 
 QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &command, QProcessEnvironment &env) {
   QString pythonCommand = command;
-  const QString advice =
+  QString advice =
     QObject::tr("Webots requires Python version 3.9, 3.8"
 #ifdef __linux__
                 ", 3.7 or 3.6"  // we also support 3.6 on ubuntu 18.04
@@ -96,32 +96,36 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
     pythonCommand = "!";
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
-#elseif __APPLE__
+#elif __APPLE__
+  advice = "To fix the problem, you could try to insert the full path of your python distribution in Webots->preferences->python command.\n";
   if (pythonCommand == "python" || pythonCommand == "python3") {
-    pythonCommand = findRightPath("3.8", false);
+    pythonCommand = findRightPath("3.8", env, false);
     shortVersion = "38";
-    if (pythonVersion == "!"){
-      pythonCommand = findRightPath("3.9", false);
+    if (pythonCommand == "!"){
+      pythonCommand = findRightPath("3.9", env, false);
       shortVersion = "39";
-      if (pythonVersion == "!"){
-        pythonCommand = findRightPath("3.7", true);
+      if (pythonCommand == "!"){
+        pythonCommand = findRightPath("3.7", env, true);
         shortVersion = "37";
       }
     }
   } else if (pythonCommand == "python3.7") {
-    pythonCommand = findRightPath("3.7", true);
+    pythonCommand = findRightPath("3.7", env, true);
     shortVersion = "37";
   } else if (pythonCommand == "python3.8") {
-    pythonCommand = findRightPath("3.8", true);
+    pythonCommand = findRightPath("3.8", env, true);
     shortVersion = "38";
   } else if (pythonCommand == "python3.9") {
-    pythonCommand = findRightPath("3.9", true);
+    pythonCommand = findRightPath("3.9", env, true);
     shortVersion = "39";
   } else {
     shortVersion = pythonCommandFound(pythonCommand, env, true);
     if (shortVersion.isEmpty())
       pythonCommand = "!";
   }
+
+  if (pythonCommand == "!")
+    WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else // Linux
     shortVersion = pythonCommandFound(pythonCommand, env, true);
     if (shortVersion.isEmpty())

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -100,27 +100,27 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   advice = "To fix the problem, you could try to insert the full path of your python distribution in "
            "Webots->preferences->python command.\n";
   if (pythonCommand == "python" || pythonCommand == "python3") {
-    pythonCommand = findRightPath("3.8", env, false);
+    pythonCommand = findWorkingPath("3.8", env, false);
     shortVersion = "38";
     if (pythonCommand == "!") {
-      pythonCommand = findRightPath("3.9", env, false);
+      pythonCommand = findWorkingPath("3.9", env, false);
       shortVersion = "39";
       if (pythonCommand == "!") {
-        pythonCommand = findRightPath("3.7", env, true);
+        pythonCommand = findWorkingPath("3.7", env, true);
         shortVersion = "37";
       }
     }
   } else if (pythonCommand == "python3.7") {
-    pythonCommand = findRightPath("3.7", env, true);
+    pythonCommand = findWorkingPath("3.7", env, true);
     shortVersion = "37";
   } else if (pythonCommand == "python3.8") {
-    pythonCommand = findRightPath("3.8", env, true);
+    pythonCommand = findWorkingPath("3.8", env, true);
     shortVersion = "38";
   } else if (pythonCommand == "python3.9") {
-    pythonCommand = findRightPath("3.9", env, true);
+    pythonCommand = findWorkingPath("3.9", env, true);
     shortVersion = "39";
   } else {
-    shortVersion = pythonCommandFound(pythonCommand, env, true);
+    shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
     if (shortVersion.isEmpty())
       pythonCommand = "!";
   }
@@ -128,7 +128,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // Linux
-  shortVersion = pythonCommandFound(pythonCommand, env, true);
+  shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
@@ -138,7 +138,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   return pythonCommand;
 }
 
-const QString WbLanguageTools::pythonCommandFound(const QString &pythonCommand, QProcessEnvironment &env, bool log) {
+const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log) {
   QString shortVersion;
   QProcess process;
   process.setProcessEnvironment(env);
@@ -157,20 +157,20 @@ const QString WbLanguageTools::pythonCommandFound(const QString &pythonCommand, 
   return shortVersion;
 }
 
-QString WbLanguageTools::findRightPath(const QString &pythonVersion, QProcessEnvironment &env, bool log) {
+QString WbLanguageTools::findWorkingPath(const QString &pythonVersion, QProcessEnvironment &env, bool log) {
   QString shortVersion;
-  QString pythonCommand = "/Library/Frameworks/Python.framework/Versions/" + pythonVersion + "/bin/python" + pythonVersion;
 
   // look for python from python.org
-  shortVersion = pythonCommandFound(pythonCommand, env, false);
+  QString pythonCommand = "/Library/Frameworks/Python.framework/Versions/" + pythonVersion + "/bin/python" + pythonVersion;
+  shortVersion = checkIfPythonCommandExist(pythonCommand, env, false);
   if (shortVersion.isEmpty()) {
     // look first possible path for python from homebrew
     pythonCommand = "/usr/local/opt/python@" + pythonVersion + " /bin/python" + pythonVersion;
-    shortVersion = pythonCommandFound(pythonCommand, env, false);
+    shortVersion = checkIfPythonCommandExist(pythonCommand, env, false);
     if (shortVersion.isEmpty()) {
       // look a second possible path for python from homebrew
       pythonCommand = "/usr/local/bin/python" + pythonVersion;
-      shortVersion = pythonCommandFound(pythonCommand, env, log);
+      shortVersion = checkIfPythonCommandExist(pythonCommand, env, log);
       if (shortVersion.isEmpty())
         pythonCommand = "!";
     }

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -37,7 +37,7 @@ private:
   ~WbLanguageTools() {}
   static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
   // cppcheck-suppress unusedPrivateFunction
-  static QString findWorkingPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
+  static QString findWorkingPythonPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
 };
 
 #endif

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -36,8 +36,9 @@ private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
   static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
-  // cppcheck-suppress unusedPrivateFunction
+#ifdef __APPLE__
   static QString findWorkingPythonPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
+#endif
 };
 
 #endif

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -35,8 +35,8 @@ public:
 private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
-  static const QString pythonCommandFound(const QString &pythonCommand, QProcessEnvironment &env, bool log);
-  static QString findRightPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
+  static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
+  static QString findWorkingPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
 };
 
 #endif

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -35,7 +35,9 @@ public:
 private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
+#if defined __APPLE__ || defined __linux__
   static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
+#endif
 #ifdef __APPLE__
   static QString findWorkingPythonPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
 #endif

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -35,6 +35,8 @@ public:
 private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
+  static const QString pythonCommandFound(const QString &pythonCommand, QProcessEnvironment &env, bool log);
+  static QString findRightPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
 };
 
 #endif

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -36,6 +36,7 @@ private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
   static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
+  // cppcheck-suppress unusedPrivateFunction
   static QString findWorkingPath(const QString &pythonVersion, QProcessEnvironment &env, bool log);
 };
 


### PR DESCRIPTION
**Description**
The python executable is not found on MacOS when launching Webots from the GUI (Spotlight, Finder, Dock). 

To fix that, we decided to hardcode the standard MacOS path to both python from python.org and python from homebrew in Webots.
It it does not work, a warning will be displayed, requesting the user to set the full path to his python executable in the preferences of webots.

Fix #3285.