### PR TITLE
Fix HighwaySign proto

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -148,7 +148,7 @@ Released on July, 5th, 2021.
     - Fixed incorrect cleaning of [Light](light.md) node ([3374](https://github.com/cyberbotics/webots/pull/3374)).
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
     - Fixed the path to the python command on macOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
-    - Fixed [HighwaySign](../guide/object-traffic.md#highwaysign) proto ([#3407](https://github.com/cyberbotics/webots/pull/3407)).
+    - Fixed [HighwaySign](../guide/object-traffic.md#highwaysign) PROTO not displaying the texture ([#3407](https://github.com/cyberbotics/webots/pull/3407)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -148,6 +148,7 @@ Released on July, 5th, 2021.
     - Fixed incorrect cleaning of [Light](light.md) node ([3374](https://github.com/cyberbotics/webots/pull/3374)).
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
     - Fixed the path to the python command on macOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
+    - Fixed [HighwaySign](../guide/object-traffic.md#highwaysign) proto ([#3407](https://github.com/cyberbotics/webots/pull/3407)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/projects/objects/traffic/protos/HighwaySign.proto
+++ b/projects/objects/traffic/protos/HighwaySign.proto
@@ -46,6 +46,7 @@ PROTO HighwaySign [
           TexturedBoxShape {
             size %<= thickness >% %<= height >% %<= length >%
             textureUrl IS texture
+            textureMapping "default"
             faceColor IS color
             frontFace FALSE
             backFace FALSE


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3406.

![highway_overtake_1](https://user-images.githubusercontent.com/44834743/125584578-62631d39-03bf-4879-b5c6-afd14f544eff.png)

I've added it to the changelog since it was already broken in 2021a.