### PR TITLE
solve thread hanging after webots process finishes

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -76,6 +76,7 @@ Released on July, 5th, 2021.
       - Exposed the `robot_description` ROS parameter (activated through the `--robot-description` flag) that contains the URDF of the robot.
     - Improved the URDF naming convention ([#2875](https://github.com/cyberbotics/webots/pull/2875)).
   - Bug fixes:
+    - Fixed resource leak in simulation server script ([#3412](https://github.com/cyberbotics/webots/pull/3412), thanks to [Luiz Felipe Vecchietti](https://github.com/lfelipesv)).
     - Sanitized controller name in MATLAB launcher ([#3404](https://github.com/cyberbotics/webots/pull/3404), thanks to [Bartek Łukawski](https://github.com/PeterBowman) and [Juan Victores](https://github.com/jgvictores)).
     - Fixed bug in [Lidar](lidar.md) / [RangeFinder](../guide/range-finder-sensors.md) measurement when hitting an edge ([#3230](https://github.com/cyberbotics/webots/pull/3230)).
     - Fixed the restart of Webots on Windows after changing the theme or the language from the preferences ([#3367](https://github.com/cyberbotics/webots/pull/3367)).

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -308,6 +308,8 @@ class Client:
             message = 'webots:' + protocol + '//' + hostname + separator + str(port)
             client.client_websocket.write_message(message)
             for line in iter(client.webots_process.stdout.readline, b''):
+                if client.webots_process == None:
+                    break
                 line = line.rstrip()
                 if line == 'pause':
                     client.idle = True

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -308,7 +308,7 @@ class Client:
             message = 'webots:' + protocol + '//' + hostname + separator + str(port)
             client.client_websocket.write_message(message)
             for line in iter(client.webots_process.stdout.readline, b''):
-                if client.webots_process == None:
+                if client.webots_process is None:
                     break
                 line = line.rstrip()
                 if line == 'pause':


### PR DESCRIPTION
**Description**
This pull request address a bug that happens in the line https://github.com/cyberbotics/webots/blob/eca5ec4ce5774d175a75601a9ff396d4cb633a94/resources/web/server/simulation_server.py#L310 of the simulation server script.

*Bug behavior*: the thread that run webots hang after the user disconnect and the webots process is terminated. Because of that there exists proccesses using the server's memory (can be checked using htop - multiple processes appears linked to the simulation_server.py script) that leads to slow down and problems with the simulation server overtime.

*Solution proposed*: Check if the webots process in terminated in the blocking 'for' loop. If the webots process is None (meaning that the user disconnected and the webots process was terminated or killed) the loop breaks and the thread is completed.

**Related Issues**
This pull-request fixes issue #3400

**Tasks**
No task addressed.

**Documentation**
No need for change in the documentation.

**Screenshots**
No need for screenshots.

**Additional context**
Add any other context about the pull-request here.
