### PR TITLE
Fixed issues with generic robot window

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -31,8 +31,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                               | Typical Value                                                             |
 |----------------------------------------------------|---------------------------------------------------------------------------|
 | WEBOTS\_HOME                                       | `C:\Program Files\Webots`                                                 |
-| Path (all controllers)                             | add `%WEBOTS_HOME%\lib\controller`                                        |
-| Path (all controllers except Python >= 3.8)        | add `%WEBOTS_HOME%\msys64\mingw64\bin`                                    |
+| Path (all controllers except Python >= 3.8)        | add `%WEBOTS_HOME%\lib\controller` and `%WEBOTS_HOME%\msys64\mingw64\bin` |
 | Path (for C++, Python < 3.8, and Java controllers) | add `%WEBOTS_HOME%\msys64\mingw64\bin\cpp`                                |
 
 %tab-end
@@ -42,7 +41,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                                  | Typical Value                                    |
 |-------------------------------------------------------|--------------------------------------------------|
 | WEBOTS\_HOME                                          | `/usr/local/webots`                              |
-| LD\_LIBRARY\_PATH                                     | add `${WEBOTS_HOME}/lib/controller`              |
+| LD\_LIBRARY\_PATH (not needed for Python controllers) | add `${WEBOTS_HOME}/lib/controller`              |
 
 %tab-end
 
@@ -51,7 +50,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                                    | Typical Value                                    |
 |---------------------------------------------------------|--------------------------------------------------|
 | WEBOTS\_HOME                                            | `/Applications/Webots.app`                       |
-| DYLD\_LIBRARY\_PATH                                     | add `${WEBOTS_HOME}/lib/controller`              |
+| DYLD\_LIBRARY\_PATH (not needed for Python controllers) | add `${WEBOTS_HOME}/lib/controller`              |
 
 %tab-end
 

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -31,7 +31,8 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                               | Typical Value                                                             |
 |----------------------------------------------------|---------------------------------------------------------------------------|
 | WEBOTS\_HOME                                       | `C:\Program Files\Webots`                                                 |
-| Path (all controllers except Python >= 3.8)        | add `%WEBOTS_HOME%\lib\controller` and `%WEBOTS_HOME%\msys64\mingw64\bin` |
+| Path (all controllers)                             | add `%WEBOTS_HOME%\lib\controller`                                        |
+| Path (all controllers except Python >= 3.8)        | add `%WEBOTS_HOME%\msys64\mingw64\bin`                                    |
 | Path (for C++, Python < 3.8, and Java controllers) | add `%WEBOTS_HOME%\msys64\mingw64\bin\cpp`                                |
 
 %tab-end
@@ -41,7 +42,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                                  | Typical Value                                    |
 |-------------------------------------------------------|--------------------------------------------------|
 | WEBOTS\_HOME                                          | `/usr/local/webots`                              |
-| LD\_LIBRARY\_PATH (not needed for Python controllers) | add `${WEBOTS_HOME}/lib/controller`              |
+| LD\_LIBRARY\_PATH                                     | add `${WEBOTS_HOME}/lib/controller`              |
 
 %tab-end
 
@@ -50,7 +51,7 @@ Generic Webots environment variables needed for all the controller languages:
 | Environment Variable                                    | Typical Value                                    |
 |---------------------------------------------------------|--------------------------------------------------|
 | WEBOTS\_HOME                                            | `/Applications/Webots.app`                       |
-| DYLD\_LIBRARY\_PATH (not needed for Python controllers) | add `${WEBOTS_HOME}/lib/controller`              |
+| DYLD\_LIBRARY\_PATH                                     | add `${WEBOTS_HOME}/lib/controller`              |
 
 %tab-end
 

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -25,6 +25,19 @@
 %pythonbegin %{
 import sys
 import os
+import platform
+if 'WEBOTS_HOME' in os.environ:
+    new_path = os.path.join(os.environ['WEBOTS_HOME'], 'lib', 'controller')
+    variable_names = {
+      'Windows': 'PATH',
+      'Linux': 'LD_LIBRARY_PATH',
+      'Darwin': 'DYLD_LIBRARY_PATH'
+    }
+    variable_name = variable_names[platform.system()]
+    if variable_name in os.environ:
+        os.environ[variable_name] += os.pathsep + new_path
+    else:
+        os.environ[variable_name] = new_path
 if os.name == 'nt' and sys.version_info >= (3, 8):  # we need to explicitly list the folders containing the DLLs
     webots_home = os.environ['WEBOTS_HOME']
     os.add_dll_directory(os.path.join(webots_home, 'lib', 'controller'))


### PR DESCRIPTION
Address #3414:
Setting `LD_LIBRARY_PATH` is needed also for python controllers in order to correctly load the generic robot window.

The documentation was previously changed in #2940.