### PR TITLE
Fix pen evaporation

### DIFF
--- a/projects/samples/devices/controllers/pen/pen.c
+++ b/projects/samples/devices/controllers/pen/pen.c
@@ -49,6 +49,8 @@ int main() {
 
   wb_robot_init();
 
+  srand(123456789); // arbitrary value that starts in a pretty way
+
   /* get a handler to the distance sensors. */
   ds0 = wb_robot_get_device("ds0");
   ds1 = wb_robot_get_device("ds1");

--- a/projects/samples/devices/controllers/pen/pen.c
+++ b/projects/samples/devices/controllers/pen/pen.c
@@ -49,7 +49,7 @@ int main() {
 
   wb_robot_init();
 
-  srand(123456789); // arbitrary value that results in a pretty looking trail
+  srand(123456789);  // arbitrary value that results in a pretty looking trail
 
   /* get a handler to the distance sensors. */
   ds0 = wb_robot_get_device("ds0");

--- a/projects/samples/devices/controllers/pen/pen.c
+++ b/projects/samples/devices/controllers/pen/pen.c
@@ -49,7 +49,7 @@ int main() {
 
   wb_robot_init();
 
-  srand(123456789); // arbitrary value that starts in a pretty way
+  srand(123456789); // arbitrary value that results in a pretty looking trail
 
   /* get a handler to the distance sensors. */
   ds0 = wb_robot_get_device("ds0");

--- a/src/controller/c/pen.c
+++ b/src/controller/c/pen.c
@@ -65,7 +65,7 @@ static void pen_write_request(WbDevice *d, WbRequest *r) {
     request_write_uchar(r, pen->red);
     request_write_uchar(r, pen->green);
     request_write_uchar(r, pen->blue);
-    request_write_uchar(r, (unsigned char)(pen->density * 255));
+    request_write_double(r, pen->density);
     pen->set_color = false;
   }
 }

--- a/src/webots/nodes/WbPen.cpp
+++ b/src/webots/nodes/WbPen.cpp
@@ -98,10 +98,9 @@ void WbPen::handleMessage(QDataStream &stream) {
       unsigned char r, g, b;
       stream >> r >> g >> b;
       mInkColor->setValue(r / 255.0f, g / 255.0f, b / 255.0f);
-
-      unsigned char density = 0;
+      double density;
       stream >> density;
-      mInkDensity->setValue((double)density / 255.0);
+      mInkDensity->setValue(density);
       WbFieldChecker::clampDoubleToRangeWithIncludedBounds(this, mInkDensity, 0.0, 1.0);
       return;
     }

--- a/src/webots/nodes/utils/WbPaintTexture.cpp
+++ b/src/webots/nodes/utils/WbPaintTexture.cpp
@@ -245,7 +245,7 @@ void WbPaintTexture::paint(const WbRay &ray, float leadSize, const WbRgb &color,
     for (int tx = ox; tx <= sx; ++tx) {
       if ((tx - x) * (tx - x) <= circleCondition) {
         const float previousDensity = mData[dataIndex + 3];
-        const float oldDensityRatio = previousDensity / (density + previousDensity);
+        const float oldDensityRatio = density + previousDensity < 1e-15 ? 0.0f : previousDensity / (density + previousDensity);
         mData[dataIndex] = oldDensityRatio * mData[dataIndex] + (1.0f - oldDensityRatio) * color.blue();
         mData[dataIndex + 1] = oldDensityRatio * mData[dataIndex + 1] + (1.0f - oldDensityRatio) * color.green();
         mData[dataIndex + 2] = oldDensityRatio * mData[dataIndex + 2] + (1.0f - oldDensityRatio) * color.red();

--- a/tests/api/controllers/distance_sensor_infra-red/distance_sensor_infra-red.c
+++ b/tests/api/controllers/distance_sensor_infra-red/distance_sensor_infra-red.c
@@ -73,17 +73,17 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 1281.5175, 0.001,
+  ts_assert_double_in_delta(value, 1283.6893, 0.001,
                             "Distance sensor 'ds0' doesn't return the right distance when hitting a object without texture "
                             "painted green (expected = %f, received = %f)",
-                            1281.5175, value);
+                            1283.6893, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);
-  ts_assert_double_in_delta(value, 1448.139, 0.001,
+  ts_assert_double_in_delta(value, 1450.385, 0.001,
                             "Distance sensor 'ds1' doesn't return the right distance when hitting a object with green texture "
                             "painted green (expected = %f, received = %f)",
-                            1448.139, value);
+                            1450.385, value);
 
   wb_pen_set_ink_color(pen0, 0xCC33FF, 0.3);
   wb_pen_set_ink_color(pen1, 0xCC33FF, 0.3);
@@ -93,17 +93,17 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 1250.4, 0.001,
+  ts_assert_double_in_delta(value, 1252.266, 0.001,
                             "Distance sensor 'ds0' doesn't return the right distance when hitting an object without texture "
                             "painted in violet (expected = %f, received = %f)",
-                            1250.4, value);
+                            1252.266, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);
-  ts_assert_double_in_delta(value, 1217.366, 0.001,
+  ts_assert_double_in_delta(value, 1217.675, 0.001,
                             "Distance sensor 'ds1' doesn't return the right distance when hitting an object with green texture "
                             "painted in violet (expected = %f, received = %f)",
-                            1217.366, value);
+                            1217.675, value);
 
   wb_pen_set_ink_color(pen0, 0xFF0000, 0.7);
   wb_pen_set_ink_color(pen1, 0xFF0000, 0.7);
@@ -113,17 +113,17 @@ int main(int argc, char **argv) {
 
   // check ds0
   value = wb_distance_sensor_get_value(ds0);
-  ts_assert_double_in_delta(value, 1024.942, 0.001,
+  ts_assert_double_in_delta(value, 1025.485, 0.001,
                             "Distance sensor 'ds0' doesn't return the right distance when hitting an object without texture "
                             "painted in red (expected = %f, received = %f)",
-                            1024.942, value);
+                            1025.485, value);
 
   // check ds1
   value = wb_distance_sensor_get_value(ds1);
-  ts_assert_double_in_delta(value, 834.5, 0.001,
+  ts_assert_double_in_delta(value, 834.98, 0.001,
                             "Distance sensor 'ds1' doesn't return the right distance when hitting an object with green texture "
                             "painted in red (expected = %f, received = %f)",
-                            834.5, value);
+                            834.98, value);
 
   ts_send_success();
   return EXIT_SUCCESS;


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/3411.

Although the ink density is a floating point value in the API, the value was cast into an `unsigned char` when sending it to webots. For small values of the random seed, the first value of `rand()` was consistently very small which resulted in it being approximated to zero. On Webots side, there was no check to verify if a division by zero was occurring, hence this first segment of the trail was actually a NaN so it persisted despite the evaporation.

Mac:
![pen](https://user-images.githubusercontent.com/44834743/125621620-c651f4f9-3377-43e5-bb7a-51d29cfb2442.png)

Windows:
![pen_1](https://user-images.githubusercontent.com/44834743/125621937-7594a44a-6f0e-4cfc-8a40-6e2082d70426.png)
