### PR TITLE
Update tutorial-8-using-ros.md with new webots-ros dependency

### DIFF
--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -24,6 +24,8 @@ sudo apt-get install python3-rosdep
 sudo rosdep init
 rosdep update
 sudo apt-get install ros-noetic-webots-ros
+sudo apt-get install ros-noetic-webots-ros
+sudo apt-get install ros-noetic-moveit-ros-planning-interface # install webots-ros package dependency
 ```
 
 %tab-end
@@ -39,6 +41,7 @@ sudo apt-get install python-rosdep
 sudo rosdep init
 rosdep update
 sudo apt-get install ros-melodic-webots-ros
+sudo apt-get install ros-melodic-moveit-ros-planning-interface # install webots-ros package dependency
 ```
 
 %tab-end

--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -24,7 +24,6 @@ sudo apt-get install python3-rosdep
 sudo rosdep init
 rosdep update
 sudo apt-get install ros-noetic-webots-ros
-sudo apt-get install ros-noetic-webots-ros
 sudo apt-get install ros-noetic-moveit-ros-planning-interface # install webots-ros package dependency
 ```
 


### PR DESCRIPTION
`webots-ros` package now depends on a new package that needs to be manually installed (used by the new TIAGo example) to successfully compile the sources.