### PR TITLE
Removed path to node.js and cleaned-up

### DIFF
--- a/scripts/install/msys.sh
+++ b/scripts/install/msys.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]
-then
+if [ $# -eq 0 ]; then
 export PATH=/mingw64/bin:/usr/bin:/c/WINDOWS/system32
 cd ~
 else
 WINDOWS_DRIVE=${1:1:1}:\\${1:3}
 export WEBOTS_HOME=${WINDOWS_DRIVE////\\}
-export PATH="$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$1/msys64/mingw64/bin":/mingw64/bin:/usr/bin:$JAVA_HOME/bin:/c/WINDOWS/system32:/c/WINDOWS:$MATLAB_HOME/bin:$1/bin/node
+PATH="/c/WINDOWS/system32:/c/WINDOWS"
+if [ -v PYTHON38_HOME ]; then
+PATH+=":$PYTHON38_HOME:$PYTHON38_HOME/Scripts"
+elif [ -v PYTHON39_HOME ]; then
+PATH+=":$PYTHON39_HOME:$PYTHON39_HOME/Scripts"
+elif [ -v PYTHON37_HOME ]; then
+PATH+=":$PYTHON37_HOME:$PYTHON37_HOME/Scripts"
+fi
+PATH+=":$1/msys64/mingw64/bin:/mingw64/bin:/usr/bin"
+if [ -v JAVA_HOME ]; then
+PATH+=":$JAVA_HOME/bin"
+fi
+if [ -v MATLAB_HOME ]; then
+PATH+=":$MATLAB_HOME/bin"
+fi
+export PATH=$PATH
 cd "$1"
 fi


### PR DESCRIPTION
This PR cleans-up the msys.sh script:
- remove the path to node binaries which are now removed from Webots.
- add path to Python, Java and MATLAB only if the corresponding environment variables are set.
- in case several python versions are installed, prefer python 3.8, then 3.9 and 3.7.