### PR TITLE
fix assets downloads on copy

### DIFF
--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -57,6 +57,9 @@ WbDownloader::~WbDownloader() {
     if (gUrlCache.contains(mUrl))
       gUrlCache.remove(mUrl);
   }
+
+  if (!mFinished)
+    gCount--;
 }
 
 QIODevice *WbDownloader::device() const {


### PR DESCRIPTION
**Description**
When copying a object (non-Proto) with a DEF and a USE with urls inside, there was an infinite downloading popup.

This is because a node was deleted before it could finish checking that the URLs were in the cache.
When deleting a node with a WbDownloader, it is not enough to remove the downloads, we also need to decrement the number of total downloads.

Fix #3419  