### PR TITLE
Fix `get_the_candies.wbt`

### DIFF
--- a/projects/robots/softbank/nao/worlds/get_the_candies.wbt
+++ b/projects/robots/softbank/nao/worlds/get_the_candies.wbt
@@ -48,9 +48,13 @@ Solid {
   children [
     DEF Candies_Area Floor {
       size 1 2.6
-      texture [
-        "webots://projects/default/worlds/textures/parquetry.jpg"
-      ]
+      appearance PBRAppearance {
+        baseColorMap ImageTexture {
+          url [
+            "webots://projects/default/worlds/textures/parquetry.jpg"
+          ]
+        }
+      }
     }
     Shelves {
       translation -0.36 0 0


### PR DESCRIPTION
**Description**
It was reported [here](https://github.com/cyberbotics/webots/issues/3265), but contrary to the others that just need to be beautified, this one actually uses a deprecated field.