### PR TITLE
Fix range finder with fully transparent objects

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -150,6 +150,7 @@ Released on July, 5th, 2021.
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
     - Fixed the path to the python command on macOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
     - Fixed [HighwaySign](../guide/object-traffic.md#highwaysign) PROTO not displaying the texture ([#3407](https://github.com/cyberbotics/webots/pull/3407)).
+    - Fixed the transparency of [Material](material.md) and [PBRAppearance](pbrappearance.md) such that the object are no longer visible to cameras when completely transparent ([#3436](https://github.com/cyberbotics/webots/pull/3436)). 
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -67,6 +67,7 @@ void WbGeometry::init() {
   mResizeConstraint = WbWrenAbstractResizeManipulator::NO_CONSTRAINT;
   mBoundingSphere = NULL;
   mPickable = false;
+  mIsTransparent = false;
 }
 
 WbGeometry::WbGeometry(const QString &modelName, WbTokenizer *tokenizer) : WbBaseNode(modelName, tokenizer) {
@@ -222,6 +223,9 @@ void WbGeometry::applyVisibilityFlagToWren(bool selected) {
       wr_node_set_visible(WR_NODE(mWrenScaleTransform), true);
     } else if (wr_node_get_parent(WR_NODE(mWrenScaleTransform)))
       wr_node_set_visible(WR_NODE(mWrenScaleTransform), false);
+  } else if (mIsTransparent) {
+    wr_renderable_set_visibility_flags(mWrenRenderable, WbWrenRenderingContext::VF_INVISIBLE_FROM_CAMERA);
+    wr_node_set_visible(WR_NODE(mWrenScaleTransform), false);
   } else if (WbNodeUtilities::isDescendantOfBillboard(this)) {
     wr_renderable_set_visibility_flags(mWrenRenderable, WbWrenRenderingContext::VF_INVISIBLE_FROM_CAMERA);
     wr_node_set_visible(WR_NODE(mWrenScaleTransform), true);
@@ -388,6 +392,13 @@ void WbGeometry::setWrenMaterial(WrMaterial *material, bool castShadows) {
   if (mWrenRenderable) {
     wr_renderable_set_material(mWrenRenderable, material, NULL);
     computeCastShadows(castShadows);
+  }
+}
+
+void WbGeometry::setTransparent(bool isTransparent) {
+  if (mIsTransparent != isTransparent) {
+    mIsTransparent = isTransparent;
+    applyVisibilityFlagToWren(isSelected());
   }
 }
 

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -123,6 +123,9 @@ public:
   static int maxIndexNumberToCastShadows();
   int triangleCount() const;
 
+  // visibility
+  void setTransparent(bool isTransparent);
+
 signals:
   void changed();
   void wrenObjectsCreated();
@@ -203,6 +206,7 @@ private:
   WbMatrix3 mOdeOffsetRotation;
 
   bool mPickable;
+  bool mIsTransparent;
 
 private slots:
   virtual void updateBoundingObjectVisibility(int optionalRendering);

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -269,8 +269,8 @@ void WbShape::applyMaterialToGeometry() {
           g->setTransparent(false);
       } else {
         mWrenMaterial = WbAppearance::fillWrenDefaultMaterial(mWrenMaterial);
-        // We need to setTransparent for default appearance in the case a previous transparent appearance was existing and
-        // replaced by the default
+        // We need to call setTransparent for default appearance in case a previous transparent appearance was existing and
+        // replaced by the default one.
         g->setTransparent(false);
       }
     } else if (pbrAppearance() && g->nodeType() != WB_NODE_POINT_SET) {
@@ -284,8 +284,8 @@ void WbShape::applyMaterialToGeometry() {
       }
     } else {
       mWrenMaterial = WbAppearance::fillWrenDefaultMaterial(mWrenMaterial);
-      // We need to setTransparent for default appearance in the case a previous transparent appearance was existing and
-      // replaced by the default
+      // We need to call setTransparent for default appearance in case a previous transparent appearance was existing and
+      // replaced by the default one.
       g->setTransparent(false);
     }
 

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -261,16 +261,33 @@ void WbShape::applyMaterialToGeometry() {
 
   if (g) {
     if (appearance()) {
-      if (appearance()->areWrenObjectsInitialized())
+      if (appearance()->areWrenObjectsInitialized()) {
         mWrenMaterial = appearance()->modifyWrenMaterial(mWrenMaterial);
-      else
+        if (appearance()->material() && appearance()->material()->transparency() == 1)
+          g->setTransparent(true);
+        else
+          g->setTransparent(false);
+      } else {
         mWrenMaterial = WbAppearance::fillWrenDefaultMaterial(mWrenMaterial);
+        // We need to setTransparent for default appearance in the case a previous transparent appearance was existing and
+        // replaced by the default
+        g->setTransparent(false);
+      }
     } else if (pbrAppearance() && g->nodeType() != WB_NODE_POINT_SET) {
       createWrenMaterial(WR_MATERIAL_PBR);
-      if (pbrAppearance()->areWrenObjectsInitialized())
+      if (pbrAppearance()->areWrenObjectsInitialized()) {
         mWrenMaterial = pbrAppearance()->modifyWrenMaterial(mWrenMaterial);
-    } else
+        if (pbrAppearance()->transparency() == 1)
+          g->setTransparent(true);
+        else
+          g->setTransparent(false);
+      }
+    } else {
       mWrenMaterial = WbAppearance::fillWrenDefaultMaterial(mWrenMaterial);
+      // We need to setTransparent for default appearance in the case a previous transparent appearance was existing and
+      // replaced by the default
+      g->setTransparent(false);
+    }
 
     if (!g->isInBoundingObject())
       g->setWrenMaterial(mWrenMaterial, mCastShadows->value());


### PR DESCRIPTION
**Description**
If a shape has a fully transparent (tranparency = 1) appearance, it should not be visible by the cameras.

**Related Issues**
Fix #3405 