### PR TITLE
Replaced memcpy by glGetBufferSubData in FrameBuffer

### DIFF
--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -167,14 +167,8 @@ namespace wren {
     glstate::bindPixelPackBuffer(mOutputDrawBuffers[index].mGlNamePbo);
 
     const Texture::GlFormatParams &params = drawBufferFormat(index);
-    const int rowSizeInBytes = params.mPixelSize * mWidth;
-    const int totalSizeInBytes = rowSizeInBytes * mHeight;
 
-    void *start = glMapBufferRange(GL_PIXEL_PACK_BUFFER, 0, totalSizeInBytes, GL_MAP_READ_BIT);
-    assert(start);
-    memcpy(data, start, totalSizeInBytes);
-
-    glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+    glGetBufferSubData(GL_PIXEL_PACK_BUFFER, 0, params.mPixelSize * mWidth * mHeight, data);
 
     glstate::bindPixelPackBuffer(currentPixelPackBuffer);
   }

--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -168,7 +168,12 @@ namespace wren {
 
     const Texture::GlFormatParams &params = drawBufferFormat(index);
 
+#ifdef __EMSCRIPTEN__
+    EM_ASM_({ Module.ctx.getBufferSubData(Module.ctx.PIXEL_PACK_BUFFER, $2, HEAPU8.subarray($0, $0 + $1)); }, data,
+            params.mPixelSize * mWidth * mHeight, 0);
+#else
     glGetBufferSubData(GL_PIXEL_PACK_BUFFER, 0, params.mPixelSize * mWidth * mHeight, data);
+#endif
 
     glstate::bindPixelPackBuffer(currentPixelPackBuffer);
   }


### PR DESCRIPTION
**Description**
Replaces the `glMapBufferRange` and `memcpy` calls by `glGetBufferSubData` in `FrameBuffer.cpp`.