### PR TITLE
Added a warning if a mesh cannot cast shadows

### DIFF
--- a/src/webots/nodes/WbTriangleMeshGeometry.cpp
+++ b/src/webots/nodes/WbTriangleMeshGeometry.cpp
@@ -115,6 +115,14 @@ void WbTriangleMeshGeometry::createWrenObjects() {
   connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::lineScaleChanged, this,
           &WbTriangleMeshGeometry::updateNormalsRepresentation);
 
+  const WbShape *shape = dynamic_cast<const WbShape *>(parentNode());
+  if (shape && shape->isCastShadowsEnabled() && 3 * mTriangleMesh->numberOfTriangles() > maxIndexNumberToCastShadows()) {
+    warn(tr("Too many triangles (%1) in mesh: unable to cast shadows, please reduce "
+            "the number of triangles below %2 or set Shape.castShadows to "
+            "FALSE to disable this warning.")
+           .arg(mTriangleMesh->numberOfTriangles())
+           .arg((int)(maxIndexNumberToCastShadows() / 3)));
+  }
   emit wrenObjectsCreated();
 }
 


### PR DESCRIPTION
This PR:
- [x] makes Webots display a warning if a `Shape` with `castShadows TRUE` contains a mesh geometry which is too large to cast shadows, e.g., the mesh has more than 21845 triangles (21845 = 65535 / 3).
- [ ] Fix all the proto files raising this warning.
- [ ] Fix all the world files raising this warning.