### PR TITLE
Fix default url branch

### DIFF
--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -1052,7 +1052,7 @@ export default class Parser {
     if (url.startsWith('webots://')) {
       if (typeof webots.currentView.repository === 'undefined')
         webots.currentView.repository = 'cyberbotics';
-      if (typeof webots.currentView.branch === 'undefined')
+      if (typeof webots.currentView.branch === 'undefined' || webots.currentView.branch === '')
         webots.currentView.branch = 'released'
       url = url.replace('webots://', 'https://raw.githubusercontent.com/' + webots.currentView.repository + '/webots/' + webots.currentView.branch + '/');
     }


### PR DESCRIPTION
**Description**
The branch should be `released` when the variable is an empty string