### PR TITLE
Fix branch.txt creation

### DIFF
--- a/scripts/get_git_info/get_git_info.sh
+++ b/scripts/get_git_info/get_git_info.sh
@@ -3,7 +3,10 @@
 # Get the name of the working branch and write it to a file if correct
 branch=$(git branch 2>&1)
 
-if [[ $branch != fatal* ]] && [[ $branch != '* (HEAD'* ]]
+if [[ $branch == '* (HEAD'* ]]
+then
+	echo "$branch" | $(sed -n -e 's/^\* \(.*\)/\1/p' | cut -c 19- | rev | cut -c 2- | rev > $WEBOTS_HOME/resources/branch.txt)
+elif [[ $branch != fatal* ]]
 then
 	echo "$branch" | $(sed -n -e 's/^\* \(.*\)/\1/p' > $WEBOTS_HOME/resources/branch.txt)
 fi

--- a/scripts/get_git_info/get_git_info.sh
+++ b/scripts/get_git_info/get_git_info.sh
@@ -3,7 +3,10 @@
 # Get the name of the working branch and write it to a file if correct
 branch=$(git branch 2>&1)
 
-if [[ $branch == '* (HEAD'* ]]
+if [[ $branch == '* (HEAD detached at origin/'* ]]
+then
+	echo "$branch" | $(sed -n -e 's/^\* \(.*\)/\1/p' | cut -c 26- | rev | cut -c 2- | rev > $WEBOTS_HOME/resources/branch.txt)
+elif [[ $branch == '* (HEAD detached at '* ]]
 then
 	echo "$branch" | $(sed -n -e 's/^\* \(.*\)/\1/p' | cut -c 19- | rev | cut -c 2- | rev > $WEBOTS_HOME/resources/branch.txt)
 elif [[ $branch != fatal* ]]

--- a/scripts/get_git_info/get_git_info.sh
+++ b/scripts/get_git_info/get_git_info.sh
@@ -9,6 +9,8 @@ then
 elif [[ $branch != fatal* ]]
 then
 	echo "$branch" | $(sed -n -e 's/^\* \(.*\)/\1/p' > $WEBOTS_HOME/resources/branch.txt)
+else
+	echo "master" > $WEBOTS_HOME/resources/branch.txt
 fi
 
 # Get the name of the github repository and write it to a file if correct
@@ -23,6 +25,8 @@ elif [[ $repo == https://github.com* ]]
 then
 	echo "$repo" | $(cut -c 20- | rev | cut -c 5- | rev > $WEBOTS_HOME/resources/repo.txt)
 fi
+else
+	echo "cyberbotics/webots" > $WEBOTS_HOME/resources/repo.txt
 fi
 
 # Get the name of the github commit and write it to a file if correct

--- a/scripts/get_git_info/get_git_info.sh
+++ b/scripts/get_git_info/get_git_info.sh
@@ -16,15 +16,12 @@ fi
 # Get the name of the github repository and write it to a file if correct
 repo=$(git config --get remote.origin.url 2>&1)
 
-if [[ $repo != "" ]]
-then
 if [[ $repo == git@github.com* ]]
 then
 	echo "$repo" | $(cut -c 16- | rev | cut -c 5- | rev > $WEBOTS_HOME/resources/repo.txt)
 elif [[ $repo == https://github.com* ]]
 then
 	echo "$repo" | $(cut -c 20- | rev | cut -c 5- | rev > $WEBOTS_HOME/resources/repo.txt)
-fi
 else
 	echo "cyberbotics/webots" > $WEBOTS_HOME/resources/repo.txt
 fi


### PR DESCRIPTION
**Description**
Compute the branch name correctly if Webots is in a `HEAD detached` branch.


I wonder if we should add a default value to `branch.txt` and `repo.txt` in case the script fails to get them.
For example, in the case a user build Webots from the `source code.zip`package and so is not in a github repository and doesn't  already has raw.githubusercontent urls.

For the default repo, I would put `cyberbotics/webots`
For the default branch I do not really know between `master` and `released`