### PR TITLE
Add exception handling in publish_release.py script

### DIFF
--- a/scripts/packaging/publish_release.py
+++ b/scripts/packaging/publish_release.py
@@ -101,21 +101,27 @@ if not releaseExists:
 
     if tagExists:
         print('Tag "%s" already exists.' % (tagName))
-        repo.create_git_release(tag=tagName,
-                                name=title,
-                                message=message,
-                                draft=draft,
-                                prerelease=True,
-                                target_commitish=options.commit)
+        try:
+            repo.create_git_release(tag=tagName,
+                                    name=title,
+                                    message=message,
+                                    draft=draft,
+                                    prerelease=True,
+                                    target_commitish=options.commit)
+        except GithubException as e:
+            print('Creation of release failed: ', e.data)
     else:
-        repo.create_git_tag_and_release(tag=tagName,
-                                        tag_message=title,
-                                        release_name=title,
-                                        release_message=message,
-                                        object=options.commit,
-                                        type='commit',
-                                        draft=draft,
-                                        prerelease=True)
+        try:
+            repo.create_git_tag_and_release(tag=tagName,
+                                            tag_message=title,
+                                            release_name=title,
+                                            release_message=message,
+                                            object=options.commit,
+                                            type='commit',
+                                            draft=draft,
+                                            prerelease=True)
+        except GithubException as e:
+            print('Creation of tag and release failed: ', e.data)
 
 for release in repo.get_releases():
     if release.title == title:

--- a/scripts/packaging/publish_release.py
+++ b/scripts/packaging/publish_release.py
@@ -93,14 +93,29 @@ for release in repo.get_releases():
 if not releaseExists:
     print('Creating release "%s" with tag "%s" on commit "%s"' % (title, tagName, options.commit))
     draft = False if tagName.startswith('nightly_') else True
-    repo.create_git_tag_and_release(tag=tagName,
-                                    tag_message=title,
-                                    release_name=title,
-                                    release_message=message,
-                                    object=options.commit,
-                                    type='commit',
-                                    draft=draft,
-                                    prerelease=True)
+    tagExists = False
+    for tag in repo.get_tags():
+        if tag.title == tagName:
+            tagExists = True
+            break
+
+    if tagExists:
+        print('Tag "%s" already exists.' % (tagName))
+        repo.create_git_release(tag=tagName,
+                                name=title,
+                                message=message,
+                                draft=draft,
+                                prerelease=True,
+                                target_commitish=options.commit)
+    else:
+        repo.create_git_tag_and_release(tag=tagName,
+                                        tag_message=title,
+                                        release_name=title,
+                                        release_message=message,
+                                        object=options.commit,
+                                        type='commit',
+                                        draft=draft,
+                                        prerelease=True)
 
 for release in repo.get_releases():
     if release.title == title:


### PR DESCRIPTION
Publishing a nightly build failed (https://github.com/cyberbotics/webots/runs/3071646906?check_suite_focus=true) with this error message:
```
  Creating release "Webots Nightly Build (14-7-2021)" with tag "nightly_14_7_2021" on commit "5569ee04f8b281e6f8077883657717f4e396f9f7"
Traceback (most recent call last):
  File "scripts/packaging/publish_release.py", line 103, in <module>
    prerelease=True)
  File "/usr/local/lib/python3.6/dist-packages/github/Repository.py", line 1009, in create_git_tag_and_release
    target_commitish=object,
  File "/usr/local/lib/python3.6/dist-packages/github/Repository.py", line 1061, in create_git_release
    "POST", f"{self.url}/releases", input=post_parameters
  File "/usr/local/lib/python3.6/dist-packages/github/Requester.py", line 355, in requestJsonAndCheck
    verb, url, parameters, headers, input, self.__customConnection(url)
  File "/usr/local/lib/python3.6/dist-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 422 {"message": "Validation Failed", "errors": [{"resource": "Release", "code": "already_exists", "field": "tag_name"}], "documentation_url": "https://docs.github.com/rest/reference/repos#create-a-release"}
Error: Process completed with exit code 1.
```

The script already checks if a release already exists but in this particular case it was not sufficient.
Handling the exceptions raised when creating the tag and release we should be able to bypass this kind of errors and still upload the packages if the release effectively exists.