### PR TITLE
Don't publish the libcontroller if it hasn't changed since yesterday

### DIFF
--- a/scripts/packaging/sync_controller_lib.sh
+++ b/scripts/packaging/sync_controller_lib.sh
@@ -10,6 +10,15 @@ VERSION=$(cat ${WEBOTS_HOME}/scripts/packaging/webots_version.txt | sed 's/ /-/g
 # Dynamic libraries to be copied
 DYNAMIC_LIBS="Controller CppController car CppCar driver CppDriver"
 
+# Don't publish the libcontroller if it hasn't changed since yesterday
+YESTERDAY_DATE=$(date --date='yesterday' +'%Y-%m-%d %H:%M:%S')
+LAST_COMMIT_YESTERDAY=$(git rev-parse --before='${YESTERDAY_DATE}' --short HEAD | awk '$1 !~ /^--/')
+INCLUDE_DIFF_SINCE_YESTERDAY=$(git diff ${LAST_COMMIT_YESTERDAY} -- include)
+SOURCE_DIFF_SINCE_YESTERDAY=$(git diff ${LAST_COMMIT_YESTERDAY} -- src/controller)
+if [ -z "${INCLUDE_DIFF_SINCE_YESTERDAY}" ] && [ -z "${SOURCE_DIFF_SINCE_YESTERDAY}" ]; then
+    exit 0
+fi
+
 # Get the repo
 rm -rf /tmp/webots-controller || true
 if [ ! -z "${GITHUB_ACTOR}" ]; then


### PR DESCRIPTION
For example, Windows builds different binaries even though the source code hasn't changed. It generates unnecessary diff in the `webots-libcontroller` repository.

This PR makes the `sync_controller_lib.sh` script skip the execution if the libcontroller hasn't changed. 