### PR TITLE
Cleanup Lidar isRotating

### DIFF
--- a/src/webots/nodes/WbLidar.hpp
+++ b/src/webots/nodes/WbLidar.hpp
@@ -104,7 +104,7 @@ private:
   int mActualHorizontalResolution;
   double mActualVerticalFieldOfView;
   double mActualFieldOfView;
-  QString mActualType;
+  bool mIsActuallyRotating;
 
   WrRenderable *mFrustumRenderable;
   WrMaterial *mFrustumMaterial;
@@ -134,7 +134,6 @@ private:
     return (sizeof(float) + sizeof(WbLidarPoint)) * actualHorizontalResolution() * actualNumberOfLayers();
   }
   double minRange() const override { return mMinRange->value(); }
-  bool isRotating() const { return mActualType.startsWith('r', Qt::CaseInsensitive); }
   double verticalFieldOfView() const { return actualFieldOfView() * ((double)height() / (double)width()); }
 
   WbLidarPoint *pointArray() { return (WbLidarPoint *)(lidarImage() + actualHorizontalResolution() * actualNumberOfLayers()); }


### PR DESCRIPTION
**Description**
Optimization proposed by @ShuffleWire in #3476. Replaces #3487.

Replaced ` bool isRotating()` and `Qstring mActualType` by `bool mIsActuallyRotating`, so that the bool is computed once and not at each step (as `Lidar` type changes are applied only after save & reload).