### PR TITLE
Fix github urls on released

### DIFF
--- a/docs/guide/samples-howto.md
+++ b/docs/guide/samples-howto.md
@@ -1,7 +1,7 @@
 ## How To
 
 This section gives various examples of complex behaviors and/or functionalities.
-The world files are located in the "[WEBOTS\_HOME/projects/samples/howto/worlds]({{ url.github_tree }}/projects/samples/howto/worlds/)" directory, and their controllers in the "[WEBOTS\_HOME/projects/samples/howto/controllers]({{ url.github_tree }}/projects/samples/howto/controllers/)" directory.
+The examples are located in "[WEBOTS\_HOME/projects/samples/howto/]({{ url.github_tree }}/projects/samples/howto/)". Each example has his own controllers and worlds directory.
 For each, the world file and its corresponding controller are named according to the behavior they exemplify.
 
 ### [asymmetric\_friction1.wbt]({{ url.github_tree }}/projects/samples/howto/asymmetric_friction/worlds/asymmetric_friction1.wbt)

--- a/docs/js/showdown-extensions.js
+++ b/docs/js/showdown-extensions.js
@@ -27,7 +27,7 @@ function wbSlugify(obj) {
 showdown.extension('wbVariables', function() {
   // static variables to maintain
   // TODO: could be computed
-  const branch = (typeof setup !== 'undefined' && typeof setup.branch !== 'undefined') ? setup.branch : 'released';
+  const branch = (typeof setup !== 'undefined' && typeof setup.branch !== 'undefined' && setup.branch !== '') ? setup.branch : 'released';
   var vars = {
     webots: {
       version: {


### PR DESCRIPTION
**Description**
Fix #3491 

The problem is that showdown-extension.js only test if branch is undefined and not if the branch variable is empty.

Also fix some outdated information in `samples-howto`