### PR TITLE
`ros` default controller: based sleep on WallTime instead of simulated time.

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -466,7 +466,7 @@ void Ros::publishClockIfNeeded() {
 
 void Ros::run(int argc, char **argv) {
   launchRos(argc, argv);
-  ros::Rate loopRate(1000);  // Hz
+  ros::WallRate loopRate(1000);  // Hz
   ros::AsyncSpinner spinner(2);
   spinner.start();
 


### PR DESCRIPTION
**Description**
The `ros` default controller uses rate control in its `Ros::run()` function. But the rate control is based on a `ros::Rate` instance, which breaks when using simulated time, hence when providing following arguments to the controller: 
```bash
--synchronize
--clock
```
The [line 469 of file Ros.cpp](https://github.com/cyberbotics/webots/blob/c5637734a664733a585219c178eb753c0ff8f37b/projects/default/controllers/ros/Ros.cpp#L469) was modified to ensure WallTime is used in any case. Failing to use WallTime when enabling simulation time does not allow the sleep function to terminate. 