### PR TITLE
LIDAR point cloud generation optimisation

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -379,7 +379,8 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double cosPhi0 = cos(phi0), sinPhi0 = sin(phi0);
 
   const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / (w - 1.0));
-  const double cosdTheta = cos(dtheta), sindTheta = sin(dtheta);
+  const double cosdTheta = cos(dtheta);
+  const double sindTheta = sin(dtheta);
   const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta);
   const double cosTheta0 = cos(theta0), sinTheta0 = sin(theta0);
 

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -373,7 +373,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double dt = -((double)mRefreshRate / 1000.0) / w;
   const double t0 = WbSimulationState::instance()->time() / 1000.0 + minWidth * dt;
 
-  const double dphi = (numberOfLayer > 1) ? (-verticalFieldOfView() / (numberOfLayer - 1)) : 0.0;
+  const double dphi = (numberOfLayers > 1) ? (-verticalFieldOfView() / (numberOfLayers - 1)) : 0.0;
   const double cosdPhi = cos(dphi), sindPhi = sin(dphi);
   const double phi0 = ((numberOfLayers > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
   const double cosPhi0 = cos(phi0), sinPhi0 = sin(phi0);

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -374,7 +374,8 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double t0 = WbSimulationState::instance()->time() / 1000.0 + minWidth * dt;
 
   const double dphi = (numberOfLayers > 1) ? (-verticalFieldOfView() / (numberOfLayers - 1)) : 0.0;
-  const double cosdPhi = cos(dphi), sindPhi = sin(dphi);
+  const double cosdPhi = cos(dphi);
+  const double sindPhi = sin(dphi);
   const double phi0 = ((numberOfLayers > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
   const double cosPhi0 = cos(phi0);
   const double sinPhi0 = sin(phi0);

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -376,7 +376,8 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double dphi = (numberOfLayers > 1) ? (-verticalFieldOfView() / (numberOfLayers - 1)) : 0.0;
   const double cosdPhi = cos(dphi), sindPhi = sin(dphi);
   const double phi0 = ((numberOfLayers > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
-  const double cosPhi0 = cos(phi0), sinPhi0 = sin(phi0);
+  const double cosPhi0 = cos(phi0);
+  const double sinPhi0 = sin(phi0);
 
   const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / (w - 1.0));
   const double cosdTheta = cos(dtheta);

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -351,19 +351,7 @@ void WbLidar::copyAllLayersToSharedMemory() {
   }
 }
 
-/* To be removed */
-#include <sys/timeb.h>
-uint64_t Time_uclock(void) {
-  struct timespec tv;
-
-  if (clock_gettime(CLOCK_REALTIME, &tv) != 0)
-    return 0;
-
-  return tv.tv_sec  * 1000000 + (tv.tv_nsec / 1000.0);
-}
-
 void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
-  uint64_t t0_chrono = Time_uclock(); /* To be removed */
   WbLidarPoint *lidarPoints = pointArray();
   const float *image = lidarImage();
   const int resolution = actualHorizontalResolution();
@@ -387,6 +375,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double cosTheta0 = cos(theta0);
   const double sinTheta0 = sin(theta0);
 
+  // We use addition law on cos and sin to recursively compute them, avoiding the costly computation.
   // cos(x+dx) = cos(x)cos(dx)-sin(x)sin(dx)
   // sin(x+dx) = sin(x)cos(dx)+cos(x)sin(dx)
 
@@ -417,8 +406,6 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
     cosPhi = cosPhi_tmp;
     sinPhi = sinPhi_tmp;
   }
-  uint64_t run_time = Time_uclock() - t0_chrono;/* To be removed */
-  printf("%ld %lf\n", run_time, (double)run_time*1000.0/(numberOfLayer*(maxWidth-minWidth)));
 }
 
 float *WbLidar::lidarImage() const {

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -388,7 +388,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
 
   double cosPhi = cosPhi0;
   double sinPhi = sinPhi0;
-  for (int i = 0; i < numberOfLayer; ++i) {
+  for (int i = 0; i < numberOfLayers; ++i) {
     double t = t0;
     double cosTheta = cosTheta0;
     double sinTheta = sinTheta0;

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -382,7 +382,8 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double cosdTheta = cos(dtheta);
   const double sindTheta = sin(dtheta);
   const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta);
-  const double cosTheta0 = cos(theta0), sinTheta0 = sin(theta0);
+  const double cosTheta0 = cos(theta0);
+  const double sinTheta0 = sin(theta0);
 
   // cos(x+dx) = cos(x)cos(dx)-sin(x)sin(dx)
   // sin(x+dx) = sin(x)cos(dx)+cos(x)sin(dx)

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -367,7 +367,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   WbLidarPoint *lidarPoints = pointArray();
   const float *image = lidarImage();
   const int resolution = actualHorizontalResolution();
-  const int numberOfLayer = actualNumberOfLayers();
+  const int numberOfLayers = actualNumberOfLayers();
   const double w = width();
 
   const double dt = -((double)mRefreshRate / 1000.0) / w;

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -375,7 +375,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
 
   const double dphi = (numberOfLayer > 1) ? (-verticalFieldOfView() / (numberOfLayer - 1)) : 0.0;
   const double cosdPhi = cos(dphi), sindPhi = sin(dphi);
-  const double phi0 = ((numberOfLayer > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
+  const double phi0 = ((numberOfLayers > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
   const double cosPhi0 = cos(phi0), sinPhi0 = sin(phi0);
 
   const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / (w - 1.0));

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -351,33 +351,70 @@ void WbLidar::copyAllLayersToSharedMemory() {
   }
 }
 
+/* To be removed */
+#include <sys/timeb.h>
+uint64_t Time_uclock(void) {
+  struct timespec tv;
+
+  if (clock_gettime(CLOCK_REALTIME, &tv) != 0)
+    return 0;
+
+  return tv.tv_sec  * 1000000 + (tv.tv_nsec / 1000.0);
+}
+
 void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
+  uint64_t t0_chrono = Time_uclock(); /* To be removed */
   WbLidarPoint *lidarPoints = pointArray();
   const float *image = lidarImage();
-
   const int resolution = actualHorizontalResolution();
+  const int numberOfLayer = actualNumberOfLayers();
   const double w = width();
-  const double time = WbSimulationState::instance()->time() / 1000.0;
 
-  for (int i = 0; i < actualNumberOfLayers(); ++i) {
-    double phi = 0;
-    if (actualNumberOfLayers() > 1)  // to avoid division by zero
-      phi = verticalFieldOfView() / 2 - i * (verticalFieldOfView() / (actualNumberOfLayers() - 1));
-    const double sinPhi = sin(phi + mCurrentTiltAngle);
-    const double cosPhi = cos(phi + mCurrentTiltAngle);
-    for (int j = minWidth; j < maxWidth; ++j) {
-      double theta = actualFieldOfView() / 2 - j * (actualFieldOfView() / (w - 1));
-      if (mIsActuallyRotating)
-        theta = -((double)j / (double)resolution) * 2 * M_PI;
-      const int index = resolution * i + j;
+  const double dt = -((double)mRefreshRate / 1000.0) / w;
+  const double t0 = WbSimulationState::instance()->time() / 1000.0 + minWidth * dt;
+
+  const double dphi = (numberOfLayer > 1) ? (-verticalFieldOfView() / (numberOfLayer - 1)) : 0.0;
+  const double cosdPhi = cos(dphi), sindPhi = sin(dphi);
+  const double phi0 = ((numberOfLayer > 1) ? (verticalFieldOfView() / 2) : 0.0) + mCurrentTiltAngle;
+  const double cosPhi0 = cos(phi0), sinPhi0 = sin(phi0);
+
+  const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / (w - 1.0));
+  const double cosdTheta = cos(dtheta), sindTheta = sin(dtheta);
+  const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta);
+  const double cosTheta0 = cos(theta0), sinTheta0 = sin(theta0);
+
+  // cos(x+dx) = cos(x)cos(dx)-sin(x)sin(dx)
+  // sin(x+dx) = sin(x)cos(dx)+cos(x)sin(dx)
+
+  double cosPhi = cosPhi0;
+  double sinPhi = sinPhi0;
+  for (int i = 0; i < numberOfLayer; ++i) {
+    double t = t0;
+    double cosTheta = cosTheta0;
+    double sinTheta = sinTheta0;
+    const int indexStart = resolution * i + minWidth;
+    const int indexEnd = resolution * i + maxWidth;
+    for (int index = indexStart; index < indexEnd; ++index) {
       const double r = image[index];
-      lidarPoints[index].x = -r * sin(theta) * cosPhi;
+      lidarPoints[index].x = -r * sinTheta * cosPhi;
       lidarPoints[index].y = r * sinPhi;
-      lidarPoints[index].z = -r * cos(theta) * cosPhi;
-      lidarPoints[index].time = (j / w) * (time - mRefreshRate / 1000.0) + (1 - (j / w)) * time;
+      lidarPoints[index].z = -r * cosTheta * cosPhi;
+      lidarPoints[index].time = t;
       lidarPoints[index].layer_id = i;
+      t += dt;
+
+      double cosTheta_tmp = cosTheta * cosdTheta - sinTheta * sindTheta;
+      double sinTheta_tmp = sinTheta * cosdTheta + cosTheta * sindTheta;
+      cosTheta = cosTheta_tmp;
+      sinTheta = sinTheta_tmp;
     }
+    double cosPhi_tmp = cosPhi * cosdPhi - sinPhi * sindPhi;
+    double sinPhi_tmp = sinPhi * cosdPhi + cosPhi * sindPhi;
+    cosPhi = cosPhi_tmp;
+    sinPhi = sinPhi_tmp;
   }
+  uint64_t run_time = Time_uclock() - t0_chrono;/* To be removed */
+  printf("%ld %lf\n", run_time, (double)run_time*1000.0/(numberOfLayer*(maxWidth-minWidth)));
 }
 
 float *WbLidar::lidarImage() const {


### PR DESCRIPTION
**Description**
After having pinpointed by @lukicdarkoo in https://github.com/cyberbotics/webots/issues/3476
The `WbLidar::updatePointCloud` method is probably the biggest bottleneck (by far) in the LiDAR implementation:
https://github.com/cyberbotics/webots/blob/c5637734a664733a585219c178eb753c0ff8f37b/src/webots/nodes/WbLidar.cpp#L354-L381

**Details**
The optimization is made using three way : 
 1) Factorize code that could be, to avoid re-computations. In particular find a way to move the condition like `if (mIsActuallyRotating)` outside the loop.
 2) Use increment instead of multiplication : replace values of the form (expression) + (counter) * (increment). We initialize the variable to an initial one, and then add at each loop a fixed amount.
 3) Replace cos() and sin() usage by an iterative method : 
Considering that we are taking cos and sin of angle that are only incremented by a fixed amount, we could use addition law on cos and sin as : 
 cos(x+dx) = cos(x)cos(dx)-sin(x)sin(dx)
 sin(x+dx) = sin(x)cos(dx)+cos(x)sin(dx)
with x is the previous value angle, and dx the angle increment.
this way , we could compute the next cos/sin that will be used on the next loop, using the current values, and the cos/sin of the increment, which is actually fixed as well. Thus cos and sin computation is only 2 multiplication and 1 addition each.

**Results**
First, I've checked as I could, so I hope I've didn't introduce bugs or miscalculations. Also, the way I compute variable (iterative way) could introduce some numerical error, but using `double` should be enough.
Execution speed is obtained by using the Time_uclock function, which will obviously be removed before merging. We record the number of us per function call, and also the number of ns per points computed.
Result should be compared using the branch origin/enhancement-optimize-lidar-point-cloud-initial, which include the original code, and add those timing things.
Maybe Webots use to do those profiling, but I found to be the most straight forward way, let me know if their are "official stuff for that.

Here is what I end up with : here are the ns per points over about 100.

  | initial | optimized
-- | -- | --
min | 14.14 | 2.31
max | 21.74 | 2.88
average | 18.85 | 2.47

The way 1) give minor improvement, but enable 2) which made the timing drop from 20ns to 15ns, and most important enable 3) which bring time from 15ns to about 2ns.

So about 7.5 times faster :) 

**Setup**
<details>
<summary>World</summary>
<pre>
#VRML_SIM R2021c utf8
WorldInfo {
  basicTimeStep 20
  FPS 25
  coordinateSystem "NUE"
}
Viewpoint {
  orientation -0.6931032800836722 0.6931032800836722 0.1980295085953349 0.75
  position 1.2 1.6 2.3
}
TexturedBackground {
}
TexturedBackgroundLight {
}
RectangleArena {
}
Robot {
  children [
    Lidar {
      horizontalResolution 3587
      verticalFieldOfView 0.5236
      numberOfLayers 600
      type "rotating"
    }
  ]
  controller "my_controller"
}
</pre>
</details>


<details>
<summary>Controller</summary>
<pre>
#include <webots/robot.h>
#include <webots/lidar.h>

#define TIME_STEP 25

int main(int argc, char **argv) {
  wb_robot_init();

  WbDeviceTag lidar = wb_robot_get_device("lidar");
  wb_lidar_enable(lidar, TIME_STEP);
  wb_lidar_enable_point_cloud(lidar);

  while (wb_robot_step(TIME_STEP) != -1) {
    wb_lidar_get_point_cloud(lidar);
  };

  wb_robot_cleanup();
  return 0;
}
</pre>
</details>