### PR TITLE
Python in virtual env, MacOS

### DIFF
--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -24,6 +24,8 @@
 #include <QtCore/QStringList>
 #include <QtCore/QTextStream>
 
+#include <cstdlib>
+
 #ifdef _WIN32
 static const QChar PATHS_SEPARATOR(';');
 #else
@@ -102,34 +104,42 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
-  if (pythonCommand == "python" || pythonCommand == "python3") {
-    pythonCommand = findWorkingPythonPath("3.8", env, false);
-    shortVersion = "38";
-    if (pythonCommand == "!") {
-      pythonCommand = findWorkingPythonPath("3.9", env, false);
-      shortVersion = "39";
-      if (pythonCommand == "!") {
-        pythonCommand = findWorkingPythonPath("3.7", env, true);
-        shortVersion = "37";
-      }
-    }
-  } else if (pythonCommand == "python3.7") {
-    pythonCommand = findWorkingPythonPath("3.7", env, true);
-    shortVersion = "37";
-  } else if (pythonCommand == "python3.8") {
-    pythonCommand = findWorkingPythonPath("3.8", env, true);
-    shortVersion = "38";
-  } else if (pythonCommand == "python3.9") {
-    pythonCommand = findWorkingPythonPath("3.9", env, true);
-    shortVersion = "39";
-  } else {
+  if (std::getenv("PWD")) {
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
-    if (shortVersion.isEmpty())
+    if (shortVersion.isEmpty()) {
       pythonCommand = "!";
-  }
+      WbLog::warning(QObject::tr("Python was not found.\n") + advice);
+    }
+  } else {
+    if (pythonCommand == "python" || pythonCommand == "python3") {
+      pythonCommand = findWorkingPythonPath("3.8", env, false);
+      shortVersion = "38";
+      if (pythonCommand == "!") {
+        pythonCommand = findWorkingPythonPath("3.9", env, false);
+        shortVersion = "39";
+        if (pythonCommand == "!") {
+          pythonCommand = findWorkingPythonPath("3.7", env, true);
+          shortVersion = "37";
+        }
+      }
+    } else if (pythonCommand == "python3.7") {
+      pythonCommand = findWorkingPythonPath("3.7", env, true);
+      shortVersion = "37";
+    } else if (pythonCommand == "python3.8") {
+      pythonCommand = findWorkingPythonPath("3.8", env, true);
+      shortVersion = "38";
+    } else if (pythonCommand == "python3.9") {
+      pythonCommand = findWorkingPythonPath("3.9", env, true);
+      shortVersion = "39";
+    } else {
+      shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
+      if (shortVersion.isEmpty())
+        pythonCommand = "!";
+    }
 
-  if (pythonCommand == "!")
-    WbLog::warning(QObject::tr("Python was not found.\n") + advice);
+    if (pythonCommand == "!")
+      WbLog::warning(QObject::tr("Python was not found.\n") + advice);
+  }
 #else  // Linux
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -104,13 +104,9 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
 #elif __APPLE__
-  if (std::getenv("PWD")) {
+  if (std::getenv("PWD"))
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
-    if (shortVersion.isEmpty()) {
-      pythonCommand = "!";
-      WbLog::warning(QObject::tr("Python was not found.\n") + advice);
-    }
-  } else {
+  else {
     if (pythonCommand == "python" || pythonCommand == "python3") {
       pythonCommand = findWorkingPythonPath("3.8", env, false);
       shortVersion = "38";
@@ -131,15 +127,14 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
     } else if (pythonCommand == "python3.9") {
       pythonCommand = findWorkingPythonPath("3.9", env, true);
       shortVersion = "39";
-    } else {
+    } else
       shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
-      if (shortVersion.isEmpty())
-        pythonCommand = "!";
-    }
-
-    if (pythonCommand == "!")
-      WbLog::warning(QObject::tr("Python was not found.\n") + advice);
   }
+  if (shortVersion.isEmpty())
+    pythonCommand = "!";
+
+  if (pythonCommand == "!")
+    WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // Linux
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {


### PR DESCRIPTION
The changes introduced in #3402 cause the pythonpath to always be the python of the system.

However, it is not possible to completely revert #3402, otherwise python controllers would not work if Webots is launched from the GUI.

So now if:

- Webots is launched from the GUI: use the hardcoded, system pythonpath.
- Webots is launched from a terminal: use the default python command.
