### PR TITLE
Hotfix shift+left drag

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,7 +4,7 @@
 Released on XX, XXth, 2021.
 
 - Bug fixes:
-  - Fixed Shift + Left Button drag event when Solid is child of Transform(s) and when horizontal plane is not clearly visible from view ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
+  - Fixed Shift + Left Button drag event when the picked [Solid](solid.md) is child of a [Transform](transform.md) node and the horizontal plane is not clearly visible from view ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
   - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502)).
   - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).
   - Fixed a crash caused when getting contact points of a PROTO ([#3522](https://github.com/cyberbotics/webots/pull/3522)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,7 +4,7 @@
 Released on XX, XXth, 2021.
 
 - Bug fixes:
-  - Fixed Shift + Left Button drag event on Solid that is child of Transform(s) ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
+  - Fixed Shift + Left Button drag event when Solid is child of Transform(s) and when horizontal plane is not clearly visible from view ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
   - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502)).
   - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).
   - Fixed starting of Webots from the Windows CMD.exe console ([#3512](https://github.com/cyberbotics/webots/pull/3512)).

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,8 +4,9 @@
 Released on XX, XXth, 2021.
 
 - Bug fixes:
-  - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502).
-  - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240).
+  - Fixed Shift + Left Button drag event on Solid that is child of Transform(s) ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
+  - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502)).
+  - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).
   - Fixed starting of Webots from the Windows CMD.exe console ([#3512](https://github.com/cyberbotics/webots/pull/3512)).
 
 ## Webots R2021b
@@ -158,7 +159,7 @@ Released on July, 16th, 2021.
     - Fixed crash provoked by canceling and switching world in the Guided Tour ([#3376](https://github.com/cyberbotics/webots/pull/3376)).
     - Fixed the path to the python command on macOS ([#3402](https://github.com/cyberbotics/webots/pull/3402)).
     - Fixed [HighwaySign](../guide/object-traffic.md#highwaysign) PROTO not displaying the texture ([#3407](https://github.com/cyberbotics/webots/pull/3407)).
-    - Fixed the transparency of [Material](material.md) and [PBRAppearance](pbrappearance.md) such that the object are no longer visible to cameras when completely transparent ([#3436](https://github.com/cyberbotics/webots/pull/3436)). 
+    - Fixed the transparency of [Material](material.md) and [PBRAppearance](pbrappearance.md) such that the object are no longer visible to cameras when completely transparent ([#3436](https://github.com/cyberbotics/webots/pull/3436)).
   - Cleanup
     - Deleted deprecated DifferentialWheels node ([#2749](https://github.com/cyberbotics/webots/pull/2749)).
     - Changed structure of the [projects/samples/howto]({{ url.github_tree }}/projects/samples/howto) directory, so each demonstration is in a dedicated directory ([#2639](https://github.com/cyberbotics/webots/pull/2639)).

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -88,6 +88,12 @@ void WbDragHorizontalEvent::apply(const QPoint &currentMousePosition) {
   // remove any x or z scaling from parents (we shouldn't touch y as we're moving on the world horizontal plane)
   displacementFromInitialPosition.setX(displacementFromInitialPosition.x() / mScaleFromParents.x());
   displacementFromInitialPosition.setZ(displacementFromInitialPosition.z() / mScaleFromParents.z());
+
+  // in case mSelectedTransform is not child of root (ex: Root --> Transform(s) --> mSelectedTransform = uppermostSolid)
+  if (!mSelectedTransform->isTopTransform())
+    displacementFromInitialPosition =
+      WbRotation(mSelectedTransform->rotationMatrix()).toQuaternion().conjugated() * displacementFromInitialPosition;
+
   mSelectedTransform->setTranslation((mInitialPosition + displacementFromInitialPosition).rounded(WbPrecision::GUI_MEDIUM));
   mSelectedTransform->emitTranslationOrRotationChangedByUser();
 }

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -91,7 +91,7 @@ void WbDragHorizontalEvent::apply(const QPoint &currentMousePosition) {
       mIsMouseRayValid = true;
     else {
       mIsMouseRayValid = false;
-      WbLog::warning(tr("To drag this element, rotate first the view so that the horizontal plane is clearly visible."));
+      WbLog::warning(tr("To drag this element, first rotate the view so that the horizontal plane is clearly visible."));
     }
 
     // in case mSelectedTransform is not child of root (ex: Root --> Transform(s) --> mSelectedTransform = uppermostSolid)

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -30,7 +30,7 @@
 #include <QtGui/QScreen>
 #include <QtWidgets/QApplication>
 
-#define DRAG_HORIZONTAL_MIN_COS 0.25  // corresponds to +/- 15deg
+#define DRAG_HORIZONTAL_MIN_COS 0.25
 
 // WbDragTransformEvent constructor
 WbDragTransformEvent::WbDragTransformEvent(WbViewpoint *viewpoint, WbAbstractTransform *selectedTransform) :

--- a/src/webots/gui/WbDragTransformEvent.cpp
+++ b/src/webots/gui/WbDragTransformEvent.cpp
@@ -30,7 +30,7 @@
 #include <QtGui/QScreen>
 #include <QtWidgets/QApplication>
 
-#define DRAG_HORIZONTAL_MIN_COS 0.05
+#define DRAG_HORIZONTAL_MIN_COS 0.25  // corresponds to +/- 15deg
 
 // WbDragTransformEvent constructor
 WbDragTransformEvent::WbDragTransformEvent(WbViewpoint *viewpoint, WbAbstractTransform *selectedTransform) :
@@ -86,7 +86,6 @@ void WbDragHorizontalEvent::apply(const QPoint &currentMousePosition) {
   if (!mIsInitializationDone) {
     WbRay normalizedMouseRay = mMouseRay;
     normalizedMouseRay.normalize();
-
     // event occurs only if the mouse ray is not parallel to the horizontal drag plane
     if (abs(normalizedMouseRay.direction().dot(mUpWorldVector)) > DRAG_HORIZONTAL_MIN_COS)
       mIsMouseRayValid = true;

--- a/src/webots/gui/WbDragTransformEvent.hpp
+++ b/src/webots/gui/WbDragTransformEvent.hpp
@@ -74,8 +74,7 @@ public:
 private:
   WbVector3 mTranslationOffset;
   WbQuaternion mCoordinateTransform;
-  bool mIsMouseRayValid = false;
-  bool mIsInitializationDone = false;
+  bool mIsMouseRayValid;
 };
 
 // WbDragVerticalEvent class

--- a/src/webots/gui/WbDragTransformEvent.hpp
+++ b/src/webots/gui/WbDragTransformEvent.hpp
@@ -73,6 +73,9 @@ public:
 
 private:
   WbVector3 mTranslationOffset;
+  WbQuaternion mCoordinateTransform;
+  bool mIsMouseRayValid = false;
+  bool mIsInitializationDone = false;
 };
 
 // WbDragVerticalEvent class


### PR DESCRIPTION
**Description**
When doing Shift+Mouse(left) drag on a Solid, Webots currently assumes that it has no parent Transform and is a child of root. Therefore, if it does have a parent Transform, the Solid is wrongly moved (#3523).