### PR TITLE
Add note about coupled-motor usage in differentials

### DIFF
--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -230,7 +230,7 @@ Using `multiplier` here also makes sense, because some differentials don't split
 This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mechanical setting.
 
 > **Note**: Although any among the coupled motors can be controlled, commands should be given to just one among them at any given time in order to avoid confusion or conflicts.
-For instance, it isn't possible to do Position Control for one motor and Velocity Control another at the same time.
+For instance, it is not possible to do Position Control for one motor and Velocity Control another at the same time.
 Whatever command is given to a motor, it is relayed to all of its siblings hence overwriting any prior settings imposed on them.
 In other words, only the last command given is the one actually being enforced across the coupling.
 

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -221,8 +221,13 @@ Although each sibling motor receives the same command, what the motors actually 
 
 > **Note**: The motors are *logically* coupled together, not *mechanically*.
 If one of the motors is physically blocked, the others are in no way affected by it.
-This provide a very nice side-effect : when used in force-control mode, coupled-motor allows to easely simulate a mechanical differential. The role of a differential is to change the speed of the wheel relatively to each other. But also, it split *equally* the motor torque to each wheel. This is why, It's only needed to apply the same torque on multiple (coupled) motor, and the physic engine will figure out speeds. It works for regular car as well as for 4*4 vehicule, as long as they have 3 differencial (front, rear, and central).
-Using `multiplier` here also make sense, because some diferential don't split in half (sometime central differential split 40%-60% to get more torque to the rear wheels). But this parameter doesn't depend on the actual speed, environnement etc... of the wheels, it's only a mecanical setting.
+This provide a useful side-effect: when used in force-control mode, coupled-motor allows to easily simulate a mechanical differential.
+The role of a differential is to change the speed of the wheel relatively to each other.
+But also, it splits *equally* the motor torque to each wheel.
+This is why, it's only needed to apply the same torque on multiple (coupled) motor and the physic engine will adapt the speeds accordingly.
+It works for regular car as well as for a 4x4 vehicule, as long as they have 3 differential (front, rear, and central).
+Using `multiplier` here also make sense, because some differentials don't split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
+This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mecanical setting.
 
 > **Note**: Although any among the coupled motors can be controlled, commands should be given to just one among them at any given time in order to avoid confusion or conflicts.
 For instance, it isn't possible to do Position Control for one motor and Velocity Control another at the same time.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -221,13 +221,13 @@ Although each sibling motor receives the same command, what the motors actually 
 
 > **Note**: The motors are *logically* coupled together, not *mechanically*.
 If one of the motors is physically blocked, the others are in no way affected by it.
-This provide a useful side-effect: when used in force-control mode, coupled-motor allows to easily simulate a mechanical differential.
+This provides a useful side-effect: when used in force-control mode, coupled-motor allows to easily simulate a mechanical differential.
 The role of a differential is to change the speed of the wheel relatively to each other.
 But also, it splits *equally* the motor torque to each wheel.
-This is why, it's only needed to apply the same torque on multiple (coupled) motor and the physic engine will adapt the speeds accordingly.
-It works for regular car as well as for a 4x4 vehicule, as long as they have 3 differential (front, rear, and central).
-Using `multiplier` here also make sense, because some differentials don't split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
-This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mecanical setting.
+This is why it's only needed to apply the same torque on multiple (coupled) motors, and the physic engine will adapt the speeds accordingly.
+It works for a regular car as well as for a 4x4 vehicle, as long as they have 3 differentials (front, rear, and central).
+Using `multiplier` here also makes sense, because some differentials don't split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
+This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mechanical setting.
 
 > **Note**: Although any among the coupled motors can be controlled, commands should be given to just one among them at any given time in order to avoid confusion or conflicts.
 For instance, it isn't possible to do Position Control for one motor and Velocity Control another at the same time.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -226,7 +226,7 @@ The role of a differential is to change the speed of the wheel relatively to eac
 But also, it splits *equally* the motor torque to each wheel.
 This is why it's only needed to apply the same torque on multiple (coupled) motors, and the physic engine will adapt the speeds accordingly.
 It works for a regular car as well as for a 4x4 vehicle, as long as they have 3 differentials (front, rear, and central).
-Using `multiplier` here also makes sense, because some differentials don't split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
+Using `multiplier` here also makes sense, because some differentials do not split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
 This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mechanical setting.
 
 > **Note**: Although any among the coupled motors can be controlled, commands should be given to just one among them at any given time in order to avoid confusion or conflicts.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -221,7 +221,7 @@ Although each sibling motor receives the same command, what the motors actually 
 
 > **Note**: The motors are *logically* coupled together, not *mechanically*.
 If one of the motors is physically blocked, the others are in no way affected by it.
-This provides a useful side-effect: when used in force-control mode, coupled-motor allows to easily simulate a mechanical differential.
+This provides a useful side-effect: when used in force-control mode, coupled-motors allow to easily simulate a mechanical differential.
 The role of a differential is to change the speed of the wheel relatively to each other.
 But also, it splits *equally* the motor torque to each wheel.
 This is why it's only needed to apply the same torque on multiple (coupled) motors, and the physic engine will adapt the speeds accordingly.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -221,6 +221,8 @@ Although each sibling motor receives the same command, what the motors actually 
 
 > **Note**: The motors are *logically* coupled together, not *mechanically*.
 If one of the motors is physically blocked, the others are in no way affected by it.
+This provide a very nice side-effect : when used in force-control mode, coupled-motor allows to easely simulate a mechanical differential. The role of a differential is to change the speed of the wheel relatively to each other. But also, it split *equally* the motor torque to each wheel. This is why, It's only needed to apply the same torque on multiple (coupled) motor, and the physic engine will figure out speeds. It works for regular car as well as for 4*4 vehicule, as long as they have 3 differencial (front, rear, and central).
+Using `multiplier` here also make sense, because some diferential don't split in half (sometime central differential split 40%-60% to get more torque to the rear wheels). But this parameter doesn't depend on the actual speed, environnement etc... of the wheels, it's only a mecanical setting.
 
 > **Note**: Although any among the coupled motors can be controlled, commands should be given to just one among them at any given time in order to avoid confusion or conflicts.
 For instance, it isn't possible to do Position Control for one motor and Velocity Control another at the same time.

--- a/docs/reference/motor.md
+++ b/docs/reference/motor.md
@@ -224,7 +224,7 @@ If one of the motors is physically blocked, the others are in no way affected by
 This provides a useful side-effect: when used in force-control mode, coupled-motors allow to easily simulate a mechanical differential.
 The role of a differential is to change the speed of the wheel relatively to each other.
 But also, it splits *equally* the motor torque to each wheel.
-This is why it's only needed to apply the same torque on multiple (coupled) motors, and the physic engine will adapt the speeds accordingly.
+Therefore it suffices to apply the same torque on multiple (coupled) motors, and the physics engine will adapt the speeds accordingly.
 It works for a regular car as well as for a 4x4 vehicle, as long as they have 3 differentials (front, rear, and central).
 Using `multiplier` here also makes sense, because some differentials do not split in half: sometimes a central differential splits 40%-60% to get more torque to the rear wheels.
 This parameter doesn't depend on the actual speed and characteristics of the wheels, it's only a mechanical setting.


### PR DESCRIPTION
Mechanical differentials drive, as described in https://en.wikipedia.org/wiki/Differential_(mechanical_device) could be very easily simulated using coupled motor. As I just figured out, even if the main role of it is to change speed to avoid slip, it also ensure that each wheel receive the **same** torque (so, for a regular car, each 2 (lets say front) wheel receive half the motor torque). That fact is often overlooked, seen as a drawback for many application (if a wheel slip, the other stop, cause no torque), but for simulation it actually awesome !
Been trying it on my project with a 4*4 configuration, and work really fine !

This is why that fact could be added in the doc.
However I do feel that my explanation is not very clear, English not been my mother-thong... feel free to update !