### PR TITLE
Fix matrix to quaternion conversion

### DIFF
--- a/src/webots/maths/WbQuaternion.hpp
+++ b/src/webots/maths/WbQuaternion.hpp
@@ -155,6 +155,7 @@ inline void WbQuaternion::fromBasisVectors(const WbVector3 &vx, const WbVector3 
     mX = 0.0;
     mY = 0.0;
     mZ = 0.0;
+    return;
   }
   double s = 2.0;
   double invS = 1.0;


### PR DESCRIPTION
This causes some undefined behaviours.

For example, if Webots is compiled in the debug mode, the following world will crash Webots after pressing Alt+1 (top view):
```
#VRML_SIM R2021b utf8
WorldInfo {
}
Viewpoint {
  orientation 0 1 0 1.5707996938995747
  position 0 0 6
}
```
with error:
```
webots-bin: maths/WbRotation.cpp:24: void WbRotation::fromQuaternion(const WbQuaternion&): Assertion `std::abs(sqrt(q.x() * q.x() + q.y() * q.y() + q.z() * q.z() + q.w() * q.w()) - 1) < 0.0000000001' failed.
./webots: line 90: 121749 Aborted                 (core dumped) "$webots_home/bin/webots-bin" "$@"
```

It doesn't happen with the released version though, the compiler manages to handle it somehow. However, it might cause some unwanted side-effects.