### PR TITLE
Fix supervisor node set visibility

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,6 +4,7 @@
 Released on XX, XXth, 2021.
 
 - Bug fixes:
+  - Fixed [`wb_supervisor_node_set_visibility`](supervisor.md#wb_supervisor_node_set_visibility) applying visibility to parent and sibling nodes if not used with geometry or [Transform](transform.md) nodes ([#3543](https://github.com/cyberbotics/webots/pull/3543)).
   - Fixed Shift + Left Button drag event when the picked [Solid](solid.md) is child of a [Transform](transform.md) node and the horizontal plane is not clearly visible from view ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
   - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502)).
   - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1850,6 +1850,9 @@ The `visible` argument specifies whether the node should be hidden (false) or sh
 By default, all the nodes are visible.
 It is relevant to show a node only if it was previously hidden using this function.
 
+Note that this function cannot hide [Fog](fog.md) and [Background][background.mb] nodes.
+Additionally, the visibility of [Propeller](propeller.md) helices may be overridden internally by Webots when running the simulation or selecting them from the scene tree.
+
 ---
 
 #### `wb_supervisor_node_add_force`

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1850,7 +1850,7 @@ The `visible` argument specifies whether the node should be hidden (false) or sh
 By default, all the nodes are visible.
 It is relevant to show a node only if it was previously hidden using this function.
 
-Note that this function cannot hide [Fog](fog.md) and [Background][background.mb] nodes.
+Note that this function cannot hide [Fog](fog.md) and [Background][background.md] nodes.
 Additionally, the visibility of [Propeller](propeller.md) helices may be overridden internally by Webots when running the simulation or selecting them from the scene tree.
 
 ---

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -265,7 +265,7 @@ void WbAnimationRecorder::addChangedLabelToList(const QString &label) {
     mChangedLabels.append(label);
 }
 
-void WbAnimationRecorder::handleNodeVisibilityChange(WbNode *node, bool visibility) {
+void WbAnimationRecorder::handleNodeVisibilityChange(const WbNode *node, bool visibility) {
   WbAnimationCommand *newCommand = NULL;
   foreach (WbAnimationCommand *command, mArtificialCommands) {
     if (command->node() == node) {

--- a/src/webots/engine/WbAnimationRecorder.hpp
+++ b/src/webots/engine/WbAnimationRecorder.hpp
@@ -94,7 +94,7 @@ private slots:
   void updateCommandsAfterNodeDeletion(QObject *);
   void addChangedCommandToList(WbAnimationCommand *command);
   void addChangedLabelToList(const QString &label);
-  void handleNodeVisibilityChange(WbNode *node, bool visibility);
+  void handleNodeVisibilityChange(const WbNode *node, bool visibility);
 
 private:
   static WbAnimationRecorder *cInstance;

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -89,7 +89,7 @@ void WbX3dStreamingServer::processTextMessage(QString message) {
   } else if (message == "reset") {
     // reset nodes visibility
     QWebSocket *client = qobject_cast<QWebSocket *>(sender());
-    foreach (WbBaseNode *node, WbWorld::instance()->viewpoint()->getInvisibleNodes())
+    foreach (const WbBaseNode *node, WbWorld::instance()->viewpoint()->getInvisibleNodes())
       client->sendTextMessage(QString("visibility:%1:1").arg(node->uniqueId()));
     resetSimulation();
     const QString &state = WbAnimationRecorder::instance()->computeUpdateData(true);

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -373,7 +373,7 @@ bool WbAbstractCamera::handleCommand(QDataStream &stream, unsigned char command)
   return commandHandled;
 }
 
-void WbAbstractCamera::setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible) {
+void WbAbstractCamera::setNodesVisibility(QList<const WbBaseNode *> nodes, bool visible) {
   QListIterator<const WbBaseNode *> it(nodes);
   while (it.hasNext()) {
     const WbBaseNode *node = it.next();

--- a/src/webots/nodes/WbAbstractCamera.cpp
+++ b/src/webots/nodes/WbAbstractCamera.cpp
@@ -373,12 +373,16 @@ bool WbAbstractCamera::handleCommand(QDataStream &stream, unsigned char command)
   return commandHandled;
 }
 
-void WbAbstractCamera::setNodeVisibility(WbBaseNode *node, bool visible) {
-  if (visible)
-    mInvisibleNodes.removeAll(node);
-  else if (!mInvisibleNodes.contains(node)) {
-    mInvisibleNodes.append(node);
-    connect(node, &QObject::destroyed, this, &WbAbstractCamera::removeInvisibleNodeFromList, Qt::UniqueConnection);
+void WbAbstractCamera::setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible) {
+  QListIterator<const WbBaseNode *> it(nodes);
+  while (it.hasNext()) {
+    const WbBaseNode *node = it.next();
+    if (visible)
+      mInvisibleNodes.removeAll(node);
+    else if (!mInvisibleNodes.contains(node)) {
+      mInvisibleNodes.append(node);
+      connect(node, &QObject::destroyed, this, &WbAbstractCamera::removeInvisibleNodeFromList, Qt::UniqueConnection);
+    }
   }
 }
 

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -58,7 +58,7 @@ public:
 
   void enableExternalWindowForAttachedCamera(bool enabled);
 
-  void setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible);
+  void setNodesVisibility(QList<const WbBaseNode *> nodes, bool visible);
 
   virtual bool isEnabled() const { return mSensor ? mSensor->isEnabled() : false; }
 

--- a/src/webots/nodes/WbAbstractCamera.hpp
+++ b/src/webots/nodes/WbAbstractCamera.hpp
@@ -58,7 +58,7 @@ public:
 
   void enableExternalWindowForAttachedCamera(bool enabled);
 
-  void setNodeVisibility(WbBaseNode *node, bool visible);
+  void setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible);
 
   virtual bool isEnabled() const { return mSensor ? mSensor->isEnabled() : false; }
 
@@ -140,7 +140,7 @@ protected:
   WrStaticMesh *mFrustumDisplayMesh;
   WrMaterial *mFrustumDisplayMaterial;
 
-  QList<WbBaseNode *> mInvisibleNodes;
+  QList<const WbBaseNode *> mInvisibleNodes;
 
   // other stuff
   WbSensor *mSensor;

--- a/src/webots/nodes/WbBaseNode.cpp
+++ b/src/webots/nodes/WbBaseNode.cpp
@@ -234,7 +234,7 @@ WbBaseNode *WbBaseNode::getFirstFinalizedProtoInstance() const {
 }
 
 bool WbBaseNode::isInvisibleNode() const {
-  return WbWorld::instance()->viewpoint()->getInvisibleNodes().contains(const_cast<WbBaseNode *>(this));
+  return WbWorld::instance()->viewpoint()->getInvisibleNodes().contains(this);
 }
 
 QString WbBaseNode::documentationUrl() const {

--- a/src/webots/nodes/WbBaseNode.hpp
+++ b/src/webots/nodes/WbBaseNode.hpp
@@ -80,7 +80,12 @@ public:
   WrTransform *wrenNode() const { return mWrenNode; }
   void setWrenNode(WrTransform *n) { mWrenNode = n; }
 
-  virtual QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const { return QList<const WbBaseNode *>(); }
+  // return the closest descendant node(s) with dedicated Wren node (may be the node itself)
+  // only WbGeometry, WbTransform, and WbMuscle have a dedicated Wren node
+  // used to properly apply Wren settings only to the current/descendant nodes and not to parent and sibling nodes
+  virtual QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const {
+    return QList<const WbBaseNode *>();
+  }
 
   // Ode functions
   virtual void createOdeObjects() { mOdeObjectsCreatedCalled = true; }

--- a/src/webots/nodes/WbBaseNode.hpp
+++ b/src/webots/nodes/WbBaseNode.hpp
@@ -80,6 +80,8 @@ public:
   WrTransform *wrenNode() const { return mWrenNode; }
   void setWrenNode(WrTransform *n) { mWrenNode = n; }
 
+  virtual QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const { return QList<const WbBaseNode *>(); }
+
   // Ode functions
   virtual void createOdeObjects() { mOdeObjectsCreatedCalled = true; }
   bool areOdeObjectsCreated() const { return mOdeObjectsCreatedCalled; }

--- a/src/webots/nodes/WbBaseNode.hpp
+++ b/src/webots/nodes/WbBaseNode.hpp
@@ -81,7 +81,7 @@ public:
   void setWrenNode(WrTransform *n) { mWrenNode = n; }
 
   // return the closest descendant node(s) with dedicated Wren node (may be the node itself)
-  // only WbGeometry, WbTransform, and WbMuscle have a dedicated Wren node
+  // only WbBillboard, WbGeometry, WbTransform, and WbMuscle have a dedicated Wren node
   // used to properly apply Wren settings only to the current/descendant nodes and not to parent and sibling nodes
   virtual QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const {
     return QList<const WbBaseNode *>();

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -497,3 +497,10 @@ WbBoundingSphere *WbBasicJoint::boundingSphere() const {
     return solid->boundingSphere();
   return NULL;
 }
+
+QList<const WbBaseNode *> WbBasicJoint::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
+  if (mEndPoint->value())
+    list << static_cast<WbBaseNode *>(mEndPoint->value())->childrenWithDedicatedWrenNode();
+  return list;
+}

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -498,9 +498,9 @@ WbBoundingSphere *WbBasicJoint::boundingSphere() const {
   return NULL;
 }
 
-QList<const WbBaseNode *> WbBasicJoint::childrenWithDedicatedWrenNode() const {
+QList<const WbBaseNode *> WbBasicJoint::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   if (mEndPoint->value())
-    list << static_cast<WbBaseNode *>(mEndPoint->value())->childrenWithDedicatedWrenNode();
+    list << static_cast<WbBaseNode *>(mEndPoint->value())->findClosestDescendantNodesWithDedicatedWrenNode();
   return list;
 }

--- a/src/webots/nodes/WbBasicJoint.hpp
+++ b/src/webots/nodes/WbBasicJoint.hpp
@@ -73,7 +73,7 @@ public:
   void updateAfterParentPhysicsChanged();
   virtual void updateEndPointZeroTranslationAndRotation() = 0;
 
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
 public slots:
   void updateEndPoint();

--- a/src/webots/nodes/WbBasicJoint.hpp
+++ b/src/webots/nodes/WbBasicJoint.hpp
@@ -73,6 +73,8 @@ public:
   void updateAfterParentPhysicsChanged();
   virtual void updateEndPointZeroTranslationAndRotation() = 0;
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+
 public slots:
   void updateEndPoint();
 

--- a/src/webots/nodes/WbBillboard.hpp
+++ b/src/webots/nodes/WbBillboard.hpp
@@ -31,6 +31,9 @@ public:
   int nodeType() const override { return WB_NODE_BILLBOARD; }
   void postFinalize() override;
   void createWrenObjects() override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override {
+    return QList<const WbBaseNode *>() << this;
+  }
 
 protected:
   void applyTranslationToWren();

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -70,7 +70,9 @@ public:
   virtual void setWrenMaterial(WrMaterial *material, bool castShadows);
   void destroyWrenObjects();
 
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; }
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override {
+    return QList<const WbBaseNode *>() << this;
+  }
 
   // Create ODE dGeom (for a WbGeometry lying into a boundingObject)
   virtual dGeomID createOdeGeom(dSpaceID space);

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -70,6 +70,8 @@ public:
   virtual void setWrenMaterial(WrMaterial *material, bool castShadows);
   void destroyWrenObjects();
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; }
+
   // Create ODE dGeom (for a WbGeometry lying into a boundingObject)
   virtual dGeomID createOdeGeom(dSpaceID space);
   void destroyOdeObjects();

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -310,17 +310,16 @@ void WbGroup::forwardJerk() {
   }
 }
 
-QList<const WbBaseNode *> WbGroup::childrenWithDedicatedWrenNode() const {
+QList<const WbBaseNode *> WbGroup::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   WbMFNode::Iterator it(*mChildren);
-  while (it.hasNext()){
+  while (it.hasNext()) {
     const WbBaseNode *const child = static_cast<WbBaseNode *>(it.next());
     assert(child);
-    list << child->childrenWithDedicatedWrenNode();
+    list << child->findClosestDescendantNodesWithDedicatedWrenNode();
   }
   return list;
 }
-
 
 ///////////////////
 // Hidden fields //

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -310,6 +310,18 @@ void WbGroup::forwardJerk() {
   }
 }
 
+QList<const WbBaseNode *> WbGroup::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
+  WbMFNode::Iterator it(*mChildren);
+  while (it.hasNext()){
+    const WbBaseNode *const child = static_cast<WbBaseNode *>(it.next());
+    assert(child);
+    list << child->childrenWithDedicatedWrenNode();
+  }
+  return list;
+}
+
+
 ///////////////////
 // Hidden fields //
 ///////////////////

--- a/src/webots/nodes/WbGroup.hpp
+++ b/src/webots/nodes/WbGroup.hpp
@@ -99,6 +99,7 @@ public:
   // lazy matrix multiplication system
   void setMatrixNeedUpdate() override;
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
   // export
   void exportBoundingObjectToX3D(WbVrmlWriter &writer) const override;
 

--- a/src/webots/nodes/WbGroup.hpp
+++ b/src/webots/nodes/WbGroup.hpp
@@ -47,6 +47,7 @@ public:
   bool shallExport() const override;
   void reset(const QString &id) override;
   void save(const QString &id) override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
   // field accessors
   int childCount() const { return mChildren->size(); }
@@ -99,7 +100,6 @@ public:
   // lazy matrix multiplication system
   void setMatrixNeedUpdate() override;
 
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
   // export
   void exportBoundingObjectToX3D(WbVrmlWriter &writer) const override;
 

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -822,7 +822,7 @@ void WbMotor::resetPhysics() {
   mCurrentVelocity = 0;
 }
 
-QList<const WbBaseNode *> WbMotor::findClosestDescendantNodesWithDedicatedWrenNode() const override {
+QList<const WbBaseNode *> WbMotor::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   WbMFIterator<WbMFNode, WbNode *> it(mMuscles);
   while (it.hasNext())

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -821,3 +821,11 @@ void WbMotor::addToCoupledMotors(WbMotor *motor) {
 void WbMotor::resetPhysics() {
   mCurrentVelocity = 0;
 }
+
+QList<const WbBaseNode *> WbMotor::findClosestDescendantNodesWithDedicatedWrenNode() const override {
+  QList<const WbBaseNode *> list;
+  WbMFIterator<WbMFNode, WbNode *> it(mMuscles);
+  while (it.hasNext())
+    list << static_cast<WbBaseNode *>(it.next());
+  return list;
+}

--- a/src/webots/nodes/WbMotor.hpp
+++ b/src/webots/nodes/WbMotor.hpp
@@ -75,6 +75,8 @@ public:
   bool refreshSensorIfNeeded() override;
   void reset(const QString &id) override;
 
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
+
   static const QList<const WbMotor *> &motors() { return cMotors; }
 
 signals:

--- a/src/webots/nodes/WbMuscle.cpp
+++ b/src/webots/nodes/WbMuscle.cpp
@@ -310,6 +310,7 @@ void WbMuscle::createWrenObjects() {
   mTransform = wr_transform_new();
   wr_transform_attach_child(mTransform, WR_NODE(mRenderable));
   wr_transform_attach_child(wrenNode(), WR_NODE(mTransform));
+  setWrenNode(mTransform);
 
   WbWrenPicker::setPickable(mRenderable, uniqueId(), true);
 }

--- a/src/webots/nodes/WbMuscle.hpp
+++ b/src/webots/nodes/WbMuscle.hpp
@@ -48,6 +48,7 @@ public:
   int nodeType() const override { return WB_NODE_MUSCLE; }
   void createWrenObjects() override;
   void postFinalize() override;
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; };
 
   void animateMesh();
 

--- a/src/webots/nodes/WbMuscle.hpp
+++ b/src/webots/nodes/WbMuscle.hpp
@@ -48,7 +48,9 @@ public:
   int nodeType() const override { return WB_NODE_MUSCLE; }
   void createWrenObjects() override;
   void postFinalize() override;
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; };
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override {
+    return QList<const WbBaseNode *>() << this;
+  };
 
   void animateMesh();
 

--- a/src/webots/nodes/WbPropeller.cpp
+++ b/src/webots/nodes/WbPropeller.cpp
@@ -412,13 +412,13 @@ void WbPropeller::reset(const QString &id) {
   updateHelix(0.0);
 }
 
-QList<const WbBaseNode *> WbPropeller::childrenWithDedicatedWrenNode() const {
-  QList<const WbBaseNode*> list;
+QList<const WbBaseNode *> WbPropeller::findClosestDescendantNodesWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
   const WbBaseNode *const fastHelix = helix(FAST_HELIX);
   if (fastHelix)
-    list << fastHelix->childrenWithDedicatedWrenNode();
+    list << fastHelix->findClosestDescendantNodesWithDedicatedWrenNode();
   const WbBaseNode *const slowHelix = helix(SLOW_HELIX);
   if (slowHelix)
-    list << slowHelix->childrenWithDedicatedWrenNode();
+    list << slowHelix->findClosestDescendantNodesWithDedicatedWrenNode();
   return list;
 }

--- a/src/webots/nodes/WbPropeller.cpp
+++ b/src/webots/nodes/WbPropeller.cpp
@@ -411,3 +411,14 @@ void WbPropeller::reset(const QString &id) {
 
   updateHelix(0.0);
 }
+
+QList<const WbBaseNode *> WbPropeller::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode*> list;
+  const WbBaseNode *const fastHelix = helix(FAST_HELIX);
+  if (fastHelix)
+    list << fastHelix->childrenWithDedicatedWrenNode();
+  const WbBaseNode *const slowHelix = helix(SLOW_HELIX);
+  if (slowHelix)
+    list << slowHelix->childrenWithDedicatedWrenNode();
+  return list;
+}

--- a/src/webots/nodes/WbPropeller.hpp
+++ b/src/webots/nodes/WbPropeller.hpp
@@ -50,6 +50,7 @@ public:
   void setMatrixNeedUpdate() override;
   void write(WbVrmlWriter &writer) const override;
   void reset(const QString &id) override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
   void prePhysicsStep(double ms);
 
@@ -68,8 +69,6 @@ public:
 
   double currentThrust() const { return mCurrentThrust; }
   double currentTorque() const { return mCurrentTorque; }
-
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
 
 private:
   // Scene Tree fields

--- a/src/webots/nodes/WbPropeller.hpp
+++ b/src/webots/nodes/WbPropeller.hpp
@@ -69,6 +69,8 @@ public:
   double currentThrust() const { return mCurrentThrust; }
   double currentTorque() const { return mCurrentTorque; }
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+
 private:
   // Scene Tree fields
   WbSFVector3 *mShaftAxis;

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -439,11 +439,11 @@ void WbShape::createWrenMaterial(int type) {
   }
 }
 
-QList<const WbBaseNode *> WbShape::childrenWithDedicatedWrenNode() const {
+QList<const WbBaseNode *> WbShape::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   const WbGeometry *const g = geometry();
   if (g)
-    list << g->childrenWithDedicatedWrenNode();
+    list << g;
   return list;
 }
 
@@ -479,8 +479,6 @@ bool WbShape::isAValidBoundingObject(bool checkOde, bool warning) const {
   const WbGeometry *const g = geometry();
   return g && g->isAValidBoundingObject(checkOde, warning);
 }
-
-
 
 ////////////
 // Export //

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -439,6 +439,14 @@ void WbShape::createWrenMaterial(int type) {
   }
 }
 
+QList<const WbBaseNode *> WbShape::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
+  const WbGeometry *const g = geometry();
+  if (g)
+    list << g->childrenWithDedicatedWrenNode();
+  return list;
+}
+
 ///////////////////////////////////////////////////////////
 //  ODE related methods for WbShapes in boundingObjects  //
 ///////////////////////////////////////////////////////////
@@ -471,6 +479,8 @@ bool WbShape::isAValidBoundingObject(bool checkOde, bool warning) const {
   const WbGeometry *const g = geometry();
   return g && g->isAValidBoundingObject(checkOde, warning);
 }
+
+
 
 ////////////
 // Export //

--- a/src/webots/nodes/WbShape.hpp
+++ b/src/webots/nodes/WbShape.hpp
@@ -47,6 +47,7 @@ public:
   bool isSuitableForInsertionInBoundingObject(bool warning = false) const override;
   void propagateSelection(bool selected) override;
   void reset(const QString &id) override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
   // field accessors
   WbAppearance *appearance() const;
@@ -72,8 +73,6 @@ public:
   void setAppearance(WbAppearance *appearance);
   void setPbrAppearance(WbPbrAppearance *appearance);
   void setGeometry(WbGeometry *geometry);
-
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
 
   // export
   bool exportNodeHeader(WbVrmlWriter &writer) const override;

--- a/src/webots/nodes/WbShape.hpp
+++ b/src/webots/nodes/WbShape.hpp
@@ -73,6 +73,8 @@ public:
   void setPbrAppearance(WbPbrAppearance *appearance);
   void setGeometry(WbGeometry *geometry);
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+
   // export
   bool exportNodeHeader(WbVrmlWriter &writer) const override;
   void exportBoundingObjectToX3D(WbVrmlWriter &writer) const override;

--- a/src/webots/nodes/WbSlot.cpp
+++ b/src/webots/nodes/WbSlot.cpp
@@ -222,3 +222,11 @@ void WbSlot::write(WbVrmlWriter &writer) const {
       mEndPoint->value()->write(writer);
   }
 }
+
+QList<const WbBaseNode *> WbSlot::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
+  const WbBaseNode *const e = static_cast<WbBaseNode *>(mEndPoint->value());
+  if (e)
+    list << e->childrenWithDedicatedWrenNode();;
+  return list;
+}

--- a/src/webots/nodes/WbSlot.cpp
+++ b/src/webots/nodes/WbSlot.cpp
@@ -223,10 +223,10 @@ void WbSlot::write(WbVrmlWriter &writer) const {
   }
 }
 
-QList<const WbBaseNode *> WbSlot::childrenWithDedicatedWrenNode() const {
+QList<const WbBaseNode *> WbSlot::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   const WbBaseNode *const e = static_cast<WbBaseNode *>(mEndPoint->value());
   if (e)
-    list << e->childrenWithDedicatedWrenNode();;
+    list << e->findClosestDescendantNodesWithDedicatedWrenNode();
   return list;
 }

--- a/src/webots/nodes/WbSlot.hpp
+++ b/src/webots/nodes/WbSlot.hpp
@@ -48,6 +48,7 @@ public:
   void detachResizeManipulator() const override;
   void reset(const QString &id) override;
   void save(const QString &id) override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
   // field accessors
   bool hasEndpoint() const { return mEndPoint->value() != NULL; }
@@ -69,8 +70,6 @@ public:
 
   // lazy matrix multiplication system
   void setMatrixNeedUpdate() override;
-
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
 
 signals:
   void endPointInserted(WbBaseNode *);  // called when a node is inserted in the endPoint

--- a/src/webots/nodes/WbSlot.hpp
+++ b/src/webots/nodes/WbSlot.hpp
@@ -70,6 +70,8 @@ public:
   // lazy matrix multiplication system
   void setMatrixNeedUpdate() override;
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+
 signals:
   void endPointInserted(WbBaseNode *);  // called when a node is inserted in the endPoint
 

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -77,3 +77,10 @@ bool WbSolidReference::isClosedLoop() const {
   }
   return false;
 }
+
+QList<const WbBaseNode *> WbSolidReference::childrenWithDedicatedWrenNode() const {
+  QList<const WbBaseNode *> list;
+  if (mSolid)
+     list << mSolid;
+  return list;
+}

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -78,9 +78,9 @@ bool WbSolidReference::isClosedLoop() const {
   return false;
 }
 
-QList<const WbBaseNode *> WbSolidReference::childrenWithDedicatedWrenNode() const {
+QList<const WbBaseNode *> WbSolidReference::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   if (mSolid)
-     list << mSolid;
+    list << mSolid;
   return list;
 }

--- a/src/webots/nodes/WbSolidReference.hpp
+++ b/src/webots/nodes/WbSolidReference.hpp
@@ -51,6 +51,8 @@ public:
   // check if mSolid is a parent of this SolidReference instance
   bool isClosedLoop() const;
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+
 signals:
   void changed();
 

--- a/src/webots/nodes/WbSolidReference.hpp
+++ b/src/webots/nodes/WbSolidReference.hpp
@@ -51,7 +51,7 @@ public:
   // check if mSolid is a parent of this SolidReference instance
   bool isClosedLoop() const;
 
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
 signals:
   void changed();

--- a/src/webots/nodes/WbTransform.hpp
+++ b/src/webots/nodes/WbTransform.hpp
@@ -46,6 +46,9 @@ public:
   void setMatrixNeedUpdate() override;
   void connectGeometryField(bool dynamic);
   void reset(const QString &id) override;
+  QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override {
+    return QList<const WbBaseNode *>() << this;
+  }
 
   // accessors to stored fields
   const WbVector3 translationFromFile(const QString &id) const { return mSavedTranslations[id]; }
@@ -86,8 +89,6 @@ public:
   void emitTranslationOrRotationChangedByUser() override;
   WbVector3 translationFrom(const WbNode *fromNode) const;
   WbMatrix3 rotationMatrixFrom(const WbNode *fromNode) const;
-
-  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; }
 
   // export
   void exportBoundingObjectToX3D(WbVrmlWriter &writer) const override;

--- a/src/webots/nodes/WbTransform.hpp
+++ b/src/webots/nodes/WbTransform.hpp
@@ -87,6 +87,8 @@ public:
   WbVector3 translationFrom(const WbNode *fromNode) const;
   WbMatrix3 rotationMatrixFrom(const WbNode *fromNode) const;
 
+  QList<const WbBaseNode *> childrenWithDedicatedWrenNode() const override { return QList<const WbBaseNode *>() << this; }
+
   // export
   void exportBoundingObjectToX3D(WbVrmlWriter &writer) const override;
   QStringList fieldsToSynchronizeWithX3D() const override;

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -234,8 +234,7 @@ void WbViewpoint::reset(const QString &id) {
   mEquilibriumVector.setXyz(0.0, 0.0, 0.0);
   mVelocity.setXyz(0.0, 0.0, 0.0);
 
-  foreach (WbBaseNode *const node, mInvisibleNodes)
-    setNodeVisibility(node, true);
+  setNodesVisibility(mInvisibleNodes, true);
 
   mInvisibleNodes.clear();
   updatePostProcessingEffects();
@@ -410,16 +409,20 @@ void WbViewpoint::decOrthographicViewHeight() {
   updateOrthographicViewHeight();
 }
 
-void WbViewpoint::setNodeVisibility(WbBaseNode *node, bool visible) {
-  WrNode *wrenNode = WR_NODE(node->wrenNode());
-  if (wrenNode)
-    wr_node_set_visible(wrenNode, visible);
+void WbViewpoint::setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible) {
+  QListIterator<const WbBaseNode *> it(nodes);
+  while (it.hasNext()) {
+    const WbBaseNode *node = it.next();
+    WrNode *wrenNode = WR_NODE(node->wrenNode());
+    if (wrenNode)
+      wr_node_set_visible(wrenNode, visible);
 
-  if (visible)
-    mInvisibleNodes.removeAll(node);
-  else if (!mInvisibleNodes.contains(node))
-    mInvisibleNodes.append(node);
-  emit nodeVisibilityChanged(node, visible);
+    if (visible)
+      mInvisibleNodes.removeAll(node);
+    else if (!mInvisibleNodes.contains(node))
+      mInvisibleNodes.append(node);
+    emit nodeVisibilityChanged(node, visible);
+  }
 }
 
 void WbViewpoint::enableNodeVisibility(bool enabled) {

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -409,7 +409,7 @@ void WbViewpoint::decOrthographicViewHeight() {
   updateOrthographicViewHeight();
 }
 
-void WbViewpoint::setNodesVisibility(QList<const WbBaseNode *>nodes, bool visible) {
+void WbViewpoint::setNodesVisibility(QList<const WbBaseNode *> nodes, bool visible) {
   QListIterator<const WbBaseNode *> it(nodes);
   while (it.hasNext()) {
     const WbBaseNode *node = it.next();

--- a/src/webots/nodes/WbViewpoint.hpp
+++ b/src/webots/nodes/WbViewpoint.hpp
@@ -120,8 +120,8 @@ public:
   void updateFollowSolidState();
   void updateOrthographicViewHeight();
 
-  void setNodeVisibility(WbBaseNode *node, bool visible);
-  QList<WbBaseNode *> getInvisibleNodes() const { return mInvisibleNodes; }
+  void setNodesVisibility(QList<const WbBaseNode *> nodes, bool visible);
+  QList<const WbBaseNode *> getInvisibleNodes() const { return mInvisibleNodes; }
   void enableNodeVisibility(bool enabled);
 
   // Ray picking based on current projection mode
@@ -194,7 +194,7 @@ private:
   WrCamera *mWrenCamera;
   WrViewport *mWrenViewport;
 
-  QList<WbBaseNode *> mInvisibleNodes;
+  QList<const WbBaseNode *> mInvisibleNodes;
   bool mNodeVisibilityEnabled;
 
   WbCoordinateSystem *mCoordinateSystem;
@@ -320,7 +320,7 @@ signals:
   void followTypeChanged(int type);
   void cameraParametersChanged();
   void refreshRequired();
-  void nodeVisibilityChanged(WbNode *node, bool visibility);
+  void nodeVisibilityChanged(const WbNode *node, bool visibility);
   void virtualRealityHeadsetRequiresRender();
 };
 

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -976,10 +976,10 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       assert(baseNode);
       if (camera)
         // cppcheck-suppress knownConditionTrueFalse
-        camera->setNodesVisibility(baseNode->childrenWithDedicatedWrenNode(), visible == 1);
+        camera->setNodesVisibility(baseNode->findClosestDescendantNodesWithDedicatedWrenNode(), visible == 1);
       else if (viewpoint)
         // cppcheck-suppress knownConditionTrueFalse
-        viewpoint->setNodesVisibility(baseNode->childrenWithDedicatedWrenNode(), visible == 1);
+        viewpoint->setNodesVisibility(baseNode->findClosestDescendantNodesWithDedicatedWrenNode(), visible == 1);
       return;
     }
     case C_SUPERVISOR_NODE_MOVE_VIEWPOINT: {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -976,10 +976,10 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       assert(baseNode);
       if (camera)
         // cppcheck-suppress knownConditionTrueFalse
-        camera->setNodeVisibility(baseNode, visible == 1);
+        camera->setNodesVisibility(baseNode->childrenWithDedicatedWrenNode(), visible == 1);
       else if (viewpoint)
         // cppcheck-suppress knownConditionTrueFalse
-        viewpoint->setNodeVisibility(baseNode, visible == 1);
+        viewpoint->setNodesVisibility(baseNode->childrenWithDedicatedWrenNode(), visible == 1);
       return;
     }
     case C_SUPERVISOR_NODE_MOVE_VIEWPOINT: {

--- a/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
+++ b/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
@@ -31,17 +31,19 @@ int main(int argc, char **argv) {
   quick_assert_color(camera1, 31, 31, 0xFF0000, "Both cameras should see the red box at the beginning.\n");
 
   WbNodeRef camera_node = wb_supervisor_node_get_from_def("CAMERA0");
-  WbNodeRef box_node = wb_supervisor_node_get_from_def("BOX");
+  WbNodeRef camera1_node = wb_supervisor_node_get_from_def("CAMERA1");
+  WbNodeRef red_box_node = wb_supervisor_node_get_from_def("RED_BOX");
+  WbNodeRef green_box_node = wb_supervisor_node_get_from_def("GREEN_BOX");
 
-  wb_supervisor_node_set_visibility(box_node, camera_node, false);
+  wb_supervisor_node_set_visibility(red_box_node, camera_node, false);
 
   wb_robot_step(TIME_STEP);
 
-  quick_assert_color(camera0, 31, 31, 0x0000FF,
+  quick_assert_color(camera0, 31, 31, 0x00FF00,
                      "Camera 0 should not see the red box after it is been hide from this camera.\n");
   quick_assert_color(camera1, 31, 31, 0xFF0000, "Camera 1 should still see the red box after it was hidden from camera 0.\n");
 
-  wb_supervisor_node_set_visibility(box_node, camera_node, true);
+  wb_supervisor_node_set_visibility(red_box_node, camera_node, true);
 
   wb_robot_step(TIME_STEP);
 
@@ -50,13 +52,14 @@ int main(int argc, char **argv) {
   quick_assert_color(camera1, 31, 31, 0xFF0000,
                      "Both cameras should see the red box again after it was shown from camera 0.\n");
 
-  wb_supervisor_node_set_visibility(box_node, camera_node, false);
-  wb_supervisor_node_remove(box_node);
+  wb_supervisor_node_set_visibility(green_box_node, camera1_node, false);
+  wb_supervisor_node_set_visibility(red_box_node, camera_node, false);
+  wb_supervisor_node_remove(red_box_node);
 
   wb_robot_step(TIME_STEP);
 
-  quick_assert_color(camera0, 31, 31, 0x0000FF, "Both cameras should not see the red box after it has been removed.\n");
-  quick_assert_color(camera1, 31, 31, 0x0000FF, "Both cameras should not see the red box after it has been removed.\n");
+  quick_assert_color(camera0, 31, 31, 0x00FF00, "Camera 0 should not see the red box after it has been removed.\n");
+  quick_assert_color(camera1, 31, 31, 0x0000FF, "Camera 1 should only see the background after red box has been removed and green box has been hidden.\n");
 
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
+++ b/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
@@ -39,8 +39,7 @@ int main(int argc, char **argv) {
 
   wb_robot_step(TIME_STEP);
 
-  quick_assert_color(camera0, 31, 31, 0x00FF00,
-                     "Camera 0 should not see the red box after it was hidden from this camera.\n");
+  quick_assert_color(camera0, 31, 31, 0x00FF00, "Camera 0 should not see the red box after it was hidden from this camera.\n");
   quick_assert_color(camera1, 31, 31, 0xFF0000, "Camera 1 should still see the red box after it was hidden from camera 0.\n");
 
   wb_supervisor_node_set_visibility(red_box_node, camera_node, true);

--- a/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
+++ b/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   wb_robot_step(TIME_STEP);
 
   quick_assert_color(camera0, 31, 31, 0x00FF00,
-                     "Camera 0 should not see the red box after it is been hide from this camera.\n");
+                     "Camera 0 should not see the red box after it was hidden from this camera.\n");
   quick_assert_color(camera1, 31, 31, 0xFF0000, "Camera 1 should still see the red box after it was hidden from camera 0.\n");
 
   wb_supervisor_node_set_visibility(red_box_node, camera_node, true);

--- a/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
+++ b/tests/api/controllers/supervisor_node_set_visibility/supervisor_node_set_visibility.c
@@ -59,7 +59,8 @@ int main(int argc, char **argv) {
   wb_robot_step(TIME_STEP);
 
   quick_assert_color(camera0, 31, 31, 0x00FF00, "Camera 0 should not see the red box after it has been removed.\n");
-  quick_assert_color(camera1, 31, 31, 0x0000FF, "Camera 1 should only see the background after red box has been removed and green box has been hidden.\n");
+  quick_assert_color(camera1, 31, 31, 0x0000FF,
+                     "Camera 1 should only see the background after red box has been removed and green box has been hidden.\n");
 
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/worlds/supervisor_node_set_visibility.wbt
+++ b/tests/api/worlds/supervisor_node_set_visibility.wbt
@@ -47,7 +47,7 @@ DEF Test Robot {
     TestSuiteEmitter {
     }
     DEF CAMERA0 Camera {
-      translation 0 0.84 5.50586e-07
+      translation 0 0.84 0
       rotation 1 0 0 4.71239
       name "camera0"
     }

--- a/tests/api/worlds/supervisor_node_set_visibility.wbt
+++ b/tests/api/worlds/supervisor_node_set_visibility.wbt
@@ -20,14 +20,24 @@ DirectionalLight {
 }
 DEF BOX Solid {
   children [
-    Shape {
+    DEF RED_BOX Shape {
       appearance Appearance {
         material Material {
           diffuseColor 1 0 0
         }
       }
       geometry Box {
-        size 0.8 0.1 0.9
+        size 0.5 0.1 0.5
+      }
+    }
+    DEF GREEN_BOX Shape {
+      appearance Appearance {
+        material Material {
+          diffuseColor 0 1 0
+        }
+      }
+      geometry Box {
+        size 0.9 0.05 0.8
       }
     }
   ]
@@ -37,12 +47,12 @@ DEF Test Robot {
     TestSuiteEmitter {
     }
     DEF CAMERA0 Camera {
-      translation 0 0.3 0
+      translation 0 0.84 5.50586e-07
       rotation 1 0 0 4.71239
       name "camera0"
     }
     DEF CAMERA1 Camera {
-      translation 0 0.3 0
+      translation 0 0.84 5.50586e-07
       rotation 1 0 0 4.71239
       name "camera1"
     }

--- a/tests/api/worlds/supervisor_node_set_visibility.wbt
+++ b/tests/api/worlds/supervisor_node_set_visibility.wbt
@@ -52,7 +52,7 @@ DEF Test Robot {
       name "camera0"
     }
     DEF CAMERA1 Camera {
-      translation 0 0.84 5.50586e-07
+      translation 0 0.84 0
       rotation 1 0 0 4.71239
       name "camera1"
     }


### PR DESCRIPTION
Fix #3529:
if given node doesn't have a dedicated Wren node, then apply visibility to closest descendants with dedicated Wren node.

Only `WbBillboard`, `WbGeometry`, `WbTransform` and `WbMuscle` have a dedicated Wren node.
For all the other nodes we have to retrieve the descendant nodes:

Nodes overriding the function to retrieve closes descendant nodes with dedicated Wren node:
|Node | Function Overridden | Comments |
| ------ | --------- | -------- |
| BasicJoint | x  | |
| Billboard | x | |
| Geometry | x | |
| Group | x | |
| Motor | x | |
| Muscle  | x | Users can override the visibility properties in the main view switching the `Muscle.isVisible` flag |
| Propeller | x | Webots code overrides the visibility properties when enabling/disabling the slow/fast helix or is the fast helix is selected from the scene tree |
| Shape | x | |
| Slot | x | |
| SolidReference | x | |
| Transform | x | |
| Background | | This function cannot be used to hide background from cameras | 
| Fog | | This function cannot be used to hide fog from cameras |

Nodes that doesn't have any associated Wren nodes:
Appearance, Background, Brake, Color, ContactProperties, Coordinate, Damping, Focus, Fog, ImageTexture, ImmersionProperties, JointParameters, Lens, LensFlare, Light, Material, Normal, PBRAppearance, Physics, Recognition, TextureCoordinate, TextureTransform, Viewpoint, WorldInfo, Zoom

Remaining nodes are derived from other nodes already listed.