### PR TITLE
Fix updating robot window on extern controller restart

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -4,6 +4,7 @@
 Released on XX, XXth, 2021.
 
 - Bug fixes:
+  - Fixed updating the robot window after restarting an extern controller ([#3544](https://github.com/cyberbotics/webots/pull/3544)).
   - Fixed Shift + Left Button drag event when the picked [Solid](solid.md) is child of a [Transform](transform.md) node and the horizontal plane is not clearly visible from view ([#3530](https://github.com/cyberbotics/webots/pull/3530)).
   - Fixed various Python API functions crashing with Python 3.9 ([#3502](https://github.com/cyberbotics/webots/pull/3502)).
   - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).

--- a/src/webots/control/WbControlledWorld.cpp
+++ b/src/webots/control/WbControlledWorld.cpp
@@ -239,6 +239,8 @@ void WbControlledWorld::addControllerConnection() {
           // automatically disconnect from previous extern controller that may have failed, the slot could be immediately used
           // to restart
           WbLog::info(tr("Closing extern controller connection for robot \"%1\".").arg(robot->name()));
+          disconnect(robot, &WbRobot::controllerChanged, this, &WbControlledWorld::updateCurrentRobotController);
+          robot->restartController();
           updateRobotController(robot);
         } else  // this controller seems to be in active use, ignore it
           continue;

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -143,7 +143,6 @@ signals:
   void startControllerRequest(WbRobot *robot);
   void immediateMessageAdded();
   void controllerChanged();
-  void controllerRestarted();
   void controllerExited();
   void wasReset();
   void toggleRemoteMode(bool enable);


### PR DESCRIPTION
Fix #3420:
properly notify `WbRobot` instance when an extern controller is restarted.

Remove the unused signal `WbRobot::controllerRestarted`.