### PR TITLE
Hotfix inaccessible points in `getPointCloud` python API

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -12,6 +12,7 @@ Released on XX, XXth, 2021.
     - Fixed mass computation after inserting a [Physics](physics.md) node in case the [Solid.boundingObject](solid.md) was already defined ([#3240](https://github.com/cyberbotics/webots/pull/3240)).
     - Fixed a crash caused when getting contact points of a PROTO ([#3522](https://github.com/cyberbotics/webots/pull/3522)).
     - Fixed starting of Webots from the Windows CMD.exe console ([#3512](https://github.com/cyberbotics/webots/pull/3512)).
+    - Fixed bug which made the points returned by `getPointCloud` python API inaccessible ([#3558](https://github.com/cyberbotics/webots/pull/3558)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/controller/python/controller.i
+++ b/src/controller/python/controller.i
@@ -625,7 +625,7 @@ class AnsiCodes(object):
     SWIG_PYTHON_THREAD_BEGIN_BLOCK;
     PyObject *points = PyList_New(size);
     for (int i = 0; i < size; i++) {
-      PyObject *value = SWIG_NewPointerObj(SWIG_as_voidptr(&rawPoints[i]), $descriptor(WbLidarPoint), 0);
+      PyObject *value = SWIG_NewPointerObj(SWIG_as_voidptr(&rawPoints[i]), $descriptor(WbLidarPoint *), 0);
       PyList_SetItem(points, i, value);
     }
     SWIG_PYTHON_THREAD_END_BLOCK;


### PR DESCRIPTION
**Description**
As reported by a user on discord, currently the data retrieved using `getPointCloud` python API is no longer accessible.

The change done in https://github.com/cyberbotics/webots/pull/3322 broke the API. Although at the time I'm sure it prevented the crash of the `enable_all_lidars.py` controller from happening ( in `sumo_interface_example.wbt`, mentioned here https://github.com/cyberbotics/webots/issues/3281), now even after reverting the change the controller doesn't appear to crash any longer. So it was either something else provoking it to begin with, or I don't know.

It can be tested using this world: [WebotsProject.zip](https://github.com/cyberbotics/webots/files/6961390/WebotsProject.zip)
