### PR TITLE
Fix Camera.getImageArray example

### DIFF
--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -942,14 +942,15 @@ Here is an example:
 
 > ```python
 > image = camera.getImageArray()
-> # display the components of each pixel
-> for x in range(0,camera.getWidth()):
->   for y in range(0,camera.getHeight()):
->     red   = image[x][y][0]
->     green = image[x][y][1]
->     blue  = image[x][y][2]
->     gray  = (red + green + blue) / 3
->     print 'r='+str(red)+' g='+str(green)+' b='+str(blue)
+> if image:
+>     # display the components of each pixel
+>     for x in range(0,camera.getWidth()):
+>         for y in range(0,camera.getHeight()):
+>             red   = image[x][y][0]
+>             green = image[x][y][1]
+>             blue  = image[x][y][2]
+>             gray  = (red + green + blue) / 3
+>             print('r='+str(red)+' g='+str(green)+' b='+str(blue))
 > ```
 
 <!-- -->


### PR DESCRIPTION
Fix example of `Camera.getImageArray`.
* check if `image` is valid: if called before the first sampling period is expired the `image` value can be `None`
* fix `print` instruction not working with Python3
* fix indentation