### PR TITLE
Update proto-design-guidelines.md

### DIFF
--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -47,7 +47,7 @@ It currently supports three possible options: `deprecated`, `hidden` and `static
 - `deprecated` means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
 - `hidden` tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
-- `nonDeterministic` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) sections.
+- `nonDeterministic` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) subsections.
 
 #### Documentation
 

--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -47,7 +47,7 @@ It currently supports three possible options: `deprecated`, `hidden` and `static
 - `deprecated` means this PROTO should not be used any more in new simulations, but is kept for backwards compatibility. When using a deprecated PROTO, Webots will display a warning message about it.
 - `hidden` tells Webots not to display this PROTO in the Add Node dialog when the user wants to insert a new PROTO.
 Hidden PROTO nodes are typically used as sub-PROTO nodes, that is they are used from another PROTO file, but not directly from a world file.
-- `static` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) section.
+- `nonDeterministic` is described in the [Procedural PROTO nodes](procedural-proto-nodes.md) sections.
 
 #### Documentation
 


### PR DESCRIPTION
The `static` tag was replaced with `nonDeterministic`, but the documentation was not fully updated.