### PR TITLE
Fix convert to base nodes for textures defined with URLs

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -13,6 +13,7 @@ Released on XX, XXth, 2021.
     - Fixed a crash caused when getting contact points of a PROTO ([#3522](https://github.com/cyberbotics/webots/pull/3522)).
     - Fixed starting of Webots from the Windows CMD.exe console ([#3512](https://github.com/cyberbotics/webots/pull/3512)).
     - Fixed bug which made the points returned by `getPointCloud` python API inaccessible ([#3558](https://github.com/cyberbotics/webots/pull/3558)).
+    - Fixed 'Convert to Base Node(s)' with textures defined by urls ([#3591](https://github.com/cyberbotics/webots/pull/3591)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -689,9 +689,9 @@ void WbBackground::exportNodeFields(WbVrmlWriter &writer) const {
     if (mUrlFields[i]->size() == 0)
       continue;
     QString imagePath = mUrlFields[i]->value()[0];
-    if (imagePath.indexOf("http") == 0)
+    if (WbUrl::isWeb(imagePath))
       backgroundFileNames[i] = imagePath;
-    else if (imagePath.indexOf("webots://") == 0)
+    else if (WbUrl::isLocalUrl(imagePath))
       backgroundFileNames[i] = imagePath.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() +
                                                                 "/" + WbApplicationInfo::branch() + "/");
     else {
@@ -712,9 +712,9 @@ void WbBackground::exportNodeFields(WbVrmlWriter &writer) const {
       continue;
 
     QString irradiancePath = mIrradianceUrlFields[i]->value()[0];
-    if (irradiancePath.indexOf("http") == 0)
+    if (WbUrl::isWeb(irradiancePath))
       irradianceFileNames[i] = mIrradianceUrlFields[i]->value()[0];
-    else if (irradiancePath.indexOf("webots://") == 0)
+    else if (WbUrl::isLocalUrl(irradiancePath))
       irradianceFileNames[i] =
         irradiancePath.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() + "/" +
                                               WbApplicationInfo::branch() + "/");

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -518,13 +518,13 @@ void WbImageTexture::exportNodeFields(WbVrmlWriter &writer) const {
   // export to ./textures folder relative to writer path
   WbField urlFieldCopy(*findField("url", true));
   for (int i = 0; i < mUrl->size(); ++i) {
-    if (mUrl->value()[i].indexOf("webots://") == 0) {
+    if (WbUrl::isLocalUrl(mUrl->value()[i])) {
       QString newUrl = mUrl->value()[i];
       dynamic_cast<WbMFString *>(urlFieldCopy.value())
         ->setItem(i, newUrl.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() + "/" +
                                                    WbApplicationInfo::branch() + "/"));
 
-    } else if (mUrl->value()[i].indexOf("http") == 0)
+    } else if (WbUrl::isWeb(mUrl->value()[i]))
       continue;
     else {
       QString texturePath(WbUrl::computePath(this, "url", mUrl, i));

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -110,7 +110,7 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
     return url;
 
   QString path;
-  if (url.startsWith("webots://"))
+  if (isLocalUrl(url))
     path = QDir::cleanPath(WbStandardPaths::webotsHomePath() + url.mid(9));
   else if (QDir::isAbsolutePath(url))  // check if the url is an absolute path
     path = QDir::cleanPath(url);
@@ -204,4 +204,8 @@ QString WbUrl::exportTexture(const WbNode *node, const WbMFString *urlField, int
 
 bool WbUrl::isWeb(const QString &url) {
   return url.startsWith("https://") || url.startsWith("http://");
+}
+
+bool WbUrl::isLocalUrl(const QString &url) {
+  return url.startsWith("webots://");
 }

--- a/src/webots/nodes/utils/WbUrl.hpp
+++ b/src/webots/nodes/utils/WbUrl.hpp
@@ -32,6 +32,7 @@ namespace WbUrl {
   const QString missing(const QString &url);
   const QString missingTexture();
   bool isWeb(const QString &url);
+  bool isLocalUrl(const QString &url);
 };  // namespace WbUrl
 
 #endif

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -49,6 +49,7 @@
 #include "WbTreeItem.hpp"
 #include "WbTreeView.hpp"
 #include "WbUndoStack.hpp"
+#include "WbUrl.hpp"
 #include "WbValueEditor.hpp"
 #include "WbVariant.hpp"
 #include "WbViewpoint.hpp"
@@ -728,7 +729,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     while (it.hasNext()) {
       it.next();
       const QString destination(WbProject::current()->worldsPath() + it.key());
-      if (!(destination.contains("webots://") || destination.contains("http://") || destination.contains("https://"))) {
+      if (!(WbUrl::isLocalUrl(it.key()) || WbUrl::isWeb(it.key()))) {
         const QFileInfo fileInfo(destination);
         if (!QDir(fileInfo.absolutePath()).exists())
           QDir().mkpath(fileInfo.absolutePath());

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -65,6 +65,8 @@
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QVBoxLayout>
 
+#include <iostream>
+
 static int gFactoryFieldEditorHeightHint = 0;
 
 struct TreeItemState {
@@ -728,10 +730,12 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     while (it.hasNext()) {
       it.next();
       const QString destination(WbProject::current()->worldsPath() + it.key());
-      const QFileInfo fileInfo(destination);
-      if (!QDir(fileInfo.absolutePath()).exists())
-        QDir().mkpath(fileInfo.absolutePath());
-      QFile::copy(it.value(), destination);
+      if (!(destination.contains("webots://") || destination.contains("http://") || destination.contains("https://"))) {
+        const QFileInfo fileInfo(destination);
+        if (!QDir(fileInfo.absolutePath()).exists())
+          QDir().mkpath(fileInfo.absolutePath());
+        QFile::copy(it.value(), destination);
+      }
     }
     // import new node
     if (WbNodeOperations::instance()->importNode(parentNode, parentField, index, "", nodeString) == WbNodeOperations::SUCCESS) {

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -65,8 +65,6 @@
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QVBoxLayout>
 
-#include <iostream>
-
 static int gFactoryFieldEditorHeightHint = 0;
 
 struct TreeItemState {


### PR DESCRIPTION
**Description**
When using the `convert to base node` option, textures and meshes defined with urls should not be saved locally.

**Related Issues**
This pull-request fixes issue #3513 