### PR TITLE
Fix 'webots://' URLs not working in the CI tests

### DIFF
--- a/tests/api/worlds/distance_sensor_infra-red_cached_images.wbt
+++ b/tests/api/worlds/distance_sensor_infra-red_cached_images.wbt
@@ -16,7 +16,7 @@ Transform {
   children [
     TexturedBoxShape {
       textureUrl [
-        "webots://projects/default/worlds/textures/tagged_wall.jpg"
+        "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/tagged_wall.jpg"
       ]
       textureMapping "compact"
     }
@@ -26,7 +26,7 @@ Transform {
   children [
     TexturedBoxShape {
       textureUrl [
-        "webots://projects/default/worlds/textures/tagged_wall.jpg"
+        "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/tagged_wall.jpg"
       ]
       textureMapping "compact"
     }

--- a/tests/api/worlds/distance_sensor_infra-red_vs_mesh.wbt
+++ b/tests/api/worlds/distance_sensor_infra-red_vs_mesh.wbt
@@ -20,7 +20,7 @@ DEF MESH Transform {
       }
       geometry Mesh {
         url [
-          "webots://projects/default/worlds/meshes/suzanne.obj"
+          "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/meshes/suzanne.obj"
         ]
       }
     }
@@ -38,7 +38,7 @@ DEF MESH Transform {
       }
       geometry Mesh {
         url [
-          "webots://projects/default/worlds/meshes/suzanne.obj"
+          "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/meshes/suzanne.obj"
         ]
       }
     }

--- a/tests/api/worlds/motions_loop.wbt
+++ b/tests/api/worlds/motions_loop.wbt
@@ -19,9 +19,6 @@ DirectionalLight {
 Floor {
   size 20 20
   tileSize 2 2
-  texture [
-    "webots://projects/default/worlds/textures/parquetry.jpg"
-  ]
 }
 DEF HEXAPOD Hexapod {
   controller "motion"

--- a/tests/api/worlds/motions_regular.wbt
+++ b/tests/api/worlds/motions_regular.wbt
@@ -19,9 +19,6 @@ DirectionalLight {
 Floor {
   size 20 20
   tileSize 2 2
-  texture [
-    "webots://projects/default/worlds/textures/parquetry.jpg"
-  ]
 }
 DEF HEXAPOD Hexapod {
   controller "motion"

--- a/tests/api/worlds/motions_reverse.wbt
+++ b/tests/api/worlds/motions_reverse.wbt
@@ -19,9 +19,6 @@ DirectionalLight {
 Floor {
   size 20 20
   tileSize 2 2
-  texture [
-    "webots://projects/default/worlds/textures/parquetry.jpg"
-  ]
 }
 DEF HEXAPOD Hexapod {
   controller "motion"

--- a/tests/api/worlds/pen_mesh.wbt
+++ b/tests/api/worlds/pen_mesh.wbt
@@ -31,7 +31,7 @@ DEF BOARD Solid {
       }
       geometry Mesh {
         url [
-          "webots://projects/default/worlds/meshes/suzanne.obj"
+          "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/meshes/suzanne.obj"
         ]
       }
     }

--- a/tests/api/worlds/supervisor_field.wbt
+++ b/tests/api/worlds/supervisor_field.wbt
@@ -26,7 +26,7 @@ DEF FLOOR Solid {
         }
         texture ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/checkered_parquetry.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/checkered_parquetry.jpg"
           ]
         }
       }

--- a/tests/api/worlds/track.wbt
+++ b/tests/api/worlds/track.wbt
@@ -96,7 +96,7 @@ DEF ROBOT1 Robot {
                     }
                     texture ImageTexture {
                       url [
-                        "webots://projects/default/worlds/textures/chessboard.jpg"
+                        "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/chessboard.jpg"
                       ]
                     }
                   }
@@ -122,7 +122,7 @@ DEF ROBOT1 Robot {
                     }
                     texture ImageTexture {
                       url [
-                        "webots://projects/default/worlds/textures/chessboard.jpg"
+                        "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/chessboard.jpg"
                       ]
                     }
                   }

--- a/tests/manual_tests/worlds/interaction_with_solid_reference_model.wbt
+++ b/tests/manual_tests/worlds/interaction_with_solid_reference_model.wbt
@@ -20,9 +20,6 @@ DirectionalLight {
   direction 0 -1 0.7
 }
 DEF FLOOR Floor {
-  texture [
-    "webots://projects/default/worlds/textures/carpet.jpg"
-  ]
 }
 DEF Leg_test Robot {
   translation 2.7330911128024204e-09 0.2800000000000001 0.04999999999999963

--- a/tests/physics/worlds/determinism.wbt
+++ b/tests/physics/worlds/determinism.wbt
@@ -33,7 +33,7 @@ DEF CAPSULE Solid {
         }
         texture ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/tagged_wall.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/tagged_wall.jpg"
           ]
         }
         textureTransform TextureTransform {

--- a/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
+++ b/tests/physics/worlds/dynamic_distance_sensor_rays.wbt
@@ -88,7 +88,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }
@@ -131,7 +131,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }

--- a/tests/physics/worlds/dynamic_radar_rays.wbt
+++ b/tests/physics/worlds/dynamic_radar_rays.wbt
@@ -90,7 +90,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }
@@ -133,7 +133,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }

--- a/tests/physics/worlds/dynamic_receiver_rays.wbt
+++ b/tests/physics/worlds/dynamic_receiver_rays.wbt
@@ -173,7 +173,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }
@@ -216,7 +216,7 @@ DEF DYNAMIC_ROBOT Robot {
                   baseColor 0 0.212802 0.869993
                   baseColorMap ImageTexture {
                     url [
-                      "webots://projects/default/worlds/textures/plastic.jpg"
+                      "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/plastic.jpg"
                     ]
                   }
                 }

--- a/tests/physics/worlds/elevation_grid_rotation.wbt
+++ b/tests/physics/worlds/elevation_grid_rotation.wbt
@@ -36,7 +36,7 @@ DEF ELEVATION_GRID Solid {
         }
         texture ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/grass.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/grass.jpg"
           ]
         }
         textureTransform TextureTransform {

--- a/tests/physics/worlds/kinematic_geometry_update.wbt
+++ b/tests/physics/worlds/kinematic_geometry_update.wbt
@@ -29,7 +29,7 @@ DEF SOLID Solid {
         }
         texture ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/tagged_wall.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/tagged_wall.jpg"
           ]
         }
         textureTransform TextureTransform {
@@ -67,7 +67,7 @@ DEF FLOOR Solid {
         }
         texture ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/tagged_wall.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/tagged_wall.jpg"
           ]
         }
         textureTransform TextureTransform {

--- a/tests/protos/worlds/template_node_id.wbt
+++ b/tests/protos/worlds/template_node_id.wbt
@@ -24,7 +24,7 @@ DEF ROBOT TemplateRobot {
       appearance PBRAppearance {
         baseColorMap DEF TEXTURE ImageTexture {
           url [
-            "webots://projects/default/worlds/textures/water.jpg"
+            "https://raw.githubusercontent.com/cyberbotics/webots/R2021b/projects/default/worlds/textures/water.jpg"
           ]
         }
       }


### PR DESCRIPTION
All the tests using `webots://` URLs passes the test suite even if texture is not found (and default not found texture is used).
Using the `https://` URLs instead works when tested locally.
This is now consistent with other tests that were already using the https URLs.

However, I'm not sure that this always works in the CI because in #3566 I still got wrong camera pixel values.

Not sure if it is better to convert also all the HTTPS URLs in the test suite and copy the corresponding textures in the `tests` folder too given that tests are passing.
