### PR TITLE
Fix missing initialization of new rotation handles nodes

### DIFF
--- a/src/webots/wren/WbTranslateRotateManipulator.cpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.cpp
@@ -36,7 +36,9 @@ const WbVector3 WbTranslateRotateManipulator::STANDARD_COORDINATE_VECTORS[3] = {
 WbTranslateRotateManipulator::WbTranslateRotateManipulator(bool isTranslationAvailable, bool isRotationAvailable) :
   WbWrenAbstractManipulator(3),
   mHasRotationHandles(isRotationAvailable),
-  mHasTranslationHandles(isTranslationAvailable) {
+  mHasTranslationHandles(isTranslationAvailable),
+  mRotationLineTransform(NULL),
+  mRotationDoubleArrowTransform(NULL) {
   initializeHandlesEntities();
 }
 
@@ -257,8 +259,10 @@ WbTranslateRotateManipulator::~WbTranslateRotateManipulator() {
 
   wr_node_delete(WR_NODE(mAxesTransform));
 
-  wr_node_delete(WR_NODE(mRotationLineTransform));
-  wr_node_delete(WR_NODE(mRotationDoubleArrowTransform));
+  if (mHasRotationHandles) {
+    wr_node_delete(WR_NODE(mRotationLineTransform));
+    wr_node_delete(WR_NODE(mRotationDoubleArrowTransform));
+  }
 
   for (int i = 0; i < 3; ++i) {
     if (mHasTranslationHandles)
@@ -319,6 +323,9 @@ void WbTranslateRotateManipulator::showNormal() {
 }
 
 void WbTranslateRotateManipulator::showRotationLine(bool show) {
+  assert(mRotationLineTransform && mRotationDoubleArrowTransform);
+  if (!mHasRotationHandles)
+    return;
   wr_node_set_visible(WR_NODE(mRotationLineTransform), show);
   wr_node_set_visible(WR_NODE(mRotationDoubleArrowTransform), show);
 }

--- a/src/webots/wren/WbTranslateRotateManipulator.cpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.cpp
@@ -37,6 +37,7 @@ WbTranslateRotateManipulator::WbTranslateRotateManipulator(bool isTranslationAva
   WbWrenAbstractManipulator(3),
   mHasRotationHandles(isRotationAvailable),
   mHasTranslationHandles(isTranslationAvailable),
+  mActiveRotationHandleMaterial(NULL),
   mRotationLineTransform(NULL),
   mRotationDoubleArrowTransform(NULL) {
   initializeHandlesEntities();
@@ -193,10 +194,10 @@ void WbTranslateRotateManipulator::initializeHandlesEntities() {
       mHasRotationHandles = false;
   }
   if (mHasRotationHandles) {
-    WrMaterial *material = wr_phong_material_new();
+    mActiveRotationHandleMaterial = wr_phong_material_new();
     const float color[3] = {0.0f, 0.0f, 0.0f};
-    wr_phong_material_set_color(material, color);
-    wr_material_set_default_program(material, WbWrenShaders::simpleShader());
+    wr_phong_material_set_color(mActiveRotationHandleMaterial, color);
+    wr_material_set_default_program(mActiveRotationHandleMaterial, WbWrenShaders::simpleShader());
 
     // Rotation line
     const float tailVertices[6] = {0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
@@ -210,7 +211,7 @@ void WbTranslateRotateManipulator::initializeHandlesEntities() {
     wr_renderable_set_drawing_mode(rotationLineRenderable, WR_RENDERABLE_DRAWING_MODE_LINES);
     wr_renderable_set_visibility_flags(rotationLineRenderable, WbWrenRenderingContext::VF_INVISIBLE_FROM_CAMERA);
     wr_renderable_set_mesh(rotationLineRenderable, WR_MESH(rotationLineMesh));
-    wr_renderable_set_material(rotationLineRenderable, material, NULL);
+    wr_renderable_set_material(rotationLineRenderable, mActiveRotationHandleMaterial, NULL);
     wr_renderable_set_drawing_order(rotationLineRenderable, WR_RENDERABLE_DRAWING_ORDER_AFTER_1);
 
     mRotationLineTransform = wr_transform_new();
@@ -232,7 +233,7 @@ void WbTranslateRotateManipulator::initializeHandlesEntities() {
     wr_renderable_set_receive_shadows(doubleArrowRenderable, false);
     wr_renderable_set_visibility_flags(doubleArrowRenderable, WbWrenRenderingContext::VF_INVISIBLE_FROM_CAMERA);
     wr_renderable_set_mesh(doubleArrowRenderable, WR_MESH(doubleArrowMesh));
-    wr_renderable_set_material(doubleArrowRenderable, material, NULL);
+    wr_renderable_set_material(doubleArrowRenderable, mActiveRotationHandleMaterial, NULL);
     wr_renderable_set_drawing_order(doubleArrowRenderable, WR_RENDERABLE_DRAWING_ORDER_AFTER_1);
 
     mRotationDoubleArrowTransform = wr_transform_new();
@@ -260,6 +261,7 @@ WbTranslateRotateManipulator::~WbTranslateRotateManipulator() {
   wr_node_delete(WR_NODE(mAxesTransform));
 
   if (mHasRotationHandles) {
+    wr_material_delete(mActiveRotationHandleMaterial);
     wr_node_delete(WR_NODE(mRotationLineTransform));
     wr_node_delete(WR_NODE(mRotationDoubleArrowTransform));
   }

--- a/src/webots/wren/WbTranslateRotateManipulator.hpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.hpp
@@ -65,6 +65,7 @@ private:
   std::vector<WrRenderable *> mRenderables;
 
   WrMaterial *mHandlesMaterials[3][2];
+  WrMaterial *mActiveRotationHandleMaterial;
 
   WrTransform *mTranslationHandlesTransforms[3];
   WrTransform *mRotationHandlesTransforms[3];


### PR DESCRIPTION
Fix wren nodes initialization and cleanup introduced in #3540.
It seems there are two issues:
* if manipulator doesn't have rotations handles, the `mRotationLineTransform` and `mRotationDoubleArrowTransform` are not initialized to NULL and could cause Webots to crash when deleting them in `~WbTranslateRotateManipulator`.
* the material used to display the black line and double arrow is not deleted causing an assertion fault:
    ```webots-bin: Scene.cpp:99: void wren::Scene::reset(): Assertion `!PhongMaterial::cachedItemCount()' failed.```

This seems the cause of the test suite failure in  #3566.
Additional assertion and checks are added to prevent misusing these nodes.