### PR TITLE
Billboard test to fast mode

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -216,12 +216,11 @@ finalMessage = 'Test suite complete'
 thread = threading.Thread(target=monitorOutputFile, args=[finalMessage])
 thread.start()
 
-webotsArguments = '--mode=fast --no-rendering --stdout --stderr --minimize --batch'
 webotsArguments = '--mode=fast --stdout --stderr --batch'
-webotsArgumentsNoRendering = webotsArguments + ' --no-rendering --minimize'
 if sys.platform != 'win32':
     webotsArguments += ' --no-sandbox'
-    webotsArgumentsRendering += ' --no-sandbox'
+webotsArgumentsNoRendering = webotsArguments + ' --no-rendering --minimize'
+
 
 for groupName in testGroups:
 
@@ -274,9 +273,9 @@ for groupName in testGroups:
     #  command.run(silent = False)
 
     if groupName == 'with_rendering':
-        command = Command(webotsFullPath + ' ' + firstSimulation + ' ' + webotsArgumentsRendering)
-    else:
         command = Command(webotsFullPath + ' ' + firstSimulation + ' ' + webotsArguments)
+    else:
+        command = Command(webotsFullPath + ' ' + firstSimulation + ' ' + webotsArgumentsNoRendering)
 
     # redirect stdout and stderr to files
     command.runTest(timeout=10 * 60)  # 10 minutes

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -217,7 +217,8 @@ thread = threading.Thread(target=monitorOutputFile, args=[finalMessage])
 thread.start()
 
 webotsArguments = '--mode=fast --no-rendering --stdout --stderr --minimize --batch'
-webotsArgumentsRendering = '--mode=fast --stdout --stderr --batch'
+webotsArguments = '--mode=fast --stdout --stderr --batch'
+webotsArgumentsNoRendering = webotsArguments + ' --no-rendering --minimize'
 if sys.platform != 'win32':
     webotsArguments += ' --no-sandbox'
     webotsArgumentsRendering += ' --no-sandbox'

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -217,7 +217,7 @@ thread = threading.Thread(target=monitorOutputFile, args=[finalMessage])
 thread.start()
 
 webotsArguments = '--mode=fast --no-rendering --stdout --stderr --minimize --batch'
-webotsArgumentsRendering = '--mode=realtime --stdout --stderr --batch'
+webotsArgumentsRendering = '--mode=fast --stdout --stderr --batch'
 if sys.platform != 'win32':
     webotsArguments += ' --no-sandbox'
     webotsArgumentsRendering += ' --no-sandbox'

--- a/tests/with_rendering/controllers/billboard/billboard.c
+++ b/tests/with_rendering/controllers/billboard/billboard.c
@@ -2,6 +2,8 @@
 #include "../../../lib/ts_assertion.h"
 #include "../../../lib/ts_utils.h"
 
+#include <time.h>
+
 bool file_exists(const char *filename) {
   FILE *file = fopen(filename, "r");
   if (file) {
@@ -55,11 +57,16 @@ int main(int argc, char **argv) {
   // as the test sometimes fails on Windows, probably because the system
   // needs some time to make the file available to other applications
   // after it was just created.
-  for (i = 0; i < 10000; i++) {
+  wb_robot_step(time_step);
+
+  time_t start_time = time(NULL);
+  while (time(NULL) - start_time < 5) {
     if (file_exists("image0.png") && file_exists("image1.png") && file_exists("image2.png"))
       break;
-
-    wb_robot_step(time_step);
+    else {
+      sleep(0.1);
+      wb_robot_step(time_step);
+    }
   }
 
   ts_assert_boolean_equal(file_exists("image0.png"), "wb_supervisor_export_image() failed to create the "

--- a/tests/with_rendering/controllers/billboard/billboard.c
+++ b/tests/with_rendering/controllers/billboard/billboard.c
@@ -63,10 +63,8 @@ int main(int argc, char **argv) {
   while (time(NULL) - start_time < 5) {
     if (file_exists("image0.png") && file_exists("image1.png") && file_exists("image2.png"))
       break;
-    else {
-      sleep(0.1);
-      wb_robot_step(time_step);
-    }
+    sleep(0.1);
+    wb_robot_step(time_step);
   }
 
   ts_assert_boolean_equal(file_exists("image0.png"), "wb_supervisor_export_image() failed to create the "

--- a/tests/with_rendering/controllers/billboard/billboard.c
+++ b/tests/with_rendering/controllers/billboard/billboard.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
   // as the test sometimes fails on Windows, probably because the system
   // needs some time to make the file available to other applications
   // after it was just created.
-  for (i = 0; i < 100; i++) {
+  for (i = 0; i < 10000; i++) {
     if (file_exists("image0.png") && file_exists("image1.png") && file_exists("image2.png"))
       break;
 


### PR DESCRIPTION
**Description**
Change the mode of the billboard test to fast.

However, the saving of screenshots is not synchronous (from the supervisor at least) and so we cannot be sure that the images are saved when the test tries to access them. That is why it was necessary to increase the size of the waiting loop if we wanted to run in fast mode (the supervisor exits the loops as soon as it detects that the images are ready).