### PR TITLE
Avoid changing the `LD_LIBRARY_PATH` environment in the `.bashrc`

### DIFF
--- a/scripts/install/bashrc.linux
+++ b/scripts/install/bashrc.linux
@@ -16,5 +16,4 @@ export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are 
 # These environment variables are necessaries to compile and run Webots #
 #########################################################################
 
-export WEBOTS_HOME=$HOME/webots                                    # Defines the path to Webots home.
-# export LD_LIBRARY_PATH=$WEBOTS_HOME/lib/webots:$LD_LIBRARY_PATH  # Add the Webots libraries to the library path (useful when launching Webots directly without using the launcher).
+export WEBOTS_HOME=$HOME/webots  # Defines the path to Webots home.

--- a/scripts/install/bashrc.linux
+++ b/scripts/install/bashrc.linux
@@ -16,5 +16,5 @@ export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are 
 # These environment variables are necessaries to compile and run Webots #
 #########################################################################
 
-export WEBOTS_HOME=$HOME/webots                                  # Defines the path to Webots home.
-export LD_LIBRARY_PATH=$WEBOTS_HOME/lib/webots:$LD_LIBRARY_PATH  # Add the Webots libraries to the library path (useful when launching Webots directly without using the launcher).
+export WEBOTS_HOME=$HOME/webots                                    # Defines the path to Webots home.
+# export LD_LIBRARY_PATH=$WEBOTS_HOME/lib/webots:$LD_LIBRARY_PATH  # Add the Webots libraries to the library path (useful when launching Webots directly without using the launcher).


### PR DESCRIPTION
It makes other packages crash. For example, RViz loads the Webots Qt library instead of the system Qt library. A developer should be responsible for configuring the `LD_LIBRARY_PATH` environment variable.