### PR TITLE
Clean-up Windows CI build

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -28,26 +28,16 @@ jobs:
         os: [windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Check Disk Usage 0
-      shell: powershell
-      run: Get-PsDrive
     - uses: msys2/setup-msys2@v2
       with:
         update: false
         install: >-
           git
           openssh
-          mingw-w64-x86_64-qt5
-    - name: Check Disk Usage 1
-      shell: powershell
-      run: Get-PsDrive
     - uses: actions/checkout@v2
       with:
          submodules: true
          fetch-depth: 15
-    - name: Check Disk Usage 2
-      shell: powershell
-      run: Get-PsDrive
     - name: Install Visual Studio 10 and OpenJDK 16
       shell: powershell
       run: |
@@ -68,9 +58,6 @@ jobs:
         echo 'export PATH=$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$GITHUB_WORKSPACE/msys64/mingw64/bin:$GITHUB_WORKSPACE/bin/node:/mingw64/bin:/usr/bin:$JAVA_HOME/bin:$PATH' >> ~/.bash_profile
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         ./scripts/install/msys64_installer.sh --all
-    - name: Check Disk Usage 3
-      shell: powershell
-      run: Get-PsDrive
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -23,27 +23,17 @@ jobs:
         os: [windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Check Disk Usage 0
-      shell: powershell
-      run: Get-PsDrive
     - uses: msys2/setup-msys2@v2
       with:
         update: false
         install: >-
           git
           openssh
-          mingw-w64-x86_64-qt5
-    - name: Check Disk Usage 1
-      shell: powershell
-      run: Get-PsDrive
     - uses: actions/checkout@v2
       with:
          submodules: true
          fetch-depth: 15
          ref: develop
-    - name: Check Disk Usage 2
-      shell: powershell
-      run: Get-PsDrive
     - name: Install Visual Studio 10 and OpenJDK 16
       shell: powershell
       run: |
@@ -64,9 +54,6 @@ jobs:
         echo 'export PATH=$PYTHON38_HOME:$PYTHON38_HOME/Scripts:$GITHUB_WORKSPACE/msys64/mingw64/bin:$GITHUB_WORKSPACE/bin/node:/mingw64/bin:/usr/bin:$JAVA_HOME/bin:$PATH' >> ~/.bash_profile
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         ./scripts/install/msys64_installer.sh --all
-    - name: Check Disk Usage 3
-      shell: powershell
-      run: Get-PsDrive
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}

--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -10,6 +10,7 @@ declare -a BASE_PACKAGES=(
   "tar"                       # Webots dependencies
   "unzip"                     # Webots dependencies
   "zip"                       # robotbenchmark square path
+  "mingw-w64-x86_64-qt5"      # Webots
   "mingw-w64-x86_64-qtwebkit" # Webots
   "mingw-w64-x86_64-libzip"   # Webots
   "mingw-w64-x86_64-libgd"    # Webots


### PR DESCRIPTION
Remove some debug statements and cleaned-up code after #3621.
We need to keep Qt5 installation into the installation script otherwise it breaks the manual installation instructions.