### PR TITLE
Fix pickable local mesh

### DIFF
--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -463,7 +463,7 @@ void WbMesh::updateUrl() {
 
   if (areWrenObjectsInitialized()) {
     buildWrenMesh(true);
-    if (n > 0 && WbUrl::isWeb(mUrl->item(0)))
+    if (n > 0)
       emit wrenObjectsCreated();  // throw signal to update pickable state
   }
 


### PR DESCRIPTION
**Description**
When adding a local mesh via the scenetree, the new mesh was not pickable.
This PR fix that.