### PR TITLE
Fix broadcast restore state when ready

### DIFF
--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -89,9 +89,9 @@ export default class Parser {
     if (webots.currentView.toolBar) {
       webots.currentView.toolBar.enableToolBarButtons(true);
       if (webots.currentView.runOnLoad === 'real-time')
-        webots.currentView.toolBar.realTime();
+        webots.currentView.toolBar.realTime(true);
       else if (webots.currentView.runOnLoad === 'run' || webots.currentView.runOnLoad === 'fast')
-        webots.currentView.toolBar.run();
+        webots.currentView.toolBar.run(true);
     }
 
     if (typeof callback === 'function')
@@ -1053,7 +1053,7 @@ export default class Parser {
       if (typeof webots.currentView.repository === 'undefined')
         webots.currentView.repository = 'cyberbotics';
       if (typeof webots.currentView.branch === 'undefined' || webots.currentView.branch === '')
-        webots.currentView.branch = 'released'
+        webots.currentView.branch = 'released';
       url = url.replace('webots://', 'https://raw.githubusercontent.com/' + webots.currentView.repository + '/webots/' + webots.currentView.branch + '/');
     }
     if (typeof prefix !== 'undefined' && !url.startsWith('http'))

--- a/resources/web/wwi/Toolbar.js
+++ b/resources/web/wwi/Toolbar.js
@@ -123,8 +123,8 @@ export default class Toolbar {
     this._view.stream.socket.send('pause');
   }
 
-  realTime() {
-    if (this._view.broadcast)
+  realTime(force) {
+    if (this._view.broadcast && !force)
       return;
     this._view.stream.socket.send('real-time:' + this._view.timeout);
     this.pauseButton.style.display = 'inline';
@@ -133,8 +133,8 @@ export default class Toolbar {
       this.runButton.style.display = 'inline';
   }
 
-  run() {
-    if (this._view.broadcast)
+  run(force) {
+    if (this._view.broadcast && !force)
       return;
     this._view.stream.socket.send('fast:' + this._view.timeout);
     this.pauseButton.style.display = 'inline';


### PR DESCRIPTION
**Description**
In the streaming viewer, if the simulation was playing and the streaming viewer was launched as `broadcast`, the simulation was paused after the loading instead of resuming.

#Fix https://github.com/cyberbotics/webots_ros2/issues/299