### PR TITLE
Documentation improve description of ROS support

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -18,6 +18,9 @@ Webots comes in three different package types: `.deb` (Debian package), `.tar.bz
 The Debian package is aimed at the latest LTS Ubuntu Linux distribution whereas the tarball and snap packages includes many dependency libraries and are therefore best suited for installation on other Linux distributions.
 All these packages can be installed from our [official GitHub repository](https://github.com/cyberbotics/webots/releases).
 
+The packages also contain a precompiled ROS API built with the latest recommended ROS distribution.
+For more details about the ROS version supported out of the box by each package please refer to [this section](tutorial-8-using-ros.md#check-compatibility-of-webots-ros-api).
+
 > **Note**: Webots will run much faster if you install an accelerated OpenGL drivers.
 If you have a NVIDIA or AMD graphics card, it is highly recommended that you install the Linux graphics drivers from these manufacturers to take the full advantage of the OpenGL hardware acceleration with Webots.
 Please find instructions in [this section](verifying-your-graphics-driver-installation.md).

--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -15,6 +15,7 @@ If you plan to use a different ROS distribution then it is recommended to instal
 export ROS_DISTRO=noetic  # or ROS_DISTRO=melodic, etc.
 cd ${WEBOTS_HOME}/projects/default/controllers/ros
 make
+```
 
 ### Installing ROS and "webots\_ros" Package
 

--- a/docs/guide/tutorial-8-using-ros.md
+++ b/docs/guide/tutorial-8-using-ros.md
@@ -5,6 +5,17 @@ This tutorial explains how to use the nodes from the `webots_ros` package provid
 These examples were tested with ROS `noetic` and `melodic` on Linux.
 There is no warranty they will work if you use a different platform or an ancient distribution of ROS.
 
+### Check Compatibility of Webots ROS API
+
+The Webots packages contain a precompiled ROS API built using the latest ROS distributions:
+- The Ubuntu 20.04 tarball package is compatible with ROS Noetic.
+- The snap, Debian and Ubuntu 18.04 tarball packages are compatible with ROS Melodic.
+If you plan to use a different ROS distribution then it is recommended to install the tarball package and recompile the ROS API:
+```sh
+export ROS_DISTRO=noetic  # or ROS_DISTRO=melodic, etc.
+cd ${WEBOTS_HOME}/projects/default/controllers/ros
+make
+
 ### Installing ROS and "webots\_ros" Package
 
 In order to use these nodes, you will first need to install the ROS framework.


### PR DESCRIPTION
Address #3672:
back port text from develop branch specifying which Webots package is compatible with given ROS version in the R2021b documentation.