### PR TITLE
Change default coordinate system in `empty.wbt`

### DIFF
--- a/resources/projects/worlds/empty.wbt
+++ b/resources/projects/worlds/empty.wbt
@@ -1,6 +1,5 @@
 #VRML_SIM R2021b utf8
 WorldInfo {
-  coordinateSystem "NUE"
 }
 Viewpoint {
 }


### PR DESCRIPTION
**Description**
Although from 2021b `ENU` is the default coordinate system (and is so defined in `WorldInfo.wrl`), when doing `File > New World` the default world loaded (`empty.wbt`) still uses `NEU`.