### PR TITLE
ENU/FLU: Convert universal robots

### DIFF
--- a/docs/guide/ure.md
+++ b/docs/guide/ure.md
@@ -19,7 +19,7 @@ Derived from [Robot](../reference/robot.md).
 ```
 UR5e/UR5e/UR10e {
   SFVec3f    translation     0 0 0
-  SFRotation rotation        1 0 0 4.712388966
+  SFRotation rotation        0 0 1 0
   SFString   name            "UR5e"
   SFString   controller      "void"
   MFString   controllerArgs  []

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -9,6 +9,8 @@ Released on XX, XXth, 2021.
     - Improved performance on [Lidar](lidar.md) point cloud generation ([#3499](https://github.com/cyberbotics/webots/pull/3499)).
     - Improved the user experience when using the object rotation around axis feature ([#3540](https://github.com/cyberbotics/webots/pull/3540)).
     - Increased the mouse wheel speed when zooming the 3D window ([#3565](https://github.com/cyberbotics/webots/pull/3565)).
+  - Bug fixes
+    - Fixed the force direction applied by the [Track](track.md) node ([#3693](https://github.com/cyberbotics/webots/pull/3693)).
   - Dependency Updates
     - **Stopped support for Ubuntu 16.04 ([#3480](https://github.com/cyberbotics/webots/pull/3480)).**
 

--- a/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
+++ b/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
@@ -13,7 +13,7 @@ PROTO ConveyorBelt [
   field SFFloat    borderThickness  0.03                                                                 # Defines the thickness of the metal part around the conveyor belt.
   field SFFloat    borderHeight     0.01                                                                 # Defines the height of the border around the conveyor.
   field SFFloat    speed            0.5                                                                  # Defines the rubber band speed in meters per second.
-  field SFFloat    acceleration     -1                                                                   # Defines the acceleration of the conveyor belt.
+  field SFFloat    acceleration     -1                                                                    # Defines the acceleration of the conveyor belt.
   field SFFloat    timer            0.0                                                                  # Defines for how long the conveyor belt should move (it will move forever if set to 0).
 ]
 {
@@ -70,7 +70,7 @@ PROTO ConveyorBelt [
             sound ""
           }
         ]
-        textureAnimation %<= -1 / size.x >% 0
+        textureAnimation %<= 1 / size.x >% 0
       }
       Shape {
         appearance IS appearance

--- a/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
+++ b/projects/objects/factory/conveyors/protos/ConveyorBelt.proto
@@ -13,7 +13,7 @@ PROTO ConveyorBelt [
   field SFFloat    borderThickness  0.03                                                                 # Defines the thickness of the metal part around the conveyor belt.
   field SFFloat    borderHeight     0.01                                                                 # Defines the height of the border around the conveyor.
   field SFFloat    speed            0.5                                                                  # Defines the rubber band speed in meters per second.
-  field SFFloat    acceleration     -1                                                                    # Defines the acceleration of the conveyor belt.
+  field SFFloat    acceleration     -1                                                                   # Defines the acceleration of the conveyor belt.
   field SFFloat    timer            0.0                                                                  # Defines for how long the conveyor belt should move (it will move forever if set to 0).
 ]
 {

--- a/projects/robots/universal_robots/protos/UR10e.proto
+++ b/projects/robots/universal_robots/protos/UR10e.proto
@@ -6,16 +6,16 @@
 # template language: javascript
 
 PROTO UR10e [
-  field SFVec3f    translation     0 0 0             # Is `Transform.translation`.
-  field SFRotation rotation        1 0 0 4.712388966 # Is `Transform.rotation`.
-  field SFString   name            "UR10e"           # Is `Solid.name`.
-  field SFString   controller      "void"            # Is `Robot.controller`.
-  field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.
-  field SFBool     supervisor      FALSE             # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE              # Is `Robot.synchronization`.
-  field SFBool     selfCollision   TRUE              # Is `Robot.selfCollision`.
-  field MFNode     toolSlot        []                # Extend the robot with new nodes at the end of the arm.
-  field SFBool     staticBase      TRUE              # Defines if the robot base should ba pinned to the static environment.
+  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
+  field SFString   name            "UR10e"  # Is `Solid.name`.
+  field SFString   controller      "void"   # Is `Robot.controller`.
+  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
+  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
+  field SFBool     selfCollision   TRUE     # Is `Robot.selfCollision`.
+  field MFNode     toolSlot        []       # Extend the robot with new nodes at the end of the arm.
+  field SFBool     staticBase      TRUE     # Defines if the robot base should ba pinned to the static environment.
 ]
 {
   Robot {

--- a/projects/robots/universal_robots/protos/UR10e.proto
+++ b/projects/robots/universal_robots/protos/UR10e.proto
@@ -42,7 +42,7 @@ PROTO UR10e [
               }
               DEF CYLINDER Transform {
                 translation 0 0 0.02
-                rotation 1 0 0 1.5707963220000003
+                rotation -0.707107 0.707107 0 -3.141593
                 children [
                   Shape {
                     appearance ScrewThread {
@@ -507,6 +507,7 @@ PROTO UR10e [
                                           children [
                                             Transform {
                                               translation 0 0.086 0
+                                              rotation 1 0 0 -1.570796
                                               children [
                                                 Cylinder {
                                                   height 0.048
@@ -516,6 +517,7 @@ PROTO UR10e [
                                             }
                                             Transform {
                                               translation 0 0.109 0
+                                              rotation 1 0 0 -1.570796
                                               children [
                                                 Cylinder {
                                                   height 0.018
@@ -540,6 +542,7 @@ PROTO UR10e [
                                     children [
                                       Transform {
                                         translation 0 0.007 0.1195
+                                        rotation 1 0 0 -1.570796
                                         children [
                                           Cylinder {
                                             height 0.12
@@ -549,7 +552,7 @@ PROTO UR10e [
                                       }
                                       Transform {
                                         translation 0 0 0.0805
-                                        rotation 1 0 0 4.712388966
+                                        rotation 1 0 0 3.141593
                                         children [
                                           Cylinder {
                                             height 0.043
@@ -574,6 +577,7 @@ PROTO UR10e [
                               children [
                                 Transform {
                                   translation 0 0.095 0
+                                  rotation 1 0 0 -1.570796
                                   children [
                                     Cylinder {
                                       height 0.075
@@ -583,7 +587,7 @@ PROTO UR10e [
                                 }
                                 Transform {
                                   translation 0 0.134 0.007
-                                  rotation 1 0 0 4.712388966
+                                  rotation 1 0 0 3.141593
                                   children [
                                     Cylinder {
                                       height 0.126
@@ -608,7 +612,7 @@ PROTO UR10e [
                         children [
                           Transform {
                             translation 0 0 0.307
-                            rotation 1 0 0 4.712388966
+                            rotation 1 0 0 3.141593
                             children [
                               Cylinder {
                                 height 0.49
@@ -618,6 +622,7 @@ PROTO UR10e [
                           }
                           Transform {
                             translation 0 0.009 0.57
+                            rotation 1 0 0 -1.570796
                             children [
                               Cylinder {
                                 height 0.129
@@ -627,7 +632,7 @@ PROTO UR10e [
                           }
                           Transform {
                             translation 0 0.06 0
-                            rotation 1 0 0 6.283185277377264
+                            rotation 1 0 0 -1.570796
                             children [
                               Capsule {
                                 height 0.05
@@ -637,7 +642,6 @@ PROTO UR10e [
                           }
                           Transform {
                             translation 0 0 0.05
-                            rotation -1 0 0 4.712389014981909
                             children [
                               Capsule {
                                 height 0.03
@@ -662,7 +666,7 @@ PROTO UR10e [
                   children [
                     Transform {
                       translation 0 0 0.33
-                      rotation 1 0 0 4.712388966
+                      rotation 1 0 0 3.141593
                       children [
                         Cylinder {
                           height 0.463
@@ -672,7 +676,7 @@ PROTO UR10e [
                     }
                     Transform {
                       translation 0 0 0.06
-                      rotation 1 0 0 4.712388966
+                      rotation 1 0 0 3.141593
                       children [
                         Cylinder {
                           height 0.1
@@ -680,12 +684,18 @@ PROTO UR10e [
                         }
                       ]
                     }
-                    Cylinder {
-                      height 0.183
-                      radius 0.077
+                    Transform {
+                      rotation 1 0 0 -1.570796
+                      children [
+                        Cylinder {
+                          height 0.183
+                          radius 0.077
+                        }
+                      ]
                     }
                     Transform {
                       translation 0 -0.005 0.612
+                      rotation 1 0 0 -1.570796
                       children [
                         Cylinder {
                           height 0.149
@@ -709,7 +719,7 @@ PROTO UR10e [
           boundingObject Group {
             children [
               Transform {
-                rotation 1 0 0 4.712388966
+                rotation 1 0 0 3.141593
                 children [
                   Cylinder {
                     height 0.183
@@ -719,6 +729,7 @@ PROTO UR10e [
               }
               Transform {
                 translation 0 0.05 0
+                rotation 1 0 0 1.570797
                 children [
                   Cylinder {
                     height 0.093
@@ -742,7 +753,7 @@ PROTO UR10e [
     model "UR10e"
     boundingObject Transform {
       translation 0 0 0.05
-      rotation 1 0 0 4.712388966
+      rotation 1 0 0 3.141593
       children [
         Cylinder {
           height 0.1

--- a/projects/robots/universal_robots/protos/UR3e.proto
+++ b/projects/robots/universal_robots/protos/UR3e.proto
@@ -6,16 +6,16 @@
 # template language: javascript
 
 PROTO UR3e [
-  field SFVec3f    translation     0 0 0             # Is `Transform.translation`.
-  field SFRotation rotation        1 0 0 4.712388966 # Is `Transform.rotation`.
-  field SFString   name            "UR3e"            # Is `Solid.name`.
-  field SFString   controller      "void"            # Is `Robot.controller`.
-  field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.
-  field SFBool     supervisor      FALSE             # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE              # Is `Robot.synchronization`.
-  field SFBool     selfCollision   TRUE              # Is `Robot.selfCollision`.
-  field MFNode     toolSlot        []                # Extend the robot with new nodes at the end of the arm.
-  field SFBool     staticBase      TRUE              # Defines if the robot base should ba pinned to the static environment.
+  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
+  field SFString   name            "UR3e"   # Is `Solid.name`.
+  field SFString   controller      "void"   # Is `Robot.controller`.
+  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
+  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
+  field SFBool     selfCollision   TRUE     # Is `Robot.selfCollision`.
+  field MFNode     toolSlot        []       # Extend the robot with new nodes at the end of the arm.
+  field SFBool     staticBase      TRUE     # Defines if the robot base should ba pinned to the static environment.
 ]
 {
   Robot {
@@ -513,6 +513,7 @@ PROTO UR3e [
                                           children [
                                             Transform {
                                               translation 0 0.07 0
+                                              rotation 1 0 0 -1.570796
                                               children [
                                                 Cylinder {
                                                   height 0.044
@@ -537,6 +538,7 @@ PROTO UR3e [
                                     children [
                                       Transform {
                                         translation 0 0.002 0.0854
+                                        rotation 1 0 0 -1.570796
                                         children [
                                           Cylinder {
                                             height 0.097
@@ -546,7 +548,7 @@ PROTO UR3e [
                                       }
                                       Transform {
                                         translation 0 0 0.0636
-                                        rotation 1 0 0 4.712388966
+                                        rotation 1 0 0 3.141593
                                         children [
                                           Cylinder {
                                             height 0.043
@@ -571,6 +573,7 @@ PROTO UR3e [
                               children [
                                 Transform {
                                   translation 0 0.075 0
+                                  rotation 1 0 0 -1.570796
                                   children [
                                     Cylinder {
                                       height 0.064
@@ -580,7 +583,7 @@ PROTO UR3e [
                                 }
                                 Transform {
                                   translation 0 0.104 0.003
-                                  rotation 1 0 0 -1.5707963071795863
+                                  rotation 1 0 0 -3.141593
                                   children [
                                     Cylinder {
                                       height 0.1
@@ -605,7 +608,7 @@ PROTO UR3e [
                         children [
                           Transform {
                             translation 0 0 0.125
-                            rotation 1 0 0 4.712388966
+                            rotation 1 0 0 3.141593
                             children [
                               Cylinder {
                                 height 0.18
@@ -624,7 +627,7 @@ PROTO UR3e [
                           }
                           Transform {
                             translation 0 0.05 0
-                            rotation 1 0 0 6.283185277377264
+                            rotation 1 0 0 -1.570796
                             children [
                               Capsule {
                                 height 0.05
@@ -659,7 +662,7 @@ PROTO UR3e [
                   children [
                     Transform {
                       translation 0 0 0.035
-                      rotation 1 0 0 4.712388966
+                      rotation 1 0 0 3.141593
                       children [
                         Cylinder {
                           height 0.073
@@ -669,7 +672,7 @@ PROTO UR3e [
                     }
                     Transform {
                       translation 0 0 0.157
-                      rotation 1 0 0 4.712388966
+                      rotation 1 0 0 3.141593
                       children [
                         Cylinder {
                           height 0.186
@@ -677,12 +680,18 @@ PROTO UR3e [
                         }
                       ]
                     }
-                    Cylinder {
-                      height 0.119
-                      radius 0.046
+                    Transform {
+                      rotation 1 0 0 -1.570796
+                      children [
+                        Cylinder {
+                          height 0.119
+                          radius 0.046
+                        }
+                      ]
                     }
                     Transform {
                       translation 0 0.002 0.2435
+                      rotation 1 0 0 -1.570796
                       children [
                         Cylinder {
                           height 0.11
@@ -707,7 +716,7 @@ PROTO UR3e [
             children [
               Transform {
                 translation 0 0 -0.003
-                rotation 1 0 0 4.712388966
+                rotation 1 0 0 3.141593
                 children [
                   Cylinder {
                     height 0.121
@@ -717,6 +726,7 @@ PROTO UR3e [
               }
               Transform {
                 translation 0 0.03 0
+                rotation 1 0 0 -1.570796
                 children [
                   Cylinder {
                     height 0.066

--- a/projects/robots/universal_robots/protos/UR3e.proto
+++ b/projects/robots/universal_robots/protos/UR3e.proto
@@ -42,7 +42,7 @@ PROTO UR3e [
               }
               DEF CYLINDER Transform {
                 translation 0 0 0.02
-                rotation 1 0 0 1.5707963220000003
+                rotation -0.707107 0.707107 0 -3.141593
                 children [
                   Shape {
                     appearance ScrewThread {
@@ -618,6 +618,7 @@ PROTO UR3e [
                           }
                           Transform {
                             translation 0 0.002 0.213
+                            rotation 1 0 0 -1.570796
                             children [
                               Cylinder {
                                 height 0.1
@@ -637,7 +638,6 @@ PROTO UR3e [
                           }
                           Transform {
                             translation 0 0 0.07
-                            rotation -1 0 0 4.712389014981909
                             children [
                               Capsule {
                                 height 0.1
@@ -755,7 +755,7 @@ PROTO UR3e [
     selfCollision IS selfCollision
     boundingObject Transform {
       translation 0 0 0.045
-      rotation 1 0 0 4.712388966
+      rotation 1 0 0 3.141593
       children [
         Cylinder {
           height 0.09

--- a/projects/robots/universal_robots/protos/UR5e.proto
+++ b/projects/robots/universal_robots/protos/UR5e.proto
@@ -7,7 +7,7 @@
 
 PROTO UR5e [
   field SFVec3f    translation     0 0 0             # Is `Transform.translation`.
-  field SFRotation rotation        1 0 0 4.712388966 # Is `Transform.rotation`.
+  field SFRotation rotation        0 0 1 0           # Is `Transform.rotation`.
   field SFString   name            "UR5e"            # Is `Solid.name`.
   field SFString   controller      "void"            # Is `Robot.controller`.
   field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.

--- a/projects/robots/universal_robots/protos/UR5e.proto
+++ b/projects/robots/universal_robots/protos/UR5e.proto
@@ -6,16 +6,16 @@
 # template language: javascript
 
 PROTO UR5e [
-  field SFVec3f    translation     0 0 0             # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0           # Is `Transform.rotation`.
-  field SFString   name            "UR5e"            # Is `Solid.name`.
-  field SFString   controller      "void"            # Is `Robot.controller`.
-  field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.
-  field SFBool     supervisor      FALSE             # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE              # Is `Robot.synchronization`.
-  field SFBool     selfCollision   TRUE              # Is `Robot.selfCollision`.
-  field MFNode     toolSlot        []                # Extend the robot with new nodes at the end of the arm.
-  field SFBool     staticBase      TRUE              # Defines if the robot base should ba pinned to the static environment.
+  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
+  field SFString   name            "UR5e"   # Is `Solid.name`.
+  field SFString   controller      "void"   # Is `Robot.controller`.
+  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
+  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
+  field SFBool     selfCollision   TRUE     # Is `Robot.selfCollision`.
+  field MFNode     toolSlot        []       # Extend the robot with new nodes at the end of the arm.
+  field SFBool     staticBase      TRUE     # Defines if the robot base should ba pinned to the static environment.
 ]
 {
   Robot {

--- a/projects/robots/universal_robots/worlds/ure.wbt
+++ b/projects/robots/universal_robots/worlds/ure.wbt
@@ -19,8 +19,8 @@ WorldInfo {
   ]
 }
 Viewpoint {
-  orientation -0.1640369459467948 0.6791727760233085 0.7154133215654017 0.6511912051080316
-  position -6.637286017984618 -2.6416602731702388 4.504946725903114
+  orientation -0.15057085537249637 0.7746188825940333 0.6142426265256801 0.6129878674589708
+  position -5.670715537973679 -2.010226364491933 4.297022314254167
   exposure 1.7
 }
 TexturedBackground {
@@ -85,15 +85,16 @@ Table {
   }
 }
 OfficeTelephone {
-  translation -1.34381 -0.209288 0.79
+  translation -1.34381 -0.209288 0.8
   rotation 0 0 1 -0.7853983071795865
+  enablePhysics FALSE
 }
 Wrench {
-  translation -1.238859 -0.5886 0.71
+  translation -1.23886 -0.5886 0.8
   rotation 0 0 1 2.094395
 }
 Hammer {
-  translation -1.60381 -0.359288 0.71
+  translation -1.60381 -0.359288 0.81
 }
 PlatformCart {
   translation 0.927687 1.793317 0
@@ -110,7 +111,7 @@ Radiator {
 }
 WoodenPalletStack {
   translation 2.8 -0.23 0
-  rotation 0 0 -1 1.5708
+  rotation 0 0 1 -1.5707953071795862
   palletNumber 5
   palletSize 0.8 1 0.11
 }
@@ -282,7 +283,7 @@ SolidBox {
 }
 FireExtinguisher {
   translation -0.75771 1.79 0
-  rotation 0 0 1 -2.8797933071795865
+  rotation 0 0 -1 1.5708
 }
 UR3e {
   translation 1.30296 0.079391 0.91
@@ -371,31 +372,31 @@ ConveyorBelt {
 }
 PlasticCrate {
   translation 0.22 0.68 0.25
-  size 0.6 0.4 0.45
+  size 0.6 0.45 0.4
   mass 1
 }
 PlasticCrate {
   translation -0.41 0.68 0.25
   name "plastic crate(1)"
-  size 0.6 0.4 0.45
+  size 0.6 0.45 0.4
   mass 1
 }
 PlasticCrate {
   translation -1.04 0.68 0.26
   name "plastic crate(2)"
-  size 0.6 0.4 0.45
+  size 0.6 0.45 0.4
   mass 1
 }
 PlasticCrate {
   translation -1.67 0.68 0.26
   name "plastic crate(3)"
-  size 0.6 0.4 0.45
+  size 0.6 0.45 0.4
   mass 1
 }
 PlasticCrate {
   translation -2.31 0.68 0.26
   name "plastic crate(4)"
-  size 0.6 0.4 0.45
+  size 0.6 0.45 0.4
   mass 1
 }
 Can {

--- a/projects/robots/universal_robots/worlds/ure.wbt
+++ b/projects/robots/universal_robots/worlds/ure.wbt
@@ -6,7 +6,6 @@ WorldInfo {
   title "Universal Robot"
   basicTimeStep 8
   physicsDisableAngularThreshold 0.1
-  coordinateSystem "NUE"
   contactProperties [
     ContactProperties {
       bounce 0.1
@@ -20,8 +19,8 @@ WorldInfo {
   ]
 }
 Viewpoint {
-  orientation 0.5593874959277706 0.7906420655431335 0.24893925683456522 5.245024193194764
-  position -3.003149059091924 3.6046653693919106 2.350193890222295
+  orientation -0.1640369459467948 0.6791727760233085 0.7154133215654017 0.6511912051080316
+  position -6.637286017984618 -2.6416602731702388 4.504946725903114
   exposure 1.7
 }
 TexturedBackground {
@@ -33,11 +32,11 @@ Floor {
   }
 }
 SquareManhole {
-  translation 0.560459 -0.03 1.782
-  rotation 0 1 0 -1.5707963071795863
+  translation 0.560459 -1.782 -0.03
+  rotation 0 0 1 -1.5707963071795863
 }
 Table {
-  translation 3.097723 0 -2.013972
+  translation 3.097723 2.013972 0
   size 1.8 0.7 0.8
   feetSize 0.05 0.05
   trayAppearance PBRAppearance {
@@ -50,29 +49,29 @@ Table {
   }
 }
 WoodenChair {
-  translation 2.921084 0 -1.648051
-  rotation 0 1 0 -2.8797933071795865
+  translation 2.921084 1.648051 0
+  rotation 0 0 1 2.0944
 }
 Monitor {
-  translation 2.520237 0.7 -2.108887
-  rotation 0 1 0 -2.8797933071795865
+  translation 2.520237 2.108887 0.7
+  rotation 0 0 1 -2.8797933071795865
 }
 Keyboard {
-  translation 2.594212 0.7 -1.8802
-  rotation 0 1 0 -2.8797933071795865
+  translation 2.594212 1.8802 0.7
+  rotation 0 0 1 -2.8797933071795865
 }
 DesktopComputer {
-  translation 2.331033 0 -2.125086
-  rotation 0 1 0 -3.1415923071795864
+  translation 2.331033 2.125086 0
+  rotation 0 0 -1 1.5708
 }
 ComputerMouse {
-  translation 2.94663 0.7 -1.914183
-  rotation 0 1 0 2.879793
+  translation 2.94663 1.914183 0.7
+  rotation 0 0 1 2.879793
   mass 0
 }
 Table {
-  translation -1.419911 0 0.81333
-  rotation 0 1 0 -1.5707963071795863
+  translation -1.419911 -0.81333 0
+  rotation 0 0 1 -1.5707963071795863
   name "table(1)"
   size 1.8 0.7 0.8
   feetSize 0.05 0.05
@@ -86,36 +85,38 @@ Table {
   }
 }
 OfficeTelephone {
-  translation -1.343811 0.7 0.209288
-  rotation 0 1 0 -0.7853983071795865
+  translation -1.34381 -0.209288 0.79
+  rotation 0 0 1 -0.7853983071795865
 }
 Wrench {
-  translation -1.238859 0.71 0.5886
-  rotation 0 1 0 2.094395
+  translation -1.238859 -0.5886 0.71
+  rotation 0 0 1 2.094395
 }
 Hammer {
-  translation -1.60381 0.71 0.359288
+  translation -1.60381 -0.359288 0.71
 }
 PlatformCart {
-  translation 0.927687 0 -1.793317
-  rotation 0 1 0 -2.8797933071795865
+  translation 0.927687 1.793317 0
+  rotation 0 0 1 -2.8797933071795865
 }
 LeverValve {
-  translation -0.73 0.502 0.83
+  translation -0.73 -0.83 0.502
+  rotation 0 0 1 3.14159
 }
 Radiator {
-  translation 0.528902 0.33 -2.341308
-  rotation 0 1 0 -1.5707963071795863
+  translation 0.528902 2.341308 0.33
+  rotation 0 0 1 -1.5707963071795863
   numberOfFins 16
 }
 WoodenPalletStack {
-  translation 2.8 0 0.23
-  rotation 0 -1 0 1.5708
+  translation 2.8 -0.23 0
+  rotation 0 0 -1 1.5708
   palletNumber 5
-  palletSize 0.8 0.11 1
+  palletSize 0.8 1 0.11
 }
 Cabinet {
-  translation -0.4 0 -2.47
+  translation -0.41 2.47 0
+  rotation 0 0 1 -1.5707953071795862
   name "cabinet(1)"
   layout [
     "RightSidedDoor (1, 1, 1, 5, 1.5)"
@@ -129,17 +130,18 @@ Cabinet {
   }
 }
 CardboardBox {
-  translation -1.21 0.3 -2.18
+  translation -1.21 2.18 0.3
 }
 CardboardBox {
-  translation -1.198389 0.75 -2.100678
-  rotation 0 1 0 2.094395
+  translation -1.198389 2.100678 0.75
+  rotation 0 0 1 2.094395
   name "cardboard box(1)"
-  size 0.4 0.3 0.6
+  size 0.4 0.6 0.3
 }
 Wall {
-  translation -2.835 0 -2.58
-  size 9 2.4 0.2
+  translation -2.835 2.58 0
+  rotation 0 1 0 0
+  size 9 0.2 2.4
   appearance Roughcast {
     textureTransform TextureTransform {
       scale 2 1
@@ -147,9 +149,9 @@ Wall {
   }
 }
 Wall {
-  translation 4.375 0 -2.58
+  translation 4.375 2.58 0
   name "wall(2)"
-  size 5 2.4 0.2
+  size 5 0.2 2.4
   appearance Roughcast {
     textureTransform TextureTransform {
       scale 2 1
@@ -157,9 +159,9 @@ Wall {
   }
 }
 Wall {
-  translation 1.77 1.2 -2.58
+  translation 1.77 2.58 1.2
   name "wall(3)"
-  size 0.21 1.2 0.2
+  size 0.21 0.2 1.2
   appearance Roughcast {
     textureTransform TextureTransform {
       scale 0.1 0.7
@@ -167,9 +169,9 @@ Wall {
   }
 }
 Wall {
-  translation 0 0 2.42
+  translation 0 -2.42 0
   name "wall(1)"
-  size 15 2.4 0.2
+  size 15 0.2 2.4
   appearance Roughcast {
     textureTransform TextureTransform {
       scale 2 1
@@ -177,7 +179,7 @@ Wall {
   }
 }
 Transform {
-  translation 1.77 1.05 -2.68
+  translation 1.77 2.68 1.05
   children [
     Shape {
       appearance PBRAppearance {
@@ -192,21 +194,21 @@ Transform {
   ]
 }
 SolidBox {
-  translation -0.135 0.305 0.0323
-  size 1.5 0.61 0.4
+  translation -0.135 -0.0323 0.305
+  size 1.5 0.4 0.61
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 1.015 0.45 0.0323
+  translation 1.015 -0.0323 0.45
   name "box(5)"
-  size 0.8 0.91 0.4
+  size 0.8 0.4 0.91
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 0.8 0.819996 -0.329556
-  rotation 1 0 0 1.047197
+  translation 0.8 0.3324 0.8246
+  rotation 1 0 0 2.61799
   name "box(6)"
   size 0.3 0.5 0.02
   contactMaterial "slope"
@@ -214,42 +216,42 @@ SolidBox {
   }
 }
 SolidBox {
-  translation 0.96 0.837316 -0.339556
-  rotation -0.4472131236215756 0.7745972141192264 0.4472131236215756 -1.823476307179586
+  translation 0.96 0.339556 0.837316
+  rotation -0.4472131236215756 -0.4472131236215756 0.7745972141192264 -1.823476307179586
   name "box(7)"
-  size 0.05 0.5 0.02
+  size 0.05 0.02 0.5
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 0.64 0.837316 -0.339556
-  rotation -0.4472131236215756 0.7745972141192264 0.4472131236215756 -1.823476307179586
+  translation 0.64 0.339556 0.837316
+  rotation -0.4472131236215756 -0.4472131236215756 0.7745972141192264 -1.823476307179586
   name "box(8)"
-  size 0.05 0.5 0.02
+  size 0.05 0.02 0.5
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 0.64 0.583496 -0.239196
-  rotation 0.6947470600351803 -0.1861570160863869 -0.6947460600350939 2.773492
+  translation 0.64 0.239196 0.583496
+  rotation 0.6947470600351803 0.6947460600350939 -0.1861570160863869 2.773492
   name "box(9)"
-  size 0.05 0.5 0.02
+  size 0.05 0.02 0.5
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 0.96 0.583496 -0.239196
-  rotation 0.6947470600351803 -0.1861570160863869 -0.6947460600350939 2.773492
+  translation 0.96 0.239196 0.583496
+  rotation 0.6947470600351803 0.6947460600350939 -0.1861570160863869 2.773492
   name "box(10)"
-  size 0.05 0.5 0.02
+  size 0.05 0.02 0.5
   appearance GalvanizedMetal {
   }
 }
 SolidBox {
-  translation 1.77 0.375 0.11
-  rotation 0 1 0 3.1415919999999997
+  translation 1.77 -0.11 0.375
+  rotation 0 0 1 3.1415919999999997
   name "box(2)"
-  size 0.2 0.75 0.18
+  size 0.2 0.18 0.75
   appearance CorrugatedMetal {
     textureTransform TextureTransform {
       scale 0.7 0.7
@@ -257,10 +259,10 @@ SolidBox {
   }
 }
 SolidBox {
-  translation 1.77 0.375 2.28
-  rotation 0 1 0 3.1415919999999997
+  translation 1.77 -2.28 0.375
+  rotation 0 0 1 3.1415919999999997
   name "box(4)"
-  size 0.2 0.75 0.18
+  size 0.2 0.18 0.75
   appearance CorrugatedMetal {
     textureTransform TextureTransform {
       scale 0.7 0.7
@@ -268,10 +270,10 @@ SolidBox {
   }
 }
 SolidBox {
-  translation 1.77 0.375 -2.43
-  rotation 0 1 0 3.1415919999999997
+  translation 1.77 2.43 0.375
+  rotation 0 0 1 3.1415919999999997
   name "box(3)"
-  size 0.2 0.75 0.18
+  size 0.2 0.18 0.75
   appearance CorrugatedMetal {
     textureTransform TextureTransform {
       scale 0.7 0.7
@@ -279,12 +281,12 @@ SolidBox {
   }
 }
 FireExtinguisher {
-  translation -0.75771 0 -1.79
-  rotation 0 1 0 -2.8797933071795865
+  translation -0.75771 1.79 0
+  rotation 0 0 1 -2.8797933071795865
 }
 UR3e {
-  translation 1.30296 0.91 -0.079391
-  rotation 1 0 0 -1.5707963071795863
+  translation 1.30296 0.079391 0.91
+  rotation 0 1 0 0
   controller "ure_can_grasper"
   controllerArgs [
     "3"
@@ -300,8 +302,8 @@ UR3e {
   ]
 }
 UR5e {
-  translation 0 0.61 0
-  rotation -0.5773502691896258 -0.5773502691896258 -0.5773502691896258 2.094395
+  translation 0 0 0.61
+  rotation 5.67193e-08 2.39745e-09 -1 1.5708
   controller "ure_can_grasper"
   selfCollision FALSE
   toolSlot [
@@ -314,8 +316,8 @@ UR5e {
   ]
 }
 UR10e {
-  translation -0.56 0.61 0.1
-  rotation 0.5773502691896258 0.5773502691896258 0.5773502691896258 -2.094395307179586
+  translation -0.56 -0.1 0.61
+  rotation 4.66309e-07 -7.19235e-09 1 -1.5707953071795862
   controller "ure_can_grasper"
   selfCollision FALSE
   toolSlot [
@@ -328,9 +330,9 @@ UR10e {
   ]
 }
 ConveyorBelt {
-  translation 3.18 0 1.05
-  rotation 0 1 0 3.141592
-  size 8 0.6 0.7
+  translation 3.18 -1.05 0
+  rotation 0 0 1 3.141592
+  size 8 0.7 0.6
   appearance CorrugatedMetal {
     textureTransform TextureTransform {
       scale 6 3.1
@@ -340,8 +342,8 @@ ConveyorBelt {
   speed 0.2
 }
 ConveyorBelt {
-  translation 1.77 0.75 -2.55
-  rotation 0 1 0 -1.5707973071795864
+  translation 1.77 2.55 0.75
+  rotation 0 0 1 -1.5707973071795864
   name "conveyor belt(2)"
   size 10 0.15 0.15
   appearance CorrugatedMetal {
@@ -353,9 +355,10 @@ ConveyorBelt {
   speed 0.2
 }
 ConveyorBelt {
-  translation 0 0 -0.69
+  translation 0 0.69 0
+  rotation 0 1 0 0
   name "conveyor belt(1)"
-  size 13 0.25 0.5
+  size 13 0.5 0.25
   appearance CorrugatedMetal {
     textureTransform TextureTransform {
       scale 6 3.1
@@ -367,91 +370,91 @@ ConveyorBelt {
   timer 90
 }
 PlasticCrate {
-  translation 0.22 0.25 -0.68
+  translation 0.22 0.68 0.25
   size 0.6 0.4 0.45
   mass 1
 }
 PlasticCrate {
-  translation -0.41 0.25 -0.68
+  translation -0.41 0.68 0.25
   name "plastic crate(1)"
   size 0.6 0.4 0.45
   mass 1
 }
 PlasticCrate {
-  translation -1.04 0.26 -0.68
+  translation -1.04 0.68 0.26
   name "plastic crate(2)"
   size 0.6 0.4 0.45
   mass 1
 }
 PlasticCrate {
-  translation -1.67 0.26 -0.68
+  translation -1.67 0.68 0.26
   name "plastic crate(3)"
   size 0.6 0.4 0.45
   mass 1
 }
 PlasticCrate {
-  translation -2.31 0.26 -0.68
+  translation -2.31 0.68 0.26
   name "plastic crate(4)"
   size 0.6 0.4 0.45
   mass 1
 }
 Can {
-  translation 1.77 0.96 -2.67
+  translation 1.77 2.67 0.96
   name "can(14)"
 }
 Can {
-  translation 1.77 0.96 -3.8
+  translation 1.77 3.8 0.96
   name "can(15)"
 }
 Can {
-  translation 1.77 0.96 -4.7
+  translation 1.77 4.7 0.96
   name "can(16)"
 }
 Can {
-  translation 1.77 0.96 -5.6
+  translation 1.77 5.6 0.96
   name "can(17)"
 }
 Can {
-  translation 1.77 0.96 -6.5
+  translation 1.77 6.5 0.96
   name "can(18)"
 }
 Can {
-  translation 1.77 0.96 -7.4
+  translation 1.77 7.4 0.96
   name "can(19)"
 }
 Can {
-  translation 0.7 0.66 0.83
+  translation 0.7 -0.83 0.66
   name "can(13)"
 }
 Can {
-  translation 1.4 0.66 1.285
+  translation 1.4 -1.285 0.66
   name "can(4)"
 }
 Can {
-  translation 2.1 0.66 0.83
+  translation 2.1 -0.83 0.66
   name "can(1)"
 }
 Can {
-  translation 2.49 0.66 1.285
+  translation 2.49 -1.285 0.66
   name "can(5)"
 }
 Can {
-  translation 3.5 0.66 0.83
+  translation 3.5 -0.83 0.66
   name "can(2)"
 }
 Can {
-  translation 3.9 0.66 1.285
+  translation 3.9 -1.285 0.66
   name "can(6)"
 }
 Can {
-  translation 4.9 0.66 0.83
+  translation 4.9 -0.83 0.66
   name "can(3)"
 }
 Can {
-  translation 5.4 0.66 1.285
+  translation 5.4 -1.285 0.66
   name "can(7)"
 }
 Can {
-  translation 6.3 0.66 0.83
+  translation 6.3 -0.83 0.66
   name "can(8)"
 }

--- a/projects/robots/universal_robots/worlds/ure.wbt
+++ b/projects/robots/universal_robots/worlds/ure.wbt
@@ -52,21 +52,25 @@ WoodenChair {
   translation 2.921084 1.648051 0
   rotation 0 0 1 2.0944
 }
-Monitor {
-  translation 2.520237 2.108887 0.7
-  rotation 0 0 1 -2.8797933071795865
+Transform {
+  translation 2.52024 2.10889 0.796
+  rotation 0 0 1 -1.3089953071795861
+  children [
+    Monitor {
+    }
+  ]
 }
 Keyboard {
-  translation 2.594212 1.8802 0.7
-  rotation 0 0 1 -2.8797933071795865
+  translation 2.59421 1.8802 0.8
+  rotation 0 0 1 1.8326
 }
 DesktopComputer {
   translation 2.331033 2.125086 0
   rotation 0 0 -1 1.5708
 }
 ComputerMouse {
-  translation 2.94663 1.914183 0.7
-  rotation 0 0 1 2.879793
+  translation 2.90217 1.90622 0.81
+  rotation 0 0 -1 -1.5707953071795862
   mass 0
 }
 Table {
@@ -86,15 +90,16 @@ Table {
 }
 OfficeTelephone {
   translation -1.34381 -0.209288 0.8
-  rotation 0 0 1 -0.7853983071795865
+  rotation 0 0 1 -2.3561953071795863
   enablePhysics FALSE
 }
 Wrench {
   translation -1.23886 -0.5886 0.8
-  rotation 0 0 1 2.094395
+  rotation 0 0 1 -2.6179953071795863
 }
 Hammer {
   translation -1.60381 -0.359288 0.81
+  rotation 0 0 1 1.5708
 }
 PlatformCart {
   translation 0.927687 1.793317 0
@@ -180,7 +185,8 @@ Wall {
   }
 }
 Transform {
-  translation 1.77 2.68 1.05
+  translation 1.77 2.67 1.05
+  rotation 1 0 0 1.5707996938995747
   children [
     Shape {
       appearance PBRAppearance {

--- a/projects/samples/devices/worlds/track.wbt
+++ b/projects/samples/devices/worlds/track.wbt
@@ -16,15 +16,15 @@ WorldInfo {
   ]
 }
 Viewpoint {
-  orientation -0.26049186253770856 0.5404381105682231 0.8000441476550434 1.0844758388285622
-  position -1.6836762676731991 -2.135293984444971 1.9550392122629308
+  orientation -0.27944964460392896 0.49890451389109725 0.8203671020645731 1.2004332121164287
+  position -1.5887779006255514 -2.537765768998335 2.138278352355133
 }
 TexturedBackground {
 }
 TexturedBackgroundLight {
 }
 RectangleArena {
-  rotation 1 0 0 1.5707963267948966
+  rotation 0 0 1 1.5707963267948966
   floorSize 2 2
 }
 DEF TRACKED_ROBOT Robot {
@@ -43,7 +43,7 @@ DEF TRACKED_ROBOT Robot {
     }
     DEF LEFT_TRACK Track {
       translation 0 0 -0.07
-      rotation 1 0 0 -1.5707953071795862
+      rotation -1 0 0 1.5707963267948966
       scale 0.5 0.5 0.5
       children [
         DEF WHEEL1 TrackWheel {
@@ -51,7 +51,7 @@ DEF TRACKED_ROBOT Robot {
           radius 0.092
           children [
             DEF TRACK_WHEEL_BIG Transform {
-              rotation 1 0 0 1.5708
+              rotation -1 0 0 3.14158898037044
               children [
                 Shape {
                   appearance PBRAppearance {
@@ -85,7 +85,7 @@ DEF TRACKED_ROBOT Robot {
           radius 0.04
           children [
             DEF TRACK_WHEEL_SMALL Transform {
-              rotation 1 0 0 1.5708
+              rotation -1 0 0 3.14158898037044
               children [
                 Shape {
                   appearance PBRAppearance {
@@ -141,7 +141,7 @@ DEF TRACKED_ROBOT Robot {
       boundingObject DEF TRACK_BO Group {
         children [
           Transform {
-            translation 0 0 -0.009
+            translation 0 -5.510910596163089e-19 -0.009
             rotation 1 0 0 1.5707963267948966
             children [
               Box {
@@ -150,8 +150,8 @@ DEF TRACKED_ROBOT Robot {
             ]
           }
           Transform {
-            translation 0.237434 0 -0.0691798
-            rotation -0.9561245578940675 0.20715432627859082 -0.20715432627859096 -1.6156483647805284
+            translation 0.237434 -4.236041031782703e-18 -0.0691798
+            rotation 0.9561245578940676 -0.20715432627859096 0.20715432627859096 1.6156483647805284
             children [
               Box {
                 size 0.13 0.08 0.03
@@ -161,8 +161,8 @@ DEF TRACKED_ROBOT Robot {
             rotationStep 0.00261799
           }
           Transform {
-            translation -0.242803 0 -0.0708334
-            rotation -0.9596913501339254 -0.19873665046755137 0.19873665046755146 -1.6119282802823234
+            translation -0.242803 -4.337294829136207e-18 -0.0708334
+            rotation 0.9596913501339253 0.19873665046755137 -0.19873665046755137 1.6119282802823234
             children [
               Box {
                 size 0.13 0.08 0.03
@@ -172,8 +172,8 @@ DEF TRACKED_ROBOT Robot {
             rotationStep 0.00261799
           }
           Transform {
-            translation -0.302 0 0.017
-            rotation 1 0 0 -3.14158898038469
+            translation -0.302 1.0409497792752502e-18 0.017
+            rotation 1 0 0 1.570799999984025
             children [
               DEF WHEEL_BO Cylinder {
                 height 0.03
@@ -183,8 +183,8 @@ DEF TRACKED_ROBOT Robot {
             ]
           }
           Transform {
-            translation 0.288 0 0.017
-            rotation 1 0 0 -3.14158898038469
+            translation 0.288 1.0409497792752502e-18 0.017
+            rotation 1 0 0 1.570799999984025
             children [
               USE WHEEL_BO
             ]
@@ -231,7 +231,7 @@ DEF TRACKED_ROBOT Robot {
     }
     Track {
       translation 0 0 0.07
-      rotation 1 0 0 -1.5707953071795862
+      rotation -1 0 0 1.5707963267948966
       scale 0.5 0.5 0.5
       children [
         USE WHEEL1
@@ -266,7 +266,7 @@ DEF TRACKED_ROBOT Robot {
 }
 DEF CONVEYOR_BELT Robot {
   translation -0.6 -6.97909e-07 0.06
-  rotation 0.5773488553723222 0.5773509760969793 0.5773509760969793 2.094397223120449
+  rotation 0.577348855372322 0.577350976096979 0.577350976096979 2.094397223120449
   children [
     Shape {
       appearance DEF APP PBRAppearance {
@@ -280,7 +280,7 @@ DEF CONVEYOR_BELT Robot {
     }
     Track {
       translation 0 0.064 0
-      rotation 1 0 0 -1.5707953071795862
+      rotation -1 0 0 1.5707963267948966
       children [
         DEF BELT Shape {
           appearance PBRAppearance {

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -387,9 +387,9 @@ const WbContactProperties *WbSimulationCluster::fillSurfaceParameters(const WbSo
       contact->surface.mode = contact->surface.mode | dContactFDir1;
       WbVector3 forceDir(m(0, 0), m(1, 0), m(2, 0));
       forceDir.normalize();
-      contact->fdir1[0] = forceDir.x();
-      contact->fdir1[1] = forceDir.y();
-      contact->fdir1[2] = forceDir.z();
+      contact->fdir1[0] = forceDir.x() * (invertedSign ? -1 : 1);
+      contact->fdir1[1] = forceDir.y() * (invertedSign ? -1 : 1);
+      contact->fdir1[2] = forceDir.z() * (invertedSign ? -1 : 1);
     }
   }
   return contactProperties;

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -613,7 +613,7 @@ void WbTrack::prePhysicsStep(double ms) {
 
   // texture animation
   if (mTextureTransform) {
-    mTextureTransform->translate(0.001 * ms * mSurfaceVelocity * mTextureAnimationField->value());
+    mTextureTransform->translate(-0.001 * ms * mSurfaceVelocity * mTextureAnimationField->value());
     mTextureTransform->modifyWrenMaterial(mShape->wrenMaterial());
   }
 

--- a/tests/api/worlds/supervisor_node_set_joint_position.wbt
+++ b/tests/api/worlds/supervisor_node_set_joint_position.wbt
@@ -195,6 +195,7 @@ Robot {
   controller ""
 }
 UR5e {
+  rotation 1 0 0 4.712388966
   controller "supervisor_node_set_joint_position_ur5e"
   supervisor TRUE
   toolSlot [


### PR DESCRIPTION
- [x] (575) robots/universal_robots/protos/UR10e.proto
- [x] (576) robots/universal_robots/protos/UR3e.proto
- [x] (577) robots/universal_robots/protos/UR5e.proto
- [x] (230) projects/robots/universal_robots/worlds/ure.wbt

This PR also fixes a Track bug that existed even before R2021b. The tracks were not handling objects placed on top properly.

Before:
```
    <-- force
 _______________
|_______________|   

    <-- force
```

Now:
```
     force -->
 _______________
|_______________|    

    <-- force
```