### PR TITLE
Attempt to fix Window CI build

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -38,10 +38,10 @@ jobs:
       with:
          submodules: true
          fetch-depth: 15
-    - name: Install Visual Studio 10 and OpenJDK 16
+    - name: Install Visual Studio 10 and OpenJDK 17
       shell: powershell
       run: |
-        choco install --force openjdk
+        choco install openjdk17
         choco install visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |
@@ -49,7 +49,7 @@ jobs:
         export PYTHON37_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON38_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.8\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON39_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.9\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
-        echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-16.0.2' >> ~/.bash_profile
+        echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-17' >> ~/.bash_profile
         echo 'export PYTHON37_HOME='$PYTHON_INSTALLATION_FOLDER'3.7.'$PYTHON37_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME='$PYTHON_INSTALLATION_FOLDER'3.8.'$PYTHON38_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON39_HOME='$PYTHON_INSTALLATION_FOLDER'3.9.'$PYTHON39_REVISION'/x64' >> ~/.bash_profile
@@ -63,10 +63,6 @@ jobs:
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
     - name: Webots Package Creation
       run: |
-        printenv
-        ls "/C/Program Files/OpenJDK"
-        ls "/C/Program Files/OpenJDK/jdk-16.0.2"
-        ls /C/hostedtoolcache/windows
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Visual Studio 10 and OpenJDK 16
       shell: powershell
       run: |
-        choco install openjdk
+        choco install --force openjdk
         choco install visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -63,6 +63,9 @@ jobs:
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
     - name: Webots Package Creation
       run: |
+        printenv
+        ls /C/Program Files/OpenJDK
+        ls /C/Program Files/OpenJDK/jdk-16.0.2
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -64,8 +64,9 @@ jobs:
     - name: Webots Package Creation
       run: |
         printenv
-        ls /C/Program Files/OpenJDK
-        ls /C/Program Files/OpenJDK/jdk-16.0.2
+        ls "/C/Program Files/OpenJDK"
+        ls "/C/Program Files/OpenJDK/jdk-16.0.2"
+        ls /C/hostedtoolcache/windows
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -59,6 +59,9 @@ jobs:
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
     - name: Webots Package Creation
       run: |
+        printenv
+        ls /C/Program Files/OpenJDK
+        ls /C/Program Files/OpenJDK/jdk-16.0.2
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -60,8 +60,9 @@ jobs:
     - name: Webots Package Creation
       run: |
         printenv
-        ls /C/Program Files/OpenJDK
-        ls /C/Program Files/OpenJDK/jdk-16.0.2
+        ls "/C/Program Files/OpenJDK"
+        ls "/C/Program Files/OpenJDK/jdk-16.0.2"
+        ls /C/hostedtoolcache/windows
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -34,10 +34,10 @@ jobs:
          submodules: true
          fetch-depth: 15
          ref: develop
-    - name: Install Visual Studio 10 and OpenJDK 16
+    - name: Install Visual Studio 10 and OpenJDK 17
       shell: powershell
       run: |
-        choco install --force openjdk
+        choco install openjdk17
         choco install visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |
@@ -45,7 +45,7 @@ jobs:
         export PYTHON37_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.7\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON38_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.8\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
         export PYTHON39_REVISION=`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.9\.[0-9]\+$' | cut -c5- | sort -n | tail -n1`
-        echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-16.0.2' >> ~/.bash_profile
+        echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-17' >> ~/.bash_profile
         echo 'export PYTHON37_HOME='$PYTHON_INSTALLATION_FOLDER'3.7.'$PYTHON37_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON38_HOME='$PYTHON_INSTALLATION_FOLDER'3.8.'$PYTHON38_REVISION'/x64' >> ~/.bash_profile
         echo 'export PYTHON39_HOME='$PYTHON_INSTALLATION_FOLDER'3.9.'$PYTHON39_REVISION'/x64' >> ~/.bash_profile
@@ -59,10 +59,6 @@ jobs:
       run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
     - name: Webots Package Creation
       run: |
-        printenv
-        ls "/C/Program Files/OpenJDK"
-        ls "/C/Program Files/OpenJDK/jdk-16.0.2"
-        ls /C/hostedtoolcache/windows
         export WEBOTS_HOME=$GITHUB_WORKSPACE
         make distrib -j4
     - name: Deploy Webots Controller

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Visual Studio 10 and OpenJDK 16
       shell: powershell
       run: |
-        choco install openjdk
+        choco install --force openjdk
         choco install visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |

--- a/scripts/install/bash_profile.windows
+++ b/scripts/install/bash_profile.windows
@@ -2,7 +2,7 @@
 # Uncomment / edit the following environment variables when the corresponding software is installed #
 #####################################################################################################
 
-# export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-16.0.2                            # Optionally defines the path to Java home.
+# export JAVA_HOME=/C/Program\ Files/OpenJDK/jdk-17                                # Optionally defines the path to Java home.
 # export PYTHON37_HOME=/C/Program\ Files/Python37                                  # Optionally defines the path to Python 3.7 home.
 # export PYTHON38_HOME=/C/Program\ Files/Python38                                  # Optionally defines the path to Python 3.8 home.
 # export PYTHON39_HOME=/C/Program\ Files/Python39                                  # Optionally defines the path to Python 3.9 home.


### PR DESCRIPTION
It seems the openjdk chocolatey package was silently upgraded from version 16 to version 17 without notice. Hence the openjdk-16.0.2 folder was not existing any more, and that broke our build process. Since the openjdk16 package doesn't exist, I upgraded to openjdk17 with the hope it will be more stable than the plain openjdk package which may be upgraded again in the future to version 18 or so. I also updated the [wiki](https://github.com/cyberbotics/webots/wiki/Windows-Optional-Dependencies/_compare/65c2be9769423f9cd7325b4a212cd6f4f4f8f617).