### PR TITLE
Use stdout and stderr callbacks

### DIFF
--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -55,9 +55,12 @@ export default class Stream {
     let data = event.data;
     if (data.startsWith('robot:') || data.startsWith('robot window:'))
       return 0; // We need to keep this condition, otherwise the robot window messages will be printed as errors.
-    else if (data.startsWith('stdout:') || data.startsWith('stderr:')) {
-      console.log(data);
+    else if (data.startsWith('stdout:')) {
+      this._view.onstdout(data.substring('stdout:'.length));
       return 0;
+    } else if (data.startsWith('stderr:')) {
+      this._view.onstderr(data.substring('stderr:'.length));
+      return 0
     } else if (data.startsWith('world:')) {
       data = data.substring(data.indexOf(':') + 1).trim();
       let currentWorld = data.substring(0, data.indexOf(':')).trim();


### PR DESCRIPTION
**Description**
I saw the unused `onstdout` and `onstderr` callbacks in the webots.js view component. Probably they were intended to be used. 

**Related Issues**
#3711

**Tasks**
Unfortunately, currently the output with color is not wrapped properly, I already asked on stackoverflow why this is like it is (see https://stackoverflow.com/questions/69336052/console-log-with-color-doesnt-wrap-first-line).
If there is a fix for that problem, I will push it, otherwise, I would probably don't use colors in the default implementation of `onstdout` or `onstderr`.
