### PR TITLE
Fix mass calculation of Mesh nodes

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -15,7 +15,7 @@ Released on XX, XXth, 2021.
     - Fixed bug which made the points returned by `getPointCloud` python API inaccessible ([#3558](https://github.com/cyberbotics/webots/pull/3558)).
     - Fixed 'Convert to Base Node(s)' with textures defined by urls ([#3591](https://github.com/cyberbotics/webots/pull/3591)).
     - Fixed pickable state for cone and cylinder ([#3644](https://github.com/cyberbotics/webots/pull/3644)).
-    - Fixed mass calculation of Mesh nodes ([#3714](https://github.com/cyberbotics/webots/pull/3714)).
+    - Fixed mass calculation of Mesh nodes ([#3719](https://github.com/cyberbotics/webots/pull/3719)).
     - Fixed regression where the v3.3 (21 DoF) variant of the [Nao](../guide/nao.md) PROTO had no hands ([#3696](https://github.com/cyberbotics/webots/pull/3696)).
 
 ## Webots R2021b

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -15,6 +15,7 @@ Released on XX, XXth, 2021.
     - Fixed bug which made the points returned by `getPointCloud` python API inaccessible ([#3558](https://github.com/cyberbotics/webots/pull/3558)).
     - Fixed 'Convert to Base Node(s)' with textures defined by urls ([#3591](https://github.com/cyberbotics/webots/pull/3591)).
     - Fixed pickable state for cone and cylinder ([#3644](https://github.com/cyberbotics/webots/pull/3644)).
+    - Fixed mass calculation of Mesh nodes ([#3714](https://github.com/cyberbotics/webots/pull/3714)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/webots/nodes/utils/WbSolidUtilities.cpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.cpp
@@ -19,6 +19,7 @@
 #include "WbCylinder.hpp"
 #include "WbElevationGrid.hpp"
 #include "WbIndexedFaceSet.hpp"
+#include "WbMesh.hpp"
 #include "WbSphere.hpp"
 #include "WbTransform.hpp"
 
@@ -53,6 +54,9 @@ void WbSolidUtilities::setDefaultMass(dMass *m) {
 
 // The mass is supposed to be homogeneously spread over the body boundingObject
 void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double density, bool warning) {
+  if (!node)
+    return;
+
   const WbShape *const shape = dynamic_cast<WbShape *>(node);
   if (shape) {
     if (shape->geometry() == NULL)
@@ -167,16 +171,24 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
     return;
   }
 
-  WbIndexedFaceSet *const ifs = dynamic_cast<WbIndexedFaceSet *>(node);
-  if (ifs) {
-    dGeomID g = ifs->odeGeom();
+  WbTriangleMeshGeometry *const tmg = dynamic_cast<WbTriangleMeshGeometry *>(node);
+  if (tmg) {
+    QString name;
+    if (dynamic_cast<WbMesh *>(node))
+      name = "Mesh";
+    else if (dynamic_cast<WbIndexedFaceSet *>(node))
+      name = "IndexedFaceSet";
+    else
+      assert(0);
+
+    dGeomID g = tmg->odeGeom();
     // The trimesh failed to build, probably because of invalid faces
     if (g == NULL) {
       if (warning)
-        ifs->parsingInfo(
-          QObject::tr("The creation of the IndexedFaceSet physical boundaries failed because its geometry is not "
-                      "suitable for representing a bounded closed volume") +
-          defaultValues);
+        tmg->parsingInfo(QObject::tr("The creation of the {} physical boundaries failed because its geometry is not "
+                                     "suitable for representing a bounded closed volume")
+                           .arg(name) +
+                         defaultValues);
       setDefaultMass(&m);
       return;
     }
@@ -188,13 +200,13 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
     if (m.mass <= 0.0 || !dIsPositiveDefinite(m.I, 3)) {
       setDefaultMass(&m);
       if (warning)
-        ifs->parsingWarn(
-          QObject::tr("Mass properties computation failed for this IndexedFaceSet") + defaultValues +
+        tmg->parsingWarn(
+          QObject::tr("Mass properties computation failed for this {}").arg(name) + defaultValues +
           QObject::tr("Please check this geometry has no singularities and can suitably represent a bounded closed volume. "
                       "Note in particular that every triangle should appear only once with its 'outward' orientation."));
     }
     dMassAdd(mass, &m);
-    ifs->setOdeMass(&m);
+    tmg->setOdeMass(&m);
 
     return;
   }

--- a/src/webots/nodes/utils/WbSolidUtilities.cpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.cpp
@@ -185,7 +185,7 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
     // The trimesh failed to build, probably because of invalid faces
     if (g == NULL) {
       if (warning)
-        tmg->parsingInfo(QObject::tr("The creation of the {} physical boundaries failed because its geometry is not "
+        tmg->parsingInfo(QObject::tr("The creation of the %1 physical boundaries failed because its geometry is not "
                                      "suitable for representing a bounded closed volume")
                            .arg(name) +
                          defaultValues);
@@ -201,7 +201,7 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
       setDefaultMass(&m);
       if (warning)
         tmg->parsingWarn(
-          QObject::tr("Mass properties computation failed for this {}").arg(name) + defaultValues +
+          QObject::tr("Mass properties computation failed for this %1").arg(name) + defaultValues +
           QObject::tr("Please check this geometry has no singularities and can suitably represent a bounded closed volume. "
                       "Note in particular that every triangle should appear only once with its 'outward' orientation."));
     }


### PR DESCRIPTION
Related to https://github.com/cyberbotics/webots-projects/issues/7 and it may also (fix) https://github.com/cyberbotics/webots/issues/3577.

We don't handle the mass property when used with Mesh nodes, this PR fixes it.