### PR TITLE
Fix Laser intersecting transparent objects #3468

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -17,7 +17,7 @@ Released on XX, XXth, 2021.
     - Fixed pickable state for cone and cylinder ([#3644](https://github.com/cyberbotics/webots/pull/3644)).
     - Fixed mass calculation of Mesh nodes ([#3719](https://github.com/cyberbotics/webots/pull/3719)).
     - Fixed regression where the v3.3 (21 DoF) variant of the [Nao](../guide/nao.md) PROTO had no hands ([#3696](https://github.com/cyberbotics/webots/pull/3696)).
-	- Fixed Laser/Infra-red distance sensor hitting fully transparent objects. ([#3726] (https://github.com/cyberbotics/webots/pull/3726)).
+    - Fixed laser and infra-red distance sensors hitting fully transparent objects ([#3726](https://github.com/cyberbotics/webots/pull/3726)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -17,6 +17,7 @@ Released on XX, XXth, 2021.
     - Fixed pickable state for cone and cylinder ([#3644](https://github.com/cyberbotics/webots/pull/3644)).
     - Fixed mass calculation of Mesh nodes ([#3719](https://github.com/cyberbotics/webots/pull/3719)).
     - Fixed regression where the v3.3 (21 DoF) variant of the [Nao](../guide/nao.md) PROTO had no hands ([#3696](https://github.com/cyberbotics/webots/pull/3696)).
+	- Fixed Laser/Infra-red distance sensor hitting fully transparent objects. ([#3726] (https://github.com/cyberbotics/webots/pull/3726)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/docs/reference/distancesensor.md
+++ b/docs/reference/distancesensor.md
@@ -137,15 +137,18 @@ Two different methods are used for calculating the distance from an object.
 
 %figure "Summary of DistanceSensor types"
 
-| type (field)             | "generic" | "infra-red" | "sonar" | "laser" |
-| ------------------------ | --------- | ----------- | ------- | ------- |
-| numberOfRays (field)     | `>` 0     | `>` 0       | `>` 0   | 1       |
-| Distance calculation     | Average   | Average     | Nearest | Nearest |
-| gaussianWidth (field)    | Used      | Used        | Ignored | Ignored |
-| Sensitive to red objects | No        | Yes         | No      | No      |
-| Draws a red spot         | No        | No          | No      | Yes     |
+| type (field)               | "generic" | "infra-red" | "sonar" | "laser" |
+| -------------------------- | --------- | ----------- | ------- | ------- |
+| numberOfRays (field)       | `>` 0     | `>` 0       | `>` 0   | 1       |
+| Distance calculation       | Average   | Average     | Nearest | Nearest |
+| gaussianWidth (field)      | Used      | Used        | Ignored | Ignored |
+| Sensitive to red objects   | No        | Yes         | No      | No      |
+| Draws a red spot           | No        | No          | No      | Yes     |
+| Ignore transparent objects | No        | Yes         | No      | Yes     |
 
 %end
+
+In order for an transparent object to be ignored by the "laser" or "infra-red" distance sensors, its bounding box object must also have the transparency set to 1.0.
 
 ### Infra-Red Sensors
 

--- a/docs/reference/distancesensor.md
+++ b/docs/reference/distancesensor.md
@@ -148,7 +148,7 @@ Two different methods are used for calculating the distance from an object.
 
 %end
 
-In order for an transparent object to be ignored by the "laser" or "infra-red" distance sensors, its bounding box object must also have the transparency set to 1.0.
+A transparent object is not perceived by "laser" and "infra-red" distance sensors if its bounding object has transparency set to 1.0.
 
 ### Infra-Red Sensors
 

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -573,6 +573,10 @@ void WbDistanceSensor::rayCollisionCallback(WbGeometry *object, dGeomID rayGeom,
   if (!mSensor->isEnabled())
     return;
 
+  if (mRayType == LASER  && object->isTransparent()) {
+    return;
+  }
+
   for (int i = 0; i < mNRays; i++)
     if (rayGeom == mRays[i].geom()) {
       if (mRayType == GENERIC)

--- a/src/webots/nodes/WbDistanceSensor.cpp
+++ b/src/webots/nodes/WbDistanceSensor.cpp
@@ -573,8 +573,9 @@ void WbDistanceSensor::rayCollisionCallback(WbGeometry *object, dGeomID rayGeom,
   if (!mSensor->isEnabled())
     return;
 
-  if (mRayType == LASER  && object->isTransparent()) {
-    return;
+  if (object->isTransparent()) {
+    if (mRayType == LASER || mRayType == INFRA_RED)
+      return;
   }
 
   for (int i = 0; i < mNRays; i++)

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -402,6 +402,11 @@ void WbGeometry::setTransparent(bool isTransparent) {
   }
 }
 
+bool WbGeometry::isTransparent() const { 
+  return mIsTransparent; 
+}
+
+
 void WbGeometry::destroyWrenObjects() {
   if (areWrenObjectsInitialized()) {
     WbWrenOpenGlContext::makeWrenCurrent();

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -402,11 +402,6 @@ void WbGeometry::setTransparent(bool isTransparent) {
   }
 }
 
-bool WbGeometry::isTransparent() const { 
-  return mIsTransparent; 
-}
-
-
 void WbGeometry::destroyWrenObjects() {
   if (areWrenObjectsInitialized()) {
     WbWrenOpenGlContext::makeWrenCurrent();

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -129,7 +129,8 @@ public:
 
   // visibility
   void setTransparent(bool isTransparent);
-
+  bool isTransparent() const;
+  
 signals:
   void changed();
   void wrenObjectsCreated();

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -130,7 +130,7 @@ public:
   // visibility
   void setTransparent(bool isTransparent);
   bool isTransparent() const { return mIsTransparent; }
-  
+
 signals:
   void changed();
   void wrenObjectsCreated();

--- a/src/webots/nodes/WbGeometry.hpp
+++ b/src/webots/nodes/WbGeometry.hpp
@@ -129,7 +129,7 @@ public:
 
   // visibility
   void setTransparent(bool isTransparent);
-  bool isTransparent() const;
+  bool isTransparent() const { return mIsTransparent; }
   
 signals:
   void changed();


### PR DESCRIPTION
This pull-request fixes issue #3468
The change make Laser Distance sensor ignore transparent objects (Bounding Box).

What was done: 

* Added a isTransparent const function to the WbGeometry class.
* Added check ignore transparent objects in WbDistanceSensor::rayCollisionCallback when in Laser mode.

I think that the documentation section here should also be changed to reflect the new behavior.
https://cyberbotics.com/doc/reference/distancesensor?version=develop#distancesensor-types

Like adding a new line in the table describing the behavior.
Ignore Transparent Objects | No | No | No | Yes

Warning: 
You need to have the transparency set to 1.0 on the BoundingBox and the Child object to have the proper behavior.
Having only one of them set can lead to unnatural effects.

Extension to other Distance Sensors?
I guess the behavior for the other modes really depends on the interpretation of the Transparent flag here.
If it is defining an object as being glass for example, then Sonar and Infra-Red are likely able to detect that.

If it is air then it should probably be handled differently since other objects are likely able to bump into it.
