### PR TITLE
FLU: fix asymetric friction

### DIFF
--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -393,8 +393,8 @@ void WbBox::recomputeBoundingSphere() const {
 WbVector3 WbBox::computeFrictionDirection(const WbVector3 &normal) const {
   WbVector3 localNormal = normal * matrix().extracted3x3Matrix();
   // Find most probable face and return first friction direction in the local coordinate system
-  if ((fabs(localNormal[1]) > fabs(localNormal[0])) && (fabs(localNormal[1]) > fabs(localNormal[2])))
-    return WbVector3(0, 0, 1);
+  if ((fabs(localNormal[2]) > fabs(localNormal[0])) && (fabs(localNormal[2]) > fabs(localNormal[1])))
+    return WbVector3(1, 0, 0);
   else
-    return WbVector3(0, 1, 0);
+    return WbVector3(0, 0, 1);
 }

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -535,7 +535,7 @@ bool WbCylinder::shallExport() const {
 WbVector3 WbCylinder::computeFrictionDirection(const WbVector3 &normal) const {
   WbVector3 localNormal = normal * matrix().extracted3x3Matrix();
   // Find most probable face and return first friction direction in the local coordinate system
-  if ((fabs(localNormal[1]) > fabs(localNormal[0])) && (fabs(localNormal[1]) > fabs(localNormal[2])))  // top or bottom face
+  if ((fabs(localNormal[2]) > fabs(localNormal[0])) && (fabs(localNormal[2]) > fabs(localNormal[1])))  // top or bottom face
     return WbVector3(1, 0, 0);
   else  // side
     return WbVector3(0, 0, 1);

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -382,5 +382,5 @@ void WbPlane::recomputeBoundingSphere() const {
 ////////////////////////
 
 WbVector3 WbPlane::computeFrictionDirection(const WbVector3 &normal) const {
-  return WbVector3(0, -1, 0);
+  return WbVector3(1, 0, 0);
 }

--- a/tests/api/worlds/asymmetric_friction.wbt
+++ b/tests/api/worlds/asymmetric_friction.wbt
@@ -29,7 +29,7 @@ DirectionalLight {
 }
 DEF BOX1 Solid {
   translation 0.121931 -0.9 1.17269
-  rotation 0.18007204322882017 0.9803922353569098 -0.08003201921280896 -0.73
+  rotation -0.8570712869942254 0.38584912920333886 0.3413931143170397 1.86553
   children [
     Shape {
       geometry DEF BOX Box {
@@ -43,7 +43,7 @@ DEF BOX1 Solid {
 }
 DEF BOX2 Solid {
   translation -0.8 -0.9 0.7
-  rotation -0.15667697224959964 0.9858098253947791 -0.06026038932676636 0.864729
+  rotation -0.27484395543776663 0.7249438824601457 0.6315988975947736 2.68309
   children [
     Shape {
       geometry DEF BOX Box {
@@ -58,10 +58,9 @@ DEF BOX2 Solid {
 }
 DEF PLANE Solid {
   translation 0 -1.16 0
-  rotation 0.2371269169977198 0.9693986606783392 -0.06353787775963689 5.74384
+  rotation -0.7931261333066688 0.45791307696489164 0.40158006749657943 1.92612
   children [
     DEF PLANE Transform {
-      rotation 1 0 0 -1.57079632679
       children [
         Shape {
           geometry Plane {


### PR DESCRIPTION
The `computeFrictionDirection` was wrongly converted in #3510 

I discovered that the cylinder asymmetric friction was wrong when trying to run robots with mecanum wheel such as SummitXL or Youbot.
With some more extensive inspection I believe that Box and Plane were wrong too.
