### PR TITLE
Fix tests_sources on Windows (master branch)

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-10.15
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
           - os: windows-2019
-            DEPENDENCIES_INSTALLATION: "choco install cppcheck --version 2.2; choco install llvm --version 11.0.0; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: "choco install cppcheck; choco install llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-10.15
             DEPENDENCIES_INSTALLATION: "brew install clang-format cppcheck"
           - os: windows-2019
-            DEPENDENCIES_INSTALLATION: "choco install cppcheck; choco install llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck; choco install -y llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -366,7 +366,7 @@ bool WbSysInfo::isVirtualMachine() {
   __get_cpuid(0x1, &eax, &ebx, &ecx, &edx);
   // cppcheck-suppress shiftTooManyBitsSigned
   // cppcheck-suppress integerOverflow
-  if (ecx & (1 << 31)) {
+  if (ecx & ((unsigned int)1 << 31)) {
     virtualMachine = 1;
     return true;
   }

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -366,7 +366,7 @@ bool WbSysInfo::isVirtualMachine() {
   __get_cpuid(0x1, &eax, &ebx, &ecx, &edx);
   // cppcheck-suppress shiftTooManyBitsSigned
   // cppcheck-suppress integerOverflow
-  if (ecx & ((unsigned int)1 << 31)) {
+  if (ecx & (1 << 31)) {
     virtualMachine = 1;
     return true;
   }

--- a/src/webots/scene_tree/WbPhysicsViewer.cpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.cpp
@@ -189,12 +189,12 @@ void WbPhysicsViewer::updateCenterOfMass() {
     return;
 
   mSolid->updateGlobalCenterOfMass();
-  mCenterOfMass[LOCAL][RELATIVE] = mSolid->centerOfMass();
+  mCenterOfMass[LOCAL][RELATIVE_POSITION] = mSolid->centerOfMass();
   const WbMatrix4 &m = mSolid->matrix();
-  mCenterOfMass[LOCAL][ABSOLUTE] = m * mSolid->centerOfMass();
-  mCenterOfMass[GLOBAL][ABSOLUTE] = mSolid->globalCenterOfMass();
+  mCenterOfMass[LOCAL][ABSOLUTE_POSITION] = m * mSolid->centerOfMass();
+  mCenterOfMass[GLOBAL][ABSOLUTE_POSITION] = mSolid->globalCenterOfMass();
   const double s = 1.0 / mSolid->absoluteScale().x();
-  mCenterOfMass[GLOBAL][RELATIVE] = m.pseudoInversed(mCenterOfMass[GLOBAL][ABSOLUTE]) * (s * s);
+  mCenterOfMass[GLOBAL][RELATIVE_POSITION] = m.pseudoInversed(mCenterOfMass[GLOBAL][ABSOLUTE_POSITION]) * (s * s);
   if (mSolid->globalMass() != 0.0) {
     const WbVector3 &com = mCenterOfMass[mIncludingExcludingDescendants->currentIndex()][mRelativeAbsolute->currentIndex()];
     for (int i = 0; i < 3; ++i)
@@ -245,7 +245,7 @@ void WbPhysicsViewer::triggerPhysicsUpdates() {
 }
 
 void WbPhysicsViewer::updateCoordinatesSystem() {
-  if (mRelativeAbsolute->currentIndex() == RELATIVE)
+  if (mRelativeAbsolute->currentIndex() == RELATIVE_POSITION)
     mRelativeAbsolute->setToolTip(tr("Coordinates with respect to selected's solid frame"));
   else
     mRelativeAbsolute->setToolTip(tr("Coordinates with respect to world's frame"));

--- a/src/webots/scene_tree/WbPhysicsViewer.hpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.hpp
@@ -66,7 +66,8 @@ private:
   // Values
   WbVector3 mCenterOfMass[2][2];
 
-  enum ComboBoxIndex { RELATIVE = 0, ABSOLUTE = 1, LOCAL, GLOBAL };
+  enum { RELATIVE = 0, ABSOLUTE = 1 };
+  enum { LOCAL = 0, GLOBAL = 1 };
 
   // Updates
   void updateMass();

--- a/src/webots/scene_tree/WbPhysicsViewer.hpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.hpp
@@ -66,7 +66,7 @@ private:
   // Values
   WbVector3 mCenterOfMass[2][2];
 
-  enum ComboBoxIndex { LOCAL, GLOBAL, RELATIVE = 0, ABSOLUTE = 1 };
+  enum ComboBoxIndex { RELATIVE = 0, ABSOLUTE = 1, LOCAL, GLOBAL };
 
   // Updates
   void updateMass();

--- a/src/webots/scene_tree/WbPhysicsViewer.hpp
+++ b/src/webots/scene_tree/WbPhysicsViewer.hpp
@@ -66,8 +66,8 @@ private:
   // Values
   WbVector3 mCenterOfMass[2][2];
 
-  enum { RELATIVE = 0, ABSOLUTE = 1 };
-  enum { LOCAL = 0, GLOBAL = 1 };
+  enum CenterOfMassPosition { RELATIVE_POSITION = 0, ABSOLUTE_POSITION = 1 };
+  enum CenterOfMassCoordinateSystem { LOCAL = 0, GLOBAL = 1 };
 
   // Updates
   void updateMass();


### PR DESCRIPTION
This PR aims at fixing the tests_sources CI test on the master branch.
It seems the newest version of cppcheck has problems with the `RELATIVE` and `ABSOLUTE` keywords.