### PR TITLE
Add error message on connection timeout

### DIFF
--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -46,6 +46,7 @@ function onDisconnect() {
   ipInput.disabled = false;
   modeSelect.disabled = false;
   broadcast.disabled = false;
+  connectButton.disabled = false;
 }
 
 function disconnect() {

--- a/resources/web/wwi/Server.js
+++ b/resources/web/wwi/Server.js
@@ -58,7 +58,7 @@ export default class Server {
 
   onError() {
     document.getElementById('webotsProgress').style.display = 'none';
-    this._view.onclose()
+    this._view.onquit()
   }
 
   onOpen(event) {

--- a/resources/web/wwi/Server.js
+++ b/resources/web/wwi/Server.js
@@ -29,7 +29,7 @@ export default class Server {
       .then(response => response.text())
       .then(function(data) {
         if (data.startsWith('Error:')) {
-          document.getElementById('webotsProgress').style.display = 'none';
+          self.onError();
           let errorMessage = data.substring(6).trim();
           errorMessage = errorMessage.charAt(0).toUpperCase() + errorMessage.substring(1);
           alert('Session server error: ' + errorMessage);
@@ -50,10 +50,15 @@ export default class Server {
         };
       })
       .catch(error => {
-        console.error(error);
-        document.getElementById('webotsProgress').style.display = 'none';
+        this.onError()
         alert('Could not connect to session server');
+        console.error(error);
       });
+  }
+
+  onError() {
+    document.getElementById('webotsProgress').style.display = 'none';
+    this._view.onclose()
   }
 
   onOpen(event) {

--- a/resources/web/wwi/Server.js
+++ b/resources/web/wwi/Server.js
@@ -48,6 +48,11 @@ export default class Server {
         self.socket.onerror = (event) => {
           console.error('Cannot connect to the simulation server');
         };
+      })
+      .catch(error => {
+        console.error(error);
+        document.getElementById('webotsProgress').style.display = 'none';
+        alert('Could not connect to session server');
       });
   }
 


### PR DESCRIPTION
**Description**
When the simulation server is offline, we noticed that we don't get any errors message.

I fixed this issue in `server.js`, but I'm not sure if we should call `this._view.onquit()`, since it's also not called when the response from the session server starts with `Error:`: https://github.com/cyberbotics/webots/blob/53b60081c13e3b3f9dfee31fa4046c45dc870219/resources/web/wwi/Server.js#L31

What's your opinion on that @BenjaminDeleze ?