### PR TITLE
fix issue with python3X_path for Windows installation from sources

### DIFF
--- a/src/controller/Makefile
+++ b/src/controller/Makefile
@@ -54,15 +54,27 @@ ifeq ($(OSTYPE),windows)
 	@echo "#"
 	@echo "# Python 3.7 controller library ("$@")"
 	@echo "#"
+ifeq ($(PYTHON37_HOME),)
+	@echo -e "# \033[0;33mPython 3.7 not installed or 'PYTHON37_HOME' not set, skipping Python 3.7 API\033[0m"
+else
 	@+PATH="$(PYTHON37_HOME):$(PATH)" make -s -C python $@
+endif
 	@echo "#"
 	@echo "# Python 3.8 controller library ("$@")"
 	@echo "#"
+ifeq ($(PYTHON38_HOME),)
+	@echo -e "# \033[0;33mPython 3.8 not installed or 'PYTHON38_HOME' not set, skipping Python 3.8 API\033[0m"
+else
 	@+PATH="$(PYTHON38_HOME):$(PATH)" make -s -C python $@
+endif
 	@echo "#"
 	@echo "# Python 3.9 controller library ("$@")"
 	@echo "#"
+ifeq ($(PYTHON39_HOME),)
+	@echo -e "# \033[0;33mPython 3.9 not installed or 'PYTHON39_HOME' not set, skipping Python 3.9 API\033[0m"
+else
 	@+PATH="$(PYTHON39_HOME):$(PATH)" make -s -C python $@
+endif
 endif
 ifeq ($(OSTYPE),darwin)
 	@echo "#"


### PR DESCRIPTION
**Description**
Makefile of controller was failling because for Windows it tries to compile even if the `PYTHON3X_HOME` was not defined (for python 3.7, 3.8 or 3.9).

This PR add checks to avoid to compile if those paths are not defined.