### PR TITLE
Fix `StraightStairs` and tiago++ world

### DIFF
--- a/projects/objects/stairs/protos/StraightStairs.proto
+++ b/projects/objects/stairs/protos/StraightStairs.proto
@@ -111,12 +111,12 @@ PROTO StraightStairs [
           ]
           texCoordIndex [
             %< for (let n = 1; n <= nSteps; ++n) { >%
-              0 1 2 -1 0 2 3 -1
-              3 1 0 -1 3 2 1 -1
-              0 1 2 -1 0 2 3 -1
-              3 1 0 -1 3 2 1 -1
-              0 1 2 -1 0 2 3 -1
-              3 1 0 -1 3 2 1 -1
+              0 2 1 -1 0 3 2 -1
+              3 0 1 -1 3 1 2 -1
+              0 2 1 -1 0 3 2 -1
+              3 0 1 -1 3 1 2 -1
+              0 2 1 -1 0 3 2 -1
+              3 0 1 -1 3 1 2 -1
             %< } >%
           ]
         }
@@ -178,7 +178,7 @@ PROTO StraightStairs [
          const pAngle = Math.atan2(stairsRise, stairsRun);
     >%
       Solid {
-        translation %<= (stairsRun - stepSize.x) * 0.5 >% %<= (stepSize.y + stringerWidth) * -0.5 >% %<= stairsRise * 0.5 >% 
+        translation %<= (stairsRun - stepSize.x) * 0.5 >% %<= (stepSize.y + stringerWidth) * -0.5 >% %<= stairsRise * 0.5 >%
         children [
           DEF GEOM Shape {
             appearance IS stringerAppearance
@@ -194,7 +194,7 @@ PROTO StraightStairs [
         boundingObject USE GEOM
       }
       Solid {
-        translation %<= (stairsRun - stepSize.x) * 0.5 >% %<= (stepSize.y + stringerWidth) * 0.5 >% %<= stairsRise * 0.5 >% 
+        translation %<= (stairsRun - stepSize.x) * 0.5 >% %<= (stepSize.y + stringerWidth) * 0.5 >% %<= stairsRise * 0.5 >%
         children [
           USE GEOM
         ]

--- a/projects/robots/pal_robotics/tiago++/worlds/tiago++.wbt
+++ b/projects/robots/pal_robotics/tiago++/worlds/tiago++.wbt
@@ -341,7 +341,7 @@ StraightStairs {
   leftRail []
   rightRail [
     StraightStairsRail {
-      translation -0.02 -0.13 0
+      translation -0.02 0 -0.13
       run 3.84
       rise 2.5
       newelHeight 0.8


### PR DESCRIPTION
**Description**
The conversion of the `StraightStairs` PROTO was incorrect, resulting in wrong textures for the steps.

The staircase in tiago++ world also had a small mistake where the rail was not in the right position.

Before
![aa](https://user-images.githubusercontent.com/44834743/136055434-8d4de41c-9143-4698-9012-a42b1fb983a5.png)
After
![a](https://user-images.githubusercontent.com/44834743/136055472-1b60a03a-6666-487a-a4fa-f44598d72d44.png)



Before
![c](https://user-images.githubusercontent.com/44834743/136055207-9e4f42ae-8ea7-4cd4-a0f2-cdbf66188afd.png)
After
![d](https://user-images.githubusercontent.com/44834743/136055222-c83fafb8-3a6c-4ee9-8de1-5e400e34c0f8.png)
