### PR TITLE
FLU: Fix rotating lidar

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -197,7 +197,7 @@ void WbLidar::prePhysicsStep(double ms) {
     if (s)
       s->rotate(WbVector3(0.0, 0.0, angle));
     if (hasBeenSetup()) {
-      mWrenCamera->rotateYaw(angle);
+      mWrenCamera->rotateRoll(angle);
       mPreviousRotatingAngle = mCurrentRotatingAngle;
       mCurrentRotatingAngle += angle;
     }


### PR DESCRIPTION
The normal Lidar was converted correctly, but the rotating one was missing one rotation.