### PR TITLE
disable clang-format

### DIFF
--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -545,8 +545,10 @@ void WbVideoRecorder::createMpeg() {
     mScriptProcess = new QProcess();
     mScriptProcess->setProcessEnvironment(env);
     mScriptProcess->start("./" + mScriptPath, QStringList());
+    // clang-format off
     connect(mScriptProcess, (void (QProcess::*)(int, QProcess::ExitStatus)) & QProcess::finished, this,
             &WbVideoRecorder::terminateVideoCreation);
+    // clang-format on
     connect(mScriptProcess, &QProcess::readyReadStandardOutput, this, &WbVideoRecorder::readStdout);
     connect(mScriptProcess, &QProcess::readyReadStandardError, this, &WbVideoRecorder::readStderr);
   } else {


### PR DESCRIPTION
Linux and mac version of clang-format are different leading to test failure.