### PR TITLE
Fix node deletion from supervisor not refreshing scene tree

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -27,6 +27,7 @@ Released on XX, XXth, 2021.
     - Fixed incorrect node enumeration in Matlab API and missing `WB_MF_ROTATION` constant ([#3808](https://github.com/cyberbotics/webots/pull/3808)).
     - Fixed incorrect boundingSphere computation for ElevationGrid ([#3828](https://github.com/cyberbotics/webots/pull/3828)).
     - Fixed memory leak due to incorrect cleaning of [ImageTexture](imagetexture.md) nodes ([#3830](https://github.com/cyberbotics/webots/pull/3830)).
+    - Fixed bug where deleting a node from Supervisor did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -27,7 +27,7 @@ Released on XX, XXth, 2021.
     - Fixed incorrect node enumeration in Matlab API and missing `WB_MF_ROTATION` constant ([#3808](https://github.com/cyberbotics/webots/pull/3808)).
     - Fixed incorrect boundingSphere computation for ElevationGrid ([#3828](https://github.com/cyberbotics/webots/pull/3828)).
     - Fixed memory leak due to incorrect cleaning of [ImageTexture](imagetexture.md) nodes ([#3830](https://github.com/cyberbotics/webots/pull/3830)).
-    - Fixed bug where deleting a node from Supervisor did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
+    - Fixed bug where deleting a node from [Supervisor](supervisor.md) did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1525,6 +1525,12 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       unsigned int nodeId;
       stream >> nodeId;
       WbNode *node = WbNode::findNode(nodeId);
+
+      // as findNode might return the internal one, it's necessary to climb the ladder up to the protoParameterNode otherwise
+      // the scene tree will not be refreshed when deleting it
+      while (node && node->protoParameterNode() != NULL)
+        node = node->protoParameterNode();
+
       if (node) {
         if (node == mRobot)
           mShouldRemoveNode = true;

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1528,7 +1528,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
 
       // as findNode might return the internal one, it's necessary to climb the ladder up to the protoParameterNode otherwise
       // the scene tree will not be refreshed when deleting it
-      while (node && node->protoParameterNode() != NULL)
+      while (node && node->protoParameterNode())
         node = node->protoParameterNode();
 
       if (!WbNodeUtilities::isVisible(node)) {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1531,6 +1531,12 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       while (node && node->protoParameterNode() != NULL)
         node = node->protoParameterNode();
 
+      if (!WbNodeUtilities::isVisible(node)) {
+        mRobot->warn(
+          tr("Node '%1' is internal to a PROTO and therefore cannot be deleted from a Supervisor.").arg(node->modelName()));
+        return;
+      }
+
       if (node) {
         if (node == mRobot)
           mShouldRemoveNode = true;


### PR DESCRIPTION
**Description**
Fixes #3863.

Although node deletion using the "delete" button and node deletion from supervisor ultimately rely on a same call to `WbNodeOperations::deleteNode` in order to clear it, when deleting from supervisor the scene tree wasn't refreshed (i.e it didn't trigger `WbMultipleValue::itemRemoved` in `WbTreeItem`). The reason for the difference is that when deleting from keyboard the exposed scene tree node is actively selected [here](https://github.com/cyberbotics/webots/blob/d6a89d8f6ad9c6b8ac2f2dd822247082e2e1219a/src/webots/scene_tree/WbSceneTree.cpp#L426-L429) whereas when deleting from supervisor what is being referenced is the internal node to the PROTO.

The proposed fix climbs the ladder until a PROTO parameter is found (if any) before deleting.
Also, deletion of internal nodes from supervisor was restricted. Although it is not possible to select an internal node from the 3D view, one might get the nodeRef from methods like `getFromProtoDef`.

This world can be used for testing: [supervisor_remove.zip](https://github.com/cyberbotics/webots/files/7481758/supervisor_remove.zip)
