### PR TITLE
Fix auto-regeneration crash

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -28,6 +28,7 @@ Released on XX, XXth, 2021.
     - Fixed incorrect boundingSphere computation for ElevationGrid ([#3828](https://github.com/cyberbotics/webots/pull/3828)).
     - Fixed memory leak due to incorrect cleaning of [ImageTexture](imagetexture.md) nodes ([#3830](https://github.com/cyberbotics/webots/pull/3830)).
     - Fixed bug where deleting a node from [Supervisor](supervisor.md) did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
+    - Fixed crash caused by the auto-regeneration of a [Robot](robot.md) node ([#3869](https://github.com/cyberbotics/webots/pull/3869)).
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1082,7 +1082,7 @@ void WbView3D::setWorld(WbSimulationWorld *w) {
   foreach (WbRobot *const robot, robots) {
     if (robot->supervisor())
       connect(robot->supervisorUtilities(), &WbSupervisorUtilities::worldModified, this,
-              &WbView3D::handleWorldModificationFromSupervior);
+              &WbView3D::handleWorldModificationFromSupervisor);
   }
 
   // initialize matter handles size
@@ -2497,7 +2497,7 @@ void WbView3D::updateVirtualRealityHeadsetOverlay() {
   renderLater();
 }
 
-void WbView3D::handleWorldModificationFromSupervior() {
+void WbView3D::handleWorldModificationFromSupervisor() {
   // refresh only if simulation is paused (or stepped)
   const WbSimulationState *const sim = WbSimulationState::instance();
   if (sim->isPaused())

--- a/src/webots/gui/WbView3D.hpp
+++ b/src/webots/gui/WbView3D.hpp
@@ -253,7 +253,7 @@ private slots:
   void updateShadowState();
   void unleashPhysicsDrags();
   void onSelectionChanged(WbAbstractTransform *selectedAbstractTransform);
-  void handleWorldModificationFromSupervior();
+  void handleWorldModificationFromSupervisor();
 };
 
 #endif

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -381,8 +381,7 @@ void WbSupervisorUtilities::processImmediateMessages(bool blockRegeneration) {
     return;
 
   WbTemplateManager::instance()->blockRegeneration(false);
-  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
-  if (robots.contains(mRobot))  // only emit if robot still exists (FieldSetRequest could have regenerated it)
+  if (WbWorld::instance()->robots().contains(mRobot))  // only emit if robot still exists (FieldSetRequest could have regenerated it)
     emit worldModified();
 }
 

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -379,8 +379,8 @@ void WbSupervisorUtilities::processImmediateMessages(bool blockRegeneration) {
   mFieldSetRequests.clear();
   if (blockRegeneration)
     return;
-  WbTemplateManager::instance()->blockRegeneration(false);
   emit worldModified();
+  WbTemplateManager::instance()->blockRegeneration(false);
 }
 
 void WbSupervisorUtilities::postPhysicsStep() {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -381,7 +381,8 @@ void WbSupervisorUtilities::processImmediateMessages(bool blockRegeneration) {
     return;
 
   WbTemplateManager::instance()->blockRegeneration(false);
-  if (WbWorld::instance()->robots().contains(mRobot))  // only emit if robot still exists (FieldSetRequest could have regenerated it)
+  // only emit if robot still exists (FieldSetRequest could have regenerated it)
+  if (WbWorld::instance()->robots().contains(mRobot))
     emit worldModified();
 }
 

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -379,8 +379,11 @@ void WbSupervisorUtilities::processImmediateMessages(bool blockRegeneration) {
   mFieldSetRequests.clear();
   if (blockRegeneration)
     return;
-  emit worldModified();
+
   WbTemplateManager::instance()->blockRegeneration(false);
+  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
+  if (robots.contains(mRobot))  // only emit if robot still exists (FieldSetRequest could have regenerated it)
+    emit worldModified();
 }
 
 void WbSupervisorUtilities::postPhysicsStep() {


### PR DESCRIPTION
**Description**
Fixes: https://github.com/cyberbotics/webots/issues/3483

The process that leads to the crash is:
- Robot A is created when loading the world, being a supervisor, a connection is made between the signal `worldModified` and `handleWorldModificationFromSupervisor`.
- The controller uses a supervisor  `field_set_...` function to change an exposed parameter of the PROTO.
- When the controller is executed, during the execution of the [immediate messages](https://github.com/cyberbotics/webots/blob/1d3919e5212a1a9b2db580bcbe8a537771482506/src/webots/nodes/utils/WbSupervisorUtilities.cpp#L367-L384) a auto-regeneration is triggered, which results in the destruction of Robot A, and the creation of Robot B.
- After the regeneration, an emission of `worldModified` is triggered [here](https://github.com/cyberbotics/webots/blob/1d3919e5212a1a9b2db580bcbe8a537771482506/src/webots/nodes/utils/WbSupervisorUtilities.cpp#L383), however the sender of this emission no longer exists (Robot A) hence the crash

The proposed solution is to emit only if the sender robot (i.e the supervisor that invoked the `supervisor_set_...` function to begin with) still exists.

World that cause the crash: [lua_regen_crash.zip](https://github.com/cyberbotics/webots/files/7503479/lua_regen_crash.zip)

