### PR TITLE
Improve API of animation

### DIFF
--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -47,7 +47,7 @@ For more complex interaction with the web component, the following functions are
 * `active()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.
 * `close()`: close the current animation.
 * `setX3d(fileName)`: set the name of the x3d file for the next model to be loaded.
-  * `fileName`: the name of the x3d file.
+  * `fileName`: name of the x3d file.
 * `setJson(fileName)`: set the name of the json file for the next animation to be loaded.
   * `fileName`: the name of the json file.
 * `load(play, mobileDevice)`: load and play the animation.

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -38,7 +38,7 @@ Please refer to [this section](web-scene.md#how-to-embed-a-web-scene-in-your-web
 The web animation is played by a web component from the [WebotsAnimation.js] package called `webots-animation`.
 
 The following attributes are available:
-* `x3d`: the name of the .x3d file containing the animation world.
+* `x3d`: the name of the .x3d file containing the 3d model.
 * `json`: the name of the .json file containing the animation steps.
 * `autoplay`: 'true' or 'false' to determine if the animation should be played automatically. If `x3d` is set, the animation will be played by default.
 

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -40,7 +40,8 @@ The web animation is played by a web component from the [WebotsAnimation.js] pac
 The following attributes are available:
 * `x3d`: the name of the .x3d file containing the 3d model.
 * `json`: the name of the .json file containing the animation sequence.
-* `autoplay`: 'true' or 'false' to determine if the animation should be played automatically. If `x3d` is set, the animation will be played by default.
+* `autoplay`: 'true' or 'false' to determine if the animation should be played automatically.
+If `json` is set, the animation will be played by default.
 
 For more complex interaction with the web component, the following functions are available:
 * `active()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -46,7 +46,7 @@ If `json` is set, the animation will be played by default.
 For more complex interaction with the web component, the following functions are available:
 * `active()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.
 * `close()`: close the current animation.
-* `setX3d(fileName)`: set the name of the x3d file for the next animation to be loaded.
+* `setX3d(fileName)`: set the name of the x3d file for the next model to be loaded.
   * `fileName`: the name of the x3d file.
 * `setJson(fileName)`: set the name of the json file for the next animation to be loaded.
   * `fileName`: the name of the json file.

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -49,7 +49,7 @@ For more complex interaction with the web component, the following functions are
 * `setX3d(fileName)`: set the name of the x3d file for the next model to be loaded.
   * `fileName`: name of the x3d file.
 * `setJson(fileName)`: set the name of the json file for the next animation to be loaded.
-  * `fileName`: the name of the json file.
+  * `fileName`: name of the json file.
 * `load(play, mobileDevice)`: load and play the animation.
   * `play`: if false, the animation will be paused, otherwise it will be played.
   * `mobileDevice`: boolean variable specifying if the application is running on a mobile device.

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -39,7 +39,7 @@ The web animation is played by a web component from the [WebotsAnimation.js] pac
 
 The following attributes are available:
 * `x3d`: the name of the .x3d file containing the 3d model.
-* `json`: the name of the .json file containing the animation steps.
+* `json`: the name of the .json file containing the animation sequence.
 * `autoplay`: 'true' or 'false' to determine if the animation should be played automatically. If `x3d` is set, the animation will be played by default.
 
 For more complex interaction with the web component, the following functions are available:

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -37,16 +37,20 @@ Please refer to [this section](web-scene.md#how-to-embed-a-web-scene-in-your-web
 
 The web animation is played by a web component from the [WebotsAnimation.js] package called `webots-animation`.
 
-To play the animation automatically, the `playWhenReady` attribute of the web component has to be set to `true` before the loading of the page.
-
-By default, the name of the X3D and JSON files will be deduced from the HTTP URL, but the `title` attribute of the web component can be used to define a custom name.
+The following attributes are available:
+* `x3d`: the name of the .x3d file containing the animation world.
+* `json`: the name of the .json file containing the animation steps.
+* `autoplay`: 'true' or 'false' to determine if the animation should be played automatically. If `x3d` is set, the animation will be played by default.
 
 For more complex interaction with the web component, the following functions are available:
 * `active()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.
 * `close()`: close the current animation.
-* `setNames(name)`: set the name of both the JSON and X3D file for the next animation to be loaded.
-  * `name`: the name used by both file.
-* `play(mobileDevice)`: load and play the animation. If no filenames were specified, it will try to guess them from the HTTP URL or take the `title` attribute if present.
+* `setX3d(fileName)`: set the name of the x3d file for the next animation to be loaded.
+  * `fileName`: the name of the x3d file.
+* `setJson(fileName)`: set the name of the json file for the next animation to be loaded.
+  * `fileName`: the name of the json file.
+* `load(play, mobileDevice)`: load and play the animation.
+  * `play`: if false, the animation will be paused, otherwise it will be played.
   * `mobileDevice`: boolean variable specifying if the application is running on a mobile device.
 
 ### Limitations

--- a/resources/web/templates/x3d_playback.html
+++ b/resources/web/templates/x3d_playback.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <h1 style="height:5%">%title%</h1>
-    <webots-animation style="height:80%; display:block;" playWhenReady="true"></webots-animation>
+    <webots-animation style="height:80%; display:block;" x3d=%x3dName% json=%jsonName%></webots-animation>
     <p style="height:5%">If the animation is not loading correctly, please refer to the <a style='color: #5DADE2;' target:'_blank' href='https://cyberbotics.com/doc/guide/web-scene#remarks-on-the-used-technologies-and-their-limitations'>User Guide</a>
       it could be that your browser prevents local files CORS requests.</p>
     <p style="height:5%">%description%</p>

--- a/resources/web/wwi/AnimationSlider.js
+++ b/resources/web/wwi/AnimationSlider.js
@@ -23,6 +23,7 @@ export default class AnimationSlider extends HTMLElement {
 
     this._offset = 0; // use to center the floating time correctly
     this._isSelected = false;
+    this._shadowRoot.getElementById('slider').style.width = '0%'
   }
 
   _mouseDown(e) {

--- a/resources/web/wwi/WebotsAnimation.js
+++ b/resources/web/wwi/WebotsAnimation.js
@@ -66,8 +66,8 @@ export default class WebotsAnimation extends HTMLElement {
 
   load(play, mobileDevice) {
     if (typeof this._x3d === 'undefined') {
-	  console.error("No x3d file defined");
-	  return;
+	    console.error("No x3d file defined");
+	    return;
     }
     if (typeof this._view === 'undefined')
       this._view = new webots.View(this, mobileDevice);

--- a/resources/web/wwi/WebotsAnimation.js
+++ b/resources/web/wwi/WebotsAnimation.js
@@ -25,10 +25,10 @@ export default class WebotsAnimation extends HTMLElement {
       }`;
     document.head.appendChild(script);
     let x3d = this.getAttribute('x3d');
-	let json = this.getAttribute('json');
+    let json = this.getAttribute('json');
 
     if (x3d)
-	  this.setX3d(x3d);
+      this.setX3d(x3d);
     if (json)
       this.setJson(json);
 

--- a/resources/web/wwi/WebotsAnimation.js
+++ b/resources/web/wwi/WebotsAnimation.js
@@ -24,8 +24,8 @@ export default class WebotsAnimation extends HTMLElement {
         return prefix + path;
       }`;
     document.head.appendChild(script);
-    let x3d = this.getAttribute('x3d');
-    let json = this.getAttribute('json');
+    const x3d = this.getAttribute('x3d');
+    const json = this.getAttribute('json');
 
     if (x3d)
       this.setX3d(x3d);

--- a/resources/web/wwi/WebotsAnimation.js
+++ b/resources/web/wwi/WebotsAnimation.js
@@ -49,7 +49,7 @@ export default class WebotsAnimation extends HTMLElement {
     Module.onRuntimeInitialized = () => {
       Promise.all(promises).then(() => {
         if (typeof this._x3d !== 'undefined' && this._x3d !== '')
-          this.load(!(this.getAttribute('autoplay') && this.getAttribute('autoplay') === "false"));
+          this.load(!(this.getAttribute('autoplay') && this.getAttribute('autoplay') === 'false'));
       });
     };
     promises.push(this._load('https://git.io/glm-js.min.js'));

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -321,9 +321,10 @@ bool WbWorld::exportAsHtml(const QString &fileName, bool animation) const {
     templateValues << QPair<QString, QString>("%setAnimation%", setAnimation);
     templateValues << QPair<QString, QString>("%title%", titleString);
     templateValues << QPair<QString, QString>("%description%", infoString);
-    templateValues << QPair<QString, QString>("%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
-    templateValues << QPair<QString, QString>("%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
-
+    templateValues << QPair<QString, QString>(
+	  "%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
+    templateValues << QPair<QString, QString>(
+	  "%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
 
     if (cX3DMetaFileExport) {
       QString metaFilename = fileName;

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -322,9 +322,9 @@ bool WbWorld::exportAsHtml(const QString &fileName, bool animation) const {
     templateValues << QPair<QString, QString>("%title%", titleString);
     templateValues << QPair<QString, QString>("%description%", infoString);
     templateValues << QPair<QString, QString>(
-	    "%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
+      "%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
     templateValues << QPair<QString, QString>(
-	    "%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
+      "%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
 
     if (cX3DMetaFileExport) {
       QString metaFilename = fileName;

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -321,6 +321,9 @@ bool WbWorld::exportAsHtml(const QString &fileName, bool animation) const {
     templateValues << QPair<QString, QString>("%setAnimation%", setAnimation);
     templateValues << QPair<QString, QString>("%title%", titleString);
     templateValues << QPair<QString, QString>("%description%", infoString);
+    templateValues << QPair<QString, QString>("%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
+    templateValues << QPair<QString, QString>("%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
+
 
     if (cX3DMetaFileExport) {
       QString metaFilename = fileName;

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -322,9 +322,9 @@ bool WbWorld::exportAsHtml(const QString &fileName, bool animation) const {
     templateValues << QPair<QString, QString>("%title%", titleString);
     templateValues << QPair<QString, QString>("%description%", infoString);
     templateValues << QPair<QString, QString>(
-	  "%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
+	    "%x3dName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".x3d"));
     templateValues << QPair<QString, QString>(
-	  "%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
+	    "%jsonName%", fileName.split('/').last().replace(QRegExp(".html$", Qt::CaseInsensitive), ".json"));
 
     if (cX3DMetaFileExport) {
       QString metaFilename = fileName;


### PR DESCRIPTION
- Split the function `setNames` in `setX3d` and `setJson`
- Introduce the `autoplay` (true by default) attribute
- Introduce the `x3d` and `json` attribute. If the x3d attribute is not set, the animation will not be loaded
- Remove the feature allowing the animation player to guess its name from the html page
- Update the animation template accordingly
- Correct the animation slider such that it would be correct if `autoplay` is set to `false`
- Update the doc

The new files are already on the server to ease the tests