### PR TITLE
Fix lights cast shadow

### DIFF
--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -632,12 +632,12 @@ namespace wren {
       const float distance = glm::distance(boundingSphere.mCenter, positionalLight->position());
       const float radius = positionalLight->radius() + boundingSphere.mRadius;
       // Check if light is too far away
-      visible = true; /*(distance <= radius && (distance - boundingSphere.mRadius < 0 ||  // Light is inside the boundingSphere
-                                         positionalLight->attenuationConstant() +
-                                             (distance - boundingSphere.mRadius) *
-                                               (positionalLight->attenuationLinear() +
-                                                (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
-                                           255.0f));*/
+      visible = (distance <= radius && (distance - boundingSphere.mRadius < 0 ||  // Light is inside the boundingSphere
+                                        positionalLight->attenuationConstant() +
+                                            (distance - boundingSphere.mRadius) *
+                                              (positionalLight->attenuationLinear() +
+                                               (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
+                                          255.0f));
     }
     return visible;
   }

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -632,10 +632,12 @@ namespace wren {
       const float distance = glm::distance(boundingSphere.mCenter, positionalLight->position());
       const float radius = positionalLight->radius() + boundingSphere.mRadius;
       // Check if light is too far away
-      visible = (distance <= radius &&
-                 positionalLight->attenuationConstant() +
-                     distance * (positionalLight->attenuationLinear() + distance * positionalLight->attenuationQuadratic()) <
-                   255.0f);
+      visible = true; /*(distance <= radius && (distance - boundingSphere.mRadius < 0 ||  // Light is inside the boundingSphere
+                                         positionalLight->attenuationConstant() +
+                                             (distance - boundingSphere.mRadius) *
+                                               (positionalLight->attenuationLinear() +
+                                                (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
+                                           255.0f));*/
     }
     return visible;
   }

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -632,14 +632,14 @@ namespace wren {
       const float distance = glm::distance(boundingSphere.mCenter, positionalLight->position());
       const float radius = positionalLight->radius() + boundingSphere.mRadius;
       // Check if light is too far away
-      visible = (distance <= radius && (distance < boundingSphere.mRadius
-                                          ||  // Light is inside the boundingSphere, necessary because pow(distance -
-                                                // boundingSphere.mRadius, 2) can be very big in this case.
-                                        positionalLight->attenuationConstant() +
-                                            (distance - boundingSphere.mRadius) *
-                                              (positionalLight->attenuationLinear() +
-                                               (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
-                                          2000.0f));
+      visible = (distance <= radius &&
+                 (distance < boundingSphere.mRadius ||  // Light is inside the boundingSphere, necessary because pow(distance -
+                                                        // boundingSphere.mRadius, 2) can be very big in this case.
+                  positionalLight->attenuationConstant() +
+                      (distance - boundingSphere.mRadius) *
+                        (positionalLight->attenuationLinear() +
+                         (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
+                    2000.0f));
       // In the shaders, the attenuation is used as such:
       // attenuationFactor = 1/(attenuation[0] + distanceToLight * (attenuation[1] + distanceToLight * attenuation[2])
       // color = 1/attenuationFactor * color * ...

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -632,12 +632,20 @@ namespace wren {
       const float distance = glm::distance(boundingSphere.mCenter, positionalLight->position());
       const float radius = positionalLight->radius() + boundingSphere.mRadius;
       // Check if light is too far away
-      visible = (distance <= radius && (distance - boundingSphere.mRadius < 0 ||  // Light is inside the boundingSphere
+      visible = (distance <= radius && (distance - boundingSphere.mRadius <
+                                          0 ||  // Light is inside the boundingSphere, necessary because pow(distance -
+                                                // boundingSphere.mRadius, 2) can be very big in this case.
                                         positionalLight->attenuationConstant() +
                                             (distance - boundingSphere.mRadius) *
                                               (positionalLight->attenuationLinear() +
                                                (distance - boundingSphere.mRadius) * positionalLight->attenuationQuadratic()) <
-                                          255.0f));
+                                          2000.0f));
+      // In the shaders, the attenuation is used as such:
+      // attenuationFactor = 1/(attenuation[0] + distanceToLight * (attenuation[1] + distanceToLight * attenuation[2])
+      // color = 1/attenuationFactor * color * ...
+      // Due to this there is no well-defined upper bound for the attenuationFactor.
+      // 2000 is a trade-off value in which the remaining light is very weak but still visible. The light become really
+      // invisible around 8000.
     }
     return visible;
   }

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -632,8 +632,8 @@ namespace wren {
       const float distance = glm::distance(boundingSphere.mCenter, positionalLight->position());
       const float radius = positionalLight->radius() + boundingSphere.mRadius;
       // Check if light is too far away
-      visible = (distance <= radius && (distance - boundingSphere.mRadius <
-                                          0 ||  // Light is inside the boundingSphere, necessary because pow(distance -
+      visible = (distance <= radius && (distance < boundingSphere.mRadius
+                                          ||  // Light is inside the boundingSphere, necessary because pow(distance -
                                                 // boundingSphere.mRadius, 2) can be very big in this case.
                                         positionalLight->attenuationConstant() +
                                             (distance - boundingSphere.mRadius) *


### PR DESCRIPTION
**Description**

The lightning is not computed correctly when the `castShadow` option is set to `true` in a `Light`.

**Context**
In `city_night.wbt` the `streetLights` seems to go "off" when we press play. It is because the BMW car has its frontlights activated and they cast shadow.

The error came from the function `affectedByLight` in WREN that is called to determine if objects are illuminated. This function is called as soon as at least one light cast shadow.

This functions contained several mistakes that I will describe thereafter.

**Tasks**

- [x] The distance was calculated between the center of the boundingSphere and the light instead of beeing calculated from the nearest point of the object to the light. As it was too difficult to calculate the distance with the nearest point, I changed it to measure the distance from the surface of the boundingSphere to light. It will give some false positive but no false negative.
- [x] Due to the previous fix, I had to add an additionnal condition to ensure that if the light is in the boundingSphere of an object, it will illuminate it
- [x] The upper bound of the attenuationFactor was previously set to 255, which is not relevant anymore. In the shaders, the attenuation is used as below. Due to this there is no well-defined upper bound for the attenuationFactor. I set it to 2000, 2000 is a trade-off value in which the remaining light is very weak but still visible. The light become really invisible around 8000.
```
attenuationFactor = 1/(attenuation[0] + distanceToLight * (attenuation[1] + distanceToLight * attenuation[2])
color = 1/attenuationFactor * color * ...
```

- [x] Document the code. I am not sure of where I inserted the comments.