### PR TITLE
Add `none` to physics plugin selector window

### DIFF
--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -364,10 +364,12 @@ void WbExtendedStringEditor::select() {
   // add webots resources and default controllers/plugins
   items += defaultEntryList();
   items.sort();
-  if (mStringType == CONTROLLER) {
+
+  if (mStringType == CONTROLLER || mStringType == PHYSICS_PLUGIN)
     items.prepend("none");
+  if (mStringType == CONTROLLER)
     items.prepend("<extern>");
-  }
+
   items.removeDuplicates();
 
   // let the user choose from an item list


### PR DESCRIPTION
**Description**
Once set, it isn't possible to remove a physics plugin other than removing it from the world file.