### PR TITLE
Change Python installation detection for macOS

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -516,11 +516,10 @@ void WbController::setProcessEnvironment() {
 #ifdef __APPLE__
     QProcess process;
     process.setProcessEnvironment(env);
-    process.start(mPythonCommand, QStringList() << "-c"
-                                                << "import sys; print(sys.exec_prefix);");
+    process.start("which", QStringList() << mPythonCommand);
     process.waitForFinished();
     const QString output = process.readAll();
-    if (output.startsWith("/usr/local/Cellar"))
+    if (output.startsWith("/usr/local/Cellar/python@"))
       addToPathEnvironmentVariable(
         env, "PYTHONPATH", WbStandardPaths::controllerLibPath() + "python" + mPythonShortVersion + "_brew", false, true);
     else


### PR DESCRIPTION
**Description**
On some systems detecting a Python installation path gives incorrect result. In example:
```
/usr/local/Cellar/python@3.9/3.9.8/bin/python3.9 -c 'import sys; print(sys.exec_prefix)'
/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9
```

The solution is to not execute Python at all and just compare `mPythonCommand` against `/usr/local/Cellar`. In this case a user can explicitly declare the version they uses by setting it in Webots settings.

**Related Issues**
This fixes #3925 

