### PR TITLE
fix arccos boundaries

### DIFF
--- a/src/webots/maths/WbAxisAngle.hpp
+++ b/src/webots/maths/WbAxisAngle.hpp
@@ -37,6 +37,7 @@ public:
       .arg(WbPrecision::doubleToString(mAxis.z(), level))
       .arg(WbPrecision::doubleToString(mAngle, level));
   }
+
 private:
   WbVector3 mAxis;
   double mAngle;

--- a/src/webots/maths/WbAxisAngle.hpp
+++ b/src/webots/maths/WbAxisAngle.hpp
@@ -29,6 +29,14 @@ public:
 
   double angle() const { return mAngle; }
 
+  // text conversion
+  QString toString(WbPrecision::Level level = WbPrecision::Level::DOUBLE_MAX) const {
+    return QString("%1 %2 %3 %4")
+      .arg(WbPrecision::doubleToString(mAxis.x(), level))
+      .arg(WbPrecision::doubleToString(mAxis.y(), level))
+      .arg(WbPrecision::doubleToString(mAxis.z(), level))
+      .arg(WbPrecision::doubleToString(mAngle, level));
+  }
 private:
   WbVector3 mAxis;
   double mAngle;

--- a/src/webots/maths/WbMathsUtilities.hpp
+++ b/src/webots/maths/WbMathsUtilities.hpp
@@ -74,9 +74,9 @@ inline double WbMathsUtilities::normalizeAngle(double angle, double lastSpot = 0
 // If not then the behavior is similar to a clamped value.
 inline double WbMathsUtilities::clampedAcos(double value) {
   assert((fabs(value) < 1.0 + EPSILON) && "Value passed to clampedAcos out of range.");
-  if (value > 1.0)
+  if (value >= 1.0)
     return 0.0;
-  if (value < -1.0)
+  if (value <= -1.0)
     return M_PI;
   return acos(value);
 }
@@ -85,9 +85,9 @@ inline double WbMathsUtilities::clampedAcos(double value) {
 // If not then the behavior is similar to a clamped value.
 inline double WbMathsUtilities::clampedAsin(double value) {
   assert((fabs(value) < 1.0 + EPSILON) && "Value passed to clampedAsin out of range.");
-  if (value > 1.0)
+  if (value >= 1.0)
     return M_PI / 2;
-  if (value < -1.0)
+  if (value <= -1.0)
     return -M_PI / 2;
   return asin(value);
 }

--- a/src/webots/maths/WbMathsUtilities.hpp
+++ b/src/webots/maths/WbMathsUtilities.hpp
@@ -74,10 +74,10 @@ inline double WbMathsUtilities::normalizeAngle(double angle, double lastSpot = 0
 // If not then the behavior is similar to a clamped value.
 inline double WbMathsUtilities::clampedAcos(double value) {
   assert((fabs(value) < 1.0 + EPSILON) && "Value passed to clampedAcos out of range.");
-  if (value >= 1.0)
+  if (value > 1.0)
     return 0.0;
-  if (value <= -1.0)
-    return 2.0 * M_PI;
+  if (value < -1.0)
+    return M_PI;
   return acos(value);
 }
 
@@ -85,9 +85,9 @@ inline double WbMathsUtilities::clampedAcos(double value) {
 // If not then the behavior is similar to a clamped value.
 inline double WbMathsUtilities::clampedAsin(double value) {
   assert((fabs(value) < 1.0 + EPSILON) && "Value passed to clampedAsin out of range.");
-  if (value >= 1.0)
+  if (value > 1.0)
     return M_PI / 2;
-  if (value <= -1.0)
+  if (value < -1.0)
     return -M_PI / 2;
   return asin(value);
 }

--- a/src/webots/maths/WbRotation.hpp
+++ b/src/webots/maths/WbRotation.hpp
@@ -132,7 +132,7 @@ public:
   bool operator!=(const WbRotation &r) const { return mX != r.mX || mY != r.mY || mZ != r.mZ || mAngle != r.mAngle; }
 
   // text conversion
-  QString toString(WbPrecision::Level level) const {
+  QString toString(WbPrecision::Level level = WbPrecision::Level::DOUBLE_MAX) const {
     return QString("%1 %2 %3 %4")
       .arg(WbPrecision::doubleToString(mX, level))
       .arg(WbPrecision::doubleToString(mY, level))


### PR DESCRIPTION
**Description**

This PR is related to these two issues #3556 and #3915 and the PR #3741. The bug came from the `clampedAcos` function in `WbMathsUtilities.hpp`
The boundaries of acos are [0,pi] for the values between [-1,1]. 
So the clamp should happen for `value` ]-1,1[ and take the value 0 or pi. However, for performance reason we can clamp between [-1,1].

Otherwise, The `NaN` issue can be reproduced by sending a rotation exactly equals to M_PI [0, 0, 1,3.14159265358979323].


In addition, I added a `ToString` function to `WbAxisAngle` Class and a default precision to the `toString` function of `WbRotation` Class.