### PR TITLE
Fix rendering when switching from wireframe

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -29,6 +29,8 @@ Released on XX, XXth, 2021.
     - Fixed memory leak due to incorrect cleaning of [ImageTexture](imagetexture.md) nodes ([#3830](https://github.com/cyberbotics/webots/pull/3830)).
     - Fixed bug where deleting a node from [Supervisor](supervisor.md) did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
     - Fixed crash caused by the auto-regeneration of a [Robot](robot.md) node ([#3869](https://github.com/cyberbotics/webots/pull/3869)).
+    - Fixed rendering issue when Webots was started in wireframe mode and switched to plain rendering ([#3939](https://github.com/cyberbotics/webots/pull/3939)).
+
 
 ## Webots R2021b
 Released on July, 16th, 2021.

--- a/src/wren/TextureCubeMapBaker.cpp
+++ b/src/wren/TextureCubeMapBaker.cpp
@@ -328,6 +328,7 @@ namespace wren {
       glstate::setStencilTest(false);
       glstate::setColorMask(true, true, true, true);
       glstate::setCullFace(false);
+      glstate::setPolygonMode(GL_FILL);
 
       unsigned int brdfTextureGlName = Texture::generateNewTexture();
 


### PR DESCRIPTION
**Description**
The issue came from the brdf texture. This texture is only created once, so if we were starting webots in wireframe mode it was created only to be compatible with wireframe. Whereas if the brdf texture is create in plain rendering mode it is compatible for both mode.

To find this bug I used [RenderDoc](https://renderdoc.org/), it seems to be a very useful tool for digging into OpenGL issues.

**Related Issues**
Fix #3938 

Plain Rendering brdf          |  wireframe rendering brdf
:-------------------------:|:-------------------------:
![good_brdf](https://user-images.githubusercontent.com/25938827/142609347-b1473837-63c8-46df-bb3e-6b36bf0dde2e.png)| ![wrong_brdf](https://user-images.githubusercontent.com/25938827/142609370-3716ec05-cdc8-4b54-9c4f-9857ae369d86.png)