### PR TITLE
Enhancement of WebotsJS

### DIFF
--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -47,7 +47,7 @@ The attributes of `webots-view` are only evaluated once: when the page is loaded
 
 For more complex interaction with the web component, the following functions are available:
 * `hasAnimation()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.
-* `close()`: close the current animation. Note that if the `webots-view` is removed from the HTML page or `loadAnimation` is called, `close` will be automatically called.
+* `close()`: close the current animation. Note that if the `webots-view` element is removed from the HTML page or `loadAnimation` or `connect` is called, `close` will be automatically called.
 * `loadAnimation(model, animation, play, mobileDevice)`: load and play the animation.
   * `model`: name of the .x3d file.
   * `animation`: name of the .json file.

--- a/docs/guide/web-animation.md
+++ b/docs/guide/web-animation.md
@@ -47,8 +47,8 @@ The attributes of `webots-view` are only evaluated once: when the page is loaded
 
 For more complex interaction with the web component, the following functions are available:
 * `hasAnimation()`: return `true` if there is already a animation loaded by the web component, `false` otherwise.
-* `close()`: close the current animation.
-* `load(model, animation, play, mobileDevice)`: load and play the animation.
+* `close()`: close the current animation. Note that if the `webots-view` is removed from the HTML page or `loadAnimation` is called, `close` will be automatically called.
+* `loadAnimation(model, animation, play, mobileDevice)`: load and play the animation.
   * `model`: name of the .x3d file.
   * `animation`: name of the .json file.
   * `play`: if false, the animation will be paused, otherwise it will be played.

--- a/docs/guide/web-scene.md
+++ b/docs/guide/web-scene.md
@@ -59,16 +59,13 @@ It may occur that the rendering in the Webots application and in the exported We
       if (typeof webotsView === 'undefined') {
         webotsView = document.createElement('webots-view');
         webotsView.style = "height:80%; display:block;"
-        webotsView.id = "webotsView"
       }
       document.body.appendChild(webotsView)
 
-      if (!webotsView.hasAnimation())
-        webotsView.loadAnimation("model.x3d", "animation.json")
+      webotsView.loadAnimation("model.x3d", "animation.json")
     }
 
     function remove() {
-      webotsView.close();
       document.body.removeChild(webotsView);
     }
     ```

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -458,7 +458,7 @@ This is the API of the `webots-streaming` web component:
   * `isMobileDevice`: boolean variable specifying if the application is running on a mobile device.
   * `callback`: function to be executed once the simulation is ready.
   * `disconnectCallback`: function to be executed once the web scene is closed.
-* `disconnect()`: close the simulation web scene.
+* `close()`: close the simulation web scene. Note that if the `webots-view` is removed from the HTML page or `connect` is called, `close` will be automatically called.
 * `hideToolbar()`: hide the toolbar. Must be called after connect.
 * `showToolbar()`: show the toolbar. Must be called after connect. The toolbar is displayed by default.
 * `displayQuit(enable)`: specify is the quit button must be displayed on the toolbar. Must be called before connect. The quit button is displayed by default.

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -458,7 +458,7 @@ This is the API of the `webots-streaming` web component:
   * `isMobileDevice`: boolean variable specifying if the application is running on a mobile device.
   * `callback`: function to be executed once the simulation is ready.
   * `disconnectCallback`: function to be executed once the web scene is closed.
-* `close()`: close the simulation web scene. Note that if the `webots-view` is removed from the HTML page or `connect` is called, `close` will be automatically called.
+* `close()`: close the simulation web scene. Note that if the `webots-view` element is removed from the HTML page or `connect` or `loadAnimation` is called, `close` will be automatically called.
 * `hideToolbar()`: hide the toolbar. Must be called after connect.
 * `showToolbar()`: show the toolbar. Must be called after connect. The toolbar is displayed by default.
 * `displayQuit(enable)`: specify is the quit button must be displayed on the toolbar. Must be called before connect. The quit button is displayed by default.

--- a/docs/reference/light.md
+++ b/docs/reference/light.md
@@ -37,9 +37,9 @@ The darkness of a shadow depends on how the occluded part is lighted (either by 
 Activating the shadows of just one [Light](#light) can have a significant impact on the global rendering performance, particularly if the world contains either lots of objects or complex meshes.
 Some shadow issues can occurs in closed spaces.
 
-### limitation
+### Limitation
 
-Due to a performance issue in Firefox on Windows and macOS (see comment of this [issue](https://github.com/cyberbotics/webots/issues/2691))), the number of lights is limited to 48 lights of _each_ kind: [PointLight](pointlight.md), [SpotLight](spotlight.md), [DirectionalLight](directionallight.md).
+Due to a performance issue in Firefox on Windows and macOS (see comment of this [issue](https://github.com/cyberbotics/webots/issues/2691)), the number of lights is limited to 48 lights of _each_ kind: [PointLight](pointlight.md), [SpotLight](spotlight.md), [DirectionalLight](directionallight.md).
 
 However it is possible to support more lights (up to 256 of each) if needed. The following procedure explains how to increase the lights limit:
 

--- a/docs/reference/light.md
+++ b/docs/reference/light.md
@@ -36,3 +36,23 @@ Shadows are additive (Several lights can cast shadows).
 The darkness of a shadow depends on how the occluded part is lighted (either by an ambient light component or by another light).
 Activating the shadows of just one [Light](#light) can have a significant impact on the global rendering performance, particularly if the world contains either lots of objects or complex meshes.
 Some shadow issues can occurs in closed spaces.
+
+### limitation
+
+Due to a performance issue in Firefox on Windows and macOS (see comment of this [issue](https://github.com/cyberbotics/webots/issues/2691))), the number of lights is limited to 48 lights of _each_ kind: [PointLight](pointlight.md), [SpotLight](spotlight.md), [DirectionalLight](directionallight.md).
+
+However it is possible to support more lights (up to 256 of each) if needed. The following procedure explains how to increase the lights limit:
+
+- Build Webots from sources (instructions are available [here](https://github.com/cyberbotics/webots/wiki)).
+
+- Modify the number of lights of `gMaxActiveDirectionalLights`, `gMaxActiveDirectionalLights` and `gMaxActiveSpotLights` in `webots/src/wren/Constants.hpp`.
+
+- Modify the number of lights of `maxDirectionalLights`, `maxPointLights` and `maxSpotLights` in the following shaders:
+  - `webots/resources/wren/shaders/pbr.frag`
+  - `webots/resources/wren/shaders/pbr_stencil_diffuse_specular.frag`
+  - `webots/resources/wren/shaders/phong.frag`
+  - `webots/resources/wren/shaders/phong_stencil_ambient_emissive.frag`
+  - `webots/resources/wren/shaders/phong_stencil_diffuse_specular.frag`
+  - `webots/resources/wren/shaders/shadow_volume.vert`
+
+- Compile Webots again.

--- a/docs/reference/light.md
+++ b/docs/reference/light.md
@@ -39,7 +39,7 @@ Some shadow issues can occurs in closed spaces.
 
 ### Limitation
 
-Due to a performance issue in Firefox on Windows and macOS (see comment of this [issue](https://github.com/cyberbotics/webots/issues/2691)), the number of lights is limited to 48 lights of _each_ kind: [PointLight](pointlight.md), [SpotLight](spotlight.md), [DirectionalLight](directionallight.md).
+Due to a performance issue in Firefox on Windows and macOS (see comment of this [issue](https://github.com/cyberbotics/webots/issues/2691)), the number of lights is limited to 48 lights of _each_ kind: [PointLight](pointlight.md), [SpotLight](spotlight.md) and [DirectionalLight](directionallight.md).
 
 However it is possible to support more lights (up to 256 of each) if needed. The following procedure explains how to increase the lights limit:
 

--- a/resources/web/streaming_viewer/setup_viewer.js
+++ b/resources/web/streaming_viewer/setup_viewer.js
@@ -50,7 +50,7 @@ function onDisconnect() {
 }
 
 function disconnect() {
-  document.getElementsByTagName('webots-view')[0].disconnect();
+  document.getElementsByTagName('webots-view')[0].close();
 }
 
 init();

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -12,6 +12,12 @@ export default class Animation {
     this._gui = typeof gui === 'undefined' || gui === 'play' ? 'real_time' : 'pause';
     this._loop = typeof loop === 'undefined' ? true : loop;
     this._speed = 1;
+    this._view3d = scene.domElement;
+    for (let i = 0; i < this._view3d.childNodes.length; i++) {
+      const child = this._view3d.childNodes[i];
+      if (child.id === 'canvas')
+        this._canvas = child;
+    }
   };
 
   init(onReady) {
@@ -36,18 +42,17 @@ export default class Animation {
   }
 
   removePlayBar() {
-    const view3d = document.getElementById('view3d');
-    if (!view3d)
+    if (typeof this._view3d === 'undefined')
       return;
 
     if (typeof this._view.mouseEvents !== 'undefined' && typeof this._view.mouseEvents.hidePlayBar) {
       this._view.mouseEvents.hidePlayBar = undefined;
-      if (typeof this._view.mouseEvents.showPlayBar !== 'undefined')
+      if (typeof this._view.mouseEvents.showPlayBar !== 'undefined') {
         this._view.mouseEvents.showPlayBar();
+        this._view.mouseEvents.showPlayBar = undefined;
+      }
     }
 
-    this._view.mouseEvents.hidePlayBar = undefined;
-    this._view.mouseEvents.showPlayBar = undefined;
     document.removeEventListener('keydown', this.keydownRef);
     this.keydownRef = undefined;
     document.removeEventListener('sliderchange', this.sliderchangeRef);
@@ -56,29 +61,35 @@ export default class Animation {
     this.fullscreenRef = undefined;
     document.removeEventListener('mouseup', this.settingsRef);
     this.settingsRef = undefined;
-    if (document.querySelector('animation-slider')) {
-      document.querySelector('animation-slider').shadowRoot.getElementById('range').removeEventListener('mousemove', this.updateFloatingTimeRef);
+
+    if (typeof this._timeSlider !== 'undefined') {
+      this._timeSlider.shadowRoot.getElementById('range').removeEventListener('mousemove', this.updateFloatingTimeRef);
       this.updateFloatingTimeRef = undefined;
-      document.querySelector('animation-slider').shadowRoot.getElementById('range').removeEventListener('mouseleave', this.hideFloatingTimeRef);
+      this._timeSlider.shadowRoot.getElementById('range').removeEventListener('mouseleave', this.hideFloatingTimeRef);
       this.hideFloatingTimeRef = undefined;
-      document.querySelector('animation-slider').removeEventListeners();
+      this._timeSlider.removeEventListeners();
+      this._timeSlider = undefined;
     }
 
-    const gtaoPane = document.getElementById('gtao-pane');
-    if (gtaoPane)
-      view3d.removeChild(gtaoPane);
+    if (typeof this._gtaoPane !== 'undefined') {
+      this._view3d.removeChild(this._gtaoPane);
+      this._gtaoPane = undefined;
+    }
 
-    const speedPane = document.getElementById('speed-pane');
-    if (speedPane)
-      view3d.removeChild(speedPane);
+    if (typeof this._speedPane !== 'undefined') {
+      this._view3d.removeChild(this._speedPane);
+      this._speedPane = undefined;
+    }
 
-    const settingsPane = document.getElementById('settings-pane');
-    if (settingsPane)
-      view3d.removeChild(settingsPane);
+    if (typeof this._settingsPane !== 'undefined') {
+      this._view3d.removeChild(this._settingsPane);
+      this._settingsPane = undefined;
+    }
 
-    const playBar = document.getElementById('play-bar');
-    if (playBar)
-      view3d.removeChild(playBar);
+    if (typeof this.play_bar !== 'undefined') {
+      this._view3d.removeChild(this.play_bar);
+      this.play_bar = undefined;
+    }
 
     this._fullscreenButton = undefined;
     this._exitFullscreenButton = undefined;
@@ -152,7 +163,7 @@ export default class Animation {
     this._start = (new Date().getTime()) - Math.floor(this._data.basicTimeStep * this._step);
     this._updateAnimationState(requestedStep);
 
-    document.getElementById('time-slider').setTime(this._formatTime(this._data.frames[requestedStep].time));
+    this._timeSlider.setTime(this._formatTime(this._data.frames[requestedStep].time));
   }
 
   _updateAnimationState(requestedStep = undefined) {
@@ -232,7 +243,7 @@ export default class Animation {
       }
 
       if (automaticMove)
-        document.getElementById('time-slider').setValue(100 * this._step / this._data.frames.length);
+        this._timeSlider.setValue(100 * this._step / this._data.frames.length);
 
       this._previousStep = this._step;
       this._view.time = this._data.frames[this._step].time;
@@ -284,20 +295,20 @@ export default class Animation {
   }
 
   _showPlayBar() {
-    document.getElementById('play-bar').style.opacity = '1';
-    document.getElementById('canvas').style.cursor = 'auto';
+    this.play_bar.style.opacity = '1';
+    this._canvas.style.cursor = 'auto';
   }
 
   _hidePlayBar() {
     const isPlaying = document.getElementById('play-button').className === 'player-btn icon-pause';
-    const isSelected = document.getElementById('time-slider').selected();
+    const isSelected = this._timeSlider.selected();
 
     if (!isSelected && isPlaying &&
-    document.getElementById('settings-pane').style.visibility === 'hidden' &&
-    document.getElementById('gtao-pane').style.visibility === 'hidden' &&
-    document.getElementById('speed-pane').style.visibility === 'hidden') {
-      document.getElementById('play-bar').style.opacity = '0';
-      document.getElementById('canvas').style.cursor = 'none'; // Warning: it does not always work if chrome dev tools is open
+    this._settingsPane.style.visibility === 'hidden' &&
+    this._gtaoPane.style.visibility === 'hidden' &&
+    this._speedPane.style.visibility === 'hidden') {
+      this.play_bar.style.opacity = '0';
+      this._canvas.style.cursor = 'none'; // Warning: it does not always work if chrome dev tools is open
     }
   }
 
@@ -311,17 +322,17 @@ export default class Animation {
     if (event.srcElement.id === 'enable-shadows' || event.srcElement.id === 'playback-li' || event.srcElement.id === 'gtao-settings') // avoid to close the settings when modifying the shadows or the other options
       return;
 
-    if (document.getElementById('settings-pane') === null || document.getElementById('gtao-pane') === null || document.getElementById('speed-pane') === null)
+    if (typeof this._settingsPane === 'undefined' || typeof this._gtaoPane === 'undefined' || typeof this._speedPane === 'undefined')
       return;
-    if (event.target.id === 'settings-button' && document.getElementById('settings-pane').style.visibility === 'hidden' && document.getElementById('gtao-pane').style.visibility === 'hidden' && document.getElementById('speed-pane').style.visibility === 'hidden') {
-      document.getElementById('settings-pane').style.visibility = 'visible';
+    if (event.target.id === 'settings-button' && this._settingsPane.style.visibility === 'hidden' && this._gtaoPane.style.visibility === 'hidden' && this._speedPane.style.visibility === 'hidden') {
+      this._settingsPane.style.visibility = 'visible';
       document.getElementById('settings-button').style.transform = 'rotate(10deg)';
       const tooltips = document.getElementsByClassName('tooltip');
       for (let i of tooltips)
         i.style.visibility = 'hidden';
-    } else if (document.getElementById('settings-pane').style.visibility === 'visible' || document.getElementById('gtao-pane').style.visibility === 'visible' || document.getElementById('speed-pane').style.visibility === 'visible') {
-      document.getElementById('settings-pane').style.visibility = 'hidden';
-      if (document.getElementById('gtao-pane').style.visibility === 'hidden' && document.getElementById('speed-pane').style.visibility === 'hidden') {
+    } else if (this._settingsPane.style.visibility === 'visible' || this._gtaoPane.style.visibility === 'visible' || this._speedPane.style.visibility === 'visible') {
+      this._settingsPane.style.visibility = 'hidden';
+      if (this._gtaoPane.style.visibility === 'hidden' && this._speedPane.style.visibility === 'hidden') {
         document.getElementById('settings-button').style.transform = '';
         const tooltips = document.getElementsByClassName('tooltip');
         for (let i of tooltips)
@@ -329,8 +340,8 @@ export default class Animation {
       }
     }
 
-    document.getElementById('gtao-pane').style.visibility = 'hidden';
-    document.getElementById('speed-pane').style.visibility = 'hidden';
+    this._gtaoPane.style.visibility = 'hidden';
+    this._speedPane.style.visibility = 'hidden';
   }
 
   _resetViewpoint() {
@@ -340,9 +351,9 @@ export default class Animation {
 
   _changeSpeed(event) {
     this._speed = event.srcElement.id;
-    document.getElementById('speed-pane').style.visibility = 'hidden';
+    this._speedPane.style.visibility = 'hidden';
     document.getElementById('speed-display').innerHTML = this._speed === '1' ? 'Normal' : this._speed;
-    document.getElementById('settings-pane').style.visibility = 'visible';
+    this._settingsPane.style.visibility = 'visible';
     for (let i of document.getElementsByClassName('check-speed')) {
       if (i.id === 'c' + this._speed)
         i.innerHTML = '&check;';
@@ -353,20 +364,20 @@ export default class Animation {
   }
 
   _openSpeedPane() {
-    document.getElementById('settings-pane').style.visibility = 'hidden';
-    document.getElementById('speed-pane').style.visibility = 'visible';
+    this._settingsPane.style.visibility = 'hidden';
+    this._speedPane.style.visibility = 'visible';
   }
 
   _closeSpeedPane() {
-    document.getElementById('settings-pane').style.visibility = 'visible';
-    document.getElementById('speed-pane').style.visibility = 'hidden';
+    this._settingsPane.style.visibility = 'visible';
+    this._speedPane.style.visibility = 'hidden';
   }
 
   _changeGtao(event) {
     changeGtaoLevel(this._textToGtaoLevel(event.srcElement.id));
-    document.getElementById('gtao-pane').style.visibility = 'hidden';
+    this._gtaoPane.style.visibility = 'hidden';
     document.getElementById('gtao-display').innerHTML = event.srcElement.id;
-    document.getElementById('settings-pane').style.visibility = 'visible';
+    this._settingsPane.style.visibility = 'visible';
     for (let i of document.getElementsByClassName('check-gtao')) {
       if (i.id === 'c' + event.srcElement.id)
         i.innerHTML = '&check;';
@@ -378,13 +389,13 @@ export default class Animation {
   }
 
   _openGtaoPane() {
-    document.getElementById('settings-pane').style.visibility = 'hidden';
-    document.getElementById('gtao-pane').style.visibility = 'visible';
+    this._settingsPane.style.visibility = 'hidden';
+    this._gtaoPane.style.visibility = 'visible';
   }
 
   _closeGtaoPane() {
-    document.getElementById('settings-pane').style.visibility = 'visible';
-    document.getElementById('gtao-pane').style.visibility = 'hidden';
+    this._settingsPane.style.visibility = 'visible';
+    this._gtaoPane.style.visibility = 'hidden';
   }
 
   _gtaoLevelToText(number) {
@@ -408,12 +419,12 @@ export default class Animation {
   }
 
   _createPlayBar() {
-    const div = document.createElement('div');
-    div.id = 'play-bar';
-    document.getElementById('view3d').appendChild(div);
+    this.play_bar = document.createElement('div');
+    this.play_bar.id = 'play-bar';
+    this._view3d.appendChild(this.play_bar);
 
-    div.addEventListener('mouseover', () => this._showPlayBar());
-    div.addEventListener('mouseleave', _ => this._onMouseLeave(_));
+    this.play_bar.addEventListener('mouseover', () => this._showPlayBar());
+    this.play_bar.addEventListener('mouseleave', _ => this._onMouseLeave(_));
 
     const leftPane = document.createElement('div');
     leftPane.className = 'left-pane';
@@ -423,10 +434,10 @@ export default class Animation {
     rightPane.className = 'right-pane';
     rightPane.id = 'right-pane';
 
-    document.getElementById('play-bar').appendChild(leftPane);
-    document.getElementById('play-bar').appendChild(rightPane);
-    this._view.mouseEvents.hidePlayBar = this._hidePlayBar;
-    this._view.mouseEvents.showPlayBar = this._showPlayBar;
+    this.play_bar.appendChild(leftPane);
+    this.play_bar.appendChild(rightPane);
+    this._view.mouseEvents.hidePlayBar = () => this._hidePlayBar();
+    this._view.mouseEvents.showPlayBar = () => this._showPlayBar();
   }
 
   _createSlider() {
@@ -434,12 +445,12 @@ export default class Animation {
       window.customElements.define('animation-slider', AnimationSlider);
       Animation.sliderDefined = true;
     }
-    const timeSlider = document.createElement('animation-slider');
-    timeSlider.id = 'time-slider';
+    this._timeSlider = document.createElement('animation-slider');
+    this._timeSlider.id = 'time-slider';
     document.addEventListener('sliderchange', this.sliderchangeRef = _ => this._updateSlider(_));
-    document.getElementById('play-bar').appendChild(timeSlider);
-    document.querySelector('animation-slider').shadowRoot.getElementById('range').addEventListener('mousemove', this.updateFloatingTimeRef = _ => this._updateFloatingTimePosition(_));
-    document.querySelector('animation-slider').shadowRoot.getElementById('range').addEventListener('mouseleave', this.hideFloatingTimeRef = _ => this._hideFloatingTimePosition(_));
+    this.play_bar.appendChild(this._timeSlider);
+    this._timeSlider.shadowRoot.getElementById('range').addEventListener('mousemove', this.updateFloatingTimeRef = _ => this._updateFloatingTimePosition(_));
+    this._timeSlider.shadowRoot.getElementById('range').addEventListener('mouseleave', this.hideFloatingTimeRef = _ => this._hideFloatingTimePosition(_));
   }
 
   _createPlayButton() {
@@ -493,7 +504,7 @@ export default class Animation {
         offset = 0;
     }
 
-    document.getElementById('time-slider').setOffset(offset);
+    this._timeSlider.setOffset(offset);
   }
 
   _createSettings() {
@@ -514,16 +525,16 @@ export default class Animation {
   }
 
   _createSettingsPane() {
-    const settingsPane = document.createElement('div');
-    settingsPane.className = 'settings-pane';
-    settingsPane.id = 'settings-pane';
-    settingsPane.style.visibility = 'hidden';
+    this._settingsPane = document.createElement('div');
+    this._settingsPane.className = 'settings-pane';
+    this._settingsPane.id = 'settings-pane';
+    this._settingsPane.style.visibility = 'hidden';
     document.addEventListener('mouseup', this.settingsRef = _ => this._changeSettingsPaneVisibility(_));
-    document.getElementById('view3d').appendChild(settingsPane);
+    this._view3d.appendChild(this._settingsPane);
 
     const settingsList = document.createElement('ul');
     settingsList.id = 'settings-list';
-    document.getElementById('settings-pane').appendChild(settingsList);
+    this._settingsPane.appendChild(settingsList);
 
     this._createResetViewpoint();
     this._createChangeShadows();
@@ -609,14 +620,14 @@ export default class Animation {
   }
 
   _createGtaoPane() {
-    const gtaoPane = document.createElement('div');
-    gtaoPane.className = 'settings-pane';
-    gtaoPane.id = 'gtao-pane';
-    gtaoPane.style.visibility = 'hidden';
-    document.getElementById('view3d').appendChild(gtaoPane);
+    this._gtaoPane = document.createElement('div');
+    this._gtaoPane.className = 'settings-pane';
+    this._gtaoPane.id = 'gtao-pane';
+    this._gtaoPane.style.visibility = 'hidden';
+    this._view3d.appendChild(this._gtaoPane);
 
     const gtaoList = document.createElement('ul');
-    gtaoPane.appendChild(gtaoList);
+    this._gtaoPane.appendChild(gtaoList);
 
     let gtaoLevelLi = document.createElement('li');
     gtaoLevelLi.className = 'first-li';
@@ -686,14 +697,14 @@ export default class Animation {
   }
 
   _createSpeedPane() {
-    const speedPane = document.createElement('div');
-    speedPane.className = 'settings-pane';
-    speedPane.id = 'speed-pane';
-    speedPane.style.visibility = 'hidden';
+    this._speedPane = document.createElement('div');
+    this._speedPane.className = 'settings-pane';
+    this._speedPane.id = 'speed-pane';
+    this._speedPane.style.visibility = 'hidden';
 
     const speedList = document.createElement('ul');
-    speedPane.appendChild(speedList);
-    document.getElementById('view3d').appendChild(speedPane);
+    this._speedPane.appendChild(speedList);
+    this._view3d.appendChild(this._speedPane);
 
     let playbackLi = document.createElement('li');
     playbackLi.className = 'first-li';
@@ -772,9 +783,9 @@ export default class Animation {
   }
 
   _updateFloatingTimePosition(e) {
-    document.querySelector('animation-slider').shadowRoot.getElementById('floating-time').style.visibility = 'visible';
+    this._timeSlider.shadowRoot.getElementById('floating-time').style.visibility = 'visible';
 
-    const bounds = document.querySelector('animation-slider').shadowRoot.getElementById('range').getBoundingClientRect();
+    const bounds = this._timeSlider.shadowRoot.getElementById('range').getBoundingClientRect();
     let x = (e.clientX - bounds.left) / (bounds.right - bounds.left) * 100;
     if (x > 100)
       x = 100;
@@ -783,13 +794,13 @@ export default class Animation {
 
     const clampedValued = Math.min(x, 99); // set maximum value to get valid step index
     const requestedStep = Math.floor(this._data.frames.length * clampedValued / 100);
-    document.getElementById('time-slider').setTime(this._formatTime(this._data.frames[requestedStep].time));
+    this._timeSlider.setTime(this._formatTime(this._data.frames[requestedStep].time));
 
-    document.getElementById('time-slider').setFloatingTimePosition(e.clientX);
+    this._timeSlider.setFloatingTimePosition(e.clientX);
   }
 
   _hideFloatingTimePosition() {
-    document.querySelector('animation-slider').shadowRoot.getElementById('floating-time').style.visibility = '';
+    this._timeSlider.shadowRoot.getElementById('floating-time').style.visibility = '';
   }
 }
 

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -116,6 +116,8 @@ export default class Parser {
 
       if (typeof callback === 'function')
         callback();
+
+      console.timeEnd('Animation loaded in: ');
     });
   }
 

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -117,7 +117,7 @@ export default class Parser {
       if (typeof callback === 'function')
         callback();
 
-      console.timeEnd('Animation loaded in: ');
+      console.timeEnd('Loaded in: ');
     });
   }
 

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -7,7 +7,6 @@ export default class Stream {
     this.wsServer = wsServer + '/';
     this._view = view;
     this._onready = onready;
-    this.socket = null;
   }
 
   connect() {
@@ -24,8 +23,10 @@ export default class Stream {
   }
 
   close() {
-    if (this.socket)
+    if (typeof this.socket !== 'undefined') {
       this.socket.close();
+      this.soclet = undefined;
+    }
   }
 
   _onSocketOpen(event) {

--- a/resources/web/wwi/WebotsView.js
+++ b/resources/web/wwi/WebotsView.js
@@ -70,6 +70,23 @@ export default class WebotsView extends HTMLElement {
     promises.push(this._loadScript('https://cyberbotics.com/wwi/R2022a/wrenjs.js'));
   }
 
+  _closeWhenDOMElementRemoved() {
+    // https://stackoverflow.com/questions/52834774/dom-event-when-element-is-removed
+    let observer = new MutationObserver(() => {
+      if (!document.body.contains(this)) {
+        this.close();
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+  }
+
+  close() {
+    if (this._hasAnimation)
+      this.closeAnimation();
+    else if (typeof this._view !== 'undefined' && typeof this._view.stream !== 'undefined' && typeof this._view.stream.socket !== 'undefined')
+      this.disconnect();
+  }
   // Animation's functions
   loadAnimation(model, animation, play, isMobileDevice) {
     if (typeof model === 'undefined') {
@@ -78,9 +95,12 @@ export default class WebotsView extends HTMLElement {
     }
 
     if (!this.initializationComplete)
-      setTimeout(() => this.loadAnimation(model, animation, play, isMobileDevice), 1000);
+      setTimeout(() => this.loadAnimation(model, animation, play, isMobileDevice), 500);
     else {
-      console.time('Animation loaded in: ');
+      // terminate the previous activity if any
+      this.close();
+
+      console.time('Loaded in: ');
       this.animationCSS.disabled = false;
       this.streamingCSS.disabled = true;
 
@@ -92,15 +112,17 @@ export default class WebotsView extends HTMLElement {
       else
         this._view.setAnimation(animation, 'play', true);
       this._hasAnimation = true;
+      this._closeWhenDOMElementRemoved();
     }
   }
 
-  close() {
+  closeAnimation() {
     this._view.animation.pause();
     this._view.animation.removePlayBar();
     this._view.removeLabels();
     this._view.destroyWorld();
     this._hasAnimation = false;
+    this.innerHTML = null;
   }
 
   hasAnimation() {
@@ -121,21 +143,31 @@ export default class WebotsView extends HTMLElement {
     // This `streaming viewer` setups a broadcast streaming where the simulation is shown but it is not possible to control it.
     // For any other use, please refer to the documentation:
     // https://www.cyberbotics.com/doc/guide/web-simulation#how-to-embed-a-web-scene-in-your-website
-    this.animationCSS.disabled = true;
-    this.streamingCSS.disabled = false;
 
-    if (typeof this._view === 'undefined')
-      this._view = new webots.View(this, isMobileDevice);
-    this._view.broadcast = broadcast;
-    this._view.setTimeout(-1); // disable timeout that stops the simulation after a given time
+    if (!this.initializationComplete)
+      setTimeout(() => this.connect(server, mode, broadcast, isMobileDevice, callback, disconnectCallback), 500);
+    else {
+      // terminate the previous activity if any
+      this.close();
+      console.time('Loaded in: ');
 
-    this._disconnectCallback = disconnectCallback;
-    this._view.open(server, mode);
-    this._view.onquit = () => this.disconnect();
-    this._view.onready = _ => {
-      if (typeof callback === 'function')
-        callback();
-    };
+      this.animationCSS.disabled = true;
+      this.streamingCSS.disabled = false;
+
+      if (typeof this._view === 'undefined')
+        this._view = new webots.View(this, isMobileDevice);
+      this._view.broadcast = broadcast;
+      this._view.setTimeout(-1); // disable timeout that stops the simulation after a given time
+
+      this._disconnectCallback = disconnectCallback;
+      this._view.open(server, mode);
+      this._view.onquit = () => this.disconnect();
+      this._view.onready = _ => {
+        if (typeof callback === 'function')
+          callback();
+      };
+      this._closeWhenDOMElementRemoved();
+    }
   }
 
   disconnect() {

--- a/resources/web/wwi/WebotsView.js
+++ b/resources/web/wwi/WebotsView.js
@@ -83,9 +83,9 @@ export default class WebotsView extends HTMLElement {
 
   close() {
     if (this._hasAnimation)
-      this.closeAnimation();
+      this._closeAnimation();
     else if (typeof this._view !== 'undefined' && typeof this._view.stream !== 'undefined' && typeof this._view.stream.socket !== 'undefined')
-      this.disconnect();
+      this._disconnect();
   }
   // Animation's functions
   loadAnimation(model, animation, play, isMobileDevice) {
@@ -116,7 +116,7 @@ export default class WebotsView extends HTMLElement {
     }
   }
 
-  closeAnimation() {
+  _closeAnimation() {
     this._view.animation.pause();
     this._view.animation.removePlayBar();
     this._view.removeLabels();
@@ -161,7 +161,7 @@ export default class WebotsView extends HTMLElement {
 
       this._disconnectCallback = disconnectCallback;
       this._view.open(server, mode);
-      this._view.onquit = () => this.disconnect();
+      this._view.onquit = () => this._disconnect();
       this._view.onready = _ => {
         if (typeof callback === 'function')
           callback();
@@ -170,7 +170,7 @@ export default class WebotsView extends HTMLElement {
     }
   }
 
-  disconnect() {
+  _disconnect() {
     let exitFullscreenButton = document.getElementById('exit_fullscreenButton');
     if (exitFullscreenButton && exitFullscreenButton.style.display !== 'none')
       exitFullscreen();

--- a/resources/web/wwi/WebotsView.js
+++ b/resources/web/wwi/WebotsView.js
@@ -80,6 +80,7 @@ export default class WebotsView extends HTMLElement {
     if (!this.initializationComplete)
       setTimeout(() => this.loadAnimation(model, animation, play, isMobileDevice), 1000);
     else {
+      console.time('Animation loaded in: ');
       this.animationCSS.disabled = false;
       this.streamingCSS.disabled = true;
 

--- a/resources/web/wwi/WrenRenderer.js
+++ b/resources/web/wwi/WrenRenderer.js
@@ -31,7 +31,7 @@ export default class WrenRenderer {
 
       _wr_scene_render(_wr_scene_get_instance(), null, true);
     } catch (error) {
-      console.log('No Context');
+      console.err('No Context');
     }
   }
 
@@ -42,7 +42,7 @@ export default class WrenRenderer {
     try {
       _wr_scene_render(_wr_scene_get_instance(), null, true);
     } catch (error) {
-      console.log('No Context');
+      console.err('No Context');
     }
   }
 }

--- a/resources/web/wwi/WrenRenderer.js
+++ b/resources/web/wwi/WrenRenderer.js
@@ -31,7 +31,7 @@ export default class WrenRenderer {
 
       _wr_scene_render(_wr_scene_get_instance(), null, true);
     } catch (error) {
-      console.err('No Context');
+      console.error('No Context');
     }
   }
 
@@ -42,7 +42,7 @@ export default class WrenRenderer {
     try {
       _wr_scene_render(_wr_scene_get_instance(), null, true);
     } catch (error) {
-      console.err('No Context');
+      console.error('No Context');
     }
   }
 }

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -85,6 +85,7 @@ export default class X3dScene {
     }
 
     this.renderMinimal();
+    clearTimeout(this._renderingTimeout);
     this._loader = undefined;
     webots.currentView.runOnLoad = false;
   }

--- a/resources/wren/shaders/pbr.frag
+++ b/resources/wren/shaders/pbr.frag
@@ -3,9 +3,9 @@
 precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 in vec3 fragmentPosition;
 in vec3 fragmentNormal;

--- a/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/pbr_stencil_diffuse_specular.frag
@@ -3,9 +3,9 @@
 precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 in vec3 fragmentPosition;
 in vec3 fragmentNormal;

--- a/resources/wren/shaders/phong.frag
+++ b/resources/wren/shaders/phong.frag
@@ -3,9 +3,9 @@
 precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 const int mainTextureIndex = 0;
 const int penTextureIndex = 1;

--- a/resources/wren/shaders/phong_stencil_ambient_emissive.frag
+++ b/resources/wren/shaders/phong_stencil_ambient_emissive.frag
@@ -3,9 +3,9 @@
 precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 const int mainTextureIndex = 0;
 const int penTextureIndex = 1;

--- a/resources/wren/shaders/phong_stencil_diffuse_specular.frag
+++ b/resources/wren/shaders/phong_stencil_diffuse_specular.frag
@@ -3,9 +3,9 @@
 precision highp float;
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 const int mainTextureIndex = 0;
 const int penTextureIndex = 1;

--- a/resources/wren/shaders/shadow_volume.vert
+++ b/resources/wren/shaders/shadow_volume.vert
@@ -3,9 +3,9 @@
 invariant gl_Position;  // On low-end GPUs, position may slightly differ causing z-fighting issues between rendering passes.
 
 // These constants must be kept in sync with the values in Constants.hpp
-const int maxDirectionalLights = 256;
-const int maxPointLights = 256;
-const int maxSpotLights = 256;
+const int maxDirectionalLights = 48;
+const int maxPointLights = 48;
+const int maxSpotLights = 48;
 
 layout(location = 0) in vec4 vCoord;
 

--- a/src/wren/Constants.hpp
+++ b/src/wren/Constants.hpp
@@ -59,9 +59,9 @@ namespace wren {
   extern const primitive::Sphere gSphereInf;
 
   // Max. active lights per frame (needs to be kept in sync with the shaders)
-  const int gMaxActiveDirectionalLights = 256;
-  const int gMaxActivePointLights = 256;
-  const int gMaxActiveSpotLights = 256;
+  const int gMaxActiveDirectionalLights = 48;
+  const int gMaxActivePointLights = 48;
+  const int gMaxActiveSpotLights = 48;
 
   // OpenGL constants
   const int gMaxShaderTextures = 13;        // conservative, OpenGL 3.3 specification requires at least 16


### PR DESCRIPTION
**Description**

- [x] Clear the timeout of rendering once the world is destroyed (was producing a `no context` message).
- [x] Switch the `no context` from message to error.
- [x] Reduce the maximum number of light to 48 to fix the bug reported in #2691
- [x] Add mechanism to automatically close the view when removed from DOM  
  - [x] For animation
  - [x] For streaming
- [x] Add mechanism to auttomatically close the view before loading a new animation/connecting to a new server
- [x] Harmonize closing behaviour 