### PR TITLE
FLU: fix orthographic mode

### DIFF
--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -645,11 +645,13 @@ void WbView3D::setProjectionMode(WrCameraProjectionMode mode, bool updatePerspec
       WbActionManager::instance()->action(WbAction::ORTHOGRAPHIC_PROJECTION)->setChecked(true);
       if (mWorld) {
         mWorld->viewpoint()->updateOrthographicViewHeight();
+        wr_config_enable_shadows(false);  // No shadows in orthographic mode
         if (updatePerspective)
           mWorld->perspective()->setProjectionMode("ORTHOGRAPHIC");
       }
       break;
     default:
+      updateShadowState();
       if (updatePerspective && mWorld)
         mWorld->perspective()->setProjectionMode("PERSPECTIVE");
       WbActionManager::instance()->action(WbAction::PERSPECTIVE_PROJECTION)->setChecked(true);
@@ -984,7 +986,8 @@ void WbView3D::updateViewport() {
 }
 
 void WbView3D::updateShadowState() {
-  if (WbPreferences::instance()->value("OpenGL/disableShadows").toBool() == wr_config_are_shadows_enabled()) {
+  if (WbPreferences::instance()->value("OpenGL/disableShadows").toBool() == wr_config_are_shadows_enabled() &&
+      mWorld->viewpoint()->projectionMode() != WR_CAMERA_PROJECTION_MODE_ORTHOGRAPHIC) {
     wr_config_enable_shadows(!WbPreferences::instance()->value("OpenGL/disableShadows").toBool());
     renderLater();
   }

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -34,6 +34,7 @@
 #include "WbWrenRenderingContext.hpp"
 #include "WbWrenShaders.hpp"
 
+#include <wren/camera.h>
 #include <wren/gl_state.h>
 #include <wren/material.h>
 #include <wren/node.h>
@@ -235,6 +236,7 @@ void WbBackground::activate() {
 
   connect(mLuminosity, &WbSFDouble::changed, this, &WbBackground::updateLuminosity);
   connect(mSkyColor, &WbMFColor::changed, this, &WbBackground::updateColor);
+  connect(WbWorld::instance()->viewpoint(), &WbViewpoint::cameraModeChanged, this, &WbBackground::updateCubemap);
   for (int i = 0; i < 6; ++i) {
     connect(mUrlFields[i], &WbMFString::changed, this, &WbBackground::updateCubemap);
     connect(mIrradianceUrlFields[i], &WbMFString::changed, this, &WbBackground::updateCubemap);
@@ -616,7 +618,9 @@ void WbBackground::applySkyBoxToWren() {
     wr_material_set_texture_cubemap_wrap_r(mSkyboxMaterial, WR_TEXTURE_WRAP_MODE_CLAMP_TO_EDGE, 0);
     wr_material_set_texture_cubemap_wrap_s(mSkyboxMaterial, WR_TEXTURE_WRAP_MODE_CLAMP_TO_EDGE, 0);
     wr_material_set_texture_cubemap_wrap_t(mSkyboxMaterial, WR_TEXTURE_WRAP_MODE_CLAMP_TO_EDGE, 0);
-    wr_scene_set_skybox(wr_scene_get_instance(), mSkyboxRenderable);
+
+    if (WbWorld::instance()->viewpoint()->projectionMode() != WR_CAMERA_PROJECTION_MODE_ORTHOGRAPHIC)
+      wr_scene_set_skybox(wr_scene_get_instance(), mSkyboxRenderable);
   }
 
   // 2. Load the irradiance map

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -14,7 +14,6 @@
 
 #include "WbViewpoint.hpp"
 
-#include "WbBackground.hpp"
 #include "WbBoundingSphere.hpp"
 #include "WbCoordinateSystem.hpp"
 #include "WbFieldChecker.hpp"

--- a/src/webots/nodes/WbViewpoint.hpp
+++ b/src/webots/nodes/WbViewpoint.hpp
@@ -15,6 +15,7 @@
 #ifndef WB_VIEWPOINT_HPP
 #define WB_VIEWPOINT_HPP
 
+#include "WbBackground.hpp"
 #include "WbBaseNode.hpp"
 #include "WbMatrix3.hpp"
 #include "WbQuaternion.hpp"
@@ -100,7 +101,12 @@ public:
   void restore();
   void save(const QString &id) override;
   void setPosition(const WbVector3 &position);
-  void setProjectionMode(int projectionMode) { mProjectionMode = projectionMode; }
+  void setProjectionMode(int projectionMode) {
+    if (projectionMode != mProjectionMode) {
+      mProjectionMode = projectionMode;
+      emit cameraModeChanged();
+    }
+  }
   void lookAt(const WbVector3 &target, const WbVector3 &upVector);
 
   // fixed views
@@ -322,6 +328,7 @@ signals:
   void refreshRequired();
   void nodeVisibilityChanged(const WbNode *node, bool visibility);
   void virtualRealityHeadsetRequiresRender();
+  void cameraModeChanged();
 };
 
 #endif


### PR DESCRIPTION
**Description**

- [x] Remove skybox rendering in orthographic mode
- [x] Remove shadows in orthographic mode

It seems like the orthographic mode was already converted. It could feel different depending on the `orthographicViewHeight`.
The `orthographicViewHeight` is a parameter that define the frustum height when in orthographic mode and that is modified when zooming in/out the scene. This parameter is automatically saved in the `.wbproj`. If we don't know that it is saved, the behviour can feel strange. For example if we:

1. Load the world and switch to orthographic mode.
2. Navigate the scene and zoom in/out.
3. Switch back to perspective mode and forget about orthographic.
4. Reload the world with the same viewpoint as in 1.
5. Switch to orthographic mode.

In 5. we will not see the same rendering as in 1. We will see the same viewpoint as in 1. __but__ with the zoom level of 2.