### PR TITLE
Enhancement-useNetconvert

### DIFF
--- a/docs/automobile/sumo-interface.md
+++ b/docs/automobile/sumo-interface.md
@@ -69,7 +69,7 @@ Here are the parameters of the `SumoInterface` PROTO (which inherits from the [S
 PROTO SumoInterface [
   field SFString  name                  "sumo interface"
   field SFBool    gui                   TRUE
-  field SFBool    useNetconvert         TRUE
+  field SFBool    useNetconvert         FALSE
   field SFBool    enableTrafficLights   TRUE
   field SFBool    enableWheelsRotation  FALSE
   field SFInt32   maxVehicles           100

--- a/projects/default/protos/SumoInterface.proto
+++ b/projects/default/protos/SumoInterface.proto
@@ -8,7 +8,7 @@
 PROTO SumoInterface [
   field SFString  name                  "sumo interface"
   field SFBool    gui                   TRUE
-  field SFBool    useNetconvert         TRUE
+  field SFBool    useNetconvert         FALSE
   field SFBool    enableTrafficLights   TRUE
   field SFBool    enableWheelsRotation  FALSE
   field SFInt32   maxVehicles           100

--- a/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
+++ b/projects/samples/robotbenchmark/highway_driving/controllers/highway_driving_benchmark/highway_driving_benchmark.py
@@ -121,7 +121,6 @@ def add_sumo(supervisor):
         s.close()
     nodeString = 'SumoInterface {'
     nodeString += '  gui FALSE'
-    nodeString += '  useNetconvert FALSE'
     nodeString += '  radius 200'
     nodeString += '  laneChangeDelay 4'
     nodeString += '  enableWheelsRotation TRUE'

--- a/projects/vehicles/worlds/city_traffic.wbt
+++ b/projects/vehicles/worlds/city_traffic.wbt
@@ -83,7 +83,6 @@ Fog {
 }
 SumoInterface {
   gui FALSE
-  useNetconvert FALSE
 }
 DEF GROUND Solid {
   boundingObject DEF GROUND_PLANE Plane {

--- a/projects/vehicles/worlds/highway.wbt
+++ b/projects/vehicles/worlds/highway.wbt
@@ -82,7 +82,6 @@ Fog {
   visibilityRange 700
 }
 SumoInterface {
-  useNetconvert FALSE
   enableHeight TRUE
 }
 Floor {

--- a/projects/vehicles/worlds/highway_overtake.wbt
+++ b/projects/vehicles/worlds/highway_overtake.wbt
@@ -93,7 +93,6 @@ DEF FLOOR Solid {
 }
 SumoInterface {
   gui FALSE
-  useNetconvert FALSE
   radius 250
   laneChangeDelay 4
 }

--- a/projects/vehicles/worlds/sumo_interface_example.wbt
+++ b/projects/vehicles/worlds/sumo_interface_example.wbt
@@ -81,6 +81,7 @@ Fog {
 }
 SumoInterface {
   enableWheelsRotation TRUE
+  useNetconvert TRUE
   children [
     DEF TRAFFIC_LIGHT_NORTH Pole {
       translation -3.9 3.9 0

--- a/projects/vehicles/worlds/village_center.wbt
+++ b/projects/vehicles/worlds/village_center.wbt
@@ -81,7 +81,6 @@ TexturedBackgroundLight {
 }
 SumoInterface {
   gui FALSE
-  useNetconvert FALSE
   maxVehicles 10
   radius 250
   children [

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1441,7 +1441,7 @@ void WbSceneTree::handleDoubleClickOrEnterPress() {
   else if ((mSelectedItem->isItem() && !mSelectedItem->isNode() && mSelectedItem->field()->isMultiple()) ||
            (mSelectedItem->isField() && !mSelectedItem->isSFNode() && !mSelectedItem->field()->isMultiple()))
     mFieldEditor->currentEditor()->takeKeyboardFocus();
-  // default behavior, collapse/expoand tree item
+  // default behavior, collapse/expand tree item
   else if (mTreeView->isExpanded(mTreeView->currentIndex()))
     mTreeView->collapse(mTreeView->currentIndex());
   else


### PR DESCRIPTION
**Description**

All our worlds but `Sumo_interface_example` are using useNetconvert as FALSE. The sumo_interface proto is not include by default in some of the worlds (`city_*`, `village_*`) so for the moment the user has to add the proto and put useNetconvert to FALSE. To use netConvert, the user has to setup a netConvert configuration file (sumo.netccfg) for which is not our "scenario tutorial". Indeed, a common way of implementing a SUMO interface is to create a net (so by using Netconvert outside webots).

Drawback: the user using the default value of useNetconvert will face to issue.
