### PR TITLE
Correction of the texture mapping for the Mesh node

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -31,6 +31,7 @@ Released on XX, XXth, 2021.
     - Fixed crash caused by the auto-regeneration of a [Robot](robot.md) node ([#3869](https://github.com/cyberbotics/webots/pull/3869)).
     - Fixed rendering issue when Webots was started in wireframe mode and switched to plain rendering ([#3939](https://github.com/cyberbotics/webots/pull/3939)).
     - Fixed missing sanity check of [Radar](radar.md) parameters at load time ([#3960](https://github.com/cyberbotics/webots/pull/3960)).
+    - Fixed texture mapping for `Wavefront` files (.obj) and updated the supported formats for the [Mesh](mesh.md) node ([#3955](https://github.com/cyberbotics/webots/pull/3955)).
 
 
 ## Webots R2021b

--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -31,7 +31,7 @@ Released on XX, XXth, 2021.
     - Fixed crash caused by the auto-regeneration of a [Robot](robot.md) node ([#3869](https://github.com/cyberbotics/webots/pull/3869)).
     - Fixed rendering issue when Webots was started in wireframe mode and switched to plain rendering ([#3939](https://github.com/cyberbotics/webots/pull/3939)).
     - Fixed missing sanity check of [Radar](radar.md) parameters at load time ([#3960](https://github.com/cyberbotics/webots/pull/3960)).
-    - Fixed texture mapping for `Wavefront` files (.obj) and updated the supported formats for the [Mesh](mesh.md) node ([#3955](https://github.com/cyberbotics/webots/pull/3955)).
+    - Fixed texture mapping for Wavefront files (.obj) and updated the supported formats for the [Mesh](mesh.md) node ([#3955](https://github.com/cyberbotics/webots/pull/3955)).
 
 
 ## Webots R2021b

--- a/docs/reference/mesh.md
+++ b/docs/reference/mesh.md
@@ -11,14 +11,9 @@ Mesh {
 The [Mesh](#mesh) node represents a 3D shape imported from an external file created by a 3D modeling software.
 The [Mesh](#mesh) node can be used either as a graphical or as a collision detection primitive (in a boundingObject).
 Currently, the following formats are supported:
-  - [3D Studio mesh](https://wiki.fileformat.com/3d/3ds) files (.3ds).
-  - [Blender](https://www.blender.org/) files (.blend).
-  - [Biovision Hierarchy](https://en.wikipedia.org/wiki/Biovision_Hierarchy) files (.bvh).
   - [Collada](https://en.wikipedia.org/wiki/COLLADA) files (.dae).
-  - [Filmbox](https://en.wikipedia.org/wiki/FBX) files (.fbx).
   - [STL](https://en.wikipedia.org/wiki/STL_(file_format)) files (.stl).
   - [Wavefront](https://wiki.fileformat.com/3d/obj) files (.obj).
-  - [X3D](https://www.web3d.org/getting-started-x3d) files (.x3d).
 
 If the file contains more than one mesh, the meshes will be merged into a single one.
 

--- a/src/webots/gui/WbImportWizard.cpp
+++ b/src/webots/gui/WbImportWizard.cpp
@@ -71,15 +71,9 @@ bool WbImportWizard::validateCurrentPage() {
     if (!QFile::exists(fileName()))
       return false;
     // check file extension
-    const QStringList supportedExtension = QStringList() << ".3ds"
-                                                         << ".bvh"
-                                                         << ".blend"
-                                                         << ".dae"
-                                                         << ".fbx"
+    const QStringList supportedExtension = QStringList() << ".dae"
                                                          << ".stl"
-                                                         << ".wrl"
-                                                         << ".obj"
-                                                         << ".x3d";
+                                                         << ".obj";
     for (int i = 0; i < supportedExtension.size(); ++i) {
       if (fileName().endsWith(supportedExtension[i], Qt::CaseInsensitive))
         return true;
@@ -96,15 +90,9 @@ QWizardPage *WbImportWizard::createIntroPage() {
 
   QLabel *label =
     new QLabel(tr("This wizard will help you importing a 3D model in Webots.\n\nThe following file formats are supported:"
-                  "\n\t- 3D Studio mesh (*.3ds)"
-                  "\n\t- Biovision Hierarchy (*.bvh)"
-                  "\n\t- Blender (*.blend)"
                   "\n\t- Collada (*.dae)"
-                  "\n\t- Filmbox (*.fbx)"
                   "\n\t- STL (*.stl)"
-                  "\n\t- VRML (*.wrl)"
-                  "\n\t- Wavefront (*.obj)"
-                  "\n\t- X3D (*.x3d)"),
+                  "\n\t- Wavefront (*.obj)"),
                page);
 
   QVBoxLayout *layout = new QVBoxLayout(page);
@@ -115,17 +103,10 @@ QWizardPage *WbImportWizard::createIntroPage() {
 
 void WbImportWizard::chooseFile() {
   const QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a File"), mFileEdit->text(),
-                                                        tr("3D Files (*.3ds *.3DS *.bvh *.BVH *.blend *.BLEND *.dae *.DAE "
-                                                           "*.fbx *.FBX *.stl *.STL *.wrl *.WRL *.obj *.OBJ *.x3d *.X3D);;"
-                                                           "3D Studio mesh (*.3ds *.3DS);;"
-                                                           "Biovision Hierarchy (*.bvh *.BVH);;"
-                                                           "Blender (*.blend *.BLEND);;"
+                                                        tr("3D Files (*.dae *.DAE *.stl *.STL *.obj *.OBJ);;"
                                                            "Collada (*.dae *.DAE);;"
-                                                           "Filmbox (*.fbx *.FBX);;"
                                                            "STL (*.stl *.STL);;"
-                                                           "VRML (*.wrl *.WRL);;"
-                                                           "Wavefront (*.obj *.OBJ);;"
-                                                           "X3D (*.x3d *.X3D)"));
+                                                           "Wavefront (*.obj *.OBJ)"));
   if (fileName.isEmpty())
     return;
   mFileEdit->setText(fileName);

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -181,10 +181,6 @@ bool WbImageTexture::loadTextureData(QIODevice *device) {
     return false;
   }
 
-  // Supported image format are PNG and JPEG with "y" axis down.
-  // QImage::mirrored() will flip the image vertically as we define "y" axis up.
-  *mImage = mImage->mirrored();
-
   mIsMainTextureTransparent = mImage->pixelFormat().alphaUsage() == QPixelFormat::UsesAlpha;
 
   if (mImage->format() != QImage::Format_ARGB32) {

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -181,6 +181,10 @@ bool WbImageTexture::loadTextureData(QIODevice *device) {
     return false;
   }
 
+  // Supported image format are PNG and JPEG with "y" axis down.
+  // QImage::mirrored() will flip the image vertically as we define "y" axis up.
+  *mImage = mImage->mirrored();
+
   mIsMainTextureTransparent = mImage->pixelFormat().alphaUsage() == QPixelFormat::UsesAlpha;
 
   if (mImage->format() != QImage::Format_ARGB32) {

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -25,8 +25,6 @@
 #include "WbViewpoint.hpp"
 #include "WbWorld.hpp"
 
-#include <math.h>
-
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
@@ -111,7 +109,8 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                                                         aiComponent_MATERIALS);
   const aiScene *scene;
   unsigned int flags = aiProcess_ValidateDataStructure | aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent;
+                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent |
+                       aiProcess_FlipUVs;
   if (WbUrl::isWeb(filePath)) {
     if (mDownloader == NULL)
       downloadAssets();

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -25,6 +25,8 @@
 #include "WbViewpoint.hpp"
 #include "WbWorld.hpp"
 
+#include <math.h>
+
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
@@ -109,7 +111,8 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                                                         aiComponent_MATERIALS);
   const aiScene *scene;
   unsigned int flags = aiProcess_ValidateDataStructure | aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent;
+                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent |
+                       aiProcess_FlipUVs;
   if (WbUrl::isWeb(filePath)) {
     if (mDownloader == NULL)
       downloadAssets();

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -111,8 +111,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                                                         aiComponent_MATERIALS);
   const aiScene *scene;
   unsigned int flags = aiProcess_ValidateDataStructure | aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent |
-                       aiProcess_FlipUVs;
+                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent;
   if (WbUrl::isWeb(filePath)) {
     if (mDownloader == NULL)
       downloadAssets();

--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -547,8 +547,7 @@ bool WbExtendedStringEditor::populateItems(QStringList &items) {
       selectFile("textures", "Texture", "*.hdr *.HDR");
       break;
     case MESH_URL:
-      selectFile("meshes", "Meshes",
-                 "*.dae *.DAE *.stl *.STL *.obj *.OBJ");
+      selectFile("meshes", "Meshes", "*.dae *.DAE *.stl *.STL *.obj *.OBJ");
       break;
     default:
       return false;

--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -548,7 +548,7 @@ bool WbExtendedStringEditor::populateItems(QStringList &items) {
       break;
     case MESH_URL:
       selectFile("meshes", "Meshes",
-                 "*.3ds *.3DS *.bvh *.BVH *.blend *.BLEND *.dae *.DAE *.fbx *.FBX *.stl *.STL *.obj *.OBJ *.x3d *.X3D");
+                 "*.dae *.DAE *.stl *.STL *.obj *.OBJ");
       break;
     default:
       return false;


### PR DESCRIPTION
**Description**
The texture mapping with `Mesh` node was not working properly. This can be seen when using `.obj` files.

I just added an option to flip the `y` axis for the texture mapping as Wren might not be aligned with the convention of `OpenGl`.

`OpenGl` and `.obj` define the `y` axis up.

**Related Issues**
This pull-request fixes issue #3945