### PR TITLE
Fix Radar sanity check and restrict field of view to 180°

### DIFF
--- a/docs/reference/changelog-r2021.md
+++ b/docs/reference/changelog-r2021.md
@@ -30,6 +30,7 @@ Released on XX, XXth, 2021.
     - Fixed bug where deleting a node from [Supervisor](supervisor.md) did not refresh the scene tree ([#3867](https://github.com/cyberbotics/webots/pull/3867)).
     - Fixed crash caused by the auto-regeneration of a [Robot](robot.md) node ([#3869](https://github.com/cyberbotics/webots/pull/3869)).
     - Fixed rendering issue when Webots was started in wireframe mode and switched to plain rendering ([#3939](https://github.com/cyberbotics/webots/pull/3939)).
+    - Fixed missing sanity check of [Radar](radar.md) parameters at load time ([#3960](https://github.com/cyberbotics/webots/pull/3960)).
 
 
 ## Webots R2021b

--- a/docs/reference/radar.md
+++ b/docs/reference/radar.md
@@ -6,7 +6,7 @@ Derived from [Device](device.md) and [Solid](solid.md).
 Radar {
   SFFloat minRange               1       # [0, maxRange)
   SFFloat maxRange               50.0    # (minRange, inf)
-  SFFloat horizontalFieldOfView  0.78    # [0, 2*pi]
+  SFFloat horizontalFieldOfView  0.78    # [0, pi]
   SFFloat verticalFieldOfView    0.1     # [0, pi]
   SFFloat minAbsoluteRadialSpeed 0.0     # [0, inf)
   SFFloat minRadialSpeed         1       # [0, maxRadialSpeed]

--- a/src/webots/nodes/WbRadar.cpp
+++ b/src/webots/nodes/WbRadar.cpp
@@ -152,8 +152,20 @@ void WbRadar::postFinalize() {
   connect(WbWrenRenderingContext::instance(), &WbWrenRenderingContext::optionalRenderingChanged, this,
           &WbRadar::updateOptionalRendering);
 
-  updateTransmittedPower();
+  updateMinRange();
+  updateMaxRange();
+  updateHorizontalFieldOfView();
+  updateVerticalFieldOfView();
+  updateMinAbsoluteRadialSpeed();
+  updateMinAndMaxRadialSpeed();
+  updateCellDistance();
+  updateCellSpeed();
+  updateRangeNoise();
+  updateSpeedNoise();
+  updateAngularNoise();
+  updateFrequency();
   updateAntennaGain();
+  updateTransmittedPower();
   updateMinDetectableSignal();
 }
 
@@ -198,7 +210,7 @@ void WbRadar::updateMaxRange() {
 }
 
 void WbRadar::updateHorizontalFieldOfView() {
-  WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(this, mHorizontalFieldOfView, 0.0, 2 * M_PI, 0.78);
+  WbFieldChecker::resetDoubleIfNotInRangeWithExcludedBounds(this, mHorizontalFieldOfView, 0.0, M_PI, 0.78);
   if (areWrenObjectsInitialized())
     applyFrustumToWren();
 }

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -316,6 +316,8 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
       }
     }
     // check distance between center and frustum planes
+    // Note: this sort of detection is only adapted for a field of view smaller than PI. If a larger FoV is desirable, the logic
+    // should be changed by having two separate frostums, more details here: https://github.com/cyberbotics/webots/pull/3960
     double distances[4];
     for (int j = 0; j < 4; ++j)
       distances[j] = frustumPlanes[j].distance(objectPosition);

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -317,7 +317,7 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
     }
     // check distance between center and frustum planes
     // Note: this sort of detection is only adapted for a field of view smaller than PI. If a larger FoV is desirable, the logic
-    // should be changed by having two separate frostums, more details here: https://github.com/cyberbotics/webots/pull/3960
+    // should be changed by having two separate frustums, more details here: https://github.com/cyberbotics/webots/pull/3960
     double distances[4];
     for (int j = 0; j < 4; ++j)
       distances[j] = frustumPlanes[j].distance(objectPosition);


### PR DESCRIPTION
**Description**
As far as I can tell, no 360°-radar sensors exist in the market currently. This feature is either achieved by combining 2 or 4 separate radars or by rotating it.
Currently, when setting a horizontal field of view to a value higher than PI, the detection breaks down because of [this](https://github.com/cyberbotics/webots/blob/1508457090e341e1bbadc81a7f019234dc9376ab/src/webots/nodes/utils/WbObjectDetection.cpp#L318-L333) snippet, instead of detecting objects in the frustum, it detects them in the slice it isn't supposed to (and occasionally certain random angles also give positive hits). This is because although in practice it was allowed, the detection logic behind the scenes wasn't meant for it:
- normals of the frustum planes are flipped
- bottom plane becomes the top plane behind the device, so distances should be adapted.

A more appropriate way of supporting a 360° radar in webots would be have 2 separate frustums, one for the front and another for the rear and do the detection in each separately, for now however I don't see the reason to do this change. Instead, the documentation and code was adapted to restrict the field of view to the actual range where it was supposed to be used in (180°).

Additionally, it seems that worlds containing radars with invalid settings (for example negative ranges) aren't actually detected/fixed at load time because the checks only occur if a value change is triggered, so this has been fixed.

