### PR TITLE
Fix webots.js texture path

### DIFF
--- a/resources/web/wwi/viewer.js
+++ b/resources/web/wwi/viewer.js
@@ -949,11 +949,7 @@ function createRobotComponent(view) {
     robotComponent.webotsView = webotsView; // Store the Webots view in the DOM element for a simpler access.
 
     // Load the robot X3D file.
-    webotsView.open(
-      computeTargetPath() + 'scenes/' + robotName + '/' + robotName + '.x3d',
-      undefined,
-      computeTargetPath() + 'scenes/' + robotName + '/'
-    );
+    webotsView.open(computeTargetPath() + 'scenes/' + robotName + '/' + robotName + '.x3d');
 
     // Load the robot meta JSON file.
     fetch(computeTargetPath() + 'scenes/' + robotName + '/' + robotName + '.meta.json')

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -116,7 +116,7 @@ webots.View = class View {
     this.animation = new Animation(url, this.x3dScene, this, gui, loop);
   }
 
-  open(url, mode, texturePathPrefix = '') {
+  open(url, mode) {
     const userAgents = navigator.userAgent;
     let chromeAgent = userAgents.indexOf('Chrome') > -1;
     let safariAgent = userAgents.indexOf('Safari') > -1;
@@ -210,6 +210,8 @@ webots.View = class View {
       this.setTimeout(-1);
     this._isWebSocketProtocol = this.url.startsWith('ws://') || this.url.startsWith('wss://');
 
+    const texturePathPrefix = url.includes('/') ? url.substring(0, url.lastIndexOf('/') + 1) : '';
+    
     if (mode === 'mjpeg') {
       this.url = url;
       this.multimediaClient = new MultimediaClient(this, this.view3D);


### PR DESCRIPTION
Fixes the computation of the texture path which was missing and causing the loading of scenes with textures to fail on webots.cloud.

This is already updated on https://cyberbotics.com/wwi/R2022a/ and in  production on https://beta.webots.cloud