### PR TITLE
Clarify `WbSkin` model supported formats

### DIFF
--- a/docs/reference/skin.md
+++ b/docs/reference/skin.md
@@ -58,6 +58,7 @@ Only positive values are permitted; non-positive scale values are automatically 
 - `name`: name of the [Skin](skin.md) device used by [`wb_robot_get_device()`](robot.md#wb_robot_get_device).
 
 - The `modelUrl` field specifies the path to the 3D model.
+The only supported file format for this field is [FBX](https://en.wikipedia.org/wiki/FBX).
 If the `modelUrl` value starts with `http://` or `https://`, Webots will get the file from the web.
 Otherwise, the file should be specified with a relative path.
 The same search algorithm as for [ImageTexture](imagetexture.md) is used (cf. [this section](imagetexture.md#search-rule-of-the-texture-path)).


### PR DESCRIPTION
**Description**
As per [this](https://github.com/cyberbotics/webots/blob/733b1bb2f5df73a95f61bb7b2ab5b45b8f772f82/src/webots/nodes/WbSkin.cpp#L223), FBX is the only supported file type.