### PR TITLE
Fixed robot trajectory

### DIFF
--- a/projects/samples/devices/worlds/emitter_receiver.wbt
+++ b/projects/samples/devices/worlds/emitter_receiver.wbt
@@ -87,7 +87,7 @@ DEF YELLOW_BOX Solid {
   }
 }
 DEF PINK_BOX Solid {
-  translation 0.1 -0.42 0.05
+  translation 0.1 -0.25 0.05
   children [
     Shape {
       appearance PBRAppearance {


### PR DESCRIPTION
It is nice to show the robot both leave and re-enter the receiver/emitter area which wasn't the case with the current demo where it was just leaving it but never re-entering it. This PR makes that the robot first leaves and then re-enters the receiver/emitter area.