### PR TITLE
The sojourner video is missing

### DIFF
--- a/docs/guide/sojourner.md
+++ b/docs/guide/sojourner.md
@@ -6,7 +6,7 @@
 
 ### Movie Presentation
 
-![youtube video](https://youtu.be/hPNr0QcEiQE)
+![youtube video](https://www.youtube.com/watch?v=oRss4eWYQaw)
 
 ### Sojourner PROTO
 

--- a/docs/guide/sojourner.md
+++ b/docs/guide/sojourner.md
@@ -4,9 +4,9 @@
 
 [Sojourner](https://en.wikipedia.org/wiki/Sojourner_(rover)) is the [NASA Pathfinder robotic rover](https://www.nasa.gov/mission_pages/mars-pathfinder) that landed on 1997 in the Ares Vallis region, and explored Mars for around three months.
 
-### Movie presentation
+### Movie Presentation
 
-youtube https://youtu.be/hPNr0QcEiQE
+![youtube video](https://youtu.be/hPNr0QcEiQE)
 
 ### Sojourner PROTO
 

--- a/docs/guide/sojourner.md
+++ b/docs/guide/sojourner.md
@@ -4,6 +4,10 @@
 
 [Sojourner](https://en.wikipedia.org/wiki/Sojourner_(rover)) is the [NASA Pathfinder robotic rover](https://www.nasa.gov/mission_pages/mars-pathfinder) that landed on 1997 in the Ares Vallis region, and explored Mars for around three months.
 
+### Movie presentation
+
+youtube https://youtu.be/hPNr0QcEiQE
+
 ### Sojourner PROTO
 
 Derived from [Robot](../reference/robot.md).

--- a/docs/guide/sojourner.md
+++ b/docs/guide/sojourner.md
@@ -4,10 +4,6 @@
 
 [Sojourner](https://en.wikipedia.org/wiki/Sojourner_(rover)) is the [NASA Pathfinder robotic rover](https://www.nasa.gov/mission_pages/mars-pathfinder) that landed on 1997 in the Ares Vallis region, and explored Mars for around three months.
 
-### Movie Presentation
-
-![youtube video](https://www.youtube.com/watch?v=_9d_vukS0Qg)
-
 ### Sojourner PROTO
 
 Derived from [Robot](../reference/robot.md).


### PR DESCRIPTION
It looks bad in the documentation to have a broken video link.
This PR fixes it by linking to a new video.
Old version: https://cyberbotics.com/doc/guide/sojourner
New version: https://cyberbotics.com/doc/guide/sojourner?version=fix-missing-video