### PR TITLE
Prevent open-al instantiation when sound is mute

### DIFF
--- a/src/webots/sound/WbSoundEngine.cpp
+++ b/src/webots/sound/WbSoundEngine.cpp
@@ -75,11 +75,12 @@ static void cleanup() {
 }
 
 static void init() {
-  if (gDefaultDevice)  // init was already done
-    return;
-  qAddPostRoutine(cleanup);
   gMute = WbPreferences::instance()->value("Sound/mute", true).toBool();
   gVolume = WbPreferences::instance()->value("Sound/volume", 80).toInt();
+
+  if (gDefaultDevice || gMute)  // init was already done or sound is mute
+    return;
+  qAddPostRoutine(cleanup);
   try {
     const ALCchar *defaultDeviceName = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
     if (defaultDeviceName == NULL)


### PR DESCRIPTION
**Description**

Prevent the instantiation of an openAL entity if the sound is mute. It aims to avoid the warnings in the CI and improve the performance.