### PR TITLE
Switch mSolid endPoint pointer to NULL when using static environnement

### DIFF
--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -22,7 +22,6 @@
 const QString WbSolidReference::STATIC_ENVIRONMENT = QString("<static environment>");
 
 void WbSolidReference::init() {
-  mSolid = NULL;
   mName = findSFString("solidName");
 }
 
@@ -68,7 +67,7 @@ void WbSolidReference::updateName() {
 }
 
 bool WbSolidReference::isClosedLoop() const {
-  if (!mSolid)
+  if (mSolid.isNull())
     return false;
 
   WbNode *parent = parentNode();

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -66,19 +66,6 @@ void WbSolidReference::updateName() {
       tr("SolidReference has an invalid '%1' name or refers to its closest upper solid, which is prohibited.").arg(name));
 }
 
-bool WbSolidReference::isClosedLoop() const {
-  if (mSolid.isNull())
-    return false;
-
-  WbNode *parent = parentNode();
-  while (parent && !parent->isWorldRoot()) {
-    if (parent == mSolid)
-      return true;
-    parent = parent->parentNode();
-  }
-  return false;
-}
-
 QList<const WbBaseNode *> WbSolidReference::findClosestDescendantNodesWithDedicatedWrenNode() const {
   QList<const WbBaseNode *> list;
   if (mSolid)

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -61,7 +61,7 @@ void WbSolidReference::updateName() {
   if (!linkToStaticEnvironment)
     mSolid = QPointer<WbSolid>(ts->findSolid(name, upperSolid()));
   else
-    mSolid = NULL;
+    mSolid.clear();
   if (!name.isEmpty() && !linkToStaticEnvironment && mSolid.isNull())
     parsingWarn(
       tr("SolidReference has an invalid '%1' name or refers to its closest upper solid, which is prohibited.").arg(name));

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -60,6 +60,8 @@ void WbSolidReference::updateName() {
   const bool linkToStaticEnvironment = name == STATIC_ENVIRONMENT;
   if (!linkToStaticEnvironment)
     mSolid = QPointer<WbSolid>(ts->findSolid(name, upperSolid()));
+  else
+    mSolid = NULL;
   if (!name.isEmpty() && !linkToStaticEnvironment && mSolid.isNull())
     parsingWarn(
       tr("SolidReference has an invalid '%1' name or refers to its closest upper solid, which is prohibited.").arg(name));

--- a/src/webots/nodes/WbSolidReference.hpp
+++ b/src/webots/nodes/WbSolidReference.hpp
@@ -48,9 +48,6 @@ public:
   bool pointsToStaticEnvironment() const { return mName->value() == STATIC_ENVIRONMENT; }
   static const QString STATIC_ENVIRONMENT;
 
-  // check if mSolid is a parent of this SolidReference instance
-  bool isClosedLoop() const;
-
   QList<const WbBaseNode *> findClosestDescendantNodesWithDedicatedWrenNode() const override;
 
 signals:


### PR DESCRIPTION
I'm not sure about that, but I've encountered this while trying to fix another bug.
I'm not sure about the repercussion of it, so please give me any feedback :)

Without this, when switching to "static environment" in joint endpoint, the mSolid pointer stay with the same value. I don't think it's the expected behavior. But not sure if setting it to NULL is the way to go !