### PR TITLE
Remove mentions of ROS Melodic from the documentation

### DIFF
--- a/docs/blog/Webots-2022-a-release.md
+++ b/docs/blog/Webots-2022-a-release.md
@@ -74,7 +74,7 @@ Several improvement enhanced the user experience:
 ## ROS and ROS 2
 
 The Webots ROS and ROS 2 interfaces were maintained and updated to benefit from the new features of Webots R2022a, such as the ENU/FLU orientations, the Skin node and the GPS speed vector.
-New versions of the `webots_ros` package were released for [melodic](https://index.ros.org/p/webots_ros/#melodic) and [noetic](https://index.ros.org/p/webots_ros/#noetic).
+A new version of the `webots_ros` package was released for [noetic](https://index.ros.org/p/webots_ros/#noetic).
 
 In addition to this, the Webots ROS 2 interface was fully redesigned to be more user friendly and scalable.
 The `webots_ros2_driver` sub-package replaces the previous `webots_ros2_core` sub-package, which is now obsolete.

--- a/docs/guide/tutorial-9-using-ros.md
+++ b/docs/guide/tutorial-9-using-ros.md
@@ -2,15 +2,15 @@
 
 This tutorial explains how to use the nodes from the `webots_ros` package provided with Webots.
 
-These examples were tested with ROS Noetic Ninjemys and ROS Melodic Morenia on Linux.
+These examples were tested with ROS Noetic Ninjemys on Linux.
 There is no warranty they will work if you use a different platform or an ancient distribution of ROS.
 
 ### Check Compatibility of Webots ROS API
 
-The Webots packages contain a precompiled ROS API built using the latest ROS distributions:
+The Webots packages contain a precompiled ROS API built using the latest ROS distribution:
 - The Ubuntu 20.04 tarball package is compatible with ROS Noetic.
-- The snap, Debian and Ubuntu 18.04 tarball packages are compatible with ROS Melodic.
 If you plan to use a different ROS distribution then it is recommended to install the tarball package and recompile the ROS API:
+
 ```sh
 export ROS_DISTRO=noetic  # or ROS_DISTRO=melodic, etc.
 cd ${WEBOTS_HOME}/projects/default/controllers/ros
@@ -21,11 +21,6 @@ make
 
 In order to use these nodes, you will first need to install the ROS framework.
 To install the latest version of ROS on Ubuntu use the following commands:
-
-%tab-component "ros"
-
-%tab "noetic"
-
 
 ```sh
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -38,28 +33,8 @@ rosdep update
 sudo apt-get install ros-noetic-webots-ros
 ```
 
-%tab-end
-
-%tab "melodic"
-
-```sh
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-sudo apt-get update
-sudo apt-get install ros-melodic-desktop-full ros-melodic-moveit # takes time, get a coffee :)
-sudo apt-get install python-rosdep
-sudo rosdep init
-rosdep update
-sudo apt-get install ros-melodic-webots-ros
-```
-
-%tab-end
-
-
-%end
-
 For more information or to install it on another platform please read [http://wiki.ros.org/ROS/Installation](http://wiki.ros.org/ROS/Installation).
-Unless you need older version for some other application, you should choose a recent distribution (Noetic Ninjemys or Melodic Morenia).
+Unless you need older version for some other application, you should choose the most recent distribution (Noetic Ninjemys).
 
 The last line is to install the [webots\_ros](http://wiki.ros.org/webots\_ros) package.
 
@@ -99,9 +74,9 @@ export WEBOTS_HOME=/snap/webots/current/usr/share/webots
 source /opt/ros/noetic/local_setup.bash
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${WEBOTS_HOME}/projects/default/controllers/ros/lib/ros
 ```
-  
+
 This is specific to the Webots snap package and ROS Noetic.
-  
+
 </details>
 
 The seed of Webots' random number generator is initialized at the beginning of the simulation and not when the ROS nodes connect.

--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -33,7 +33,7 @@ It is a bit more difficult to set up but allows for more flexibility.
 
 This controller uses the "libCppController" library and proposes the available Webots functionalities on the ROS network according to the robot's configuration.
 Using the "roscpp" library, it provides these Webots functions mostly as ROS services and uses standard messages type to avoid dependencies on third-party packages.
-The list of services and messages can be found [here](http://docs.ros.org/melodic/api/webots_ros/html/index-msg.html).
+The list of services and messages can be found [here](http://docs.ros.org/noetic/api/webots_ros/html/index-msg.html).
 
 During simulation there can be multiple instances of robots or devices and other Webots applications connected to the ROS network.
 Therefore the controller uses a specific syntax to declare its services or topics on the network: `[robot_unique_name]/[device_name]/[service/topic_name]`.

--- a/lib/controller/matlab/WB_NODE_COLLADA_SHAPE.m
+++ b/lib/controller/matlab/WB_NODE_COLLADA_SHAPE.m
@@ -1,2 +1,0 @@
-function value = WB_NODE_COLLADA_SHAPE
-value = 6;

--- a/lib/controller/matlab/WB_NODE_COLLADA_SHAPE.m
+++ b/lib/controller/matlab/WB_NODE_COLLADA_SHAPE.m
@@ -1,0 +1,2 @@
+function value = WB_NODE_COLLADA_SHAPE
+value = 6;

--- a/projects/robots/universal_robots/resources/ros_package/ur_e_webots/README.md
+++ b/projects/robots/universal_robots/resources/ros_package/ur_e_webots/README.md
@@ -12,7 +12,7 @@ source devel/setup.bash
 ```
 
 You need to install the `universal_robots` package too in order to get the URDF definitions of the robots (used for example for RVIZ visualization and MoveIt).
-Until Kinetic, you can install it using the package manager (`apt install ros-$ROS_DISTRO-universal-robot`), but from Melodic, you need to compile it from [sources](https://github.com/ros-industrial/universal_robot/tree/melodic-devel).
+Until Kinetic, you can install it using the package manager (`apt install ros-$ROS_DISTRO-universal-robot`), but from Melodic, you need to compile it from [sources](https://github.com/ros-industrial/universal_robot/tree/melodic-devel-staging).
 
 ## Usage
 
@@ -45,11 +45,11 @@ If your simulation uses more than one robot running the `universal_robots_ros` c
        alt="rosin_logo" height="60" >
 </a></br>
 
-Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.  
+Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
 More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
 
 <img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg"
-     alt="eu_flag" height="45" align="left" >  
+     alt="eu_flag" height="45" align="left" >
 
-This project has received funding from the European Union’s Horizon 2020  
+This project has received funding from the European Union’s Horizon 2020
 research and innovation programme under grant agreement no. 732287.


### PR DESCRIPTION
**Description**
As discussed with @omichel and @BenjaminDeleze, we will no longer support `ROS Melodic` as it runs with `Python 2` on `Ubuntu 18` (end of support in March 2022). It requires too many settings to make it run with `Python 3` as the `libcontroller` use `Python 3`.

Thus I changed the documentation accordingly.