### PR TITLE
Fixed small memory leaks

### DIFF
--- a/src/webots/core/WbTelemetry.cpp
+++ b/src/webots/core/WbTelemetry.cpp
@@ -90,11 +90,14 @@ void WbTelemetry::requestReplyFinished() {
   assert(reply);
   if (!reply)
     return;
-  if (reply->error())
+  if (reply->error()) {
+    reply->deleteLater();
     return;
+  }
   disconnect(reply, &QNetworkReply::finished, this, &WbTelemetry::requestReplyFinished);
   const QString answer = QString::fromUtf8(reply->readAll()).trimmed();
   QStringList answers = answer.split(" ");
   WbPreferences::instance()->setValue("General/telemetryId", answers[0]);
   WbPreferences::instance()->setValue("General/telemetryPassword", answers[1]);  // stored for later use
+  reply->deleteLater();
 }

--- a/src/webots/core/WbWebotsUpdateManager.cpp
+++ b/src/webots/core/WbWebotsUpdateManager.cpp
@@ -85,4 +85,5 @@ void WbWebotsUpdateManager::downloadReplyFinished() {
   mError = "";
   mTargetVersionAvailable = true;
   emit targetVersionAvailable();
+  reply->deleteLater();
 }

--- a/src/webots/core/WbWebotsUpdateManager.cpp
+++ b/src/webots/core/WbWebotsUpdateManager.cpp
@@ -60,12 +60,13 @@ void WbWebotsUpdateManager::downloadReplyFinished() {
   if (!reply)
     return;
 
+  disconnect(reply, &QNetworkReply::finished, this, &WbWebotsUpdateManager::downloadReplyFinished);
+
   if (reply->error()) {
     mError = tr("Cannot get the Webots current version due to: \"%1\"").arg(reply->errorString());
+    reply->deleteLater();
     return;
   }
-
-  disconnect(reply, &QNetworkReply::finished, this, &WbWebotsUpdateManager::downloadReplyFinished);
 
   bool success = false;
   QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
@@ -77,6 +78,8 @@ void WbWebotsUpdateManager::downloadReplyFinished() {
     }
   }
 
+  reply->deleteLater();
+
   if (!success) {
     mError = tr("Invalid answer from the GitHub REST API.");
     return;
@@ -85,5 +88,4 @@ void WbWebotsUpdateManager::downloadReplyFinished() {
   mError = "";
   mTargetVersionAvailable = true;
   emit targetVersionAvailable();
-  reply->deleteLater();
 }

--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -100,7 +100,7 @@ void WbDownloader::download(const QUrl &url) {
   else
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
 
-  assert(mNetworkReply);
+  assert(mNetworkReply == NULL);
   mNetworkReply = WbNetwork::instance()->networkAccessManager()->get(request);
   connect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished, Qt::UniqueConnection);
   connect(WbApplication::instance(), &WbApplication::worldLoadingWasCanceled, mNetworkReply, &QNetworkReply::abort);

--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -100,6 +100,7 @@ void WbDownloader::download(const QUrl &url) {
   else
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
 
+  assert(mNetworkReply);
   mNetworkReply = WbNetwork::instance()->networkAccessManager()->get(request);
   connect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished, Qt::UniqueConnection);
   connect(WbApplication::instance(), &WbApplication::worldLoadingWasCanceled, mNetworkReply, &QNetworkReply::abort);


### PR DESCRIPTION
[QNetworkReply](https://doc.qt.io/qt-5/qnetworkreply.html) objects need to be released using the `deleteLater()` method.
