### PR TITLE
Allow the use of WebotsView in Safari

### DIFF
--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -117,15 +117,6 @@ webots.View = class View {
   }
 
   open(url, mode) {
-    const userAgents = navigator.userAgent;
-    let chromeAgent = userAgents.indexOf('Chrome') > -1;
-    let safariAgent = userAgents.indexOf('Safari') > -1;
-
-    // Verify that chrome userAgent is false because safari userAgent is also included in Chrome browser.
-    if (!chromeAgent && safariAgent) {
-      alert('Safari does not have the technical capabilities to display a Webots simulation.\n\nPlease use a compatible browser (Chrome, Firefox, Edge, Opera).');
-      return;
-    }
     this.url = url;
     if (typeof mode === 'undefined')
       mode = 'x3d';
@@ -211,7 +202,7 @@ webots.View = class View {
     this._isWebSocketProtocol = this.url.startsWith('ws://') || this.url.startsWith('wss://');
 
     const texturePathPrefix = url.includes('/') ? url.substring(0, url.lastIndexOf('/') + 1) : '';
-    
+
     if (mode === 'mjpeg') {
       this.url = url;
       this.multimediaClient = new MultimediaClient(this, this.view3D);


### PR DESCRIPTION
Since version 15, Safari support webgl2. 
I tested if with https://www.cyberbotics.com/animations/soccer_example/soccer.html. It works more or less, there is sometimes some troubles to load the page, but once it is loaded it works well.
And with https://cyberbotics1.epfl.ch/open-roberta/ and I experimented no issue with this one.
