### PR TITLE
Remove webots -> libcontroller notification of relayed commands in motor couplings

### DIFF
--- a/src/controller/c/motor.c
+++ b/src/controller/c/motor.c
@@ -294,7 +294,6 @@ void wb_motor_set_velocity(WbDeviceTag tag, double velocity) {
       else
         fprintf(stderr, "Error: %s(): invalid sibling in coupling.\n", __FUNCTION__);
     }
-
   } else
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
   robot_mutex_unlock_step();

--- a/src/controller/c/motor.c
+++ b/src/controller/c/motor.c
@@ -240,6 +240,14 @@ void wb_motor_set_position_no_mutex(WbDeviceTag tag, double pos) {
   if (m) {
     m->requests[C_MOTOR_SET_POSITION] = 1;
     m->position = pos;
+
+    for (int i = 0; i < m->siblings_size; ++i) {
+      Motor *s = motor_get_struct(m->siblings[i]);
+      if (s)
+        s->position = isinf(pos) ? pos : pos * s->multiplier;
+      else
+        fprintf(stderr, "Error: %s(): invalid sibling in coupling.\n", __FUNCTION__);
+    }
   } else
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
 }
@@ -278,6 +286,15 @@ void wb_motor_set_velocity(WbDeviceTag tag, double velocity) {
     }
     m->requests[C_MOTOR_SET_VELOCITY] = 1;
     m->velocity = velocity;
+
+    for (int i = 0; i < m->siblings_size; ++i) {
+      Motor *s = motor_get_struct(m->siblings[i]);
+      if (s)
+        s->velocity = velocity * s->multiplier;
+      else
+        fprintf(stderr, "Error: %s(): invalid sibling in coupling.\n", __FUNCTION__);
+    }
+
   } else
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
   robot_mutex_unlock_step();
@@ -349,6 +366,14 @@ void wb_motor_set_force(WbDeviceTag tag, double force) {
   if (m) {
     m->requests[C_MOTOR_SET_FORCE] = 1;
     m->force = force;
+
+    for (int i = 0; i < m->siblings_size; ++i) {
+      Motor *s = motor_get_struct(m->siblings[i]);
+      if (s)
+        s->force = force * s->multiplier;
+      else
+        fprintf(stderr, "Error: %s(): invalid sibling in coupling.\n", __FUNCTION__);
+    }
   } else
     fprintf(stderr, "Error: %s(): invalid device tag.\n", __FUNCTION__);
   robot_mutex_unlock_step();

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -345,7 +345,6 @@ void WbMotor::setTargetPosition(double position) {
   }
 
   mUserControl = false;
-  mNeedToConfigure = true;  // each sibling has to notify libcontroller about velocityControl/positionControl
   awake();
 }
 
@@ -358,7 +357,6 @@ void WbMotor::setVelocity(double velocity) {
     mTargetVelocity = mTargetVelocity >= 0.0 ? m : -m;
   }
 
-  mNeedToConfigure = true;  // each sibling has to notify libcontroller about velocityControl/positionControl
   awake();
 }
 

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -617,6 +617,9 @@ void WbMotor::addConfigureToStream(QDataStream &stream) {
   stream << (double)mTargetPosition;
   stream << (double)mTargetVelocity;
   stream << (double)mMultiplier->value();
+  stream << (int)mCoupledMotors.size();
+  for (int i = 0; i < mCoupledMotors.size(); ++i)
+    stream << (WbDeviceTag)mCoupledMotors[i]->tag();
   mNeedToConfigure = false;
 }
 


### PR DESCRIPTION
**Description**
Currently, in the context of coupled motors when Webots receives an API request (for instance setting of the target position), it relays this message to the other motors within the same coupling which results in each of them notifying libcontroller about their own updated state. This is necessary to ensure data symmetry between Webots and libcontroller, since for example when requesting data, the locally available one is usually provided (without asking Webots for it, hence it needs to be up to date). This is especially a problem with coupled motors since (currently) a single API call may affect multiple motors, not just the one associated with the tag from which the request stemmed.

This continuous exchange of information is however unnecessarily heavy and currently blocks the possibility of exposing the `robot_step_begin` and `robot_step_end` APIs. The proposed solution is to have libcontroller itself relay the information to other motors within its coupling.