### PR TITLE
Update cpp-java-python.md

### DIFF
--- a/docs/guide/cpp-java-python.md
+++ b/docs/guide/cpp-java-python.md
@@ -63,16 +63,16 @@ There is no `WbDeviceTag` in C++/Java/Python.
 
 using namespace webots;
 
-int main(int argc, char **argv) {
-  Robot *robot = new Robot();
+int main() {
+  Robot robot;
 
-  int timeStep = (int) robot->getBasicTimeStep();
-  LED *led = robot->getLED("ledName");
-  DistanceSensor *distanceSensor = robot->getDistanceSensor("distanceSensorName");
+  int timeStep = (int) robot.getBasicTimeStep();
+  LED *led = robot.getLED("ledName");
+  DistanceSensor *distanceSensor = robot.getDistanceSensor("distanceSensorName");
   distanceSensor->enable(timeStep);
 
   // Main control loop
-  while (robot->step(timeStep) != -1) {
+  while (robot.step(timeStep) != -1) {
     // Read the sensors
     double val = distanceSensor->getValue();
 
@@ -82,7 +82,6 @@ int main(int argc, char **argv) {
     led->set(1);
   }
 
-  delete robot;
   return 0;
 }
 ```


### PR DESCRIPTION
**Description**
In the C++ example, it is not necessary to use a pointer to a heap-allocated `World` object. Instead a local variable can be used (which also gets rid of the need to delete the `World` object.

**Related Issues**
None

**Tasks**
Add the list of tasks of this PR.
  - [x] Update C++ example source code in the documentation

**Documentation**
https://cyberbotics.com/doc/guide/cpp-java-python?version=released
