### PR TITLE
Fixed broken dependencies in libCppController

### DIFF
--- a/src/controller/cpp/Makefile
+++ b/src/controller/cpp/Makefile
@@ -77,9 +77,10 @@ CPPSRC = Accelerometer.cpp \
 
 OBJECTS = $(CPPSRC:.cpp=.o)
 CPPOBJS = $(addprefix $(OBJDIR)/, $(OBJECTS))
+DEPENDENCIES = $(addprefix $(OBJDIR)/,$(notdir $(CPPSRC:.cpp=.d)))
 
 ifneq (,$(filter $(MAKECMDGOALS),debug release profile)) # if $(MAKECMDGOALS) is either of those
--include $(addprefix $(OBJDIR)/,$(notdir $(CPPSRC:.cpp=.d)))
+-include $(DEPENDENCIES)
 endif
 
 ifeq ($(OSTYPE),windows)
@@ -123,8 +124,6 @@ $(TARGET):$(CPPOBJS) $(LIBCONTROLLER)
 $(LIBCONTROLLER):
 	@echo "Warning: $(LIBCONTROLLER) doesn't exist, rebuild it first."
 
--include $(DEPENDENCIES)
-
 # cpp compilation rule
 $(OBJDIR)/%.o:%.cpp
 	@echo "# compiling "$<
@@ -133,7 +132,8 @@ $(OBJDIR)/%.o:%.cpp
 # dependency rule
 $(OBJDIR)/%.d:%.cpp
 	@echo "# updating "$(notdir $@)
-	@$(CXX) $(CPPINCLUDES) -MM $< > $@
+	@printf $(OBJDIR)/ > $@
+	@$(CXX) $(CPPINCLUDES) -MM $< >> $@
 
 ifeq ($(OSTYPE),windows)
 FILES_TO_REMOVE = $(WEBOTS_CONTROLLER_LIB_PATH)/CppController.dll $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.a *.def *.exp


### PR DESCRIPTION
The management of the dependencies was broken in the libCppController:
```bash
$ cd src/controller/cpp
$ make release
[...]
$ touch ../../../include/controller/cpp/webots/Robot.hpp
$ make release
make: Nothing to be done for 'release'.
```

This was due to the fact that the `build/release/Robot.d` dependency file was starting with:
```
Robot.o: Robot.cpp \
```
whereas it should start with:
```
build/release/Robot.o: Robot.cpp \
```
Hence the dependencies for `Robot.o` where silently ignored.

This PR fixes this bug.