### PR TITLE
Fix world save API

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -8,7 +8,7 @@ Released on XX XX, 2022.
   - Bug fixes
     - Fixed the URDF exportation of [SolidReference](solidreference.md) nodes ([#4102](https://github.com/cyberbotics/webots/pull/4102)).
     - Fixed insufficient value sanity check in Solid's `postPhysicsStep` resulting in exploding [Track](track.md) ([#4133](https://github.com/cyberbotics/webots/pull/4133)).
-
+    - Fixed `wb_supervisor_world_save` behavior when no argument is provided in non-C APIs ([#4140](https://github.com/cyberbotics/webots/pull/4140)).
 ## Webots R2022a
 Released on December 21th, 2022.
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -9,6 +9,7 @@ Released on XX XX, 2022.
     - Fixed the URDF exportation of [SolidReference](solidreference.md) nodes ([#4102](https://github.com/cyberbotics/webots/pull/4102)).
     - Fixed insufficient value sanity check in Solid's `postPhysicsStep` resulting in exploding [Track](track.md) ([#4133](https://github.com/cyberbotics/webots/pull/4133)).
     - Fixed `wb_supervisor_world_save` behavior when no argument is provided in non-C APIs ([#4140](https://github.com/cyberbotics/webots/pull/4140)).
+
 ## Webots R2022a
 Released on December 21th, 2022.
 

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -2747,8 +2747,8 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 ```c
 #include <webots/supervisor.h>
 
-void wb_supervisor_world_load(const char *filename);
-bool wb_supervisor_world_save(const char *filename);
+void wb_supervisor_world_load(const char *file);
+bool wb_supervisor_world_save(const char *file);
 void wb_supervisor_world_reload();
 ```
 
@@ -2807,7 +2807,7 @@ public class Supervisor extends Robot {
 ```MATLAB
 wb_supervisor_world_load('filename')
 success = wb_supervisor_world_save()
-success = wb_supervisor_world_save('filename')
+success = wb_supervisor_world_save('file')
 wb_supervisor_world_reload()
 ```
 
@@ -2834,15 +2834,15 @@ As a result of changing the current world, all the supervisor and robot controll
 You may wish to save some data in a file from your supervisor and robot controller programs in order to reload it from the new world.
 
 The `wb_supervisor_world_save` function saves the current world.
-The `filename` parameter defines the path to the target world file.
+The `file` parameter defines the path to the target world file.
 It should end with the `.wbt` extension.
 It can be defined either as an absolute path, or as a path relative to the current supervisor controller.
 If NULL, the current world path is used instead (e.g., a simple save operation).
 The boolean return value indicates the success of the save operation.
 Be aware that this function can overwrite silently existing files, so that the corresponding data may be lost.
 
-> **Note** [C++, Java, Python, MATLAB]: In the other APIs, the `Robot.worldSave` function can be called without argument.
-In this case, a simple save operation is performed.
+> **Note** [C++, Java, Python, MATLAB]: Only for the C API it is required to pass NULL in order to perform a simple save operation.
+For all others the `Robot.worldSave` function can be called without argument.
 
 The `wb_supervisor_world_reload` function sends a request to the simulator process, asking it to reload the current world immediately.
 As a result of reloading the current world, all the supervisor and robot controller processes are terminated and restarted.

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -2748,7 +2748,7 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 #include <webots/supervisor.h>
 
 void wb_supervisor_world_load(const char *filename);
-bool wb_supervisor_world_save(const char *file);
+bool wb_supervisor_world_save(const char *filename);
 void wb_supervisor_world_reload();
 ```
 
@@ -2807,7 +2807,7 @@ public class Supervisor extends Robot {
 ```MATLAB
 wb_supervisor_world_load('filename')
 success = wb_supervisor_world_save()
-success = wb_supervisor_world_save('file')
+success = wb_supervisor_world_save('filename')
 wb_supervisor_world_reload()
 ```
 
@@ -2834,7 +2834,7 @@ As a result of changing the current world, all the supervisor and robot controll
 You may wish to save some data in a file from your supervisor and robot controller programs in order to reload it from the new world.
 
 The `wb_supervisor_world_save` function saves the current world.
-The `file` parameter defines the path to the target world file.
+The `filename` parameter defines the path to the target world file.
 It should end with the `.wbt` extension.
 It can be defined either as an absolute path, or as a path relative to the current supervisor controller.
 If NULL, the current world path is used instead (e.g., a simple save operation).

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -2747,7 +2747,7 @@ To stop the inertia of a single [Solid](solid.md) node please refer to [this sec
 ```c
 #include <webots/supervisor.h>
 
-void wb_supervisor_world_load(const char *file);
+void wb_supervisor_world_load(const char *filename);
 bool wb_supervisor_world_save(const char *file);
 void wb_supervisor_world_reload();
 ```

--- a/include/controller/c/webots/supervisor.h
+++ b/include/controller/c/webots/supervisor.h
@@ -60,7 +60,7 @@ typedef enum {
 } WbSimulationMode;
 
 void wb_supervisor_world_load(const char *filename);
-bool wb_supervisor_world_save(const char *file);
+bool wb_supervisor_world_save(const char *filename);
 void wb_supervisor_world_reload();
 
 void wb_supervisor_simulation_quit(int status);

--- a/include/controller/c/webots/supervisor.h
+++ b/include/controller/c/webots/supervisor.h
@@ -60,7 +60,7 @@ typedef enum {
 } WbSimulationMode;
 
 void wb_supervisor_world_load(const char *filename);
-bool wb_supervisor_world_save(const char *filename);
+bool wb_supervisor_world_save(const char *file);
 void wb_supervisor_world_reload();
 
 void wb_supervisor_simulation_quit(int status);

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -1736,22 +1736,12 @@ bool wb_supervisor_save_world(const char *filename) {
   return wb_supervisor_world_save(filename);
 }
 
-bool wb_supervisor_world_save(const char *filename) {
+bool wb_supervisor_world_save(const char *file) {
   if (!robot_check_supervisor(__FUNCTION__))
     return false;
 
-  if (filename) {
-    if (!filename[0]) {
-      fprintf(stderr, "Error: %s() called with an empty 'filename' argument.\n", __FUNCTION__);
-      return false;
-    }
-
-    if (strcmp("wbt", wb_file_get_extension(filename)) != 0) {
-      fprintf(stderr, "Error: the target file given to %s() ends with the '.wbt' extension.\n", __FUNCTION__);
-      return false;
-    }
-  } else {
-    fprintf(stderr, "Error: %s() called with a NULL 'filename' argument.\n", __FUNCTION__);
+  if (file && strcmp("wbt", wb_file_get_extension(file)) != 0) {
+    fprintf(stderr, "Error: the target file given to %s() should have the '.wbt' extension.\n", __FUNCTION__);
     return false;
   }
 
@@ -1762,7 +1752,7 @@ bool wb_supervisor_world_save(const char *filename) {
   save_request = true;
 
   robot_mutex_lock_step();
-  save_filename = supervisor_strdup(filename);
+  save_filename = supervisor_strdup(file);
   wb_robot_flush_unlocked();
   robot_mutex_unlock_step();
 

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -1736,11 +1736,11 @@ bool wb_supervisor_save_world(const char *filename) {
   return wb_supervisor_world_save(filename);
 }
 
-bool wb_supervisor_world_save(const char *file) {
+bool wb_supervisor_world_save(const char *filename) {
   if (!robot_check_supervisor(__FUNCTION__))
     return false;
 
-  if (file && strcmp("wbt", wb_file_get_extension(file)) != 0) {
+  if (filename && strcmp("wbt", wb_file_get_extension(filename)) != 0) {
     fprintf(stderr, "Error: the target file given to %s() should have the '.wbt' extension.\n", __FUNCTION__);
     return false;
   }
@@ -1752,7 +1752,7 @@ bool wb_supervisor_world_save(const char *file) {
   save_request = true;
 
   robot_mutex_lock_step();
-  save_filename = supervisor_strdup(file);
+  save_filename = supervisor_strdup(filename);
   wb_robot_flush_unlocked();
   robot_mutex_unlock_step();
 


### PR DESCRIPTION
**Description**
The function `supervisor_world_save` isn't behaving as documented/intended.
If no argument is provided (or if NULL is provided in case of C API), the world should be saved.
If an argument is provided but isn't valid (no `.wbt` extension ), a warning should be printed.
If a valid argument (filename + extension, or path + filename + extension), the world should be saved as such.
The PR restores this functionality.

~~PS: I don't know if the change of argument name is warranted. C api uses "filename" and all others "file". Technically the provided string can be a path, so "file" might make more sense but it's debatable. Either way should be consistent.~~

