### PR TITLE
Generalize update of Webots version in world file header

### DIFF
--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -221,10 +221,10 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
             else:
                 miss_rotation = False
 
-            if 'R2021b' in line:
-                line = '#VRML_SIM R2022a utf8 \r\n'
-            elif 'R2022a' in line:
+            if 'R2022a' in line:
                 warning_verbose += 'The version of the file was already 2022a. '
+            elif '#VRML_SIM' in line:
+                line = '#VRML_SIM R2022a utf8 \r\n'
             if type in ['coordinateSystem']:  # remove the 'coordinateSystem ENU'
                 vector = None
             elif type in ['position'] and len(vector) == 3:


### PR DESCRIPTION
**Description**
The [`convert_nue_to_enu_rub_to_flu.py`](https://github.com/cyberbotics/webots/blob/42fc2753ccda54b7747cf6e1c2d97820f609f7e6/scripts/converter/convert_nue_to_enu_rub_to_flu.py#L224) script only allows to update the version at the first line of the world or proto file if the version being updated is `R2021b`. 

For instance, the line `#VRML_SIM R2018b utf8` is not updated by the script and therefore requires to be modified by hand to `#VRML_SIM R2022a utf8`. 

This pull request should allow the script to update the Webots version in any case. 
