### PR TITLE
Fix node string display

### DIFF
--- a/src/webots/gui/WbNewProtoWizard.cpp
+++ b/src/webots/gui/WbNewProtoWizard.cpp
@@ -19,6 +19,7 @@
 #include "WbFileUtil.hpp"
 #include "WbLineEdit.hpp"
 #include "WbMessageBox.hpp"
+#include "WbMultipleValue.hpp"
 #include "WbNodeModel.hpp"
 #include "WbPreferences.hpp"
 #include "WbProject.hpp"
@@ -132,8 +133,10 @@ void WbNewProtoWizard::accept() {
       for (int i = 0; i < fieldModels.size(); ++i) {
         if (mExposedFieldCheckBoxes[i + 1]->isChecked()) {
           WbValue *defaultValue = fieldModels[i]->defaultValue();
-          parameters +=
-            "  field " + defaultValue->vrmlTypeName() + " " + fieldModels[i]->name() + " " + defaultValue->toString() + "\n";
+          QString vrmlStringValue = defaultValue->toString();
+          if (defaultValue->type() == WB_SF_NODE)
+            vrmlStringValue += "{}";
+          parameters += "  field " + defaultValue->vrmlTypeName() + " " + fieldModels[i]->name() + " " + vrmlStringValue + "\n";
         }
       }
 

--- a/src/webots/gui/WbNewProtoWizard.cpp
+++ b/src/webots/gui/WbNewProtoWizard.cpp
@@ -132,11 +132,21 @@ void WbNewProtoWizard::accept() {
 
       for (int i = 0; i < fieldModels.size(); ++i) {
         if (mExposedFieldCheckBoxes[i + 1]->isChecked()) {
-          WbValue *defaultValue = fieldModels[i]->defaultValue();
-          QString vrmlStringValue = defaultValue->toString();
-          if (defaultValue->type() == WB_SF_NODE)
-            vrmlStringValue += "{}";
-          parameters += "  field " + defaultValue->vrmlTypeName() + " " + fieldModels[i]->name() + " " + vrmlStringValue + "\n";
+          const WbValue *defaultValue = fieldModels[i]->defaultValue();
+          QString vrmlDefaultValue = defaultValue->toString();
+
+          if (defaultValue->type() == WB_SF_NODE && vrmlDefaultValue != "NULL")
+            vrmlDefaultValue += "{}";
+
+          const WbMultipleValue *mv = dynamic_cast<const WbMultipleValue *>(defaultValue);
+          if (defaultValue->type() == WB_MF_NODE && mv) {
+            vrmlDefaultValue = "[ ";
+            for (int j = 0; j < mv->size(); ++j)
+              vrmlDefaultValue += mv->itemToString(j) + "{} ";
+            vrmlDefaultValue += "]";
+          }
+          parameters +=
+            "  field " + defaultValue->vrmlTypeName() + " " + fieldModels[i]->name() + " " + vrmlDefaultValue + "\n";
         }
       }
 

--- a/src/webots/scene_tree/WbValueEditor.cpp
+++ b/src/webots/scene_tree/WbValueEditor.cpp
@@ -62,10 +62,10 @@ void WbValueEditor::edit(WbNode *node, WbField *field, int index) {
   if (mField->singleType() != WB_SF_NODE && mField->hasRestrictedValues()) {
     if (mField->singleType() != WB_SF_STRING) {
       foreach (const WbVariant acceptedVariant, mField->acceptedValues())
-        mComboBox->addItem(acceptedVariant.toStringRepresentation());
+        mComboBox->addItem(acceptedVariant.toSimplifiedStringRepresentation());
     } else {  // In case of MF/SF_STRING we don't want to display the starting and ending '"'
       foreach (const WbVariant acceptedVariant, mField->acceptedValues())
-        mComboBox->addItem(acceptedVariant.toStringRepresentation().chopped(1).remove(0, 1));
+        mComboBox->addItem(acceptedVariant.toSimplifiedStringRepresentation().chopped(1).remove(0, 1));
     }
     connect(mComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(apply()), Qt::UniqueConnection);
     connect(field, &WbField::valueChanged, this, &WbValueEditor::updateComboBoxIndex, Qt::UniqueConnection);

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -161,7 +161,7 @@ void WbField::checkValueIsAccepted() {
   if (!mModel->isValueAccepted(mValue, &refusedIndex)) {
     QString acceptedValuesList = "";
     foreach (const WbVariant acceptedValue, mModel->acceptedValues())
-      acceptedValuesList += acceptedValue.toStringRepresentation() + ", ";
+      acceptedValuesList += acceptedValue.toSimplifiedStringRepresentation() + ", ";
     acceptedValuesList.chop(2);
     QString error;
     if (isSingle()) {

--- a/src/webots/vrml/WbMultipleValue.cpp
+++ b/src/webots/vrml/WbMultipleValue.cpp
@@ -56,7 +56,7 @@ QString WbMultipleValue::toString(WbPrecision::Level level) const {
 
 QString WbMultipleValue::itemToString(int index, WbPrecision::Level level) const {
   assert(index >= 0 && index < size());
-  QString value = variantValue(index).toStringRepresentation(level);
+  QString value = variantValue(index).toSimplifiedStringRepresentation(level);
   return type() == WB_MF_NODE ? value + "{}" : value;
 }
 

--- a/src/webots/vrml/WbMultipleValue.cpp
+++ b/src/webots/vrml/WbMultipleValue.cpp
@@ -56,8 +56,7 @@ QString WbMultipleValue::toString(WbPrecision::Level level) const {
 
 QString WbMultipleValue::itemToString(int index, WbPrecision::Level level) const {
   assert(index >= 0 && index < size());
-  QString value = variantValue(index).toSimplifiedStringRepresentation(level);
-  return type() == WB_MF_NODE ? value + "{}" : value;
+  return variantValue(index).toSimplifiedStringRepresentation(level);
 }
 
 bool WbMultipleValue::valueAtIndexEqualsSingleValue(int index, const WbValue *other) const {

--- a/src/webots/vrml/WbMultipleValue.cpp
+++ b/src/webots/vrml/WbMultipleValue.cpp
@@ -56,7 +56,8 @@ QString WbMultipleValue::toString(WbPrecision::Level level) const {
 
 QString WbMultipleValue::itemToString(int index, WbPrecision::Level level) const {
   assert(index >= 0 && index < size());
-  return variantValue(index).toStringRepresentation(level);
+  QString value = variantValue(index).toStringRepresentation(level);
+  return type() == WB_MF_NODE ? value + "{}" : value;
 }
 
 bool WbMultipleValue::valueAtIndexEqualsSingleValue(int index, const WbValue *other) const {

--- a/src/webots/vrml/WbSingleValue.hpp
+++ b/src/webots/vrml/WbSingleValue.hpp
@@ -34,7 +34,7 @@ public:
   // return generic value
   virtual WbVariant variantValue() const = 0;
   QString toString(WbPrecision::Level level = WbPrecision::DOUBLE_MAX) const override {
-    return variantValue().toStringRepresentation(level);
+    return variantValue().toSimplifiedStringRepresentation(level);
   }
 
 protected:

--- a/src/webots/vrml/WbVariant.cpp
+++ b/src/webots/vrml/WbVariant.cpp
@@ -142,7 +142,7 @@ void WbVariant::clear() {
   mType = -1;
 }
 
-const QString WbVariant::toStringRepresentation(WbPrecision::Level level) const {
+const QString WbVariant::toSimplifiedStringRepresentation(WbPrecision::Level level) const {
   switch (mType) {
     case WB_SF_BOOL:
       return mBool ? "TRUE" : "FALSE";

--- a/src/webots/vrml/WbVariant.cpp
+++ b/src/webots/vrml/WbVariant.cpp
@@ -162,7 +162,7 @@ const QString WbVariant::toStringRepresentation(WbPrecision::Level level) const 
       return mRotation->toString(level);
     case WB_SF_NODE: {
       if (mNode)
-        return mNode->fullName() + "{}";
+        return mNode->fullName();
       else
         return "NULL";
     }

--- a/src/webots/vrml/WbVariant.hpp
+++ b/src/webots/vrml/WbVariant.hpp
@@ -56,7 +56,7 @@ public:
   bool isEmpty() const { return mType == -1; }
   virtual void clear();
 
-  const QString toStringRepresentation(WbPrecision::Level level = WbPrecision::DOUBLE_MAX) const;
+  const QString toSimplifiedStringRepresentation(WbPrecision::Level level = WbPrecision::DOUBLE_MAX) const;
 
   // setters
   virtual void setBool(bool b);

--- a/tests/parser/expected_results.txt
+++ b/tests/parser/expected_results.txt
@@ -25,7 +25,7 @@ parser/worlds/proto_missing_ending_curly_bracket.wbt "Expected field name or '}'
 parser/worlds/proto_missing_item_value_in_field.wbt "Expected floating point value, found 'field'."
 parser/worlds/proto_nested_parameter.wbt VOID
 parser/worlds/proto_not_allowed_field_value.wbt "Invalid 'translation' changed to 0 0 0. The value should be in the list: {0 0 0}."
-parser/worlds/proto_not_allowed_mf_field_value.wbt "Invalid 'Transform{}' removed from 'extensionSlot' field. The values should be in the list: {Solid{}, Group{}}."
+parser/worlds/proto_not_allowed_mf_field_value.wbt "Invalid 'Transform' removed from 'extensionSlot' field. The values should be in the list: {Solid, Group}."
 parser/worlds/proto_parameter_missing_ending_curly_bracket.wbt "Expected field name or '}', found ']'."
 parser/worlds/proto_typo_in_alias.wbt "PROTO parameter 'rotation' has no matching IS field."
 parser/worlds/proto_typo_in_is_keyword.wbt "Expected floating point value, found 'ISNOT'."


### PR DESCRIPTION
**Description**
In https://github.com/cyberbotics/webots/pull/4104, in order to pre-fill the PROTO parameters the function `toStringRepresentation` was modified such that for SFNodes the `{}` is also included in the representation (just the name alone is not VRML compliant for a node, the brackets are needed). This function however didn't aim to be VRML compliant and is used for other things, most notably to display the names of nodes in the scene tree, which meant this change added curly brackets in the GUI as well.

Although the addition of curly brackets could have been done at the level of other functions (like `WbMultipleValue::toString`, `itemToString`), these too serve other purposes and changing it would have side-effects.

All things considered, the best option appears to be to add the brackets locally where it's needed.

