### PR TITLE
Advertise simulation servers

### DIFF
--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -74,7 +74,7 @@ Then, the selected simulation server starts a Webots instance that communicates 
 To test the session and simulation servers, simply open the `$WEBOTS_HOME/resources/web/streaming_viewer/index.html` file in your browser.
 In the user interface, under the `Connect to:` field, type for example:
 ```
-ws://localhost:1999/session?url=https://github.com/cyberbotics/webots/tree/develop/projects/languages/python/worlds/example.wbt
+http://localhost:1999/session?url=https://github.com/cyberbotics/webots/tree/develop/projects/languages/python/worlds/example.wbt
 ```
 Click the `Connect` button to initiate the streaming.
 Webots will clone the `example.wbt` simulation from GitHub and start it.
@@ -413,7 +413,8 @@ Similarly to [this section](web-streaming.md#how-to-embed-a-web-scene-in-your-we
 
 This is the API of the `webots-streaming` web component:
 * `connect(servers, mode, broadcast, mobileDevice, callback, disconnectCallback) `: function instantiating the simulation web interface and taking as argument:
-  * `server`: The URL of the server. Three different URL formats are supported:
+  * `server`: The URL of theserver. Different URL formats are supported:
+      * URL to a session server: "https://beta.webots.cloud/ajax/server/session.php?url=https://github.com/cyberbotics/webots/projects/languages/python/worlds/example.wbt"
       * URL to a WBT file (i.e. "ws://localhost:80/simple/worlds/simple.wbt"): this is the format required to start a web simulation. The URL value specifies both the session server host and the desired simulation name.
       * WebSocket URL (i.e. "ws://localhost:80"): this format is used for web broadcast streaming.
       * URL to a X3D file (i.e. "file.x3d"): this format is used for showing a [web scene](web-scene.md) or a [web animation](web-animation.md).

--- a/docs/guide/web-simulation.md
+++ b/docs/guide/web-simulation.md
@@ -222,18 +222,21 @@ The simulation server creates and starts a Webots instance with the desired simu
 
 These are the configuration parameters for the simulation server:
 ```
-    # server:              fully qualilified domain name of simulation server
-    # ssl:                 for https/wss URL (true by default)
-    # port:                local port on which the server is listening
-    # portRewrite:         port rewritten in the URL by apache (true by default)
-    # docker:              launch webots inside a docker (false by default)
-    # allowedRepositories: list of allowed GitHub simulation repositories
-    # projectsDir:         directory in which projects are located
-    # webotsHome:          directory in which Webots is installed (WEBOTS_HOME)
-    # maxConnections:      maximum number of simultaneous Webots instances
-    # logDir:              directory where the log files are written
-    # monitorLogEnabled:   store monitor data in a file (true by default)
-    # debug:               output debug information to stdout (false by default)
+# server:              fully qualilified domain name of simulation server
+# ssl:                 for https/wss URL (true by default)
+# port:                local port on which the server is listening
+# portRewrite:         port rewritten in the URL by apache (true by default)
+# docker:              launch webots inside a docker (false by default)
+# allowedRepositories: list of allowed GitHub simulation repositories
+# blockedRepositories: list of blocked GitHub simulation repositories
+# shareIdleTime:       maximum load for running non-allowed repositories
+# notify:              webservices to be notified about the server status
+# projectsDir:         directory in which projects are located
+# webotsHome:          directory in which Webots is installed (WEBOTS_HOME)
+# maxConnections:      maximum number of simultaneous Webots instances
+# logDir:              directory where the log files are written
+# monitorLogEnabled:   store monitor data in a file (true by default)
+# debug:               output debug information to stdout (false by default)
 ```
 
 HTTP request handlers:
@@ -413,9 +416,8 @@ Similarly to [this section](web-streaming.md#how-to-embed-a-web-scene-in-your-we
 
 This is the API of the `webots-streaming` web component:
 * `connect(servers, mode, broadcast, mobileDevice, callback, disconnectCallback) `: function instantiating the simulation web interface and taking as argument:
-  * `server`: The URL of theserver. Different URL formats are supported:
+  * `server`: The URL of the server. Different URL formats are supported:
       * URL to a session server: "https://beta.webots.cloud/ajax/server/session.php?url=https://github.com/cyberbotics/webots/projects/languages/python/worlds/example.wbt"
-      * URL to a WBT file (i.e. "ws://localhost:80/simple/worlds/simple.wbt"): this is the format required to start a web simulation. The URL value specifies both the session server host and the desired simulation name.
       * WebSocket URL (i.e. "ws://localhost:80"): this format is used for web broadcast streaming.
       * URL to a X3D file (i.e. "file.x3d"): this format is used for showing a [web scene](web-scene.md) or a [web animation](web-animation.md).
   * `mode`: `x3d` or `mjpeg`.

--- a/resources/web/server/session_server.py
+++ b/resources/web/server/session_server.py
@@ -206,7 +206,7 @@ def retrieve_load(url, i):
     if 'administrator' in config:
         protocol = 'https://' if config['ssl'] else 'http://'
         separator = '/' if config['portRewrite'] else ':'
-        check_string = f'Check it at{protocol}{config["server"]}{separator}{config["port"]}/monitor\n\n' + \
+        check_string = f'Check it at {protocol}{config["server"]}{separator}{config["port"]}/monitor\n\n' + \
                        '-Simulation Server'
     try:
         response = urlopen(url, timeout=5)

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -559,7 +559,7 @@ class MonitorHandler(tornado.web.RequestHandler):
                 self.write(f'<tr><td><a href="{repository}">{repository}</a></td></tr>')
             self.write('</table>')
         if 'notify' in config:
-            self.write(f'<table class="bordered"><thead><tr><th>Share Idle Time: {config["shareIdleTime"]}</th></thead>\n')
+            self.write(f'<table class="bordered"><thead><tr><th>Share Idle Time: {config["shareIdleTime"]}%</th></thead>\n')
             for notify in config['notify']:
                 slash = notify.find('/', 8)
                 if slash > -1:
@@ -798,7 +798,7 @@ def main():
         config['notify'] = [config['notify']]
 
     if 'shareIdleTime' not in config:
-        config['shareIdleTime'] = 0.5
+        config['shareIdleTime'] = 50
 
     if 'ssl' not in config:
         config['ssl'] = True

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -305,10 +305,7 @@ class Client:
                 line = client.webots_process.stdout.readline().rstrip()
                 if line.startswith('open'):  # Webots world is loaded, ready to receive connections
                     break
-            if 'server' not in config:
-                hostname = client.websocket.request.host.split(':')[0]
-            else:
-                hostname = config['server']
+            hostname = config['server']
             protocol = 'wss:' if config['ssl'] else 'ws:'
             separator = '/' if config['portRewrite'] else ':'
             asyncio.set_event_loop(asyncio.new_event_loop())
@@ -806,15 +803,20 @@ def main():
     if 'portRewrite' not in config:
         config['portRewrite'] = True
 
+    if 'server' not in config:
+        config['server'] = 'localhost'
+        logging.error('Warning: server name not defined in configuration file.')
+
     url = 'https' if config['ssl'] else 'http'
     url += '://' + config['server']
     url += '/' if config['portRewrite'] else ':'
     url += str(config['port'])
 
     for server in config['notify']:
+        allowedRepositories = ','.join(config['allowedRepositories']) if 'allowedRepositories' in config else ''
         x = requests.post(server, data={'url': url,
                                         'shareIdleTime': config['shareIdleTime'],
-                                        'allowedRepositories': ','.join(config['allowedRepositories'])})
+                                        'allowedRepositories': allowedRepositories})
         print(x.text)
 
     # startup the server

--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -793,7 +793,7 @@ def main():
         subprocess.Popen(["/opt/janus/bin/janus"])
 
     if 'notify' not in config:
-        config['notify'] = ['https://beta.webots.cloud/ajax/simulation_server_pulse.php']
+        config['notify'] = ['https://beta.webots.cloud/ajax/server/setup.php']
     elif isinstance(config['notify'], str):
         config['notify'] = [config['notify']]
 

--- a/resources/web/wwi/Server.js
+++ b/resources/web/wwi/Server.js
@@ -8,26 +8,24 @@ export default class Server {
     this._onready = onready;
     // url has one of the following form:
     // "ws(s)://cyberbotics1.epfl.ch:80/simple/worlds/simple.wbt", or
-    // "wss://cyberbotics1.epfl.ch/session
-    //  ?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
-    const n = this._url.indexOf('/session?url=', 6);
-    // 6 is for skipping the "ws(s)://domain" part of the URL which smallest form is 6 characters long: "ws://a"
+    // "http://cyberbotics1.epfl.ch/session?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
+    // "https://webots.cloud/ajax/server/session.php?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
+    const n = this._url.indexOf('?url=https://github.com/', 8);
+    // 8 is for skipping the "http(s)://domain" part of the URL which smallest form is 8 characters long: "https://a"
     if (n === -1) {
       const m = url.lastIndexOf('/');
       this._project = url.substring(this._url.indexOf('/', 6) + 1, m - 7); // e.g., "simple"
       this._worldFile = url.substring(m + 1); // e.g., "simple.wbt"
     } else
-      this._repository = this._url.substring(n + 13);
+      this._repository = this._url.substring(n + 5);
   }
 
   connect() {
-    const n = this._url.indexOf('/session?url=', 6);
-    const url = 'http' + (n > 0 ? this._url.substring(2, n + 8) : this._url.substring(2, this._url.indexOf('/', 6)) + '/session');
     let progressMessage = document.getElementById('webotsProgressMessage');
     if (progressMessage)
       progressMessage.innerHTML = 'Connecting to session server...';
     let self = this;
-    fetch(url)
+    fetch(self._url)
       .then(response => response.text())
       .then(function(data) {
         if (data.startsWith('Error:')) {

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -142,7 +142,8 @@ webots.View = class View {
           this.view3D.appendChild(this.toolBar.domElement);
 
         if (this.url.endsWith('.wbt')) { // url expected form: "wss://localhost:1999/simple/worlds/simple.wbt" or
-          // "wss://localhost/1999/?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
+          // "http://localhost/1999/session?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
+          // "https://webots.cloud/ajax/server/session.php?url=https://github.com/cyberbotics/webots/blob/master/projects/languages/python/worlds/example.wbt"
           this._server = new Server(this.url, this, finalizeWorld);
           this._server.connect();
         } else { // url expected form: "ws://cyberbotics1.epfl.ch:80"
@@ -187,7 +188,7 @@ webots.View = class View {
 
     if (this.broadcast)
       this.setTimeout(-1);
-    this._isWebSocketProtocol = this.url.startsWith('ws://') || this.url.startsWith('wss://');
+    this._isWebSocketProtocol = this.url.startsWith('ws://') || this.url.startsWith('wss://') || this.url.endsWith('.wbt');
 
     const texturePathPrefix = url.includes('/') ? url.substring(0, url.lastIndexOf('/') + 1) : '';
 


### PR DESCRIPTION
This PR changes the simulation server so that it will notify a server (for example webots.cloud) about its availability to host public simulations.
The monitor page of the simulation was also improved.
Additionally, the `webots.js` API is improved: the URL passed to the connect method is now `https` instead of `wss` which is more straightforward.
The result can be seen at https://beta.webots.cloud/server
