### PR TITLE
Fix documentation for lidar and rangeFinder about minRange and maxRange

### DIFF
--- a/docs/reference/lidar.md
+++ b/docs/reference/lidar.md
@@ -159,11 +159,11 @@ A typically good value for this field is to set it just big enough so that the s
 More information about the frustum is provided in the [frustum](camera.md#frustum) section of the [Camera](camera.md) node.
 
 - The `minRange` field defines the minimum range of the lidar, objects closer to the lidar than the minimum range are not detected (but still occlude other objects).
-If the range value is smaller than the `minRange` value then infinity is returned.
+If the range value is smaller than the `minRange` value then the `minRange` value is returned.
 
 - The `maxRange` field defines the distance between the lidar and the far clipping plane of the OpenGL view frustum.
 This field defines the maximum range that the lidar can achieve and so the maximum possible value of the range image (in meter).
-If the range value is bigger than the `maxRange` value then infinity is returned.
+If the range value is bigger than the `maxRange` value then the `maxRange` value is returned.
 
 - The `type` field should either be 'fixed' or 'rotating', it defines if the lidar has a rotating or fixed head.
 

--- a/docs/reference/rangefinder.md
+++ b/docs/reference/rangefinder.md
@@ -62,11 +62,11 @@ A typically good value for this field is to set it just big enough so that the s
 More information about the frustum is provided in the [frustum](camera.md#frustum) section of the [Camera](camera.md) node.
 
 - The `minRange` field defines the minimum range of the range-finder (objects closer to the range-finder than the minimum range are not detected (but still occlude other objects).
-If the depth is smaller than the `minRange` value then infinity is returned.
+If the depth is smaller than the `minRange` value then the `minRange` value is returned.
 
 - The `maxRange` defines the distance between the range-finder and the far clipping plane of the OpenGL view frustum.
 This field defines the maximum range that a range-finder can achieve and so the maximum possible value of the range image (in meter).
-If the depth is bigger than the `maxRange` value then infinity is returned.
+If the depth is bigger than the `maxRange` value then the `maxRange` value is returned.
 
 - If the `motionBlur` field is greater than 0.0, the image is blurred by the motion of the range-finder or objects in the field of view.
 More information on motion blur is provided in the [motionBlur](camera.md) field description of the [Camera](camera.md) node.


### PR DESCRIPTION
**Description**
The `Field Summary` is not correct about the `maxRange` and `minRange`, saying that values out of bound will return INF instead of `maxRange` and `minRange`.