### PR TITLE
Refresh docs for objects and fix unlinked PROTO

### DIFF
--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -28,7 +28,7 @@ Asphalt {
 
 ### Asphalt Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -96,7 +96,7 @@ BlanketFabric {
 
 ### BlanketFabric Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -129,7 +129,7 @@ BrushedAluminium {
 
 ### BrushedAluminium Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -162,7 +162,7 @@ BrushedSteel {
 
 ### BrushedSteel Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -199,7 +199,7 @@ CarpetFibers {
 
 ### CarpetFibers Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `type`: Defines the carpet type. This field accepts the following values: `"wooly"`, `"synthetic"`, and `"pattern"`.
 
@@ -234,7 +234,7 @@ CementTiles {
 
 ### CementTiles Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -297,7 +297,7 @@ CorrodedMetal {
 
 ### CorrodedMetal Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -330,7 +330,7 @@ CorrugatedMetal {
 
 ### CorrugatedMetal Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -363,7 +363,7 @@ CorrugatedPlates {
 
 ### CorrugatedPlates Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -396,7 +396,7 @@ CorrugatedPvc {
 
 ### CorrugatedPvc Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -429,7 +429,7 @@ DamascusSteel {
 
 ### DamascusSteel Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -492,7 +492,7 @@ ElectricConduit {
 
 ### ElectricConduit Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -525,7 +525,7 @@ FlexibleAluminiumDuct {
 
 ### FlexibleAluminiumDuct Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -588,7 +588,7 @@ GalvanizedMetal {
 
 ### GalvanizedMetal Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -659,7 +659,7 @@ Grass {
 
 ### Grass Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `type`: Defines the grass type. This field accepts the following values: `"maintained"`, `"artificial"`, `"artificial_white"`, `"prickly"`, and `"mossy"`.
 
@@ -694,7 +694,7 @@ HammeredCopper {
 
 ### HammeredCopper Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -732,7 +732,7 @@ Leather {
 
 ### Leather Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `tone`: Defines the tone of the leather. This field accepts the following values: `"dark"` and `"light"`.
 
@@ -770,7 +770,7 @@ LedStrip {
 
 ### LedStrip Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -805,7 +805,7 @@ Marble {
 
 ### Marble Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -838,7 +838,7 @@ MarbleTiles {
 
 ### MarbleTiles Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -964,7 +964,7 @@ OldPlywood {
 
 ### OldPlywood Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -997,7 +997,7 @@ OldSteel {
 
 ### OldSteel Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1030,7 +1030,7 @@ OsbWood {
 
 ### OsbWood Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1063,7 +1063,7 @@ PaintedWood {
 
 ### PaintedWood Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1104,7 +1104,7 @@ Parquetry {
 
 - `type`: Defines the parquetry type. This field accepts the following values: `"chequered"`, `"dark strip"`, `"light strip"`, and `"mosaic"`.
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1146,7 +1146,7 @@ Pavement {
 
 - `type`: Defines the pavement type. This field accepts the following values: `"black stone"`, `"braun stone"`, `"braun square stone"`, `"grid"`, `"slate"`, and `"tiles"`.
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1209,7 +1209,7 @@ PerforatedMetal {
 
 ### PerforatedMetal Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1242,7 +1242,7 @@ Plaster {
 
 ### Plaster Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1278,7 +1278,7 @@ Plastic {
 
 ### Plastic Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `type`: Defines the plastic type. This field accepts the following values: `"rough"` and `"padded"`.
 
@@ -1313,7 +1313,7 @@ PorcelainChevronTiles {
 
 ### PorcelainChevronTiles Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1366,7 +1366,7 @@ ReflectiveSurface {
   SFFloat metalness         0.5
   SFColor emissiveColor     0 0 0
   SFFloat emissiveIntensity 1
-  SFColor baseColorMap      1 1 1
+  SFColor colorOverride      1 1 1
   SFBool  useBaseColorMap   TRUE
   SFNode  textureTransform  NULL
   SFFloat IBLStrength       1
@@ -1379,6 +1379,8 @@ ReflectiveSurface {
 [More information.](http://www.apache.org/licenses/LICENSE-2.0)
 
 ### ReflectiveSurface Field Summary
+
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `useBaseColorMap`: Defines wheather the base color texture should be used or not.
 
@@ -1413,7 +1415,7 @@ RoughConcrete {
 
 ### RoughConcrete Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1446,7 +1448,7 @@ RoughOak {
 
 ### RoughOak Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1479,7 +1481,7 @@ RoughPine {
 
 ### RoughPine Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1545,7 +1547,7 @@ Roughcast {
 
 ### Roughcast Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1569,6 +1571,7 @@ Derived from [PBRAppearance](../reference/pbrappearance.md).
 ```
 Rubber {
   SFString  type              "flat"
+  SFColor   colorOverride     1 1 1
   SFNode    textureTransform  NULL
   SFFloat   IBLStrength       1
 }
@@ -1582,6 +1585,8 @@ Rubber {
 ### Rubber Field Summary
 
 - `type`: Defines the rubber type. This field accepts the following values: `"flat"` and `"dotted"`.
+
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1618,7 +1623,7 @@ RustyMetal {
 
 - `rustLevel`: Defines how much the metal is rusted. This field accepts the following values: `1` and `2`.
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1681,7 +1686,7 @@ SandyGround {
 
 ### SandyGround Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1715,7 +1720,7 @@ ScratchedPaint {
 
 ### ScratchedPaint Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1750,7 +1755,7 @@ ScrewThread {
 
 ### ScrewThread Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1888,7 +1893,7 @@ ThreadMetalPlate {
 
 - `type`: Defines the motif type on the material. This field accepts the following values: `"oval"` and `"square"`.
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1957,7 +1962,7 @@ VarnishedPine {
 
 ### VarnishedPine Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 
@@ -1990,7 +1995,7 @@ WireFence {
 
 ### WireFence Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 - `textureTransform`: Defines an optional 2d texture transform.
 

--- a/docs/guide/appearances.md
+++ b/docs/guide/appearances.md
@@ -1366,7 +1366,7 @@ ReflectiveSurface {
   SFFloat metalness         0.5
   SFColor emissiveColor     0 0 0
   SFFloat emissiveIntensity 1
-  SFColor colorOverride      1 1 1
+  SFColor colorOverride     1 1 1
   SFBool  useBaseColorMap   TRUE
   SFNode  textureTransform  NULL
   SFFloat IBLStrength       1

--- a/docs/guide/generate_objects_doc.py
+++ b/docs/guide/generate_objects_doc.py
@@ -48,6 +48,8 @@ DESCRIPTION_STATE = 0
 FIELDS_STATE = 1
 BODY_STATE = 2
 
+TAG = 'R2022a'
+
 fileList = []
 upperCategories = {'projects': ['appearances']}
 
@@ -183,6 +185,9 @@ for proto in prioritaryProtoList + fileList:
                 fieldString = re.sub(r'\s*(#.*)', '', match.group(), 0, re.MULTILINE)
                 # remove intial '*field' string
                 fieldString = re.sub(r'^\s*.*field\s', '  ', fieldString, 0, re.MULTILINE)
+                # update urls
+                fieldString = fieldString.replace(
+                    'webots://', 'https://raw.githubusercontent.com/cyberbotics/webots/' + TAG + '/')
                 # remove unwanted spaces between field type and field name (if needed)
                 if spacesToRemove > 0:
                     fieldString = fieldString.replace(fieldType + ' ' * spacesToRemove, fieldType)

--- a/docs/guide/object-apartment-structure.md
+++ b/docs/guide/object-apartment-structure.md
@@ -239,7 +239,7 @@ GenericDoorAppearance {
 
 ### GenericDoorAppearance Field Summary
 
-- `colorOverride`: Defines the default color multiplied with the texture color.
+- `colorOverride`: Defines the color to be multiplied with the texture color.
 
 ## Radiator
 

--- a/docs/guide/object-balls.md
+++ b/docs/guide/object-balls.md
@@ -21,7 +21,7 @@ Ball {
   SFColor    color           1.0 0.54 0.08
   SFFloat    radius          0.0325
   SFFloat    mass            0.055
-  MFVec3f    centerOfMass    [0 -0.0001 0]
+  MFVec3f    centerOfMass    [0 0 -0.0001]
   SFFloat    linearDamping   0.17
   SFFloat    angularDamping  0.33
   SFString   contactMaterial "default"

--- a/docs/guide/object-bathroom.md
+++ b/docs/guide/object-bathroom.md
@@ -86,7 +86,7 @@ Toilet {
 
 ### Toilet Field Summary
 
-- `lidColor`: Defines the color fo the lid.
+- `lidColor`: Defines the color of the lid.
 
 ## WashingMachine
 
@@ -112,3 +112,4 @@ WashingMachine {
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
+

--- a/docs/guide/object-buildings.md
+++ b/docs/guide/object-buildings.md
@@ -1223,3 +1223,4 @@ Windmill {
 ### Windmill Field Summary
 
 - `enableBoundingObject`: Defines whether the windmill should have a bounding object.
+

--- a/docs/guide/object-cabinet.md
+++ b/docs/guide/object-cabinet.md
@@ -97,7 +97,7 @@ Derived from [Slot](../reference/slot.md).
 
 ```
 CabinetHandle {
-  SFVec3f    translation   0 0 0
+  SFVec3f    translation  0 0 0
   SFRotation rotation     0 0 1 0
   SFString   name         "cabinet handle"
   SFFloat    handleLength 0.065

--- a/docs/guide/object-chairs.md
+++ b/docs/guide/object-chairs.md
@@ -138,3 +138,4 @@ WoodenChair {
 - `color`: Defines the color of the chair.
 
 - `physics`: Defines the physics of the chair.
+

--- a/docs/guide/object-factory.md
+++ b/docs/guide/object-factory.md
@@ -16,7 +16,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 CardboardBox {
-  SFVec3f    translation 0 0.3 0
+  SFVec3f    translation 0 0 0.3
   SFRotation rotation    0 0 1 0
   SFString   name        "cardboard box"
   SFVec3f    size        0.6 0.6 0.6
@@ -131,7 +131,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 WoodenBox {
-  SFVec3f    translation         0 0.3 0
+  SFVec3f    translation         0 0 0.3
   SFRotation rotation            0 0 1 0
   SFString   name                "wooden box"
   SFVec3f    size                0.6 0.6 0.6
@@ -205,7 +205,6 @@ ConveyorBelt {
 A controllable conveyor platform.
 The default controller makes it move at a constant speed for a configurable amount of time.
 The conveyor contains 3 controllable LEDs.
-Another controller gives the possibility to set the speed of the belt using the keyboard.
 
 %figure
 
@@ -217,7 +216,7 @@ Derived from [Robot](../reference/robot.md).
 
 ```
 ConveyorPlatform {
-   SFVec3f     translation      0 0 0
+   SFVec3f     translation      0 0 0.065
    SFRotation  rotation         0 0 1 0
    SFString    name             "Conveyor platform"
    SFString    model            "Conveyor platform"
@@ -456,7 +455,7 @@ Derived from [Solid](../reference/solid.md).
 ```
 PipeSection {
   SFVec3f    translation   0 0 0.25
-  SFRotation rotation      1 0 0 1.5708
+  SFRotation rotation      0 0 1 0
   SFString   name          "pipe section"
   SFFloat    height        0.5
   SFFloat    radius        0.03
@@ -527,7 +526,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Bolt {
-  SFVec3f    translation      0 0 0.027
+  SFVec3f    translation      0 0 0.013
   SFRotation rotation         0 0 1 0
   SFString   name             "bolt"
   SFNode     appearance       OldSteel {}
@@ -564,7 +563,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 CapScrew {
-  SFVec3f    translation           0 0 0.012
+  SFVec3f    translation           0 0 0.01
   SFRotation rotation              0 0 1 0
   SFString   name                  "cap screw"
   SFNode     appearance            OldSteel {}
@@ -612,7 +611,7 @@ ElectricalPlug {
   SFRotation rotation              0 0 1 0
   SFString   name                  "electrical plug"
   SFColor    color                 1 1 1
-  MFVec3f    cablePath             [0 0 0, 0 0 -0.03, 0.1 0 -0.03]
+  MFVec3f    cablePath             [0 0 0, -0.03 0 0, -0.03 0 -0.1]
   SFBool     enablePhysics         TRUE
   SFBool     enableBoundingObject  TRUE
 }
@@ -677,7 +676,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 EyeScrew {
-  SFVec3f    translation      0 0 0.036
+  SFVec3f    translation      0 0 0.01
   SFRotation rotation         0 0 1 0
   SFString   name             "eye screw"
   SFNode     appearance       OldSteel { colorOverride 0.73 0.74 0.71 }
@@ -740,7 +739,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Nut {
-  SFVec3f    translation     0 0 0.004
+  SFVec3f    translation     0 0 0.012
   SFRotation rotation        0 0 1 0
   SFString   name            "nut"
   SFNode     appearance      OldSteel {}
@@ -834,7 +833,7 @@ Derived from [Transform](../reference/transform.md).
 
 ```
 ScrewHole {
-  SFVec3f    translation     0 0 0
+  SFVec3f    translation     0 0 0.2
   SFRotation rotation        0 0 1 0
   SFFloat    radius          0.06
   SFFloat    depth           0.1
@@ -887,7 +886,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Washer {
-  SFVec3f    translation     0 0 0.001
+  SFVec3f    translation     0 0 0.016
   SFRotation rotation        0 0 1 0
   SFString   name            "washer"
   SFNode     appearance       OldSteel {}
@@ -1048,3 +1047,4 @@ SmallValve {
 - `controller`: Defines the controller of the valve which is used to limit its rotation.
 
 - `absoluteStop`: Defines the maximum rotational angle in radians. This value is sent to the controller using the controllerArgs field.
+

--- a/docs/guide/object-floors.md
+++ b/docs/guide/object-floors.md
@@ -149,7 +149,7 @@ UnevenTerrain {
   SFVec3f    translation    0 0 0
   SFRotation rotation       0 0 1 0
   SFString   name           "uneven terrain"
-  SFVec3f    size           50 5 50
+  SFVec3f    size           50 50 5
   SFInt32    xDimension     50
   SFInt32    yDimension     50
   SFNode     appearance     SandyGround { textureTransform TextureTransform { scale 50 50 } }

--- a/docs/guide/object-fruits.md
+++ b/docs/guide/object-fruits.md
@@ -14,7 +14,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Apple {
-  SFVec3f    translation         0 0.05 0
+  SFVec3f    translation         0 0 0.05
   SFRotation rotation            0 0 1 0
   SFString   name                "apple"
   SFFloat    mass                0.15
@@ -78,7 +78,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Orange {
-  SFVec3f    translation 0 0.05 0
+  SFVec3f    translation 0 0 0.05
   SFRotation rotation    0 0 1 0
   SFString   name        "orange"
   SFFloat    mass        0.15

--- a/docs/guide/object-geometries.md
+++ b/docs/guide/object-geometries.md
@@ -144,7 +144,6 @@ The `size` and `angles` fields specify the edges and angles of the parallelepipe
 - `angles.x`: angle in y direction between front and back faces of the prism
 - `angles.y`: angle between base and side edges of the parallelogram face
 - `angles.z`: angle in z direction between front and back faces of the prism
-
 Available texture mappings:
 - `cube` mapping: see texture at projects/samples/geometries/worlds/textures/cube\_mapping.jpg
 - `compact` cube mapping: see texture at projects/samples/geometries/worlds/textures/compact\_mapping.jpg
@@ -166,7 +165,7 @@ Derived from [IndexedFaceSet](../reference/indexedfaceset.md).
 ```
 TexturedParallelepiped {
   SFVec3f  size    0.1 0.1 0.1
-  SFVec3f  angles  0.7854 0.0 0.0
+  SFVec3f  angles  0.0 0.7854 0.0
   SFString mapping "flat"
   SFBool   front   TRUE
   SFBool   back    TRUE
@@ -201,3 +200,4 @@ TexturedParallelepiped {
 - `top`: Defines whether the top face should be included.
 
 - `bottom`: Defines whether the bottom face should be included.
+

--- a/docs/guide/object-kitchen.md
+++ b/docs/guide/object-kitchen.md
@@ -19,7 +19,7 @@ BiscuitBox {
   SFVec3f    translation 0 0 0
   SFRotation rotation    0 0 1 0
   SFString   name        "biscuit box"
-  SFVec3f    size        0.24 0.04 0.08
+  SFVec3f    size        0.08 0.24 0.04
   MFString   textureUrl  "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/objects/kitchen/breakfast/protos/textures/biscuit_box.jpg"
   SFFloat    mass        0.4
 }
@@ -55,7 +55,7 @@ CerealBox {
   SFVec3f    translation 0 0 0
   SFRotation rotation    0 0 1 0
   SFString   name        "cereal box"
-  SFVec3f    size        0.08 0.3 0.2
+  SFVec3f    size        0.08 0.2 0.3
   MFString   textureUrl  "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/objects/kitchen/breakfast/protos/textures/cereal_box_2.jpg"
   SFFloat    mass        1
 }
@@ -159,7 +159,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 HotPlate {
-  SFVec3f    translation 0 0.71 0
+  SFVec3f    translation 0 0 0.71
   SFRotation rotation    0 0 1 0
   SFString   name        "hot plate"
   MFString   textureUrl  "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/objects/kitchen/components/protos/textures/components.jpg"
@@ -189,7 +189,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Sink {
-  SFVec3f    translation 0 0.72 0
+  SFVec3f    translation 0 0 0.72
   SFRotation rotation    0 0 1 0
   SFString   name        "sink"
   MFString   textureUrl  "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/objects/kitchen/components/protos/textures/components.jpg"
@@ -219,10 +219,10 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Worktop {
-  SFVec3f    translation  0 0.71 0
+  SFVec3f    translation  0 0 0.71
   SFRotation rotation     0 0 1 0
   SFString   name         "worktop"
-  SFVec3f    size         0.44 0.06 0.7
+  SFVec3f    size         0.7 0.44 0.06
   SFNode     appearance   Marble { }
 }
 ```
@@ -290,7 +290,7 @@ Oven {
   SFRotation rotation       0 0 1 0
   SFString   name           "oven"
   SFColor    mainColor      1 1 1
-  SFString   type           "oven"  # Either "oven" or "microwave"
+  SFString   type           "oven"
 }
 ```
 
@@ -302,6 +302,8 @@ Oven {
 #### Oven Field Summary
 
 - `mainColor`: Defines the color of the oven.
+
+- `type`: Either "oven" or "microwave".
 
 ## Utensils
 

--- a/docs/guide/object-lego.md
+++ b/docs/guide/object-lego.md
@@ -39,7 +39,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 LegoWheel {
-  SFVec3f    translation 0 0.0219974 0
+  SFVec3f    translation 0 0 0.0219974
   SFRotation rotation    0 0 1 0
   SFString   name        "LEGO wheel"
 }

--- a/docs/guide/object-lights.md
+++ b/docs/guide/object-lights.md
@@ -2,7 +2,7 @@
 
 ## CeilingLight
 
-A ceiling light (0.19 x 0.8 x 0.19 m).
+A ceiling light (0.19 x 0.19 x 0.8 m).
 
 %figure
 
@@ -14,7 +14,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 CeilingLight {
-  SFVec3f    translation                0 2.4 0
+  SFVec3f    translation                0 0 2.4
   SFRotation rotation                   0 0 1 0
   SFString   name                       "ceiling light"
   SFColor    bulbColor                  1 1 1
@@ -68,7 +68,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 CeilingSpotLight {
-  SFVec3f    translation               0 1.0 0
+  SFVec3f    translation               0 0 1
   SFRotation rotation                  0 0 1 0
   SFString   name                      "ceiling light"
   SFNode     supportAppearance         DamascusSteel { }
@@ -110,7 +110,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 ConstructionLamp {
-  SFVec3f    translation               0 0.07 0
+  SFVec3f    translation               0 0 0.07
   SFRotation rotation                  0 0 1 0
   SFString   name                      "construction lamp"
   SFNode     supportAppearance         MetalPipePaint { }
@@ -171,7 +171,7 @@ DoubleFluorescentLamp {
 
 ## FloorLight
 
-A floor light (0.19 x 1.6 x 0.19 m).
+A floor light (0.19 x 0.19 x 1.6 m).
 
 %figure
 

--- a/docs/guide/object-obstacles.md
+++ b/docs/guide/object-obstacles.md
@@ -65,3 +65,4 @@ Ramp30deg {
 ### Ramp30deg Field Summary
 
 - `color`: Defines the color of the ramp.
+

--- a/docs/guide/object-plants.md
+++ b/docs/guide/object-plants.md
@@ -2,7 +2,7 @@
 
 ## BunchOfSunFlowers
 
-Five sun flowers into a pot (0.17 x 0.95 x 0.17 m).
+Five sun flowers into a pot (0.17 x 0.17 x 0.95 m).
 
 %figure
 
@@ -36,7 +36,7 @@ BunchOfSunFlowers {
 
 ## PottedTree
 
-A potted tree (0.3 x 1.3 x 0.3 m).
+A potted tree (0.3 x 0.3 x 1.3 m).
 
 %figure
 

--- a/docs/guide/object-road.md
+++ b/docs/guide/object-road.md
@@ -37,7 +37,7 @@ Road {
          SFBool               rightBarrier              FALSE
          SFBool               leftBarrier               FALSE
          SFBool               bottom                    FALSE
-         MFVec3f              wayPoints                 [ 0 0 0, 0 0 1 ]
+         MFVec3f              wayPoints                 [ 0 0 0, 1 0 0 ]
          MFFloat              roadTilt                  [ 0, 0]
          MFFloat              startingAngle             []
          MFFloat              endingAngle               []
@@ -426,7 +426,7 @@ Crossroad {
   SFString   name             "crossroad"
   SFString   id               ""
   SFFloat    speedLimit       -1.0
-  MFVec3f    shape            [ 0 0 0, 0 0 1, 1 0 0]
+  MFVec3f    shape            [ 0 0 0, 0 1 0, 1 0 0 ]
   MFString   connectedRoadIDs []
   SFBool     boundingObject   FALSE
   SFBool     bottom           FALSE

--- a/docs/guide/object-rocks.md
+++ b/docs/guide/object-rocks.md
@@ -14,7 +14,7 @@ Derived from [Solid](../reference/solid.md).
 
 ```
 Rock10cm {
-  SFVec3f    translation      0 0.05 0
+  SFVec3f    translation      0 0 0.05
   SFRotation rotation         0 0 1 0
   SFString   name             "rock 10 cm"
   MFString   texture          "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/default/worlds/textures/rock.jpg"

--- a/docs/guide/object-school-furniture.md
+++ b/docs/guide/object-school-furniture.md
@@ -32,7 +32,7 @@ Blackboard {
 
 ## Book
 
-A book (0.2 x 0.02 x 0.15 m).
+A book (0.02 x 0.15 x 0.2 m).
 
 %figure
 
@@ -90,3 +90,4 @@ Clock {
 
 > **License**: Copyright Cyberbotics Ltd. Licensed for use only with Webots.
 [More information.](https://cyberbotics.com/webots_assets_license)
+

--- a/docs/guide/object-stairs.md
+++ b/docs/guide/object-stairs.md
@@ -17,7 +17,7 @@ StraightStairs {
   SFVec3f    translation        0 0 0
   SFRotation rotation           0 0 1 0
   SFString   name               "straight stairs"
-  SFVec3f    stepSize           0.4 0.03 1.27
+  SFVec3f    stepSize           0.4 1.27 0.03
   SFFloat    stepRise           0.15
   SFInt32    nSteps             5
   SFFloat    stringerWidth      0.02
@@ -72,7 +72,7 @@ StraightStairsLanding {
   SFVec3f    translation     0 0 0
   SFRotation rotation        0 0 1 0
   SFString   name            "straight stairs landing"
-  SFVec3f    landingSize     0.4 0.03 1.27
+  SFVec3f    landingSize     0.4 1.27 0.03
   SFFloat    height          2.0
   SFVec2f    stringerSize    0.3 0.02
   SFBool     stringerLeft    TRUE

--- a/docs/guide/object-street-furniture.md
+++ b/docs/guide/object-street-furniture.md
@@ -622,9 +622,9 @@ PublicToilet {
 
 - `height`: Defines the height of the toilet.
 
-- `length`: Defines the lenght of the toilet.
+- `length`: Defines the length of the toilet.
 
-- `width`: Defines the wdith of the toilet.
+- `width`: Defines the width of the toilet.
 
 - `backDisplayTexture`: Defines the texture used on the back display.
 
@@ -905,3 +905,4 @@ WorkTrashContainer {
 
 > **License**: Creative Commons Attribution 4.0 International License.
 [More information.](https://creativecommons.org/licenses/by/4.0/legalcode)
+

--- a/docs/guide/object-tables.md
+++ b/docs/guide/object-tables.md
@@ -2,7 +2,7 @@
 
 ## Desk
 
-A desk (1.2 x 0.7 x 0.72 m).
+A desk (0.7 x 1.2 x 0.72 m).
 
 %figure
 
@@ -108,3 +108,4 @@ Table {
 - `trayAppearance`: Defines the appearance of the tray.
 
 - `legAppearance`: Defines the appearance of the feet.
+

--- a/docs/guide/object-toys.md
+++ b/docs/guide/object-toys.md
@@ -45,7 +45,7 @@ PaperBoat {
 
 ## RubberDuck
 
-A rubber yellow duck (10.13 x 7.42 x 10.66 cm).
+A rubber yellow duck (7.42 x 10.66 x 10.13 cm).
 
 %figure
 

--- a/docs/guide/object-traffic.md
+++ b/docs/guide/object-traffic.md
@@ -54,7 +54,7 @@ CautionSign {
   SFFloat    height       2
   SFFloat    radius       0.03
   SFColor    color        0.576471 0.576471 0.576471
-  MFNode     signBoards   [ CautionPanel { translation 0 -0.17 0 } ]
+  MFNode     signBoards   [ CautionPanel { translation 0 0 -0.17 } ]
 }
 ```
 
@@ -95,7 +95,7 @@ ControlledStreetLight {
   SFFloat    beamWidth    1.1
   MFColor    color        [ 1 0.9 0.8 ]
   SFFloat    cutOffAngle  1.4
-  SFVec3f    direction    0 -1 -0.1
+  SFVec3f    direction    0.1 0 -1
   SFFloat    radius       1000
   SFBool     castShadows  FALSE
 }
@@ -289,7 +289,7 @@ ExitSign {
   SFFloat    height       2
   SFFloat    radius       0.03
   SFColor    color        0.576471 0.576471 0.576471
-  MFNode     signBoards   [ ExitPanel { translation 0 -0.051 0 } ]
+  MFNode     signBoards   [ ExitPanel { translation 0 0 -0.051 } ]
 }
 ```
 
@@ -505,7 +505,7 @@ OrderSign {
   SFFloat    height       2
   SFFloat    radius       0.03
   SFColor    color        0.576471 0.576471 0.576471
-  MFNode     signBoards   [ OrderPanel { translation 0 -0.175 -0.026 } ]
+  MFNode     signBoards   [ OrderPanel { translation 0.026 0 -0.175  } ]
 }
 ```
 
@@ -783,7 +783,7 @@ SpeedLimitSign {
   SFFloat    height       2
   SFFloat    radius       0.03
   SFColor    color        0.576471 0.576471 0.576471
-  MFNode     signBoards   [ SpeedLimitPanel { translation 0 0 -0.023 } ]
+  MFNode     signBoards   [ SpeedLimitPanel { translation 0.023 0 0 } ]
 }
 ```
 
@@ -856,7 +856,7 @@ StopSign {
   SFFloat    height       2
   SFFloat    radius       0.03
   SFColor    color        0.576471 0.576471 0.576471
-  MFNode     signBoards   [ StopPanel { translation 0 -0.097 0 } ]
+  MFNode     signBoards   [ StopPanel { translation 0 0 -0.097 } ]
 }
 ```
 
@@ -896,7 +896,7 @@ StreetLight {
   SFFloat    beamWidth     1.1
   SFColor    color         1 1 1
   SFFloat    cutOffAngle   1.4
-  SFVec3f    direction     0 -1 -0.1
+  SFVec3f    direction     0.1 0 -1
   SFBool     on            TRUE
   SFFloat    radius        1000
   SFFloat    intensity     30

--- a/docs/guide/object-trees.md
+++ b/docs/guide/object-trees.md
@@ -254,6 +254,7 @@ Sassafras {
 ### Sassafras Field Summary
 
 - `burnt`: Defines whether the tree is burnt (after a wildfire).
+
 - `enableBoundingObject`: Defines whether the tree should have a bounding object.
 
 ## SimpleTree
@@ -335,7 +336,7 @@ Tree {
   SFVec3f    translation          0 0 0
   SFRotation rotation             0 0 1 0
   SFString   name                 "tree"
-  SFVec3f    scale                1 4 1
+  SFVec3f    scale                1 1 4
   MFString   texture              "https://raw.githubusercontent.com/cyberbotics/webots/R2022a/projects/objects/trees/protos/textures/cherry_tree.png"
   SFNode     boundingObject       NULL
   SFBool     locked               TRUE
@@ -352,6 +353,7 @@ Tree {
 
 - `name`: Defines the name of the tree.
 
-- `scale`: The first and last components of the scale define the radius of the tree and the middle one defines it's height.
+- `scale`: The first and middle components of the scale define the radius of the tree and the last one defines it's height.
 
 - `texture`: Defines the texture used for the tree.
+

--- a/projects/appearances/protos/Asphalt.proto
+++ b/projects/appearances/protos/Asphalt.proto
@@ -4,7 +4,7 @@
 # An asphalt material. The color can be overridden using the `colorOverride` field. Useful with the `Road` PROTO.
 
 PROTO Asphalt [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/BlanketFabric.proto
+++ b/projects/appearances/protos/BlanketFabric.proto
@@ -4,7 +4,7 @@
 # A blanket fabric material.
 
 PROTO BlanketFabric [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/BrushedAluminium.proto
+++ b/projects/appearances/protos/BrushedAluminium.proto
@@ -4,7 +4,7 @@
 # A brushed aluminum material.
 
 PROTO BrushedAluminium [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/BrushedSteel.proto
+++ b/projects/appearances/protos/BrushedSteel.proto
@@ -4,7 +4,7 @@
 # A brushed steel material.
 
 PROTO BrushedSteel [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/CarpetFibers.proto
+++ b/projects/appearances/protos/CarpetFibers.proto
@@ -5,7 +5,7 @@
 # template language: javascript
 
 PROTO CarpetFibers [
-  field SFColor                                   colorOverride    1 1 1   # Defines the default color multiplied with the texture color.
+  field SFColor                                   colorOverride    1 1 1   # Defines the color to be multiplied with the texture color.
   field SFString{"wooly", "synthetic", "pattern"} type             "wooly" # Defines the carpet type.
   field SFNode                                    textureTransform NULL    # Defines an optional 2d texture transform.
   field SFFloat                                   IBLStrength      1       # Defines the strength of ambient lighting from the Background node.

--- a/projects/appearances/protos/CementTiles.proto
+++ b/projects/appearances/protos/CementTiles.proto
@@ -4,7 +4,7 @@
 # A cement tiles material.
 
 PROTO CementTiles [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/CorrodedMetal.proto
+++ b/projects/appearances/protos/CorrodedMetal.proto
@@ -4,7 +4,7 @@
 # A corroded metal material. The color can be overridden using the `colorOverride` field.
 
 PROTO CorrodedMetal [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/CorrugatedMetal.proto
+++ b/projects/appearances/protos/CorrugatedMetal.proto
@@ -4,7 +4,7 @@
 # A corrugated metal material. The color can be overridden using the `colorOverride` field.
 
 PROTO CorrugatedMetal [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/CorrugatedPlates.proto
+++ b/projects/appearances/protos/CorrugatedPlates.proto
@@ -4,7 +4,7 @@
 # A corrugated plates material. The color can be overridden using the `colorOverride` field.
 
 PROTO CorrugatedPlates [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/CorrugatedPvc.proto
+++ b/projects/appearances/protos/CorrugatedPvc.proto
@@ -4,7 +4,7 @@
 # A corrugated PVC material. The color can be overridden using the `colorOverride` field.
 
 PROTO CorrugatedPvc [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/DamascusSteel.proto
+++ b/projects/appearances/protos/DamascusSteel.proto
@@ -4,7 +4,7 @@
 # A damascus steel material. The color can be overridden using the `colorOverride` field.
 
 PROTO DamascusSteel [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/DarkParquetry.proto
+++ b/projects/appearances/protos/DarkParquetry.proto
@@ -7,7 +7,7 @@
 # template language: javascript
 
 PROTO DarkParquetry [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/ElectricConduit.proto
+++ b/projects/appearances/protos/ElectricConduit.proto
@@ -4,7 +4,7 @@
 # An electric conduit material. The color can be overridden using the `colorOverride` field.
 
 PROTO ElectricConduit [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/FlexibleAluminiumDuct.proto
+++ b/projects/appearances/protos/FlexibleAluminiumDuct.proto
@@ -4,7 +4,7 @@
 # A flexible aluminium duct material. The color can be overridden using the `colorOverride` field.
 
 PROTO FlexibleAluminiumDuct [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/GalvanizedMetal.proto
+++ b/projects/appearances/protos/GalvanizedMetal.proto
@@ -4,7 +4,7 @@
 # A galvanized metal material. The color can be overridden using the `colorOverride` field.
 
 PROTO GalvanizedMetal [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Grass.proto
+++ b/projects/appearances/protos/Grass.proto
@@ -5,7 +5,7 @@
 # template language: javascript
 
 PROTO Grass [
-  field SFColor  colorOverride    1 1 1         # Defines the default color multiplied with the texture color.
+  field SFColor  colorOverride    1 1 1         # Defines the color to be multiplied with the texture color.
   field SFString{"maintained", "artificial", "artificial_white", "prickly", "mossy"}
                  type             "maintained"  # Defines the grass type.
   field SFNode   textureTransform NULL          # Defines an optional 2d texture transform.

--- a/projects/appearances/protos/HammeredCopper.proto
+++ b/projects/appearances/protos/HammeredCopper.proto
@@ -4,7 +4,7 @@
 # An hammered copper steel material. The color can be overridden using the `colorOverride` field.
 
 PROTO HammeredCopper [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Leather.proto
+++ b/projects/appearances/protos/Leather.proto
@@ -5,7 +5,7 @@
 # template language: javascript
 
 PROTO Leather [
-  field SFColor                      colorOverride     1 1 1      # Defines the default color multiplied with the texture color.
+  field SFColor                      colorOverride     1 1 1      # Defines the color to be multiplied with the texture color.
   field SFString{"dark", "light"}    tone              "dark"     # Defines the tone of the leather.
   field SFString{"dollaro", "grain"} type              "dollaro"  # Defines the type of the leather.
   field SFNode                       textureTransform  NULL       # Defines an optional 2d texture transform.

--- a/projects/appearances/protos/LedStrip.proto
+++ b/projects/appearances/protos/LedStrip.proto
@@ -4,7 +4,7 @@
 # A led strip material.
 
 PROTO LedStrip [
-  field SFColor colorOverride     1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride     1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform  NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength       1      # Defines the strength of ambient lighting from the Background node.
   field SFFloat emissiveIntensity 1      # Defines the intensity of the leds.

--- a/projects/appearances/protos/Marble.proto
+++ b/projects/appearances/protos/Marble.proto
@@ -4,7 +4,7 @@
 # A beige marble material.
 
 PROTO Marble [
-  field SFColor colorOverride     1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride     1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform  NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength       1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/MarbleTiles.proto
+++ b/projects/appearances/protos/MarbleTiles.proto
@@ -4,7 +4,7 @@
 # A marble tiles material.
 
 PROTO MarbleTiles [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/OldPlywood.proto
+++ b/projects/appearances/protos/OldPlywood.proto
@@ -4,7 +4,7 @@
 # An old plywood material.
 
 PROTO OldPlywood [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/OldSteel.proto
+++ b/projects/appearances/protos/OldSteel.proto
@@ -4,7 +4,7 @@
 # An old battered steel material.
 
 PROTO OldSteel [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/OsbWood.proto
+++ b/projects/appearances/protos/OsbWood.proto
@@ -4,7 +4,7 @@
 # An OSB wood material. The color can be overridden using the `colorOverride` field.
 
 PROTO OsbWood [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/PaintedWood.proto
+++ b/projects/appearances/protos/PaintedWood.proto
@@ -4,7 +4,7 @@
 # A painted wood material. The color can be overridden using the `colorOverride` field.
 
 PROTO PaintedWood [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Parquetry.proto
+++ b/projects/appearances/protos/Parquetry.proto
@@ -9,7 +9,7 @@
 PROTO Parquetry [
   field SFString{"chequered", "dark strip", "light strip", "mosaic"}
                  type             "mosaic"  # Defines the parquetry type.
-  field SFColor  colorOverride    1 1 1     # Defines the default color multiplied with the texture color.
+  field SFColor  colorOverride    1 1 1     # Defines the color to be multiplied with the texture color.
   field SFNode   textureTransform NULL      # Defines an optional 2d texture transform.
   field SFFloat  IBLStrength      1         # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Pavement.proto
+++ b/projects/appearances/protos/Pavement.proto
@@ -9,7 +9,7 @@
 PROTO Pavement [
   field SFString{"black stone", "braun stone", "braun square stone", "grid", "slate", "tiles"}
                  type             "braun square stone" # Defines the pavement type.
-  field SFColor  colorOverride     1 1 1               # Defines the default color multiplied with the texture color.
+  field SFColor  colorOverride     1 1 1               # Defines the color to be multiplied with the texture color.
   field SFNode   textureTransform  NULL                # Defines an optional 2d texture transform.
   field SFFloat  IBLStrength       1                   # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/PerforatedMetal.proto
+++ b/projects/appearances/protos/PerforatedMetal.proto
@@ -4,7 +4,7 @@
 # A perforated metal material.
 
 PROTO PerforatedMetal [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Plaster.proto
+++ b/projects/appearances/protos/Plaster.proto
@@ -4,7 +4,7 @@
 # A plaster material. The color can be overridden using the `colorOverride` field.
 
 PROTO Plaster [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Plastic.proto
+++ b/projects/appearances/protos/Plastic.proto
@@ -5,7 +5,7 @@
 # template language: javascript
 
 PROTO Plastic [
-  field SFColor  colorOverride    1 1 1         # Defines the default color multiplied with the texture color.
+  field SFColor  colorOverride    1 1 1         # Defines the color to be multiplied with the texture color.
   field SFString{"rough", "padded"}
                  type             "rough"       # Defines the plastic type.
   field SFNode   textureTransform NULL          # Defines an optional 2d texture transform.

--- a/projects/appearances/protos/PorcelainChevronTiles.proto
+++ b/projects/appearances/protos/PorcelainChevronTiles.proto
@@ -4,7 +4,7 @@
 # A porcelain chevron tiles material.
 
 PROTO PorcelainChevronTiles [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/ReflectiveSurface.proto
+++ b/projects/appearances/protos/ReflectiveSurface.proto
@@ -8,7 +8,7 @@ PROTO ReflectiveSurface [
   field SFFloat metalness         0.5
   field SFColor emissiveColor     0 0 0
   field SFFloat emissiveIntensity 1
-  field SFColor baseColorMap      1 1 1
+  field SFColor colorOverride      1 1 1 # Defines the default color multiplied with the texture color.
   field SFBool  useBaseColorMap   TRUE   # Defines wheather the base color texture should be used or not.
   field SFNode  textureTransform  NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength       1      # Defines the strength of ambient lighting from the Background node.

--- a/projects/appearances/protos/ReflectiveSurface.proto
+++ b/projects/appearances/protos/ReflectiveSurface.proto
@@ -8,7 +8,7 @@ PROTO ReflectiveSurface [
   field SFFloat metalness         0.5
   field SFColor emissiveColor     0 0 0
   field SFFloat emissiveIntensity 1
-  field SFColor colorOverride      1 1 1 # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride      1 1 1 # Defines the color to be multiplied with the texture color.
   field SFBool  useBaseColorMap   TRUE   # Defines wheather the base color texture should be used or not.
   field SFNode  textureTransform  NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength       1      # Defines the strength of ambient lighting from the Background node.

--- a/projects/appearances/protos/ReflectiveSurface.proto
+++ b/projects/appearances/protos/ReflectiveSurface.proto
@@ -8,7 +8,7 @@ PROTO ReflectiveSurface [
   field SFFloat metalness         0.5
   field SFColor emissiveColor     0 0 0
   field SFFloat emissiveIntensity 1
-  field SFColor colorOverride      1 1 1 # Defines the color to be multiplied with the texture color.
+  field SFColor colorOverride     1 1 1  # Defines the color to be multiplied with the texture color.
   field SFBool  useBaseColorMap   TRUE   # Defines wheather the base color texture should be used or not.
   field SFNode  textureTransform  NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength       1      # Defines the strength of ambient lighting from the Background node.

--- a/projects/appearances/protos/RoughConcrete.proto
+++ b/projects/appearances/protos/RoughConcrete.proto
@@ -4,7 +4,7 @@
 # A rough concrete material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughConcrete [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/RoughOak.proto
+++ b/projects/appearances/protos/RoughOak.proto
@@ -4,7 +4,7 @@
 # A rough oak material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughOak [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/RoughPine.proto
+++ b/projects/appearances/protos/RoughPine.proto
@@ -4,7 +4,7 @@
 # A pine wood material. The color can be overridden using the `colorOverride` field.
 
 PROTO RoughPine [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Roughcast.proto
+++ b/projects/appearances/protos/Roughcast.proto
@@ -4,7 +4,7 @@
 # A rough plaster material. Useful with the `Wall` PROTO.
 
 PROTO Roughcast [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Rubber.proto
+++ b/projects/appearances/protos/Rubber.proto
@@ -7,7 +7,7 @@
 
 PROTO Rubber [
   field SFString{"flat", "dotted"} type              "flat"   # Defines the rubber type.
-  field SFColor                    colorOverride     1 1 1    # Defines the default color multiplied with the texture color.
+  field SFColor                    colorOverride     1 1 1    # Defines the color to be multiplied with the texture color.
   field SFNode                     textureTransform  NULL     # Defines an optional 2d texture transform.
   field SFFloat                    IBLStrength       1        # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/Rubber.proto
+++ b/projects/appearances/protos/Rubber.proto
@@ -7,6 +7,7 @@
 
 PROTO Rubber [
   field SFString{"flat", "dotted"} type              "flat"   # Defines the rubber type.
+  field SFColor                    colorOverride     1 1 1    # Defines the default color multiplied with the texture color.
   field SFNode                     textureTransform  NULL     # Defines an optional 2d texture transform.
   field SFFloat                    IBLStrength       1        # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/RustyMetal.proto
+++ b/projects/appearances/protos/RustyMetal.proto
@@ -7,7 +7,7 @@
 
 PROTO RustyMetal [
   field SFInt32{1, 2}  rustLevel        1      # Defines how much the metal is rusted.
-  field SFColor        colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor        colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode         textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat        IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/SandyGround.proto
+++ b/projects/appearances/protos/SandyGround.proto
@@ -4,7 +4,7 @@
 # A sandy ground material. The color can be selected using the `colorOverride` field. Useful with the UnevenTerrain PROTO.
 
 PROTO SandyGround [
-  field SFColor colorOverride    1 1 1                           # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1                           # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform TextureTransform { scale 4 4 }  # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1                               # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/ScratchedPaint.proto
+++ b/projects/appearances/protos/ScratchedPaint.proto
@@ -5,7 +5,7 @@
 # template language: javascript
 
 PROTO ScratchedPaint [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
   field SFBool  metalScratch     TRUE   # Defines if the scratches should uncover metal or not.

--- a/projects/appearances/protos/ScrewThread.proto
+++ b/projects/appearances/protos/ScrewThread.proto
@@ -4,7 +4,7 @@
 # A screw thread material. The color can be overridden using the `colorOverride` field.
 
 PROTO ScrewThread [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/SlatePavement.proto
+++ b/projects/appearances/protos/SlatePavement.proto
@@ -7,7 +7,7 @@
 # template language: javascript
 
 PROTO SlatePavement [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/SquarePavement.proto
+++ b/projects/appearances/protos/SquarePavement.proto
@@ -8,7 +8,7 @@
 # template language: javascript
 
 PROTO SquarePavement [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/StonePavement.proto
+++ b/projects/appearances/protos/StonePavement.proto
@@ -7,7 +7,7 @@
 # template language: javascript
 
 PROTO StonePavement [
-  field SFColor                          colorOverride    1 1 1     # Defines the default color multiplied with the texture color.
+  field SFColor                          colorOverride    1 1 1     # Defines the color to be multiplied with the texture color.
   field SFString{"recent", "old square"} type             "recent"  # Defines the pavement type.
   field SFNode                           textureTransform NULL      # Defines an optional 2d texture transform.
   field SFFloat                          IBLStrength      1         # Defines the strength of ambient lighting from the Background node.

--- a/projects/appearances/protos/ThreadMetalPlate.proto
+++ b/projects/appearances/protos/ThreadMetalPlate.proto
@@ -7,7 +7,7 @@
 
 PROTO ThreadMetalPlate [
   field SFString{"oval", "square"} type               "oval" # Defines the motif type on the material.
-  field SFColor                    colorOverride      1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor                    colorOverride      1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode                     textureTransform   NULL   # Defines an optional 2d texture transform.
   field SFFloat                    IBLStrength        1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/VarnishedPine.proto
+++ b/projects/appearances/protos/VarnishedPine.proto
@@ -4,7 +4,7 @@
 # A pine wood material covered with a layer of varnish. The color can be overridden using the `colorOverride` field.
 
 PROTO VarnishedPine [
-  field SFColor colorOverride    0.8039 0.6745 0.5764  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    0.8039 0.6745 0.5764  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL                  # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1                     # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/appearances/protos/WireFence.proto
+++ b/projects/appearances/protos/WireFence.proto
@@ -4,7 +4,7 @@
 # A wire fence material. The color can be overridden using the `colorOverride` field.
 
 PROTO WireFence [
-  field SFColor colorOverride    1 1 1  # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride    1 1 1  # Defines the color to be multiplied with the texture color.
   field SFNode  textureTransform NULL   # Defines an optional 2d texture transform.
   field SFFloat IBLStrength      1      # Defines the strength of ambient lighting from the Background node.
 ]

--- a/projects/objects/apartment_structure/protos/GenericDoorAppearance.proto
+++ b/projects/objects/apartment_structure/protos/GenericDoorAppearance.proto
@@ -4,7 +4,7 @@
 # A generic varnished, painted wooden door's appearance.
 
 PROTO GenericDoorAppearance [
-  field SFColor colorOverride  1 1 1   # Defines the default color multiplied with the texture color.
+  field SFColor colorOverride  1 1 1   # Defines the color to be multiplied with the texture color.
 ]
 {
   PBRAppearance {


### PR DESCRIPTION
**Description**
 - regenerates the docs for objects in the `released` branch, some FLU related changes have not yet been updated.
 - removes unlinked fields (needs to be done in `released` since changing the proto header of objects requires regenerating the docs)