### PR TITLE
Add a scale option for Mesh and ColladaShapes

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -12,6 +12,7 @@ Released on XX, XXth, 2022.
     - Added some objects on the hospital theme: hospital bed, drip stand, medicine bottle, hand sanitizer, curtain, photo frame, flower pot, emergency exit sign and a fabric appearance ([#4166](https://github.com/cyberbotics/webots/pull/4166)).
   - Enhancements:
     - Improved the structure of the **Nao** PROTO: the **version** field changed and the **color** field was replaced with a **customColor** field ([#4180](https://github.com/cyberbotics/webots/pull/4180)).
+    - Added a `scale` field to the `Mesh` node and the `ColladaShapes` PROTO ([#4203](https://github.com/cyberbotics/webots/pull/4203)).
   - Dependency Updates
     - remove WebKit, WebChannel and WebEngine dependencies ([#4137](https://github.com/cyberbotics/webots/pull/4137)).
 

--- a/docs/reference/mesh.md
+++ b/docs/reference/mesh.md
@@ -3,6 +3,7 @@
 ```
 Mesh {
   field MFString url  [ ]
+  field SFVec3f scale 1 1 1
   field SFString name ""
   field SFInt32 materialIndex -1
 }
@@ -26,6 +27,9 @@ If the `url` value starts with `http://` or `https://`, Webots will get the file
 Otherwise, the file should be specified with a relative path.
 The same search algorithm as for [ImageTexture](imagetexture.md) is used (cf. [this section](imagetexture.md#search-rule-of-the-texture-path)).
 Absolute paths work as well, but they are not recommended because they are not portable across systems.
+
+The `scale` field specifies a possibly non-uniform scale. Only non-null values are permitted; null values scale are automatically reset to 1.
+Negative values will mirror the mesh along the according planes.
 
 The `name` field defines which sub-mesh is included.
 If the `name` value is an empty string then all sub-meshes are included.

--- a/docs/reference/mesh.md
+++ b/docs/reference/mesh.md
@@ -28,8 +28,9 @@ Otherwise, the file should be specified with a relative path.
 The same search algorithm as for [ImageTexture](imagetexture.md) is used (cf. [this section](imagetexture.md#search-rule-of-the-texture-path)).
 Absolute paths work as well, but they are not recommended because they are not portable across systems.
 
-The `scale` field specifies a possibly non-uniform scale. Only non-null values are permitted; null values scale are automatically reset to 1.
-Negative values will mirror the mesh along the according planes.
+The `scale` field specifies a possibly non-uniform scale.
+Only non-zero values are permitted, zero values are automatically reset to 1.
+Negative values are allowed.
 
 The `name` field defines which sub-mesh is included.
 If the `name` value is an empty string then all sub-meshes are included.

--- a/projects/shapes/protos/ColladaShapes.proto
+++ b/projects/shapes/protos/ColladaShapes.proto
@@ -6,7 +6,7 @@
 
 PROTO ColladaShapes [
   field SFString  url  ""  # URL of a Collada file (similar to ImageTexture node).
-  field SFVec3f  scale  1 1 1  # Resize the mesh by this possibly non-uniform scale. Negative values will mirror the mesh along according planes.
+  field SFVec3f  scale  1 1 1
 ]
 {
   %<
@@ -23,7 +23,7 @@ PROTO ColladaShapes [
     }
     if (scale.y == 0.0) {
       console.error(`All 'scale' coordinates must be not null: y is set to 1.0.`);
-      scale.y = 2.0;
+      scale.y = 1.0;
     }
     if (scale.z == 0.0) {
       console.error(`All 'scale' coordinates must be not null: z is set to 1.0.`);

--- a/projects/shapes/protos/ColladaShapes.proto
+++ b/projects/shapes/protos/ColladaShapes.proto
@@ -6,6 +6,7 @@
 
 PROTO ColladaShapes [
   field SFString  url  ""  # URL of a Collada file (similar to ImageTexture node).
+  field SFVec3f  scale  1 1 1  # Resize the mesh by this possibly non-uniform scale. Negative values will mirror the mesh along according planes.
 ]
 {
   %<
@@ -14,12 +15,27 @@ PROTO ColladaShapes [
       console.error(`The given Collada url (${url}) is not valid.`);
       url = fields.url.defaultValue;
     }
+
+    let scale = fields.scale.value;
+    if (scale.x == 0.0) {
+      console.error(`All 'scale' coordinates must be not null: x is set to 1.0.`);
+      scale.x = 1.0;
+    }
+    if (scale.y == 0.0) {
+      console.error(`All 'scale' coordinates must be not null: y is set to 1.0.`);
+      scale.y = 2.0;
+    }
+    if (scale.z == 0.0) {
+      console.error(`All 'scale' coordinates must be not null: z is set to 1.0.`);
+      scale.z = 1.0;
+    }
+    let scaleString = scale.x + ' ' + scale.y + ' ' + scale.z;
   >%
 
   Group {
     children [
       %< if (url !== '') { >%
-        %<= wbcollada.getVrmlFromFile(url) >%
+        %<= wbcollada.getVrmlFromFile(url, scaleString) >%
       %< } >%
     ]
   }

--- a/resources/nodes/Mesh.wrl
+++ b/resources/nodes/Mesh.wrl
@@ -2,7 +2,7 @@
 
 Mesh {
   field MFString url [ ]   # URL of a 3D file such as DAE, STL, OBJ or FBX format (similar to ImageTexture node)
-  field SFVec3f scale 1 1 1   # Resize the mesh by this possibly non-uniform scale. Negative values will mirror the mesh along the according planes.
+  field SFVec3f scale 1 1 1
   field SFString name ""   # Filter geometries based on the given name (for example, Collada files can contain multiple geometries in a single file).
   field SFInt32 materialIndex -1   # Filter geometries in Collada files based on the material index (Collada files can contain multiple geometries with different materials).
 }

--- a/resources/nodes/Mesh.wrl
+++ b/resources/nodes/Mesh.wrl
@@ -2,6 +2,7 @@
 
 Mesh {
   field MFString url [ ]   # URL of a 3D file such as DAE, STL, OBJ or FBX format (similar to ImageTexture node)
+  field SFVec3f scale 1 1 1   # Resize the mesh by this possibly non-uniform scale. Negative values will mirror the mesh along the according planes.
   field SFString name ""   # Filter geometries based on the given name (for example, Collada files can contain multiple geometries in a single file).
   field SFInt32 materialIndex -1   # Filter geometries in Collada files based on the material index (Collada files can contain multiple geometries with different materials).
 }

--- a/src/webots/core/WbQjsCollada.cpp
+++ b/src/webots/core/WbQjsCollada.cpp
@@ -24,7 +24,7 @@ WbQjsCollada *WbQjsCollada::instance() {
   return WbQjsCollada::cInstance;
 }
 
-QString WbQjsCollada::getVrmlFromFile(const QString &filePath) {
-  emit WbQjsCollada::instance()->vrmlFromFileRequested(filePath);
+QString WbQjsCollada::getVrmlFromFile(const QString &filePath, const QString &scaleString) {
+  emit WbQjsCollada::instance()->vrmlFromFileRequested(filePath, scaleString);
   return WbQjsCollada::cVrmlResponse;
 }

--- a/src/webots/core/WbQjsCollada.cpp
+++ b/src/webots/core/WbQjsCollada.cpp
@@ -24,7 +24,7 @@ WbQjsCollada *WbQjsCollada::instance() {
   return WbQjsCollada::cInstance;
 }
 
-QString WbQjsCollada::getVrmlFromFile(const QString &filePath, const QString &scaleString) {
-  emit WbQjsCollada::instance()->vrmlFromFileRequested(filePath, scaleString);
+QString WbQjsCollada::getVrmlFromFile(const QString &filePath, const QString &scale) {
+  emit WbQjsCollada::instance()->vrmlFromFileRequested(filePath, scale);
   return WbQjsCollada::cVrmlResponse;
 }

--- a/src/webots/core/WbQjsCollada.hpp
+++ b/src/webots/core/WbQjsCollada.hpp
@@ -25,10 +25,10 @@ public:
   Q_INVOKABLE static WbQjsCollada *instance();
   Q_INVOKABLE WbQjsCollada(){};
 
-  Q_INVOKABLE QString getVrmlFromFile(const QString &filePath, const QString &scaleString);
+  Q_INVOKABLE QString getVrmlFromFile(const QString &filePath, const QString &scale);
 
 signals:
-  void vrmlFromFileRequested(const QString &filePath, const QString &scaleString);
+  void vrmlFromFileRequested(const QString &filePath, const QString &scale);
 
 public:
   void setVrmlResponse(const QString &vrml) { WbQjsCollada::cVrmlResponse = vrml; };

--- a/src/webots/core/WbQjsCollada.hpp
+++ b/src/webots/core/WbQjsCollada.hpp
@@ -25,10 +25,10 @@ public:
   Q_INVOKABLE static WbQjsCollada *instance();
   Q_INVOKABLE WbQjsCollada(){};
 
-  Q_INVOKABLE QString getVrmlFromFile(const QString &filePath);
+  Q_INVOKABLE QString getVrmlFromFile(const QString &filePath, const QString &scaleString);
 
 signals:
-  void vrmlFromFileRequested(const QString &filePath);
+  void vrmlFromFileRequested(const QString &filePath, const QString &scaleString);
 
 public:
   void setVrmlResponse(const QString &vrml) { WbQjsCollada::cVrmlResponse = vrml; };

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -329,7 +329,8 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
 }
 
 uint64_t WbMesh::computeHash() const {
-  const QByteArray meshPathNameIndex = (path() + mScale->value().toString() + mName->value() + mMaterialIndex->value()).toUtf8();
+  const QByteArray meshPathNameIndex =
+    (path() + mScale->value().toString() + mName->value() + mMaterialIndex->value()).toUtf8();
   return WbTriangleMeshCache::sipHash13x(meshPathNameIndex.constData(), meshPathNameIndex.size());
 }
 

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -166,7 +166,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
   }
 
   // check scale field and reverse faces if necessary
-  WbVector3 scale = WbVector3(1.0, 1.0, 1.0);
+  WbVector3 scale(1.0, 1.0, 1.0);
   if (mScale) {
     scale = mScale->value();
     if (scale.x() == 0.0) {

--- a/src/webots/nodes/WbMesh.hpp
+++ b/src/webots/nodes/WbMesh.hpp
@@ -51,6 +51,7 @@ protected:
 private:
   // user accessible fields
   WbMFString *mUrl;
+  WbSFVector3 *mScale;
   WbSFString *mName;
   WbSFInt *mMaterialIndex;
   WbDownloader *mDownloader;
@@ -62,6 +63,7 @@ private:
 
 private slots:
   void updateUrl();
+  void updateScale();
   void updateName();
   void updateMaterialIndex();
   void downloadUpdate();

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -298,9 +298,9 @@ static bool addTextureMap(QString &stream, const aiMaterial *material, const QSt
   return false;
 }
 
-static void addModelNode(QString &stream, const aiNode *node, const aiScene *scene, const QString &fileName, const QString &scaleString,
-                         const QString &referenceFolder, bool importTextureCoordinates, bool importNormals,
-                         bool importAppearances, bool importAsSolid, bool importBoundingObjects,
+static void addModelNode(QString &stream, const aiNode *node, const aiScene *scene, const QString &fileName,
+                         const QString &scaleString, const QString &referenceFolder, bool importTextureCoordinates,
+                         bool importNormals, bool importAppearances, bool importAsSolid, bool importBoundingObjects,
                          bool referenceMeshes = false) {
   // ColladaShapes check for sub-meshes
   if (referenceMeshes) {

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -306,8 +306,8 @@ static void addModelNode(QString &stream, const aiNode *node, const aiScene *sce
     if (node->mNumChildren > 0) {
       for (unsigned int i = 0; i < node->mNumChildren; ++i)
         if (node->mChildren[i]->mNumMeshes > 0)
-          addModelNode(stream, node->mChildren[i], scene, fileName, scaleString, referenceFolder, importTextureCoordinates, importNormals,
-                       importAppearances, importAsSolid, importBoundingObjects, referenceMeshes);
+          addModelNode(stream, node->mChildren[i], scene, fileName, scaleString, referenceFolder, importTextureCoordinates,
+                       importNormals, importAppearances, importAsSolid, importBoundingObjects, referenceMeshes);
     }
   }
 
@@ -453,8 +453,8 @@ static void addModelNode(QString &stream, const aiNode *node, const aiScene *sce
     }
 
     for (unsigned int i = 0; i < node->mNumChildren; ++i)
-      addModelNode(stream, node->mChildren[i], scene, fileName, scaleString, referenceFolder, importTextureCoordinates, importNormals,
-                   importAppearances, importAsSolid, importBoundingObjects, referenceMeshes);
+      addModelNode(stream, node->mChildren[i], scene, fileName, scaleString, referenceFolder, importTextureCoordinates,
+                   importNormals, importAppearances, importAsSolid, importBoundingObjects, referenceMeshes);
 
     stream += " ]";
     if (importAsSolid) {
@@ -471,8 +471,9 @@ WbNodeOperations::OperationResult WbNodeOperations::importExternalModel(const QS
                                                                         bool importAsSolid, bool importBoundingObjects) {
   QString stream = "";
   QString scaleString = "1 1 1";
-  WbNodeOperations::OperationResult result = getVrmlFromExternalModel(stream, filename, scaleString, importTextureCoordinates, importNormals,
-                                                                      importAppearances, importAsSolid, importBoundingObjects);
+  WbNodeOperations::OperationResult result =
+    getVrmlFromExternalModel(stream, filename, scaleString, importTextureCoordinates, importNormals, importAppearances,
+                             importAsSolid, importBoundingObjects);
   if (result == FAILURE)
     return FAILURE;
 
@@ -482,7 +483,8 @@ WbNodeOperations::OperationResult WbNodeOperations::importExternalModel(const QS
   return result;
 }
 
-WbNodeOperations::OperationResult WbNodeOperations::getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scaleString,
+WbNodeOperations::OperationResult WbNodeOperations::getVrmlFromExternalModel(QString &stream, const QString &filename,
+                                                                             const QString &scaleString,
                                                                              bool importTextureCoordinates, bool importNormals,
                                                                              bool importAppearances, bool importAsSolid,
                                                                              bool importBoundingObjects, bool referenceMeshes) {
@@ -496,8 +498,9 @@ WbNodeOperations::OperationResult WbNodeOperations::getVrmlFromExternalModel(QSt
     WbLog::warning(tr("Invalid data, please verify mesh file (bone weights, normals, ...): %1").arg(importer.GetErrorString()));
     return FAILURE;
   }
-  addModelNode(stream, scene->mRootNode, scene, filename, scaleString, QFileInfo(filename).dir().absolutePath(), importTextureCoordinates,
-               importNormals, importAppearances, importAsSolid, importBoundingObjects, referenceMeshes);
+  addModelNode(stream, scene->mRootNode, scene, filename, scaleString, QFileInfo(filename).dir().absolutePath(),
+               importTextureCoordinates, importNormals, importAppearances, importAsSolid, importBoundingObjects,
+               referenceMeshes);
   return SUCCESS;
 }
 

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -300,7 +300,8 @@ static bool addTextureMap(QString &stream, const aiMaterial *material, const QSt
 
 static void addModelNode(QString &stream, const aiNode *node, const aiScene *scene, const QString &fileName, const QString &scaleString,
                          const QString &referenceFolder, bool importTextureCoordinates, bool importNormals,
-                         bool importAppearances, bool importAsSolid, bool importBoundingObjects, bool referenceMeshes = false) {
+                         bool importAppearances, bool importAsSolid, bool importBoundingObjects,
+                         bool referenceMeshes = false) {
   // ColladaShapes check for sub-meshes
   if (referenceMeshes) {
     if (node->mNumChildren > 0) {

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -47,7 +47,7 @@ public:
   OperationResult importVrml(const QString &filename, bool fromSupervisor = false);
   OperationResult importExternalModel(const QString &filename, bool importTextureCoordinates, bool importNormals,
                                       bool importAppearances, bool importAsSolid, bool importBoundingObjects);
-  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scaleString,
+  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scale,
                                            bool importTextureCoordinates, bool importNormals, bool importAppearances,
                                            bool importAsSolid, bool importBoundingObjects, bool referenceMeshes = false);
 
@@ -73,7 +73,7 @@ public:
 public slots:
   void requestUpdateDictionary();
   void requestUpdateSceneDictionary(WbNode *node, bool fromUseToDef);
-  void onVrmlExportRequested(const QString &filePath, const QString &scaleString);
+  void onVrmlExportRequested(const QString &filePath, const QString &scale);
 
 signals:
   void nodeAdded(WbNode *node);

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -47,7 +47,7 @@ public:
   OperationResult importVrml(const QString &filename, bool fromSupervisor = false);
   OperationResult importExternalModel(const QString &filename, bool importTextureCoordinates, bool importNormals,
                                       bool importAppearances, bool importAsSolid, bool importBoundingObjects);
-  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, bool importTextureCoordinates,
+  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scaleString, bool importTextureCoordinates,
                                            bool importNormals, bool importAppearances, bool importAsSolid,
                                            bool importBoundingObjects, bool referenceMeshes = false);
 
@@ -73,7 +73,7 @@ public:
 public slots:
   void requestUpdateDictionary();
   void requestUpdateSceneDictionary(WbNode *node, bool fromUseToDef);
-  void onVrmlExportRequested(const QString &filePath);
+  void onVrmlExportRequested(const QString &filePath, const QString &scaleString);
 
 signals:
   void nodeAdded(WbNode *node);

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -47,9 +47,9 @@ public:
   OperationResult importVrml(const QString &filename, bool fromSupervisor = false);
   OperationResult importExternalModel(const QString &filename, bool importTextureCoordinates, bool importNormals,
                                       bool importAppearances, bool importAsSolid, bool importBoundingObjects);
-  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scaleString, bool importTextureCoordinates,
-                                           bool importNormals, bool importAppearances, bool importAsSolid,
-                                           bool importBoundingObjects, bool referenceMeshes = false);
+  OperationResult getVrmlFromExternalModel(QString &stream, const QString &filename, const QString &scaleString,
+                                           bool importTextureCoordinates, bool importNormals, bool importAppearances,
+                                           bool importAsSolid, bool importBoundingObjects, bool referenceMeshes = false);
 
   OperationResult initNewNode(WbNode *newNode, WbNode *parentNode, WbField *field, int newNodeIndex = -1,
                               bool subscribe = false, bool finalize = true);


### PR DESCRIPTION
**Description**
Adding a scale option to the `Mesh` node and the `ColladaShapes` permits to easily adapt a mesh file by adjusting the size or by mirroring the mesh.

