### PR TITLE
Fix unlinked field in `Mavic2Pro` and `PedestrianCrossing` PROTO

### DIFF
--- a/docs/guide/mavic-2-pro.md
+++ b/docs/guide/mavic-2-pro.md
@@ -22,6 +22,7 @@ PROTO Mavic2Pro {
   SFString   customData          ""
   SFBool     supervisor          FALSE
   SFBool     synchronization     TRUE
+  MFFloat    battery             []
   MFNode     bodySlot            []
   MFNode     cameraSlot          [ Camera { width 400 height 240 } ]
 }

--- a/docs/guide/object-traffic.md
+++ b/docs/guide/object-traffic.md
@@ -604,6 +604,7 @@ PedestrianCrossing {
   SFVec3f    translation          0 0 0
   SFRotation rotation             0 0 1 0
   SFString   name                 "pedestrian crossing"
+  SFVec3f    scale                1 1 1
   SFVec2f    size                 20 8
   SFInt32    textureFiltering     4
   SFBool     enableBoundingObject TRUE

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -15,6 +15,7 @@ Released on XX XX, 2022.
     - Fixed `wb_supervisor_world_save` behavior when no argument is provided in non-C APIs ([#4140](https://github.com/cyberbotics/webots/pull/4140)).
     - Fixed the ROS `camera/recognition_objects` topic that was always returning an empty list of objects ([#4139](https://github.com/cyberbotics/webots/pull/4139)).
     - Fixed depths greater than `maxRange` to return `inf` for the `RangeFinder` device ([#4167](https://github.com/cyberbotics/webots/pull/4167)).
+    - Converted missing sample world `gears.wbt` to ENU ([4201](https://github.com/cyberbotics/webots/pull/4201)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/projects/objects/traffic/protos/PedestrianCrossing.proto
+++ b/projects/objects/traffic/protos/PedestrianCrossing.proto
@@ -8,6 +8,7 @@ PROTO PedestrianCrossing [
   field SFVec3f    translation          0 0 0
   field SFRotation rotation             0 0 1 0
   field SFString   name                 "pedestrian crossing"
+  field SFVec3f    scale                1 1 1
   field SFVec2f    size                 20 8                   # Defines the size of the pedestrian crossing.
   field SFInt32    textureFiltering     4                      # Defines the filtering level for the texture used for the pedestrian crossing.
   field SFBool     enableBoundingObject TRUE                   # Defines whether the pedestrian crossing should have a bounding object.

--- a/projects/samples/howto/gears/worlds/gears.wbt
+++ b/projects/samples/howto/gears/worlds/gears.wbt
@@ -5,11 +5,10 @@ WorldInfo {
   ]
   title "Gears example"
   basicTimeStep 8
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation 0 1 0 1.5707963267948966
-  position 0.2780916968916953 0.0015751684699579721 -0.03763246734023667
+  orientation 0 0 1 4.71238898038469
+  position -0.041748615977272176 0.27118552471245 -0.0005254140023221207
 }
 TexturedBackground {
   texture "empty_office"
@@ -17,11 +16,10 @@ TexturedBackground {
 TexturedBackgroundLight {
 }
 Robot {
-  rotation 0 1 0 1.5708
+  rotation 0 0 1 1.5708
   children [
     DEF MOTORIZED HingeJoint {
       jointParameters HingeJointParameters {
-        axis 0 0 1
       }
       device [
         PositionSensor {
@@ -30,7 +28,6 @@ Robot {
         }
       ]
       endPoint Gear {
-        rotation 1.1127701588714633e-10 -2.5015786939261218e-08 -0.9999999999999996 1.7921184929557338e-05
         appearance PBRAppearance {
           baseColor 0.8 0 0
           roughness 0.5
@@ -44,13 +41,12 @@ Robot {
     }
     DEF PASSIVE HingeJoint {
       jointParameters HingeJointParameters {
-        axis 0 0 1
-        anchor 0.083 0 0
+        anchor 0 0.083 0
         dampingConstant 1e-08
       }
       endPoint Gear {
-        translation 0.083 0 0
-        rotation 0 0 1 0.539999999999999
+        translation 0 0.083 0
+        rotation 1 0 0 0.261799
         appearance PBRAppearance {
           baseColor 0.203922 0.396078 0.643137
           roughness 0.5


### PR DESCRIPTION
**Description**

Fixes https://github.com/cyberbotics/webots/issues/4204

I tried again to clean the proto cache and let webots rebuild it but no warnings are shown. Yet somehow the mavic does show a warning when opened, rightfully so. It means there might be more, but at this point I don't know how to find them other than opening all PROTO one by one.