### PR TITLE
Fix bugs tracks

### DIFF
--- a/projects/samples/devices/worlds/track.wbt
+++ b/projects/samples/devices/worlds/track.wbt
@@ -205,11 +205,11 @@ DEF TRACKED_ROBOT Robot {
               metalness 0
             }
             geometry Box {
-              size 0.044 0.005 0.03
+              size 0.044 0.03 0.005
             }
           }
           Transform {
-            translation 0 0.003 0
+            translation 0 0 0.003
             children [
               Shape {
                 appearance PBRAppearance {
@@ -218,7 +218,7 @@ DEF TRACKED_ROBOT Robot {
                   metalness 0
                 }
                 geometry Box {
-                  size 0.02 0.006 0.03
+                  size 0.02 0.03 0.006
                 }
               }
             ]

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -26,5 +26,4 @@
     <script type="module" src="https://cyberbotics.com/wwi/R2022a/WebotsView.js"></script>
     <script src="setup_viewer.js"></script>
   </body>
-
 </html>

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -353,7 +353,6 @@ export default class Parser {
     if (typeof use === 'undefined')
       return;
 
-    const id = getNodeAttribute(node, 'id');
     let result = WbWorld.instance.nodes.get(use);
 
     if (typeof result === 'undefined') {
@@ -363,7 +362,9 @@ export default class Parser {
 
     if (typeof result === 'undefined')
       return;
-
+    let id = getNodeAttribute(node, 'id');
+    if (typeof id === 'undefined')
+      id = getAnId();
     const useNode = result.clone(id);
     if (typeof parentNode !== 'undefined') {
       useNode.parent = parentNode.id;

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -41,8 +41,6 @@
 #include <wren/renderable.h>
 #include <wren/transform.h>
 
-static const WbQuaternion TRACK_PAD_TRANSFORM(WbVector3(1, 0, 0), -M_PI_2);
-
 void WbTrack::init() {
   mDeviceField = findMFNode("device");
   mTextureAnimationField = findSFVector2("textureAnimation");
@@ -528,7 +526,7 @@ void WbTrack::updateAnimatedGeometries() {
     float position[3];
     float rotation[4];
     WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(position);
-    WbRotation(WbQuaternion(WbVector3(0.0, 1.0, 0.0), beltPosition.rotation) * TRACK_PAD_TRANSFORM).toFloatArray(rotation);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rotation);
 
     WrTransform *transform = wr_transform_new();
     wr_transform_set_position(transform, position);
@@ -656,7 +654,7 @@ void WbTrack::animateMesh() {
     float position[3];
     float rotation[4];
     WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(position);
-    WbRotation(WbQuaternion(WbVector3(0.0, 1.0, 0.0), beltPosition.rotation) * TRACK_PAD_TRANSFORM).toFloatArray(rotation);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rotation);
 
     wr_transform_set_position(mBeltElements[i], position);
     wr_transform_set_orientation(mBeltElements[i], rotation);
@@ -932,14 +930,15 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
   }
 
   for (int i = 1; i < mGeometriesCountField->value(); ++i) {
-    position = mBeltPositions[i].position.toString(WbPrecision::DOUBLE_MAX) + " 0";
+    position = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.x(), WbPrecision::DOUBLE_MAX)) + " 0 " +
+               QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.y(), WbPrecision::DOUBLE_MAX));
     rotation = QString("0 0 -1 %1").arg(WbPrecision::doubleToString(mBeltPositions[i].rotation, WbPrecision::DOUBLE_MAX));
 
     if (writer.isX3d()) {
       writer << "<Transform ";
       writer << "translation='" << position << "' ";
       writer << "rotation='" << rotation << "'>";
-      writer << "<Transform USE='" << QString::number(node->uniqueId()) << "'></Transform>";
+      writer << "<Group USE='" << QString::number(node->uniqueId()) << "'></Group>";
       writer << "</Transform>";
     } else {
       writer.indent();

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -896,8 +896,10 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
     parsingWarn(tr("Track field 'animatedGeometry' must have a DEF name for exportation. One have been generated."));
   }
 
-  QString position = mBeltPositions[0].position.toString(WbPrecision::DOUBLE_MAX) + " 0";
-  QString rotation = QString("0 0 -1 %1").arg(WbPrecision::doubleToString(mBeltPositions[0].rotation, WbPrecision::DOUBLE_MAX));
+  QString position = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.x(), WbPrecision::DOUBLE_MAX)) +
+                     " 0 " +
+                     QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.y(), WbPrecision::DOUBLE_MAX));
+  QString rotation = QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[0].rotation, WbPrecision::DOUBLE_MAX));
 
   if (writer.isX3d()) {
     writer << "<Transform ";
@@ -932,7 +934,7 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
   for (int i = 1; i < mGeometriesCountField->value(); ++i) {
     position = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.x(), WbPrecision::DOUBLE_MAX)) + " 0 " +
                QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.y(), WbPrecision::DOUBLE_MAX));
-    rotation = QString("0 0 -1 %1").arg(WbPrecision::doubleToString(mBeltPositions[i].rotation, WbPrecision::DOUBLE_MAX));
+    rotation = QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[i].rotation, WbPrecision::DOUBLE_MAX));
 
     if (writer.isX3d()) {
       writer << "<Transform ";

--- a/tests/api/worlds/track.wbt
+++ b/tests/api/worlds/track.wbt
@@ -1,6 +1,7 @@
 #VRML_SIM R2022a utf8
 WorldInfo {
   basicTimeStep 8
+  coordinateSystem "NUE"
   contactProperties [
     ContactProperties {
       material1 "wheel material"
@@ -9,11 +10,10 @@ WorldInfo {
       ]
     }
   ]
-  coordinateSystem "NUE"
 }
 Viewpoint {
-  orientation 0.11557297011013826 0.9538647509090101 0.2771009302640705 3.72576
-  position -0.569827 0.725051 -0.769219
+  orientation 0.938608372339704 0.05773892548854658 0.34011842034391465 4.70163844511325
+  position -1.748605365238676 0.7711193165098691 -0.5761128805191615
   follow "tracked robot"
 }
 Background {
@@ -90,7 +90,6 @@ DEF ROBOT1 Robot {
           radius 0.115
           children [
             Transform {
-              rotation 1 0 0 1.5708
               children [
                 Shape {
                   appearance Appearance {
@@ -116,7 +115,6 @@ DEF ROBOT1 Robot {
           radius 0.115
           children [
             Transform {
-              rotation 1 0 0 1.5708
               children [
                 Shape {
                   appearance Appearance {
@@ -167,7 +165,7 @@ DEF ROBOT1 Robot {
           }
         }
         geometry Box {
-          size 0.02 0.01 0.03
+          size 0.02 0.03 0.01
         }
       }
       geometriesCount 30


### PR DESCRIPTION
Fix several issues related to tracks:
  - [x] During FLU conversion (#3555) a rotation was introduced in `WbTrack.wbt` instead of turning the geometries.
  - [x] The export in X3D comported two problems:
    - [x] It was not converted to FLU
    - [x] It was exported some node as `Transform USE=36` but the DEF node was a `Group`.
  - [x] The `USE` mechanism in `Parser.js` did not handle the case where the USE node had no defined ID.