### PR TITLE
Fixed compilation warning

### DIFF
--- a/tests/physics/plugins/physics/ode_dif_exporter/ode_dif_exporter.c
+++ b/tests/physics/plugins/physics/ode_dif_exporter/ode_dif_exporter.c
@@ -1,7 +1,6 @@
 #include <ode/ode.h>
 #include <plugins/physics.h>
 
-#include <stdio.h> /* FILENAME_MAX */
 #ifdef WINDOWS
 #include <direct.h>
 #define GetCurrentDir _getcwd
@@ -30,7 +29,7 @@
 
 static dWorldID main_world = 0;
 static int step_counter = 0;
-static char current_path[FILENAME_MAX];
+static char current_path[1024];
 static bool message_sent = false;
 
 static void send_message(const char *msg, bool success) {
@@ -66,7 +65,7 @@ void webots_physics_step() {
     send_message("World badly defined", false);
 
   if (step_counter == 100) {
-    char filename[FILENAME_MAX];
+    char filename[sizeof(current_path) + 8];
     snprintf(filename, sizeof(filename), "%s%code.dif", current_path, SEP);
 
     FILE *f = fopen(filename, "w");


### PR DESCRIPTION
The compilation of this file in the CI was raising a warning:
```bash
ode_dif_exporter.c: In function ‘webots_physics_step’:
ode_dif_exporter.c:70:47: warning: ‘ode.dif’ directive output may be truncated writing 7 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
   70 |     snprintf(filename, sizeof(filename), "%s%code.dif", current_path, SEP);
      |                                               ^~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /home/runner/work/webots/webots/artifact/webots/include/ode/ode/odeconfig.h:29,
                 from /home/runner/work/webots/webots/artifact/webots/include/ode/ode/ode.h:28,
                 from ode_dif_exporter.c:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 9 and 4104 bytes into a destination of size 4096
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
See for example [here](https://github.com/cyberbotics/webots/runs/5137408063?check_suite_focus=true).
