### PR TITLE
Fix gtao artifact

### DIFF
--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -43,7 +43,7 @@ export default class X3dScene {
     this._nextRenderingTime = (new Date()).getTime() + renderingMinTimeStep;
     clearTimeout(this._renderingTimeout);
     this._renderingTimeout = null;
-    setTimeout(() => this.render(), 40);
+    setTimeout(() => this.render(), 80);
   }
 
   renderMinimal() {

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -43,6 +43,7 @@ export default class X3dScene {
     this._nextRenderingTime = (new Date()).getTime() + renderingMinTimeStep;
     clearTimeout(this._renderingTimeout);
     this._renderingTimeout = null;
+    setTimeout(() => this.render(), 40);
   }
 
   renderMinimal() {


### PR DESCRIPTION
To avoid the gtao artifact, the canvas is now rendered every 80ms (half the max rate).
I tested it on my PC and on the Mac and I did not perceive a performance drop.