### PR TITLE
Uploaded new libpico packages compatible with C++17

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -115,7 +115,7 @@ $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
 	@echo "# downloading $(PICO_PACKAGE)"
 	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 	@wget -qq $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	@if [ "$$(md5sum $(PICO_PACKAGE) | awk '{print $$1;}')" != "2a05b1e86e88a43756a754a69e82a20f" ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@if [ "$$(md5sum $(PICO_PACKAGE) | awk '{print $$1;}')" != "13ce4d080f1db578cb2b73206b52e4cb" ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
 	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 
 lua-gd-clean:

--- a/dependencies/Makefile.mac
+++ b/dependencies/Makefile.mac
@@ -228,5 +228,5 @@ $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
 	@echo "# downloading $(PICO_PACKAGE)"
 	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 	@$(WGET) $(DEPENDENCIES_URL)/$(PICO_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	@if [ "7b357ddff59913c725b3c592375f7443" != `md5 -q $(PICO_PACKAGE)` ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@if [ "a29f2e1bbeb7681f70574ed8a70a1f34" != `md5 -q $(PICO_PACKAGE)` ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
 	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)


### PR DESCRIPTION
Since Qt6 requires C++17, all the include files used by Webots should be C++17 compliant, including libpico, which wasn't.
So, I fixed the libpico package to be C++17 compliant and uploaded this new version.
Consequently the MD5 sums changed and need to be fixed.
#4202 fixed the MD5 sum for the Windows version.
This PR fixes the MD5 sums for the Linux and macOS versions.
