### PR TITLE
Add new matlab command preference

### DIFF
--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -27,6 +27,7 @@ When Webots is started for the first time, the path is defined to the default in
 
 By default, the most recent version is chosen.
 If Matlab is installed at a custom path or if another version must be used, the absolute path can be easily filled in.
+For Windows, the executable located in "R20XXx\bin\win64" should be given, and not the one located in "R20XXx\bin".
 
 ### How to Run the Examples?
 

--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -17,28 +17,16 @@ Webots {{ webots.version.full }} supports only 64bits MATLAB versions from 2015b
 
 On Windows the [MATLAB MinGW-w64 C/C++ Compiler](https://fr.mathworks.com/matlabcentral/fileexchange/52848-matlab-support-for-mingw-w64-c-c-compiler) needs to be installed in addition to MATLAB.
 
-Webots must be able to access the "matlab" executable (usually a script) in order to run controller m-files.
-Webots looks for the "matlab" executable in every directory of your *PATH* (or *Path* on Windows) environment variable.
-Note that this is similar to calling "matlab" from a terminal (or *Command Prompt* on Windows), therefore, if MATLAB can be started from a terminal then it can also be started from Webots.
+Webots must be able to access the "matlab" executable (usually a script) in order to execute the controller m-files.
+The absolute path to the executable can be changed in the Webots preferences, in the General tab.
+When Webots is started for the first time, the path is defined to the default installation directory of Matlab, depending on the OS:
 
-On Windows, the MATLAB installer will normally add MATLAB's bin directories to your *Path* environment variable, so usually, Webots will be able to locate MATLAB after a standard installation.
-However, in case it does not work, please make sure that your *Path* environment variable contains this directory (or something slightly different, according to your MATLAB version): `C:\Program Files\MATLAB\R2021b\bin`.
-With older versions of MATLAB (e.g., R2017b), your *Path* environment variable should also include: `C:\Program Files\MATLAB\R2017b\bin\win64`.
+* Windows: C:\Program Files\MATLAB\R20XXx\bin\win64\MATLAB.exe
+* Linux: /usr/local/MATLAB/R20XXx/bin/matlab
+* MacOS: /Applications/MATLAB_R20XXx.app
 
-
-On Linux, the MATLAB installer normally suggests to add a symlink to the "matlab" startup script in the "/usr/local/bin" directory.
-This is a good option to make "matlab" globally accessible.
-Otherwise you can create the link at anytime afterwards with this shell command (please change according to your actual MATLAB installation directory and version):
-
-```sh
-$ sudo ln -s /usr/local/MATLAB/R2021b/bin/matlab /usr/local/bin/matlab
-```
-
-Similarly, on macOS, if Webots is unable to find the "matlab" startup script then you should add a symlink in "/usr/bin":
-
-```sh
-$ sudo ln -s /Applications/MATLAB_R2021b.app/bin/matlab /usr/local/bin/matlab
-```
+By default, the most recent version is chosen.
+If Matlab is installed at a custom path or if another version must be used, the absolute path can be easily filled in.
 
 ### How to Run the Examples?
 

--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -21,9 +21,9 @@ Webots must be able to access the "matlab" executable (usually a script) in orde
 The absolute path to the executable can be changed in the Webots preferences, in the General tab.
 When Webots is started for the first time, the path is defined to the default installation directory of Matlab, depending on the OS:
 
-* Windows: C:\Program Files\MATLAB\R20XXx\bin\win64\MATLAB.exe
-* Linux: /usr/local/MATLAB/R20XXx/bin/matlab
-* MacOS: /Applications/MATLAB_R20XXx.app
+- *Windows*: C:\Program Files\MATLAB\R20XXx\bin\win64\MATLAB.exe
+- *Linux*: /usr/local/MATLAB/R20XXx/bin/matlab
+- *MacOS*: /Applications/MATLAB_R20XXx.app
 
 By default, the most recent version is chosen.
 If Matlab is installed at a custom path or if another version must be used, the absolute path can be easily filled in.

--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -27,7 +27,8 @@ When Webots is started for the first time, the path is defined to the default in
 
 By default, the most recent version is chosen.
 If Matlab is installed at a custom path or if another version must be used, the absolute path can be easily filled in.
-For Windows, the executable located in "R20XXx\bin\win64" should be given, and not the one located in "R20XXx\bin".
+On Windows, there are two MATLAB.exe files: one is located in "bin\MATLAB.exe" and the other one in "bin\win64\MATLAB.exe".
+"bin\win64\MATLAB.exe" should be used in the preferences, because "bin\MATLAB.exe" is just a launcher that causes problem with stdout/stderr streams and with the termination of the process.
 
 ### How to Run the Examples?
 

--- a/docs/guide/using-matlab.md
+++ b/docs/guide/using-matlab.md
@@ -17,18 +17,18 @@ Webots {{ webots.version.full }} supports only 64bits MATLAB versions from 2015b
 
 On Windows the [MATLAB MinGW-w64 C/C++ Compiler](https://fr.mathworks.com/matlabcentral/fileexchange/52848-matlab-support-for-mingw-w64-c-c-compiler) needs to be installed in addition to MATLAB.
 
-Webots must be able to access the "matlab" executable (usually a script) in order to execute the controller m-files.
+Webots must be able to access the MATLAB executable (usually a script) in order to execute the controller m-files.
 The absolute path to the executable can be changed in the Webots preferences, in the General tab.
-When Webots is started for the first time, the path is defined to the default installation directory of Matlab, depending on the OS:
+When Webots is started for the first time, the path is defined to the default installation directory of MATLAB, depending on the OS:
 
 - *Windows*: C:\Program Files\MATLAB\R20XXx\bin\win64\MATLAB.exe
 - *Linux*: /usr/local/MATLAB/R20XXx/bin/matlab
 - *MacOS*: /Applications/MATLAB_R20XXx.app
 
 By default, the most recent version is chosen.
-If Matlab is installed at a custom path or if another version must be used, the absolute path can be easily filled in.
+If MATLAB is installed at a custom path or if another version must be used, the absolute path can be easily filled in.
 On Windows, there are two MATLAB.exe files: one is located in "bin\MATLAB.exe" and the other one in "bin\win64\MATLAB.exe".
-"bin\win64\MATLAB.exe" should be used in the preferences, because "bin\MATLAB.exe" is just a launcher that causes problem with stdout/stderr streams and with the termination of the process.
+"bin\win64\MATLAB.exe" should be used in the preferences, because "bin\MATLAB.exe" is just a launcher that causes problems with stdout/stderr streams and with the termination of the process.
 
 ### How to Run the Examples?
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -7,7 +7,7 @@ Released on XX XX, 2022.
     - Added two new PBR appearances: ScuffedPlastic and WornBurlap ([#4174](https://github.com/cyberbotics/webots/pull/4174)).
     - Added a new HDR background: `music_hall` ([#4177](https://github.com/cyberbotics/webots/pull/4177)).
     - Replaced cubic background PNG images with more efficient JPG images ([#4182](https://github.com/cyberbotics/webots/pull/4182)).
-    - Changed the way Matlab is detected in the system using a new Webots preference ([#4233](https://github.com/cyberbotics/webots/pull/4233)).
+    - Changed the way MATLAB is detected in the system using a new Webots preference ([#4233](https://github.com/cyberbotics/webots/pull/4233)).
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -7,6 +7,7 @@ Released on XX XX, 2022.
     - Added two new PBR appearances: ScuffedPlastic and WornBurlap ([#4174](https://github.com/cyberbotics/webots/pull/4174)).
     - Added a new HDR background: `music_hall` ([#4177](https://github.com/cyberbotics/webots/pull/4177)).
     - Replaced cubic background PNG images with more efficient JPG images ([#4182](https://github.com/cyberbotics/webots/pull/4182)).
+    - Changed the way Matlab is detected in the system using a new Webots preference ([#4233](https://github.com/cyberbotics/webots/pull/4233)).
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -674,12 +674,12 @@ void WbController::reportFailedStart() {
       break;
     case WbFileUtil::MATLAB:
       if (mCommand == "!")
-        warn(tr("The Matlab executable field is empty in the Webots preferences (Tools > Preferences... > General). Please "
-                "provide the correct absolute path to the Matlab executable."));
+        warn(tr("The MATLAB executable field is empty in the Webots preferences (Tools > Preferences... > General). Please "
+                "provide the correct absolute path to the MATLAB executable."));
       else
         warn(tr(
-          "The Matlab executable provided in the Webots preferences could not be started. Please provide the correct absolute "
-          "path to the Matlab executable."));
+          "The MATLAB executable provided in the Webots preferences could not be started. Please provide the correct absolute "
+          "path to the MATLAB executable."));
 #ifdef __linux__
       matlabDefaultPath = "/usr/local/MATLAB/R20XXx/bin/matlab";
 #else

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -689,7 +689,7 @@ void WbController::reportFailedStart() {
       matlabDefaultPath = "C:\\Program Files\\MATLAB\\R20XXx\\bin\\win64\\MATLAB.exe";
 #endif
 #endif
-      warn(tr("The default installation path for MATLAB is: %1").arg(matlabPath));
+      warn(tr("The default installation path for MATLAB is: %1").arg(matlabDefaultPath));
 
       break;
     default:

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -33,7 +33,6 @@ static const QChar PATHS_SEPARATOR(':');
 #endif
 
 static QString gJavaCommand;
-static QString gMatlabCommand;
 
 void WbLanguageTools::prependToPath(const QString &dir, QString &path) {
   if (path.isEmpty())
@@ -193,37 +192,6 @@ QString WbLanguageTools::findWorkingPythonPath(const QString &pythonVersion, QPr
 
 const QStringList WbLanguageTools::pythonArguments() {
   return QStringList("-u");
-}
-
-const QString &WbLanguageTools::matlabCommand() {
-  if (gMatlabCommand.isEmpty()) {
-#ifdef _WIN32
-    // on Windows there are two MATLAB .exe files, one is located in
-    // bin/matlab.exe and the other one in bin/win64/MATLAB.exe.
-    // bin/matlab.exe is normally in the PATH, but we must call bin/win64/MATLAB.exe
-    // because bin/matlab.exe is just a launcher that causes problem with stdout/stderr
-    // and with the termination of the QProcess.
-    QString PATH = qgetenv("PATH");
-    QStringList dirs = PATH.split(';', Qt::SkipEmptyParts);
-    foreach (QString dir, dirs) {
-      if (QDir(dir).exists()) {
-        QString file = dir + "\\win64\\MATLAB.exe";
-        if (QFile::exists(file)) {
-          gMatlabCommand = file;
-          break;
-        }
-      }
-    }
-    if (gMatlabCommand.isEmpty()) {
-      WbLog::warning(QObject::tr("To run Matlab controllers, you need to install Matlab 64-bit and ensure it is available "
-                                 "from the DOS CMD.EXE console."));
-      gMatlabCommand = "!";
-    }
-#else
-    gMatlabCommand = "matlab";
-#endif
-  }
-  return gMatlabCommand;
 }
 
 const QStringList WbLanguageTools::matlabArguments() {

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -137,35 +137,33 @@ void WbPreferences::setDefaultPythonCommand() {
 }
 
 void WbPreferences::setDefaultMatlabCommand() {
-  QString matlabPath, matlabAppWc, matlabVersionsWc, matlabExecPath, command;
-  QStringList matlabVersions;
 #ifdef __APPLE__
-  matlabPath = "/Applications/";
-  matlabAppWc = "MATLAB_R20???.app";
+  QString matlabPath = "/Applications/";
+  QString matlabAppWc = "MATLAB_R20???.app";
   QDir matlabDir(matlabPath);
-  matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
+  QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
   if (matlabVersions.isEmpty()) {
     setDefault("General/matlabCommand", "");
     return;
   }
 #else
-  matlabVersionsWc = "R20???";
+  QString matlabVersionsWc = "R20???";
 #ifdef _WIN32
-  matlabPath = "C:\\Program Files\\MATLAB\\";
-  matlabExecPath = "\\bin\\win64\\MATLAB.exe";
+  QString matlabPath = "C:\\Program Files\\MATLAB\\";
+  QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
-  matlabPath = "/usr/local/MATLAB/";
-  matlabExecPath = "/bin/matlab";
+  QString matlabPath = "/usr/local/MATLAB/";
+  QString matlabExecPath = "/bin/matlab";
 #endif
   QDir matlabDir(matlabPath);
   if (!matlabDir.exists()) {
     setDefault("General/matlabCommand", "");
     return;
   }
-  matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
+  QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
 #endif
 
-  command = matlabPath + matlabVersions.takeLast();
+  const QString command = matlabPath + matlabVersions.last();
 #if defined _WIN32 || defined __linux__
   command = command + matlabExecPath;
 #endif

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -166,7 +166,7 @@ void WbPreferences::setDefaultMatlabCommand() {
 
   QString command = matlabPath + matlabVersions.last();
 #if defined _WIN32 || defined __linux__
-  command = command + matlabExecPath;
+  command += matlabExecPath;
 #endif
 
   setDefault("General/matlabCommand", command);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -150,11 +150,12 @@ void WbPreferences::setDefaultMatlabCommand() {
   }
 #else
   matlabVersionsWc = "R20???";
-  matlabExecPath = "/bin/matlab";
 #ifdef _WIN32
-  matlabPath = "C:/Program Files/MATLAB/";
+  matlabPath = "C:\\Program Files\\MATLAB\\";
+  matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
   matlabPath = "/usr/local/MATLAB/";
+  matlabExecPath = "/bin/matlab";
 #endif
   QDir matlabDir(matlabPath);
   if (!matlabDir.exists()) {
@@ -168,11 +169,8 @@ void WbPreferences::setDefaultMatlabCommand() {
   foreach (QString version, matlabVersions) { lastVersion = version; }
 
   command = matlabPath + lastVersion;
-#ifdef __linux__
+#if defined __APPLE__ || defined __linux__
   command = command + matlabExecPath;
-#endif
-#ifdef _WIN32
-  command = command + matlabExecPath + ".exe";
 #endif
 
   setDefault("General/matlabCommand", command);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -153,6 +153,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
   QString matlabPath = "/usr/local/MATLAB/";
+  // cppcheck-suppress unreadVariable
   QString matlabExecPath = "/bin/matlab";
 #endif
   QDir matlabDir(matlabPath);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -153,6 +153,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   const QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
   const QString matlabPath = "/usr/local/MATLAB/";
+  // cppcheck-suppress unreadVariable
   const QString matlabExecPath = "/bin/matlab";
 #endif
   const QDir matlabDir(matlabPath);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -138,37 +138,34 @@ void WbPreferences::setDefaultPythonCommand() {
 
 void WbPreferences::setDefaultMatlabCommand() {
 #ifdef __APPLE__
-  QString matlabPath = "/Applications/";
-  QString matlabAppWc = "MATLAB_R20???.app";
-  QDir matlabDir(matlabPath);
-  QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
+  const QString matlabPath = "/Applications/";
+  const QString matlabAppWc = "MATLAB_R20???.app";
+  const QDir matlabDir(matlabPath);
+  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
   if (matlabVersions.isEmpty()) {
     setDefault("General/matlabCommand", "");
     return;
   }
 #else
-  QString matlabVersionsWc = "R20???";
+  const QString matlabVersionsWc = "R20???";
 #ifdef _WIN32
-  QString matlabPath = "C:\\Program Files\\MATLAB\\";
-  QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
+  const QString matlabPath = "C:\\Program Files\\MATLAB\\";
+  const QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
-  QString matlabPath = "/usr/local/MATLAB/";
-  // cppcheck-suppress unreadVariable
-  QString matlabExecPath = "/bin/matlab";
+  const QString matlabPath = "/usr/local/MATLAB/";
+  const QString matlabExecPath = "/bin/matlab";
 #endif
-  QDir matlabDir(matlabPath);
+  const QDir matlabDir(matlabPath);
   if (!matlabDir.exists()) {
     setDefault("General/matlabCommand", "");
     return;
   }
-  QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
+  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
 #endif
 
-  QString shortCommand = matlabPath + matlabVersions.last();
+  QString command = matlabPath + matlabVersions.last();
 #if defined _WIN32 || defined __linux__
-  const QString command = shortCommand + matlabExecPath;
-#else
-  const QString command = shortCommand;
+  command = command + matlabExecPath;
 #endif
 
   setDefault("General/matlabCommand", command);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -165,7 +165,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
 #endif
 
-  command = matlabPath + matlabVersions.last();
+  command = matlabPath + matlabVersions.takeLast();
 #if defined _WIN32 || defined __linux__
   command = command + matlabExecPath;
 #endif

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -109,6 +109,7 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("Directories/www", QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/");
 
   setDefaultPythonCommand();
+  setDefaultMatlabCommand();
 }
 
 WbPreferences::~WbPreferences() {
@@ -133,6 +134,48 @@ void WbPreferences::setDefaultPythonCommand() {
     }
   }
   setDefault("General/pythonCommand", "python");
+}
+
+void WbPreferences::setDefaultMatlabCommand() {
+  QString matlabPath, matlabAppWc, matlabVersionsWc, matlabExecPath, command;
+  QStringList matlabVersions;
+#ifdef __APPLE__
+  matlabPath = "/Applications/";
+  matlabAppWc = "MATLAB_R20???.app";
+  QDir matlabDir(matlabPath);
+  matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
+  if (matlabApp.empty()) {
+    setDefault("General/matlabCommand", "");
+    return;
+  }
+#else
+  matlabVersionsWc = "R20???";
+  matlabExecPath = "/bin/matlab";
+#ifdef _WIN32
+  matlabPath = "C:/Program Files/MATLAB/";
+#else  // __linux__
+  matlabPath = "/usr/local/MATLAB/";
+#endif
+  QDir matlabDir(matlabPath);
+  if (!matlabDir.exists()) {
+    setDefault("General/matlabCommand", "");
+    return;
+  }
+  matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
+#endif
+
+  QString lastVersion;
+  foreach (QString version, matlabVersions) { lastVersion = version; }
+
+  command = matlabPath + lastVersion;
+#ifdef __linux__
+  command = command + matlabExecPath;
+#endif
+#ifdef _WIN32
+  command = command + matlabExecPath + ".exe";
+#endif
+
+  setDefault("General/matlabCommand", command);
 }
 
 void WbPreferences::setDefault(const QString &key, const QVariant &value) {

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -163,9 +163,11 @@ void WbPreferences::setDefaultMatlabCommand() {
   QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
 #endif
 
-  const QString command = matlabPath + matlabVersions.last();
+  QString shortCommand = matlabPath + matlabVersions.last();
 #if defined _WIN32 || defined __linux__
-  command = command + matlabExecPath;
+  const QString command = shortCommand + matlabExecPath;
+#else
+  const QString command = shortCommand;
 #endif
 
   setDefault("General/matlabCommand", command);

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -144,7 +144,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   matlabAppWc = "MATLAB_R20???.app";
   QDir matlabDir(matlabPath);
   matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
-  if (matlabApp.empty()) {
+  if (matlabVersions.isEmpty()) {
     setDefault("General/matlabCommand", "");
     return;
   }
@@ -169,7 +169,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   foreach (QString version, matlabVersions) { lastVersion = version; }
 
   command = matlabPath + lastVersion;
-#if defined __APPLE__ || defined __linux__
+#if defined _WIN32 || defined __linux__
   command = command + matlabExecPath;
 #endif
 

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -165,10 +165,7 @@ void WbPreferences::setDefaultMatlabCommand() {
   matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
 #endif
 
-  QString lastVersion;
-  foreach (QString version, matlabVersions) { lastVersion = version; }
-
-  command = matlabPath + lastVersion;
+  command = matlabPath + matlabVersions.last();
 #if defined _WIN32 || defined __linux__
   command = command + matlabExecPath;
 #endif

--- a/src/webots/core/WbPreferences.hpp
+++ b/src/webots/core/WbPreferences.hpp
@@ -50,6 +50,7 @@ private:
   QString findPreviousSettingsLocation() const;
   void setDefault(const QString &key, const QVariant &value);
   void setDefaultPythonCommand();
+  void setDefaultMatlabCommand();
 
   QString mCompanyName;
   QString mApplicationName;

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -87,6 +87,8 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
   mNumberOfThreadsCombo->setCurrentIndex(mNumberOfThreads - 1);
   if (mPythonCommand)
     mPythonCommand->setText(prefs->value("General/pythonCommand").toString());
+  if (mMatlabCommand)
+    mMatlabCommand->setText(prefs->value("General/matlabCommand").toString());
   mExtraProjectsPath->setText(prefs->value("General/extraProjectsPath").toString());
   mTelemetryCheckBox->setChecked(prefs->value("General/telemetry").toBool());
   mCheckWebotsUpdateCheckBox->setChecked(prefs->value("General/checkWebotsUpdateOnStartup").toBool());
@@ -147,6 +149,8 @@ void WbPreferencesDialog::accept() {
   prefs->setValue("General/numberOfThreads", mNumberOfThreadsCombo->currentIndex() + 1);
   if (mPythonCommand)
     prefs->setValue("General/pythonCommand", mPythonCommand->text());
+  if (mMatlabCommand)
+    prefs->setValue("General/matlabCommand", mMatlabCommand->text());
   prefs->setValue("General/extraProjectsPath", mExtraProjectsPath->text());
   prefs->setValue("General/telemetry", mTelemetryCheckBox->isChecked());
   prefs->setValue("General/checkWebotsUpdateOnStartup", mCheckWebotsUpdateCheckBox->isChecked());
@@ -308,11 +312,16 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
     mPythonCommand = NULL;
   } else
     layout->addWidget(mPythonCommand = new WbLineEdit(this), 6, 1);
+  
   // row 7
+  layout->addWidget(new QLabel(tr("Matlab command:"), this), 6, 0);
+  layout->addWidget(mMatlabCommand = new WbLineEdit(this), 6, 1);
+  
+  // row 8
   layout->addWidget(new QLabel(tr("Extra projects path:"), this), 7, 0);
   layout->addWidget(mExtraProjectsPath, 7, 1);
 
-  // row 8
+  // row 9
   mDisableSaveWarningCheckBox = new QCheckBox(tr("Display save warning only for scene tree edit"), this);
   mDisableSaveWarningCheckBox->setToolTip(
     tr("If this option is enabled, Webots will not display any warning when you quit, reload\nor load a new world after the "
@@ -321,7 +330,7 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   layout->addWidget(new QLabel(tr("Warnings:"), this), 8, 0);
   layout->addWidget(mDisableSaveWarningCheckBox, 8, 1);
 
-  // row 9
+  // row 10
   mTelemetryCheckBox = new QCheckBox(tr("Send technical data to Webots developers"), this);
   mTelemetryCheckBox->setToolTip(tr("We need your help to continue to improve Webots: more information at:\n"
                                     "https://cyberbotics.com/doc/guide/telemetry"));
@@ -331,7 +340,7 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   layout->addWidget(label, 9, 0);
   layout->addWidget(mTelemetryCheckBox, 9, 1);
 
-  // row 10
+  // row 11
   mCheckWebotsUpdateCheckBox = new QCheckBox(tr("Check for Webots updates on startup"), this);
   mCheckWebotsUpdateCheckBox->setToolTip(tr("If this option is enabled, Webots will check if a new version is available for "
                                             "download\nat every startup. If available, it will inform you about it."));

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -312,14 +312,14 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
     mPythonCommand = NULL;
   } else
     layout->addWidget(mPythonCommand = new WbLineEdit(this), 6, 1);
-  
+
   // row 7
-  layout->addWidget(new QLabel(tr("Matlab command:"), this), 6, 0);
-  layout->addWidget(mMatlabCommand = new WbLineEdit(this), 6, 1);
-  
+  layout->addWidget(new QLabel(tr("Matlab command:"), this), 7, 0);
+  layout->addWidget(mMatlabCommand = new WbLineEdit(this), 7, 1);
+
   // row 8
-  layout->addWidget(new QLabel(tr("Extra projects path:"), this), 7, 0);
-  layout->addWidget(mExtraProjectsPath, 7, 1);
+  layout->addWidget(new QLabel(tr("Extra projects path:"), this), 8, 0);
+  layout->addWidget(mExtraProjectsPath, 8, 1);
 
   // row 9
   mDisableSaveWarningCheckBox = new QCheckBox(tr("Display save warning only for scene tree edit"), this);
@@ -327,8 +327,8 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
     tr("If this option is enabled, Webots will not display any warning when you quit, reload\nor load a new world after the "
        "current world was modified by either changing the viewpoint,\ndragging, rotating, applying a force or applying a "
        "torque to an object. It will however\nstill display a warning if the world was modified from the scene tree."));
-  layout->addWidget(new QLabel(tr("Warnings:"), this), 8, 0);
-  layout->addWidget(mDisableSaveWarningCheckBox, 8, 1);
+  layout->addWidget(new QLabel(tr("Warnings:"), this), 9, 0);
+  layout->addWidget(mDisableSaveWarningCheckBox, 9, 1);
 
   // row 10
   mTelemetryCheckBox = new QCheckBox(tr("Send technical data to Webots developers"), this);
@@ -337,15 +337,15 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   QLabel *label =
     new QLabel(tr("Telemetry (<a style='color: #5DADE2;' href='https://cyberbotics.com/doc/guide/telemetry'>info</a>):"), this);
   connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
-  layout->addWidget(label, 9, 0);
-  layout->addWidget(mTelemetryCheckBox, 9, 1);
+  layout->addWidget(label, 10, 0);
+  layout->addWidget(mTelemetryCheckBox, 10, 1);
 
   // row 11
   mCheckWebotsUpdateCheckBox = new QCheckBox(tr("Check for Webots updates on startup"), this);
   mCheckWebotsUpdateCheckBox->setToolTip(tr("If this option is enabled, Webots will check if a new version is available for "
                                             "download\nat every startup. If available, it will inform you about it."));
-  layout->addWidget(new QLabel(tr("Update policy:"), this), 10, 0);
-  layout->addWidget(mCheckWebotsUpdateCheckBox, 10, 1);
+  layout->addWidget(new QLabel(tr("Update policy:"), this), 11, 0);
+  layout->addWidget(mCheckWebotsUpdateCheckBox, 11, 1);
 
   setTabOrder(mStartupModeCombo, mEditorFontEdit);
   setTabOrder(mEditorFontEdit, chooseFontButton);

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -314,7 +314,7 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
     layout->addWidget(mPythonCommand = new WbLineEdit(this), 6, 1);
 
   // row 7
-  layout->addWidget(new QLabel(tr("Matlab command:"), this), 7, 0);
+  layout->addWidget(new QLabel(tr("MATLAB command:"), this), 7, 0);
   layout->addWidget(mMatlabCommand = new WbLineEdit(this), 7, 1);
 
   // row 8

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -58,7 +58,7 @@ private:
   QDialogButtonBox *mButtonBox;
   QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mAmbientOcclusionCombo, *mTextureQualityCombo,
     *mTextureFilteringCombo;
-  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mExtraProjectsPath, *mHttpProxyHostName, *mHttpProxyPort, *mHttpProxyUsername,
+  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectsPath, *mHttpProxyHostName, *mHttpProxyPort, *mHttpProxyUsername,
     *mHttpProxyPassword, *mCacheSize;
   QCheckBox *mDisableSaveWarningCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox, *mDisableShadowsCheckBox,
     *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox;

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -58,8 +58,8 @@ private:
   QDialogButtonBox *mButtonBox;
   QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mAmbientOcclusionCombo, *mTextureQualityCombo,
     *mTextureFilteringCombo;
-  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectsPath, *mHttpProxyHostName, *mHttpProxyPort, *mHttpProxyUsername,
-    *mHttpProxyPassword, *mCacheSize;
+  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectsPath, *mHttpProxyHostName, *mHttpProxyPort,
+    *mHttpProxyUsername, *mHttpProxyPassword, *mCacheSize;
   QCheckBox *mDisableSaveWarningCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox, *mDisableShadowsCheckBox,
     *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox;
 


### PR DESCRIPTION
**Description**
Until now, Matlab is started by Webots by searching in the PATH of the system. This approach could cause problems, especially on MacOS where PATHs are managed differently between the terminal and the Finder (see issue #2608). Also, symlinks were needed on some operating systems.

To simplify the procedure for the user, this PR aims to create a General Webots preference to specify the absolute path to the Matlab executable. This way the user also has more control over which version of Matlab to use. When a Matlab controller is started, the specified executable is directly used as the start command.

**Related Issues**
This pull-request does not directly fix issue #2608, but brings an easier way to handle Matlab execution.

**Tasks**
  - [x] Add Matlab command preference in WbPreferences and WbPreferencesDialog.
  - [x] Start Matlab using the preference field from WbController.
  - [x] Update documentation.
  - [x] Update changelog.

**Documentation**
https://cyberbotics.com/doc/guide/using-matlab?version=fix-matlab-preference-path

**Screenshots**
New matlab command field in the preferences:
![matlab_pref](https://user-images.githubusercontent.com/61198661/153910154-328944cc-5111-4355-b04b-30584e365698.png)
