### PR TITLE
Automatically convert urls

### DIFF
--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -180,7 +180,8 @@ WbBackground::~WbBackground() {
 }
 
 void WbBackground::downloadAsset(const QString &url, int index, bool postpone) {
-  if (!WbUrl::isWeb(url))
+  const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  if (!WbUrl::isWeb(completeUrl))
     return;
   if (index < 6) {
     delete mTexture[index];
@@ -195,7 +196,7 @@ void WbBackground::downloadAsset(const QString &url, int index, bool postpone) {
   if (postpone)
     connect(mDownloader[index], &WbDownloader::complete, this, &WbBackground::downloadUpdate);
 
-  mDownloader[index]->download(QUrl(url));
+  mDownloader[index]->download(QUrl(completeUrl));
 }
 
 void WbBackground::downloadAssets() {
@@ -330,9 +331,10 @@ void WbBackground::updateCubemap() {
       for (int i = 0; i < 6; i++) {
         if (hasCompleteBackground) {
           const QString &url = mUrlFields[i]->item(0);
-          if (WbUrl::isWeb(url)) {
+          const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+          if (WbUrl::isWeb(completeUrl)) {
             if (mDownloader[i] == NULL) {
-              downloadAsset(url, i, true);
+              downloadAsset(completeUrl, i, true);
               postpone = true;
             }
           } else {
@@ -342,9 +344,10 @@ void WbBackground::updateCubemap() {
         }
         if (mIrradianceUrlFields[i]->size() > 0) {
           const QString &irradianceUrl = mIrradianceUrlFields[i]->item(0);
-          if (WbUrl::isWeb(irradianceUrl)) {
+          const QString completeUrl = WbUrl::computePath(this, "url", irradianceUrl, false);
+          if (WbUrl::isWeb(completeUrl)) {
             if (mDownloader[i + 6] == NULL) {
-              downloadAsset(irradianceUrl, i + 6, true);
+              downloadAsset(completeUrl, i + 6, true);
               postpone = true;
             }
           } else {

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -156,12 +156,16 @@ WbCamera::~WbCamera() {
 void WbCamera::downloadAssets() {
   WbAbstractCamera::downloadAssets();
   const QString &noiseMaskUrl = mNoiseMaskUrl->value();
-  if (WbUrl::isWeb(noiseMaskUrl)) {
-    delete mDownloader;
-    mDownloader = new WbDownloader(this);
-    if (isPostFinalizedCalled())  // URL changed from the scene tree or supervisor
-      connect(mDownloader, &WbDownloader::complete, this, &WbCamera::updateNoiseMaskUrl);
-    mDownloader->download(QUrl(noiseMaskUrl));
+  if (!noiseMaskUrl.isEmpty()) {
+    const QString completeUrl = WbUrl::computePath(this, "url", noiseMaskUrl, false);
+
+    if (WbUrl::isWeb(completeUrl)) {
+      delete mDownloader;
+      mDownloader = new WbDownloader(this);
+      if (isPostFinalizedCalled())  // URL changed from the scene tree or supervisor
+        connect(mDownloader, &WbDownloader::complete, this, &WbCamera::updateNoiseMaskUrl);
+      mDownloader->download(QUrl(completeUrl));
+    }
   }
 }
 
@@ -1098,8 +1102,9 @@ void WbCamera::updateNoiseMaskUrl() {
 
   QString noiseMaskUrl = mNoiseMaskUrl->value();
   if (!noiseMaskUrl.isEmpty()) {  // use custom noise mask
+    QString completeUrl = WbUrl::computePath(this, "url", noiseMaskUrl, false);
     QIODevice *device;
-    if (WbUrl::isWeb(noiseMaskUrl)) {
+    if (WbUrl::isWeb(completeUrl)) {
       if (isPostFinalizedCalled() && mDownloader == NULL) {
         // url was changed from the scene tree or supervisor
         downloadAssets();
@@ -1115,10 +1120,10 @@ void WbCamera::updateNoiseMaskUrl() {
       device = mDownloader->device();
       assert(device);
     } else {
-      noiseMaskUrl = WbUrl::computePath(this, "noiseMaskUrl", noiseMaskUrl);
+      completeUrl = WbUrl::computePath(this, "noiseMaskUrl", noiseMaskUrl);
       device = NULL;
     }
-    const QString error = mWrenCamera->setNoiseMask(noiseMaskUrl.toUtf8().constData(), device);
+    const QString error = mWrenCamera->setNoiseMask(completeUrl.toUtf8().constData(), device);
     if (!error.isEmpty())
       parsingWarn(error);
     delete mDownloader;

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -89,14 +89,15 @@ void WbImageTexture::downloadAssets() {
   if (mUrl->size() == 0)
     return;
   const QString &url(mUrl->item(0));
-  if (WbUrl::isWeb(url)) {
+  QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  if (WbUrl::isWeb(completeUrl)) {
     if (mDownloader != NULL && mDownloader->device() != NULL)
       delete mDownloader;
     mDownloader = new WbDownloader(this);
     if (!WbWorld::instance()->isLoading())  // URL changed from the scene tree or supervisor
       connect(mDownloader, &WbDownloader::complete, this, &WbImageTexture::downloadUpdate);
 
-    mDownloader->download(QUrl(url));
+    mDownloader->download(QUrl(completeUrl));
   }
 }
 
@@ -300,7 +301,9 @@ void WbImageTexture::updateUrl() {
   }
   if (n > 0) {
     const QString &url = mUrl->item(0);
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(url) && mDownloader == NULL) {
+    QString completeUrl = WbUrl::computePath(this, "url", url, false);
+
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && mDownloader == NULL) {
       // url was changed from the scene tree or supervisor
       downloadAssets();
       return;

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -89,7 +89,7 @@ void WbImageTexture::downloadAssets() {
   if (mUrl->size() == 0)
     return;
   const QString &url(mUrl->item(0));
-  QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  const QString completeUrl = WbUrl::computePath(this, "url", url, false);
   if (WbUrl::isWeb(completeUrl)) {
     if (mDownloader != NULL && mDownloader->device() != NULL)
       delete mDownloader;
@@ -301,7 +301,7 @@ void WbImageTexture::updateUrl() {
   }
   if (n > 0) {
     const QString &url = mUrl->item(0);
-    QString completeUrl = WbUrl::computePath(this, "url", url, false);
+    const QString completeUrl = WbUrl::computePath(this, "url", url, false);
 
     if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && mDownloader == NULL) {
       // url was changed from the scene tree or supervisor

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -58,13 +58,14 @@ void WbMesh::downloadAssets() {
   if (mUrl->size() == 0)
     return;
   const QString &url(mUrl->item(0));
-  if (WbUrl::isWeb(url)) {
+  const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  if (WbUrl::isWeb(completeUrl)) {
     delete mDownloader;
     mDownloader = new WbDownloader(this);
     if (!WbWorld::instance()->isLoading())  // URL changed from the scene tree or supervisor
       connect(mDownloader, &WbDownloader::complete, this, &WbMesh::downloadUpdate);
 
-    mDownloader->download(QUrl(url));
+    mDownloader->download(QUrl(completeUrl));
   }
 }
 

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -104,13 +104,18 @@ void WbSkin::downloadAssets() {
     assert(appearance);
     appearance->downloadAssets();
   }
-  if (!mModelUrl->value().isEmpty() && WbUrl::isWeb(mModelUrl->value())) {
-    delete mDownloader;
-    mDownloader = new WbDownloader(this);
-    if (!WbWorld::instance()->isLoading())  // URL changed from the scene tree or supervisor
-      connect(mDownloader, &WbDownloader::complete, this, &WbSkin::downloadUpdate);
 
-    mDownloader->download(QUrl(mModelUrl->value()));
+  const QString url = mModelUrl->value();
+  if (!url.isEmpty()) {
+    const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+    if (WbUrl::isWeb(completeUrl)) {
+      delete mDownloader;
+      mDownloader = new WbDownloader(this);
+      if (!WbWorld::instance()->isLoading())  // URL changed from the scene tree or supervisor
+        connect(mDownloader, &WbDownloader::complete, this, &WbSkin::downloadUpdate);
+
+      mDownloader->download(QUrl(completeUrl));
+    }
   }
 }
 
@@ -227,8 +232,8 @@ void WbSkin::updateModelUrl() {
              .arg(supportedExtensions.join("', '")));
       return;
     }
-
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(mModelUrl->value()) && mDownloader == NULL) {
+    const QString completeUrl = WbUrl::computePath(this, "url", mModelUrl->value(), false);
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && mDownloader == NULL) {
       // url was changed from the scene tree or supervisor
       downloadAssets();
       mIsModelUrlValid = true;

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -105,7 +105,7 @@ void WbSkin::downloadAssets() {
     appearance->downloadAssets();
   }
 
-  const QString url = mModelUrl->value();
+  const QString &url = mModelUrl->value();
   if (!url.isEmpty()) {
     const QString completeUrl = WbUrl::computePath(this, "url", url, false);
     if (WbUrl::isWeb(completeUrl)) {

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -126,7 +126,7 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
                                     WbApplicationInfo::branch() + "/");
       return newUrl;
     }
-    
+
     const QString error = QObject::tr("'%1' not found.").arg(url);
     if (node)
       node->parsingWarn(error);

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -14,6 +14,7 @@
 
 #include "WbUrl.hpp"
 
+#include "WbApplicationInfo.hpp"
 #include "WbFileUtil.hpp"
 #include "WbLog.hpp"
 #include "WbMFString.hpp"
@@ -119,11 +120,20 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
     if (QFileInfo(path).exists())
       return checkIsFile(node, field, path);
     const QString error = QObject::tr("'%1' not found.").arg(url);
-    if (node)
-      node->parsingWarn(error);
-    else
-      WbLog::warning(error, false, WbLog::PARSING);
-    return missing(url);
+
+    if (isLocalUrl(url)) {
+      QString newUrl(url);
+
+      newUrl.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() + "/" +
+                                    WbApplicationInfo::branch() + "/");
+      return newUrl;
+    } else {
+      if (node)
+        node->parsingWarn(error);
+      else
+        WbLog::warning(error, false, WbLog::PARSING);
+      return missing(url);
+    }
   }
 
   // check if the url is defined relatively

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -119,15 +119,15 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
   if (!path.isEmpty()) {
     if (QFileInfo(path).exists())
       return checkIsFile(node, field, path);
-    const QString error = QObject::tr("'%1' not found.").arg(url);
 
     if (isLocalUrl(url)) {
       QString newUrl(url);
-
       newUrl.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() + "/" +
                                     WbApplicationInfo::branch() + "/");
       return newUrl;
     }
+    
+    const QString error = QObject::tr("'%1' not found.").arg(url);
     if (node)
       node->parsingWarn(error);
     else

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -127,13 +127,12 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
       newUrl.replace("webots://", "https://raw.githubusercontent.com/" + WbApplicationInfo::repo() + "/" +
                                     WbApplicationInfo::branch() + "/");
       return newUrl;
-    } else {
-      if (node)
-        node->parsingWarn(error);
-      else
-        WbLog::warning(error, false, WbLog::PARSING);
-      return missing(url);
     }
+    if (node)
+      node->parsingWarn(error);
+    else
+      WbLog::warning(error, false, WbLog::PARSING);
+    return missing(url);
   }
 
   // check if the url is defined relatively


### PR DESCRIPTION
**Description**
If a `webots://` url is not found locally, automatically convert it to `raw.githubusercontent.com` format.
It is usefull especially in the context of webots.cloud.

- [x] imageTexture
- [x] camera noise mask
- [x] mesh
- [x] background
- [x] skin