### PR TITLE
Forbid USE of TrackWheel

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -8,7 +8,7 @@ Released on XX XX, 2022.
     - Added a new HDR background: `music_hall` ([#4177](https://github.com/cyberbotics/webots/pull/4177)).
     - Replaced cubic background PNG images with more efficient JPG images ([#4182](https://github.com/cyberbotics/webots/pull/4182)).
     - Changed the way MATLAB is detected in the system using a new Webots preference ([#4233](https://github.com/cyberbotics/webots/pull/4233)).
-    - Forbid the USE of [TrackWheel](trackwheel.md) to avoid wrong behaviour ([#4257](https://github.com/cyberbotics/webots/pull/4257)).
+    - Forbid the USE of [TrackWheel](trackwheel.md) to avoid wrong behavior ([#4257](https://github.com/cyberbotics/webots/pull/4257)).
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -8,6 +8,7 @@ Released on XX XX, 2022.
     - Added a new HDR background: `music_hall` ([#4177](https://github.com/cyberbotics/webots/pull/4177)).
     - Replaced cubic background PNG images with more efficient JPG images ([#4182](https://github.com/cyberbotics/webots/pull/4182)).
     - Changed the way MATLAB is detected in the system using a new Webots preference ([#4233](https://github.com/cyberbotics/webots/pull/4233)).
+    - Forbid the USE of [TrackWheel](trackwheel.md) to avoid wrong behaviour ([#4257](https://github.com/cyberbotics/webots/pull/4257)).
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes

--- a/projects/samples/devices/worlds/track.wbt
+++ b/projects/samples/devices/worlds/track.wbt
@@ -44,7 +44,7 @@ DEF TRACKED_ROBOT Robot {
       translation 0 0.07 0
       scale 0.5 0.5 0.5
       children [
-        DEF WHEEL1 TrackWheel {
+        DEF WHEEL1_LEFT TrackWheel {
           position -0.3 0.015
           radius 0.092
           children [
@@ -71,14 +71,14 @@ DEF TRACKED_ROBOT Robot {
             }
           ]
         }
-        DEF WHEEL2 TrackWheel {
+        DEF WHEEL2_LEFT TrackWheel {
           position 0.288 0.015
           radius 0.092
           children [
             USE TRACK_WHEEL_BIG
           ]
         }
-        DEF WHEEL3 TrackWheel {
+        DEF WHEEL3_LEFT TrackWheel {
           position 0.185 -0.088
           radius 0.04
           children [
@@ -105,28 +105,28 @@ DEF TRACKED_ROBOT Robot {
             }
           ]
         }
-        DEF WHEEL4 TrackWheel {
+        DEF WHEEL4_LEFT TrackWheel {
           position 0.09135 -0.088
           radius 0.04
           children [
             USE TRACK_WHEEL_SMALL
           ]
         }
-        DEF WHEEL5 TrackWheel {
+        DEF WHEEL5_LEFT TrackWheel {
           position -0.00245 -0.088
           radius 0.04
           children [
             USE TRACK_WHEEL_SMALL
           ]
         }
-        DEF WHEEL6 TrackWheel {
+        DEF WHEEL6_LEFT TrackWheel {
           position -0.09625 -0.088
           radius 0.04
           children [
             USE TRACK_WHEEL_SMALL
           ]
         }
-        DEF WHEEL7 TrackWheel {
+        DEF WHEEL7_LEFT TrackWheel {
           position -0.19 -0.088
           radius 0.04
           children [
@@ -227,17 +227,59 @@ DEF TRACKED_ROBOT Robot {
       }
       geometriesCount 40
     }
-    Track {
+    DEF RIGHT_TRACK Track {
       translation 0 -0.07 0
       scale 0.5 0.5 0.5
       children [
-        USE WHEEL1
-        USE WHEEL2
-        USE WHEEL3
-        USE WHEEL4
-        USE WHEEL5
-        USE WHEEL6
-        USE WHEEL7
+        DEF WHEEL1_RIGHT TrackWheel {
+          position -0.3 0.015
+          radius 0.092
+          children [
+            USE TRACK_WHEEL_BIG
+          ]
+        }
+        DEF WHEEL2_RIGHT TrackWheel {
+          position 0.288 0.015
+          radius 0.092
+          children [
+            USE TRACK_WHEEL_BIG
+          ]
+        }
+        DEF WHEEL3_RIGHT TrackWheel {
+          position 0.185 -0.088
+          radius 0.04
+          children [
+            USE TRACK_WHEEL_SMALL
+          ]
+        }
+        DEF WHEEL4_RIGHT TrackWheel {
+          position 0.09135 -0.088
+          radius 0.04
+          children [
+            USE TRACK_WHEEL_SMALL
+          ]
+        }
+        DEF WHEEL5_RIGHT TrackWheel {
+          position -0.00245 -0.088
+          radius 0.04
+          children [
+            USE TRACK_WHEEL_SMALL
+          ]
+        }
+        DEF WHEEL6_RIGHT TrackWheel {
+          position -0.09625 -0.088
+          radius 0.04
+          children [
+            USE TRACK_WHEEL_SMALL
+          ]
+        }
+        DEF WHEEL7_RIGHT TrackWheel {
+          position -0.19 -0.088
+          radius 0.04
+          children [
+            USE TRACK_WHEEL_SMALL
+          ]
+        }
       ]
       name "right track"
       contactMaterial "track material"

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -1872,6 +1872,13 @@ bool WbNodeUtilities::isAValidUseableNode(const WbNode *node, QString *warning) 
     return false;
   }
 
+  const WbTrackWheel *const trackWheel = dynamic_cast<WbTrackWheel *>(n);
+  if (trackWheel) {
+    if (warning)
+      *warning = QObject::tr("TrackWheel nodes cannot be USEd.");
+    return false;
+  }
+
   const WbBallJointParameters *const ballJointParameters = dynamic_cast<WbBallJointParameters *>(n);
   if (ballJointParameters) {
     if (warning)


### PR DESCRIPTION
**Description**
USE of TrackWheel are a bad practice, here is why:

- Define two tracks: T1 and T2.
- Define a TrackWheel in T1 with a DEF.
- Insert a USE of this TrackWheel in T2.
- Run T1 at speed v1 and T2 at speed v2.
- The USEd TrackWheel in T2 will go at speed v1 which is wrong.

So it is better to forbid the USE of TrackWheel.

(I took advantage of this PR to harmonize a bit the naming in `track.wbt`.)

Does it need to add an entry in the changelog?