### PR TITLE
modified behavior of default matlab command

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -674,12 +674,11 @@ void WbController::reportFailedStart() {
       break;
     case WbFileUtil::MATLAB:
       if (mCommand == "!")
-        warn(tr("The MATLAB executable field is empty in the Webots preferences (Tools > Preferences... > General). Please "
-                "provide the correct absolute path to the MATLAB executable."));
+        warn(tr("Webots could not find the MATLAB executable in the system. Please provide the correct absolute path to the "
+                "MATLAB executable in the Webots preferences (Tools > Preferences... > General)."));
       else
-        warn(tr(
-          "The MATLAB executable provided in the Webots preferences could not be started. Please provide the correct absolute "
-          "path to the MATLAB executable."));
+        warn(tr("The MATLAB executable provided in the Webots preferences (Tools > Preferences... > General) could not be "
+                "started. Please provide the correct absolute path to the MATLAB executable."));
 #ifdef __linux__
       matlabDefaultPath = "/usr/local/MATLAB/R20XXx/bin/matlab";
 #else
@@ -689,7 +688,7 @@ void WbController::reportFailedStart() {
       matlabDefaultPath = "C:\\Program Files\\MATLAB\\R20XXx\\bin\\win64\\MATLAB.exe";
 #endif
 #endif
-      warn(tr("The default installation path for MATLAB is: %1").arg(matlabDefaultPath));
+      warn(tr("The preference can be left empty to use the default MATLAB installation path: %1").arg(matlabDefaultPath));
 
       break;
     default:
@@ -810,12 +809,16 @@ void WbController::startMatlab() {
     warn(tr("MATLAB controllers should be launched as extern controllers with the snap package of Webots."));
     return;
   }
-  if (mMatlabCommand.isEmpty()) {
-    mCommand = "!";
-    return;
-  }
 
-  mCommand = mMatlabCommand;
+  if (mMatlabCommand.isEmpty()) {
+    mCommand = WbLanguageTools::matlabCommand();
+
+    if (mCommand.isEmpty()) {
+      mCommand = "!";
+      return;
+    }
+  } else
+    mCommand = mMatlabCommand;
 
   mArguments = WbLanguageTools::matlabArguments();
   mArguments << "-r"

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -211,6 +211,7 @@ QString WbLanguageTools::matlabCommand() {
   const QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
 #else  // __linux__
   const QString matlabPath = "/usr/local/MATLAB/";
+  // cppcheck-suppress unreadVariable
   const QString matlabExecPath = "/bin/matlab";
 #endif
   const QDir matlabDir(matlabPath);
@@ -227,7 +228,6 @@ QString WbLanguageTools::matlabCommand() {
 #endif
 
   return command;
-  // setDefault("General/matlabCommand", command);
 }
 
 const QStringList WbLanguageTools::matlabArguments() {

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -194,6 +194,42 @@ const QStringList WbLanguageTools::pythonArguments() {
   return QStringList("-u");
 }
 
+QString WbLanguageTools::matlabCommand() {
+#ifdef __APPLE__
+  const QString matlabPath = "/Applications/";
+  const QString matlabAppWc = "MATLAB_R20???.app";
+  const QDir matlabDir(matlabPath);
+  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
+  if (matlabVersions.isEmpty()) {
+    // setDefault("General/matlabCommand", "");
+    return "";
+  }
+#else
+  const QString matlabVersionsWc = "R20???";
+#ifdef _WIN32
+  const QString matlabPath = "C:\\Program Files\\MATLAB\\";
+  const QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
+#else  // __linux__
+  const QString matlabPath = "/usr/local/MATLAB/";
+  const QString matlabExecPath = "/bin/matlab";
+#endif
+  const QDir matlabDir(matlabPath);
+  if (!matlabDir.exists()) {
+    // setDefault("General/matlabCommand", "");
+    return "";
+  }
+  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
+#endif
+
+  QString command = matlabPath + matlabVersions.last();
+#if defined _WIN32 || defined __linux__
+  command += matlabExecPath;
+#endif
+
+  return command;
+  // setDefault("General/matlabCommand", command);
+}
+
 const QStringList WbLanguageTools::matlabArguments() {
   QStringList arguments("-nosplash");
   arguments << "-nodesktop";

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -134,7 +134,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
 
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
-#else  // Linux
+#elif __linux__
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -134,7 +134,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
 
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
-#elif __linux__
+#else  // __linux__
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";
@@ -201,7 +201,6 @@ QString WbLanguageTools::matlabCommand() {
   const QDir matlabDir(matlabPath);
   const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
   if (matlabVersions.isEmpty()) {
-    // setDefault("General/matlabCommand", "");
     return "";
   }
 #else
@@ -216,7 +215,6 @@ QString WbLanguageTools::matlabCommand() {
 #endif
   const QDir matlabDir(matlabPath);
   if (!matlabDir.exists()) {
-    // setDefault("General/matlabCommand", "");
     return "";
   }
   const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -135,6 +135,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // __linux__
+    // cppcheck-suppress unusedPrivateFunction
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -135,7 +135,6 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // __linux__
-    // cppcheck-suppress unusedPrivateFunction
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -26,7 +26,7 @@ public:
   static const QStringList pythonArguments();
   static const QString &javaCommand();
   static const QStringList javaArguments();
-  static const QString &matlabCommand();
+  static QString matlabCommand();
   static const QStringList matlabArguments();
 
   // add dir in front of path, in a platform independent way

--- a/src/webots/control/WbLanguageTools.hpp
+++ b/src/webots/control/WbLanguageTools.hpp
@@ -36,6 +36,7 @@ private:
   WbLanguageTools() {}
   ~WbLanguageTools() {}
 #if defined __APPLE__ || defined __linux__
+  // cppcheck-suppress unusedPrivateFunction
   static const QString checkIfPythonCommandExist(const QString &pythonCommand, QProcessEnvironment &env, bool log);
 #endif
 #ifdef __APPLE__

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -109,7 +109,6 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("Directories/www", QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/");
 
   setDefaultPythonCommand();
-  setDefaultMatlabCommand();
 }
 
 WbPreferences::~WbPreferences() {
@@ -134,42 +133,6 @@ void WbPreferences::setDefaultPythonCommand() {
     }
   }
   setDefault("General/pythonCommand", "python");
-}
-
-void WbPreferences::setDefaultMatlabCommand() {
-#ifdef __APPLE__
-  const QString matlabPath = "/Applications/";
-  const QString matlabAppWc = "MATLAB_R20???.app";
-  const QDir matlabDir(matlabPath);
-  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabAppWc, QDir::Files, QDir::Name);
-  if (matlabVersions.isEmpty()) {
-    setDefault("General/matlabCommand", "");
-    return;
-  }
-#else
-  const QString matlabVersionsWc = "R20???";
-#ifdef _WIN32
-  const QString matlabPath = "C:\\Program Files\\MATLAB\\";
-  const QString matlabExecPath = "\\bin\\win64\\MATLAB.exe";
-#else  // __linux__
-  const QString matlabPath = "/usr/local/MATLAB/";
-  // cppcheck-suppress unreadVariable
-  const QString matlabExecPath = "/bin/matlab";
-#endif
-  const QDir matlabDir(matlabPath);
-  if (!matlabDir.exists()) {
-    setDefault("General/matlabCommand", "");
-    return;
-  }
-  const QStringList matlabVersions = matlabDir.entryList(QStringList() << matlabVersionsWc, QDir::Dirs, QDir::Name);
-#endif
-
-  QString command = matlabPath + matlabVersions.last();
-#if defined _WIN32 || defined __linux__
-  command += matlabExecPath;
-#endif
-
-  setDefault("General/matlabCommand", command);
 }
 
 void WbPreferences::setDefault(const QString &key, const QVariant &value) {

--- a/src/webots/core/WbPreferences.hpp
+++ b/src/webots/core/WbPreferences.hpp
@@ -50,7 +50,6 @@ private:
   QString findPreviousSettingsLocation() const;
   void setDefault(const QString &key, const QVariant &value);
   void setDefaultPythonCommand();
-  void setDefaultMatlabCommand();
 
   QString mCompanyName;
   QString mApplicationName;


### PR DESCRIPTION
**Description**
PR #4233 was adding a new MATLAB preference to indicate a custom MATLAB path. Its first behavior was to set the default MATLAB installation path in the preference when starting Webots for the first time.

This implementation is problematic in case the user installs MATLAB after Webots. 

This PR removes the default preference settings. Instead, when the user runs a MATLAB controller, Webots first checks the preference field. If it is empty, it will check the default installation path of MATLAB. If both paths are missing, an error message is displayed.
