### PR TITLE
Fix error make distrib

### DIFF
--- a/src/webots/vrml/WbProtoList.cpp
+++ b/src/webots/vrml/WbProtoList.cpp
@@ -59,8 +59,8 @@ WbProtoList::~WbProtoList() {
 
 void WbProtoList::findProtosRecursively(const QString &dirPath, QFileInfoList &protoList, bool inProtos) {
   QDir dir(dirPath);
-  if (!dir.exists() || !dir.isReadable())
-    // no PROTO nodes
+  if (!dir.exists() || !dir.isReadable() || dirPath == WbStandardPaths::resourcesPath() + "templates")
+    // no PROTO nodes or skipped directories
     return;
 
   // search in folder


### PR DESCRIPTION
**Description**
When generating the proto cache, `make distrib` complains that [this proto](https://github.com/cyberbotics/webots/blob/develop/resources/templates/protos/template.proto) is invalid, which is normal since it's only the skeleton of one, not a fully fledged one.
As such, when searching protos recursively we should skip this directory. To my knowledge at the moment there is only this exception hence why I've added it directly in the function.