### PR TITLE
Fix `Skin` segmentation and  Range Finder invisibility

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -22,6 +22,7 @@ Released on XX XX, 2022.
     - Fixed bug where changes in a DEF node did not propagate for PROTO ([#4245](https://github.com/cyberbotics/webots/pull/4245)).
     - Fixed incorrect update of [Mesh](mesh.md) node in a [Shape](shape.md) when the url is updated either manually or from a supervisor ([#4245](https://github.com/cyberbotics/webots/pull/4245)).
     - Fixed a bug that caused an object to sink into the ground after moving it with a supervisor ([#4070](https://github.com/cyberbotics/webots/pull/4070)).
+    - Fixed bug where the [Skin](skin.md) node was invisible both to segmentation and `RangeFinder` devices ([#4281](https://github.com/cyberbotics/webots/pull/4281)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -526,6 +526,11 @@ void WbSkin::createWrenSkeleton() {
     wr_renderable_set_visibility_flags(renderable, WbWrenRenderingContext::VM_REGULAR);
     wr_renderable_set_scene_culling(renderable, false);
 
+    // used for rendering range finder camera
+    WrMaterial *depthMaterial = wr_phong_material_new();
+    wr_material_set_default_program(depthMaterial, WbWrenShaders::encodeDepthShader());
+    wr_renderable_set_material(renderable, depthMaterial, "encodeDepth");
+
     // used for rendering segmentation camera
     WrMaterial *segmentationMaterial = wr_phong_material_new();
     wr_material_set_default_program(segmentationMaterial, WbWrenShaders::segmentationShader());
@@ -535,6 +540,7 @@ void WbSkin::createWrenSkeleton() {
 
     mMaterials.push_back(material);
     mSegmentationMaterials.push_back(segmentationMaterial);
+    mEncodeDepthMaterials.push_back(depthMaterial);
     mMeshes.push_back(meshes[i]);
     mMaterialNames.push_back(QString(materialNames[i]));
     mRenderables.push_back(renderable);
@@ -634,6 +640,10 @@ void WbSkin::deleteWrenSkeleton() {
   for (WrMaterial *material : mMaterials)
     wr_material_delete(material);
 
+  // delete encode depth material
+  for (WrMaterial *depthMaterial : mEncodeDepthMaterials)
+    wr_material_delete(depthMaterial);
+
   // delete camera segmentation material
   for (WrMaterial *segmentationMaterial : mSegmentationMaterials)
     wr_material_delete(segmentationMaterial);
@@ -650,6 +660,7 @@ void WbSkin::deleteWrenSkeleton() {
   mRenderables.clear();
   mMaterials.clear();
   mSegmentationMaterials.clear();
+  mEncodeDepthMaterials.clear();
   mMeshes.clear();
   mBoneTransforms.clear();
   mBonesMap.clear();

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -20,6 +20,7 @@
 #include "WbBoundingSphere.hpp"
 #include "WbDownloader.hpp"
 #include "WbMFNode.hpp"
+#include "WbNodeUtilities.hpp"
 #include "WbProject.hpp"
 #include "WbProtoModel.hpp"
 #include "WbResizeManipulator.hpp"
@@ -164,6 +165,18 @@ void WbSkin::postFinalize() {
 
   mBoundingSphere = new WbBoundingSphere(this);
   updateModelUrl();
+
+  // apply segmentation color
+  const WbSolid *solid = WbNodeUtilities::findUpperSolid(this);
+  WbRgb color(0.0, 0.0, 0.0);
+  while (solid) {
+    if (solid->recognitionColorSize() > 0) {
+      color = solid->recognitionColor(0);
+      break;
+    }
+    solid = WbNodeUtilities::findUpperSolid(solid);
+  }
+  setSegmentationColor(color);
 }
 
 void WbSkin::updateTranslation() {
@@ -208,6 +221,16 @@ QString WbSkin::modelPath() const {
   if (mModelUrl->value().isEmpty())
     return QString();
   return WbUrl::computePath(this, "modelUrl", mModelUrl->value());
+}
+
+void WbSkin::setSegmentationColor(const WbRgb &color) {
+  const float segmentationColor[3] = {(float)color.red(), (float)color.green(), (float)color.blue()};
+
+  for (int i = 0; i < mSegmentationMaterials.size(); ++i) {
+    if (!mSegmentationMaterials[i])
+      continue;
+    wr_phong_material_set_linear_diffuse(mSegmentationMaterials[i], segmentationColor);
+  }
 }
 
 void WbSkin::updateModelUrl() {
@@ -503,9 +526,15 @@ void WbSkin::createWrenSkeleton() {
     wr_renderable_set_visibility_flags(renderable, WbWrenRenderingContext::VM_REGULAR);
     wr_renderable_set_scene_culling(renderable, false);
 
+    // used for rendering segmentation camera
+    WrMaterial *segmentationMaterial = wr_phong_material_new();
+    wr_material_set_default_program(segmentationMaterial, WbWrenShaders::segmentationShader());
+    wr_renderable_set_material(renderable, segmentationMaterial, "segmentation");
+
     wr_transform_attach_child(mRenderablesTransform, WR_NODE(renderable));
 
     mMaterials.push_back(material);
+    mSegmentationMaterials.push_back(segmentationMaterial);
     mMeshes.push_back(meshes[i]);
     mMaterialNames.push_back(QString(materialNames[i]));
     mRenderables.push_back(renderable);
@@ -605,6 +634,10 @@ void WbSkin::deleteWrenSkeleton() {
   for (WrMaterial *material : mMaterials)
     wr_material_delete(material);
 
+  // delete camera segmentation material
+  for (WrMaterial *segmentationMaterial : mSegmentationMaterials)
+    wr_material_delete(segmentationMaterial);
+
   for (WrTransform *transform : mBoneTransforms)
     wr_node_delete(WR_NODE(transform));
 
@@ -616,6 +649,7 @@ void WbSkin::deleteWrenSkeleton() {
   mMaterialNames.clear();
   mRenderables.clear();
   mMaterials.clear();
+  mSegmentationMaterials.clear();
   mMeshes.clear();
   mBoneTransforms.clear();
   mBonesMap.clear();

--- a/src/webots/nodes/WbSkin.hpp
+++ b/src/webots/nodes/WbSkin.hpp
@@ -104,6 +104,7 @@ private:
   QVector<WrRenderable *> mRenderables;
   QStringList mMaterialNames;
   QVector<WrMaterial *> mMaterials;
+  QVector<WrMaterial *> mSegmentationMaterials;
   QVector<WrDynamicMesh *> mMeshes;
 
   WrStaticMesh *mBoneMesh;
@@ -131,6 +132,8 @@ private:
   QString modelPath() const;
   void updateModel();
   void applyToScale() override;
+
+  void setSegmentationColor(const WbRgb &color);
 
 private slots:
   virtual void updateTranslation();

--- a/src/webots/nodes/WbSkin.hpp
+++ b/src/webots/nodes/WbSkin.hpp
@@ -105,6 +105,7 @@ private:
   QStringList mMaterialNames;
   QVector<WrMaterial *> mMaterials;
   QVector<WrMaterial *> mSegmentationMaterials;
+  QVector<WrMaterial *> mEncodeDepthMaterials;
   QVector<WrDynamicMesh *> mMeshes;
 
   WrStaticMesh *mBoneMesh;


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/4266

The Skin class doesn't inherit from the `WbGeometry` but instead loads and instantiates its own meshes. As such, both the segmentation and range finder logic is currently missing for the Skin node, meaning it's invisible to both types of camera.

As these features are entirely missing, perhaps it's not really a bug but since it doesn't seem an intended behavior I still targeted the master branch.

Range finder behavior

https://user-images.githubusercontent.com/44834743/155672494-486251df-701b-4c13-ba2d-73d204583fca.mp4

https://user-images.githubusercontent.com/44834743/155672550-fdbf8cbc-35ea-4091-982e-4d471a9fc1a5.mp4

Segmentation behavior

https://user-images.githubusercontent.com/44834743/155672571-a91d45e5-49dd-4198-a4ec-e13db3615634.mp4

https://user-images.githubusercontent.com/44834743/155672583-2874a060-338d-4a07-a42a-a6f9d4ad2e6e.mp4


 