### PR TITLE
Fix simulation server when worlds is a top folder

### DIFF
--- a/resources/web/server/simulation_server.py
+++ b/resources/web/server/simulation_server.py
@@ -223,6 +223,8 @@ class Client:
                 logging.info(output[1:].strip('\n'))
         if version == default_branch and folder == '':
             os.rename('trunk', repository)
+        if project == '':
+            project = '/' + repository
         self.project_instance_path += project
         logging.info('Done')
         if path:


### PR DESCRIPTION
When a github repo has a structure like:
`https://github.com/cyberbotics/my_robot_repository/worlds/my_world.wbt`

It was not possible to load it with the `simulation_server.py`

It had to be something like:
`https://github.com/cyberbotics/my_robot_repository/my_robot/worlds/my_world.wbt`

It was because, when copying the files from github, the simulation server put them in a folder: the `my_robot` folder. But if this folder did not exist, the folder took the name of the repository:`my_robot_repository`. However, the path of the `.wbt` was not updated so webots was trying to open:
`/tmp/xxxxxxxxx/worlds/my_worlds.wbt`
instead of 
`/tmp/xxxxxxxxx/my_robot_repository/worlds/my_worlds.wbt`

