### PR TITLE
Fix update rate of webotsjs

### DIFF
--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -29,7 +29,6 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QMutableListIterator>
 
-#include <cassert>
 // this function is used to round the transform position coordinates
 #define ROUND(x, precision) (roundf((x) / precision) * precision)
 

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -158,7 +158,6 @@ void WbAnimationRecorder::cleanup() {
 WbAnimationRecorder::WbAnimationRecorder() :
   mIsRecording(false),
   mStartedFromGui(false),
-  mLastUpdateTime(0.0),
   mFile(NULL),
   mFirstFrame(true),
   mStreamingServer(false) {
@@ -299,8 +298,6 @@ void WbAnimationRecorder::updateCommandsAfterNodeDeletion(QObject *node) {
 }
 
 void WbAnimationRecorder::update() {
-  double currentTime = WbSimulationState::instance()->time();
-  assert(currentTime > mLastUpdateTime);
   const QString data = computeUpdateData();
   if (data.isEmpty())
     return;
@@ -313,7 +310,6 @@ void WbAnimationRecorder::update() {
   out << data;
 
   mFirstFrame = false;
-  mLastUpdateTime = currentTime;
 }
 
 QString WbAnimationRecorder::computeUpdateData(bool force) {
@@ -383,7 +379,6 @@ void WbAnimationRecorder::startRecording(const QString &targetFile) {
 
   connect(WbSimulationState::instance(), &WbSimulationState::physicsStepEnded, this, &WbAnimationRecorder::update);
 
-  mLastUpdateTime = -1;
   mIsRecording = true;
   mFirstFrame = true;
 

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -29,6 +29,7 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QMutableListIterator>
 
+#include <cassert>
 // this function is used to round the transform position coordinates
 #define ROUND(x, precision) (roundf((x) / precision) * precision)
 
@@ -299,21 +300,20 @@ void WbAnimationRecorder::updateCommandsAfterNodeDeletion(QObject *node) {
 
 void WbAnimationRecorder::update() {
   double currentTime = WbSimulationState::instance()->time();
-  if (mLastUpdateTime < 0.0 || currentTime - mLastUpdateTime >= 1000.0 / WbWorld::instance()->worldInfo()->fps()) {
-    const QString data = computeUpdateData();
-    if (data.isEmpty())
-      return;
+  assert(currentTime > mLastUpdateTime);
+  const QString data = computeUpdateData();
+  if (data.isEmpty())
+    return;
 
-    QTextStream out(mFile);
+  QTextStream out(mFile);
 
-    if (!mFirstFrame)
-      out << ",\n";
+  if (!mFirstFrame)
+    out << ",\n";
 
-    out << data;
+  out << data;
 
-    mFirstFrame = false;
-    mLastUpdateTime = currentTime;
-  }
+  mFirstFrame = false;
+  mLastUpdateTime = currentTime;
 }
 
 QString WbAnimationRecorder::computeUpdateData(bool force) {

--- a/src/webots/engine/WbAnimationRecorder.hpp
+++ b/src/webots/engine/WbAnimationRecorder.hpp
@@ -113,8 +113,6 @@ private:
   bool mIsRecording;
   bool mStartedFromGui;
 
-  double mLastUpdateTime;
-
   QString mAnimationFilename;
   QFile *mFile;
   bool mFirstFrame;

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -40,6 +40,8 @@
 #include <QtWebSockets/QWebSocket>
 #include <QtWebSockets/QWebSocketServer>
 
+#include <cassert>
+
 WbMainWindow *WbStreamingServer::cMainWindow = NULL;
 
 WbStreamingServer::WbStreamingServer(bool monitorActivity, bool disableTextStreams, bool ssl, bool controllerEdit,
@@ -473,11 +475,11 @@ void WbStreamingServer::sendUpdatePackageToClients() {
 
   if (mWebSocketClients.size() > 0) {
     const qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    if (mLastUpdateTime < 0.0 || currentTime - mLastUpdateTime >= 1000.0 / WbWorld::instance()->worldInfo()->fps()) {
-      foreach (QWebSocket *client, mWebSocketClients)
-        pauseClientIfNeeded(client);
-      mLastUpdateTime = currentTime;
-    }
+    assert(currentTime > mLastUpdateTime);
+
+    foreach (QWebSocket *client, mWebSocketClients)
+      pauseClientIfNeeded(client);
+    mLastUpdateTime = currentTime;
   }
 }
 

--- a/src/webots/gui/WbStreamingServer.cpp
+++ b/src/webots/gui/WbStreamingServer.cpp
@@ -40,8 +40,6 @@
 #include <QtWebSockets/QWebSocket>
 #include <QtWebSockets/QWebSocketServer>
 
-#include <cassert>
-
 WbMainWindow *WbStreamingServer::cMainWindow = NULL;
 
 WbStreamingServer::WbStreamingServer(bool monitorActivity, bool disableTextStreams, bool ssl, bool controllerEdit,
@@ -474,12 +472,8 @@ void WbStreamingServer::sendUpdatePackageToClients() {
   sendActivityPulse();
 
   if (mWebSocketClients.size() > 0) {
-    const qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    assert(currentTime > mLastUpdateTime);
-
     foreach (QWebSocket *client, mWebSocketClients)
       pauseClientIfNeeded(client);
-    mLastUpdateTime = currentTime;
   }
 }
 
@@ -612,7 +606,6 @@ void WbStreamingServer::resetSimulation() {
   WbApplication::instance()->simulationReset(true);
   QCoreApplication::processEvents();  // this is required to make sure the simulation reset has been performed before sending
                                       // the update
-  mLastUpdateTime = -1.0;
   mPauseTimeout = -1.0;
 }
 

--- a/src/webots/gui/WbStreamingServer.hpp
+++ b/src/webots/gui/WbStreamingServer.hpp
@@ -103,7 +103,6 @@ private:
   QWebSocketServer *mWebSocketServer;
   WbStreamingTcpServer *mTcpServer;
   QStringList mEditableControllers;
-  qint64 mLastUpdateTime;
 
   QString mCurrentWorldLoadingStatus;
   QString mMessageToClients;

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -29,6 +29,8 @@
 #include <QtCore/QFileInfo>
 #include <QtWebSockets/QWebSocket>
 
+#include <cassert>
+
 WbX3dStreamingServer::WbX3dStreamingServer(bool monitorActivity, bool disableTextStreams, bool ssl, bool controllerEdit) :
   WbStreamingServer(monitorActivity, disableTextStreams, ssl, controllerEdit, true),
   mX3dWorldGenerationTime(-1.0) {
@@ -127,16 +129,16 @@ void WbX3dStreamingServer::sendUpdatePackageToClients() {
 
   if (mWebSocketClients.size() > 0) {
     const qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    if (mLastUpdateTime < 0.0 || currentTime - mLastUpdateTime >= 1000.0 / WbWorld::instance()->worldInfo()->fps()) {
-      const QString &state = WbAnimationRecorder::instance()->computeUpdateData(false);
-      if (!state.isEmpty()) {
-        foreach (QWebSocket *client, mWebSocketClients) {
-          sendWorldStateToClient(client, state);
-          pauseClientIfNeeded(client);
-        }
+    assert(currentTime > mLastUpdateTime);
+
+    const QString &state = WbAnimationRecorder::instance()->computeUpdateData(false);
+    if (!state.isEmpty()) {
+      foreach (QWebSocket *client, mWebSocketClients) {
+        sendWorldStateToClient(client, state);
+        pauseClientIfNeeded(client);
       }
-      mLastUpdateTime = currentTime;
     }
+    mLastUpdateTime = currentTime;
   }
 }
 

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -29,8 +29,6 @@
 #include <QtCore/QFileInfo>
 #include <QtWebSockets/QWebSocket>
 
-#include <cassert>
-
 WbX3dStreamingServer::WbX3dStreamingServer(bool monitorActivity, bool disableTextStreams, bool ssl, bool controllerEdit) :
   WbStreamingServer(monitorActivity, disableTextStreams, ssl, controllerEdit, true),
   mX3dWorldGenerationTime(-1.0) {
@@ -128,9 +126,6 @@ void WbX3dStreamingServer::sendUpdatePackageToClients() {
   sendActivityPulse();
 
   if (mWebSocketClients.size() > 0) {
-    const qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    assert(currentTime > mLastUpdateTime);
-
     const QString &state = WbAnimationRecorder::instance()->computeUpdateData(false);
     if (!state.isEmpty()) {
       foreach (QWebSocket *client, mWebSocketClients) {
@@ -138,7 +133,6 @@ void WbX3dStreamingServer::sendUpdatePackageToClients() {
         pauseClientIfNeeded(client);
       }
     }
-    mLastUpdateTime = currentTime;
   }
 }
 
@@ -213,7 +207,6 @@ void WbX3dStreamingServer::generateX3dWorld() {
   mX3dWorld = worldString;
   mX3dWorldTextures = writer.texturesList();
   mX3dWorldGenerationTime = WbSimulationState::instance()->time();
-  mLastUpdateTime = -1.0;
 }
 
 void WbX3dStreamingServer::sendWorldToClient(QWebSocket *client) {

--- a/src/webots/gui/WbX3dStreamingServer.hpp
+++ b/src/webots/gui/WbX3dStreamingServer.hpp
@@ -49,8 +49,6 @@ private:
   QString mX3dWorld;
   QHash<QString, QString> mX3dWorldTextures;
   double mX3dWorldGenerationTime;
-
-  qint64 mLastUpdateTime;
 };
 
 #endif


### PR DESCRIPTION
Webots was not sending an update to webotsjs at each timetep but according to the number of fps which is not what we want.

I put some `assert` to make sure that `currentTime > mLastUpdateTime` but I'm not sure if it's really necessary because the two variables (`currentTime` and `mLastUpdateTime`) are only used for the assert.