### PR TITLE
Remove Ubuntu 18 from develop tests

### DIFF
--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -20,11 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         include:
-          - os: ubuntu-18.04
-            JAVA_VERSION: "11"
-            ROS_DISTRO: "melodic"
           - os: ubuntu-20.04
             JAVA_VERSION: "16"
             ROS_DISTRO: "noetic"
@@ -54,18 +51,13 @@ jobs:
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
     - name: Prepare Webots Controller Deployment
-      if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-18.04' }}
+      if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-20.04' }}
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.WEBOTS_CONTROLLER_DEPLOY_KEY }}
     - name: Deploy Webots Controller
-      if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-18.04' }}
+      if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-20.04' }}
       run: scripts/packaging/sync_controller_lib.sh
-    - name: Rename Webots Tarball Package
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
-      run: |
-        sudo apt install --yes rename
-        rename 's/\.tar.bz2$/_ubuntu-18.04.tar.bz2/' distribution/*.tar.bz2
     - name: Create/Update GitHub release
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
@@ -90,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -122,11 +114,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         include:
-          - os: ubuntu-18.04
-            ROS_DISTRO: melodic
-            python: 2.7
           - os: ubuntu-20.04
             ROS_DISTRO: noetic
             python: 3.6
@@ -190,7 +179,7 @@ jobs:
     if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'test distribution') }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -72,6 +72,5 @@ jobs:
     - name: Test Workflows Synchronization
       if: needs.job-skipper.outputs.should_skip != 'true' && (matrix.os == 'ubuntu-18.04' && matrix.python == '3.9')
       run: |
-        if [[ "$(diff .github/workflows/test_suite_linux.yml .github/workflows/test_suite_linux_develop.yml | grep -c -e '^<' -e '^>')" -ne "13" ]]; then echo Linux Workflows not synchronized; exit -1; fi
         if [[ "$(diff .github/workflows/test_suite_mac.yml .github/workflows/test_suite_mac_develop.yml | grep -c -e '^<' -e '^>')" -ne "10" ]]; then echo macOS Workflows not synchronized; exit -1; fi
         if [[ "$(diff .github/workflows/test_suite_windows.yml .github/workflows/test_suite_windows_develop.yml | grep -c -e '^<' -e '^>')" -ne "8" ]]; then echo Windows Workflows not synchronized; exit -1; fi


### PR DESCRIPTION
Since the develop branch is not compatible any more with Ubuntu 18.04 due to the upgrade to Qt6, we need to adapt the workflows accordingly.
Now the diff between the `test_suite_linux.yml` and `test_suite_linux_develop.yml` is so important that the workflow synchronization test is not very useful and more painful to maintain, so I disabled it.