### PR TITLE
Fix `name` and `materialIndex` causing crash on `.obj` meshes

### DIFF
--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -308,8 +308,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
 }
 
 uint64_t WbMesh::computeHash() const {
-  QString meshPathNameIndex = path();
-  meshPathNameIndex += (mIsCollada ? mName->value() + QString::number(mMaterialIndex->value()) : "");
+  const QString meshPathNameIndex = path() + (mIsCollada ? mName->value() + QString::number(mMaterialIndex->value()) : "");
   return WbTriangleMeshCache::sipHash13x(meshPathNameIndex.toUtf8().constData(), meshPathNameIndex.size());
 }
 

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -523,7 +523,7 @@ void WbMesh::updateUrl() {
   if (path().isEmpty())
     return;
 
-  mIsCollada = path().mid(path().lastIndexOf('.') + 1).toLower() == "dae" ? true : false;
+  mIsCollada = (path().mid(path().lastIndexOf('.') + 1).toLower() == "dae");
 
   // we want to replace the windows backslash path separators (if any) with cross-platform forward slashes
   const int n = mUrl->size();

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -98,9 +98,6 @@ void WbMesh::createResizeManipulator() {
 }
 
 bool WbMesh::checkIfNameExists(const aiScene *scene, const QString &name) const {
-  if (!mIsCollada)
-    return false;
-
   std::list<aiNode *> queue;
   queue.push_back(scene->mRootNode);
   aiNode *node = NULL;

--- a/src/webots/nodes/WbMesh.hpp
+++ b/src/webots/nodes/WbMesh.hpp
@@ -53,6 +53,7 @@ private:
   WbMFString *mUrl;
   WbSFString *mName;
   WbSFInt *mMaterialIndex;
+  bool mIsCollada;
   WbDownloader *mDownloader;
 
   WbMesh &operator=(const WbMesh &);  // non copyable


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/4313

Although these fields should only apply to collada files, no distinction was made if the mesh happened to be an `obj`, resulting in crashes.
