### PR TITLE
Fix download of invalid url

### DIFF
--- a/src/webots/nodes/utils/WbDownloader.cpp
+++ b/src/webots/nodes/utils/WbDownloader.cpp
@@ -115,9 +115,8 @@ void WbDownloader::finished() {
       mError = tr("Cannot download %1: %2").arg(mUrl.toString()).arg(mNetworkReply->errorString());
     disconnect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished);
     if (!mError.isEmpty() && !mOffline) {
-      mError = QString();
-      mOffline = true;
-      download(mUrl);
+      connect(mNetworkReply, &QObject::destroyed, this, &WbDownloader::destroyed);
+      mNetworkReply->deleteLater();
       return;
     }
 
@@ -147,6 +146,13 @@ void WbDownloader::finished() {
     WbSimulationState::instance()->resumeSimulation();
   } else if (gDisplayPopUp)
     emit WbApplication::instance()->setWorldLoadingProgress(progress());
+}
+
+void WbDownloader::destroyed() {
+  mNetworkReply = NULL;
+  mError = QString();
+  mOffline = true;
+  download(mUrl);
 }
 
 void WbDownloader::displayPopUp() {

--- a/src/webots/nodes/utils/WbDownloader.hpp
+++ b/src/webots/nodes/utils/WbDownloader.hpp
@@ -51,6 +51,7 @@ private:
 
 private slots:
   void finished();
+  void destroyed();
   static void displayPopUp();
 };
 


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/4312 (more details about the issue available here).

As far as I can see, this is the cleanest approach (I could think of) to keep the assert while preventing a memory leak. Basically we trigger the second download only after the reply of the first has been properly destroyed. I'm open to better solutions though, if there's better ways.