### PR TITLE
Fix excessive post-finalization resulting in multiple signal connections

### DIFF
--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -109,7 +109,8 @@ void WbGroup::recomputeBoundingSphere() const {
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
     WbBaseNode *const n = static_cast<WbBaseNode *>(it.next());
-    n->postFinalize();
+    if (!n->isPostFinalizedCalled())
+      n->postFinalize();
     mBoundingSphere->addSubBoundingSphere(n->boundingSphere());
   }
 }


### PR DESCRIPTION
**Description**

Steps to reproduce:
1. add a print message to WbMesh::updateUrl
2. from the scene tree, change the `url` of the mesh asset several time (always proving an invalid web url, ex: https://asd.com/1,https://asd.com/12, ... )
3. from each attempt to the next, the number of calls to `updateUrl` increases which doesn't make sense.

As it turns out, when the url changes, along with rebuilding the mesh (which in this case doesn't occur since the url is invalid) a re-computation of the [bounding sphere](https://github.com/cyberbotics/webots/blob/87fdad1f5ce5b88919a1a3b63a81e96c91972aac/src/webots/nodes/WbMesh.cpp#L78-L79) is issued as well which, as can be seen [here](https://github.com/cyberbotics/webots/blob/87fdad1f5ce5b88919a1a3b63a81e96c91972aac/src/webots/nodes/WbGroup.cpp#L112) results in the node being post-finalized over and over in the topmost group. Doing so creates additional [connections](https://github.com/cyberbotics/webots/blob/87fdad1f5ce5b88919a1a3b63a81e96c91972aac/src/webots/nodes/WbMesh.cpp#L88-L94) between `mUrl` and `updateUrl`, which explains why the number of calls increases (not just `url` either, connections for all signals are created as well, but ultimately a change of url is what triggers it all).

The fix is to restrict the post-finalization only to non-postfinalized nodes.