### PR TITLE
Removed reference to deprecated example

### DIFF
--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -94,11 +94,4 @@ It is possible to implement such a ROS node in C++ using the "roscpp" library on
 However, in this case, you need to setup a build configuration to handle both the "catkin\_make" from ROS and the "Makefile" from Webots to have the resulting binary linked both against the Webots "libController" and the "roscpp" library.
 An example is provided [here]({{ url.github_tree }}/projects/vehicles/controllers/ros_automobile) to create a specific controller for controlling a vehicle.
 
-An even more generic solution, is to use an [extern controller](running-extern-robot-controllers.md) and run the controller as a regular ROS node on the ROS side.
-A very simple example is provided [here]({{ url.github_tree }}/projects/languages/ros/webots_ros/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
-A launch file is available to launch Webots with the correct world file, the extern controller and a simple ROS node moving the robot straight as long as there is no obstacle (detected using the front [DistanceSensor](../reference/distancesensor.md)), it can be launched with:
-```
-roslaunch webots_ros webots_ros_python.launch
-```
-
 A [second more complicated example]({{ url.github_tree }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots) shows how to interface a model of a Universal Robots arm in Webots with ROS using [rospy](http://wiki.ros.org/rospy).

--- a/docs/guide/using-ros.md
+++ b/docs/guide/using-ros.md
@@ -94,4 +94,11 @@ It is possible to implement such a ROS node in C++ using the "roscpp" library on
 However, in this case, you need to setup a build configuration to handle both the "catkin\_make" from ROS and the "Makefile" from Webots to have the resulting binary linked both against the Webots "libController" and the "roscpp" library.
 An example is provided [here]({{ url.github_tree }}/projects/vehicles/controllers/ros_automobile) to create a specific controller for controlling a vehicle.
 
+An even more generic solution, is to use an [extern controller](running-extern-robot-controllers.md) and run the controller as a regular ROS node on the ROS side.
+A very simple example is provided [here](https://github.com/cyberbotics/webots_ros/blob/master/scripts/ros_python.py), it is written in pure Python and should work on Windows, Linux and macOS, straight out of the box.
+A launch file is available to launch Webots with the correct world file, the extern controller and a simple ROS node moving the robot straight as long as there is no obstacle (detected using the front [DistanceSensor](../reference/distancesensor.md)), it can be launched with:
+```
+roslaunch webots_ros webots_ros_python.launch
+```
+
 A [second more complicated example]({{ url.github_tree }}/projects/robots/universal_robots/resources/ros_package/ur_e_webots) shows how to interface a model of a Universal Robots arm in Webots with ROS using [rospy](http://wiki.ros.org/rospy).


### PR DESCRIPTION
A user reported that the `ros_python.py` link was broken.
See https://cyberbotics.com/doc/guide/using-ros?version=fix-reference-to-deprecated-example