### PR TITLE
Fix perspective save and camera overlays

### DIFF
--- a/docs/guide/the-user-interface.md
+++ b/docs/guide/the-user-interface.md
@@ -207,7 +207,7 @@ If the light sensor device is disabled or the first measurement is not available
   - The **Show Pen Painting Rays** allows you to display, or to hide, the rays in which the pen devices paint.
 These rays are drawn as violet lines if painting is enabled, otherwise as gray lines.
 
-  - The **Show Normals** allows you to display, or to hide, the normals of the [IndexedFaceSet](../reference/indexedfaceset.md) and [Mesh](../reference/mesh.md) nodes. The color of a normal is magenta if it was not creased using the [IndexedFaceSet](../reference/indexedfaceset.md) `creaseAngle`, otherwise, it is yellow. The length of the normal representation is proportional to the [WorldInfo](../reference/worldinfo.md) `lineScale` parameter.  
+  - The **Show Normals** allows you to display, or to hide, the normals of the [IndexedFaceSet](../reference/indexedfaceset.md) and [Mesh](../reference/mesh.md) nodes. The color of a normal is magenta if it was not creased using the [IndexedFaceSet](../reference/indexedfaceset.md) `creaseAngle`, otherwise, it is yellow. The length of the normal representation is proportional to the [WorldInfo](../reference/worldinfo.md) `lineScale` parameter.
 
   - The **Show Radar Frustums** allows you to display, or to hide, the radar frustum.
 If the radar device is enabled the frustum is drawn in blue, otherwise if the radar is disabled or the first measurement is not available yet, the frustum is drawn in gray.
@@ -235,7 +235,7 @@ These options can be used to improve interacting with the 3D scene by disabling 
 
   - The **Disable 3D View Context Menu** option prevents opening the node context menu when right-clicking on the 3D window.
   But the context menu can still be open right-clicking on the node in the scene tree.
-  This is particularly useful during web streaming, where the context menu is opened directly on client web interface and it is not needed to open in on the Webots server instance.  
+  This is particularly useful during web streaming, where the context menu is opened directly on client web interface and it is not needed to open in on the Webots server instance.
 
   - The **Disable Object Move** option prevents moving object from the 3D window using the translation and rotations handles or the `SHIFT + mouse drag/mouse wheel` method.
   Objects can still be moved by changing the translation and rotation fields from the scene tree.
@@ -275,7 +275,7 @@ The build menu is described in more details [here](webots-built-in-editor.md).
 ### Overlays Menu
 
 The **Overlays** menu provides actions specific to rendering device overlays ([Camera](../reference/camera.md), [Display](../reference/display.md), `Rangefinder`).
-Some actions of this menu are active only when a robot is selected in the 3D window or when there is only one robot in the simulation:
+Some actions of this menu are active only when a robot is selected in the 3D window:
 
 - The **Camera Devices** submenu contains the list of all the camera devices of the selected robot and its descendant robots and lets the user show or hide single camera overlay images by checking or unchecking the corresponding item.
 Camera overlays differ from the display overlays because of their magenta border.

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -25,6 +25,7 @@ Released on XX XX, 2022.
     - Fixed bug where the [Skin](skin.md) node was invisible both to segmentation and `RangeFinder` devices ([#4281](https://github.com/cyberbotics/webots/pull/4281)).
     - Fixed measurements close to the near plane for the [RangeFinder](rangefinder.md) device ([#4309](https://github.com/cyberbotics/webots/pull/4309)).
     - Fixed bug where updating the url of a [Mesh](mesh.md) node resulted in multiple updated being issued ([#4325](https://github.com/cyberbotics/webots/pull/4325)).
+    - Fixed perspective (i.e when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -25,7 +25,7 @@ Released on XX XX, 2022.
     - Fixed bug where the [Skin](skin.md) node was invisible both to segmentation and `RangeFinder` devices ([#4281](https://github.com/cyberbotics/webots/pull/4281)).
     - Fixed measurements close to the near plane for the [RangeFinder](rangefinder.md) device ([#4309](https://github.com/cyberbotics/webots/pull/4309)).
     - Fixed bug where updating the url of a [Mesh](mesh.md) node resulted in multiple updated being issued ([#4325](https://github.com/cyberbotics/webots/pull/4325)).
-    - Fixed perspective (i.e when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
+    - Fixed perspective (i.e., when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1114,8 +1114,7 @@ void WbMainWindow::savePerspective(bool reloading, bool saveToFile, bool isSaveE
   }
 
   perspective->setMainWindowState(saveState());
-  if (perspective->simulationViewState()[0].isEmpty() || perspective->simulationViewState()[1].isEmpty())
-    perspective->setSimulationViewState(mSimulationView->saveState());
+  perspective->setSimulationViewState(mSimulationView->saveState());
   perspective->setMinimizedState(mMinimizedDockState);
 
   const int id = mDockWidgets.indexOf(mMaximizedWidget);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1113,15 +1113,10 @@ bool WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
     perspective->clearRenderingDevicesPerspectiveList();
   }
 
-  const bool saveScreenPerspective =
-    !WbPreferences::booleanEnvironmentVariable("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE");
-  if (saveScreenPerspective || perspective->mainWindowState().isEmpty())
-    perspective->setMainWindowState(saveState());
-  if (saveScreenPerspective || perspective->simulationViewState()[0].isEmpty() ||
-      perspective->simulationViewState()[1].isEmpty())
+  perspective->setMainWindowState(saveState());
+  if (perspective->simulationViewState()[0].isEmpty() || perspective->simulationViewState()[1].isEmpty())
     perspective->setSimulationViewState(mSimulationView->saveState());
-  if (saveScreenPerspective)
-    perspective->setMinimizedState(mMinimizedDockState);
+  perspective->setMinimizedState(mMinimizedDockState);
 
   const int id = mDockWidgets.indexOf(mMaximizedWidget);
   perspective->setMaximizedDockId(id);
@@ -1160,19 +1155,19 @@ bool WbMainWindow::savePerspective(bool reloading, bool saveToFile) {
   }
   perspective->setConsolesSettings(settingsList);
 
-  if (saveScreenPerspective) {
-    // save rendering devices perspective
-    const QList<WbRenderingDevice *> renderingDevices = WbRenderingDevice::renderingDevices();
-    foreach (const WbRenderingDevice *device, renderingDevices) {
-      if (device->overlay() != NULL)
-        perspective->setRenderingDevicePerspective(device->computeShortUniqueName(), device->perspective());
-    }
-
-    // save rendering devices perspective of external window
-    WbRenderingDeviceWindowFactory::instance()->saveWindowsPerspective(*perspective);
+  // save rendering devices perspective
+  const QList<WbRenderingDevice *> renderingDevices = WbRenderingDevice::renderingDevices();
+  foreach (const WbRenderingDevice *device, renderingDevices) {
+    if (device->overlay() != NULL)
+      perspective->setRenderingDevicePerspective(device->computeShortUniqueName(), device->perspective());
   }
 
-  if (!saveToFile)
+  // save rendering devices perspective of external window
+  WbRenderingDeviceWindowFactory::instance()->saveWindowsPerspective(*perspective);
+
+  const bool disableSavePerspective =
+    WbPreferences::booleanEnvironmentVariable("WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE");
+  if (!saveToFile || disableSavePerspective)
     return false;
 
   // save our new perspective in the file

--- a/src/webots/gui/WbMainWindow.hpp
+++ b/src/webots/gui/WbMainWindow.hpp
@@ -51,7 +51,7 @@ public:
   virtual ~WbMainWindow();
 
   void lockFullScreen(bool isLocked);
-  bool savePerspective(bool reloading, bool saveToFile);
+  void savePerspective(bool reloading, bool saveToFile, bool isSaveEvent = false);
   void restorePerspective(bool reloading, bool firstLoad, bool loadingFromMemory);
 
   const QString &enabledIconPath() const { return mEnabledIconPath; }

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -1070,12 +1070,6 @@ WbRobot *WbSimulationView::selectedRobot() const {
       return robot;
   }
 
-  if (WbWorld::instance()) {
-    const QList<WbRobot *> &robotList = WbWorld::instance()->robots();
-    if (robotList.size() == 1)
-      return robotList.first();
-  }
-
   return NULL;
 }
 

--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -199,17 +199,20 @@ bool WbWrenTextureOverlay::applyDimensionsToWren(bool showIfNeeded) {
   float overlayHeight = mPixelSize * mHeight;
   const float overlayRatio = overlayWidth / overlayHeight;
 
-  if (overlayWidth >= view3dWidth || overlayHeight >= view3dHeight) {
-    if (overlayWidth >= view3dWidth && overlayHeight < view3dHeight) {
-      overlayWidth = view3dWidth - 2.0f * cBorderSizeHorizontal;
-      overlayHeight = overlayWidth / overlayRatio;
-      mPixelSize = view3dWidth / mWidth;
-    } else if (overlayHeight >= view3dHeight) {
-      overlayHeight = view3dHeight - 2.0f * cBorderSizeVertical;
-      overlayWidth = overlayHeight * overlayRatio;
-      mPixelSize = view3dHeight / mHeight;
-    }
-  } else if (overlayWidth < minSize || overlayHeight < minSize) {
+  // enforce horizontal constraint
+  if (mPercentagePosition.x() * view3dWidth + overlayWidth > view3dWidth) {
+    overlayWidth = view3dWidth - mPercentagePosition.x() * view3dWidth - 2.0f * cBorderSizeHorizontal;
+    overlayHeight = overlayWidth / overlayRatio;
+    mPixelSize = overlayWidth / mWidth;
+  }
+  // enforce vertical constraint
+  if (mPercentagePosition.y() * view3dHeight + overlayHeight > view3dHeight) {
+    overlayHeight = view3dHeight - mPercentagePosition.y() * view3dHeight - 2.0f * cBorderSizeVertical;
+    overlayWidth = overlayHeight * overlayRatio;
+    mPixelSize = overlayHeight / mHeight;
+  }
+  // enforce minimal size constraint
+  if (overlayWidth < minSize || overlayHeight < minSize) {
     if (overlayWidth < overlayHeight) {
       overlayWidth = minSize;
       overlayHeight = overlayWidth / overlayRatio;

--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -200,11 +200,11 @@ bool WbWrenTextureOverlay::applyDimensionsToWren(bool showIfNeeded) {
   const float overlayRatio = overlayWidth / overlayHeight;
 
   if (overlayWidth >= view3dWidth || overlayHeight >= view3dHeight) {
-    if (overlayWidth > overlayHeight) {
+    if (overlayWidth >= view3dWidth && overlayHeight < view3dHeight) {
       overlayWidth = view3dWidth - 2.0f * cBorderSizeHorizontal;
       overlayHeight = overlayWidth / overlayRatio;
       mPixelSize = view3dWidth / mWidth;
-    } else {
+    } else if (overlayHeight >= view3dHeight) {
       overlayHeight = view3dHeight - 2.0f * cBorderSizeVertical;
       overlayWidth = overlayHeight * overlayRatio;
       mPixelSize = view3dHeight / mHeight;


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/4341 and an issue with overlays where what is shown in the menu doesn't correspond to what's selected.


- [x] `WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE` behavior

If the variable is not defined or is false:
  - any change to the layout/overlays persists across reloads and restarts, except where expressly undesired (while making movies) 

If the variable is true:
- any change to the layout/overlays is ignored
- if the user saves, the disabler is ignored and we do indeed save the perspective.

- [x] camera overlays (`Overlays > Camera devices` not representative of the overlays being active)

It is unclear to me why in the `selectedRobot` method we arbitrarily take the first robot as selection by default (if a node isn't selected). This has the following side-effects:
- is counter-intuitive, because the robot picked isn't actually selected as the name entails (i.e by the user) but chosen instead by default
- if there's multiple robots, none of them is selected, only if 1 exists in the world.
- despite this choice being made on paper, in practice when the world is loaded the robot is neither selected in the scene tree nor is it highlighted in the 3D view. So it's selected under the hood, but there's no visible proof of it.
- It breaks the `Overlays` menu, because since a robot is selected under the hood we create the `Camera devices` sub-menu that shows that all the cameras are being visualized when in fact they are not. This menu should be populated only if we actually select a robot and the only fields that should be "checked" are those that are actually visible.

It seems reasonable to assume that choice was made for a reason, so removing it might have side-effects of its own but I haven't found any so far.
