### PR TITLE
Fixed annoying warning

### DIFF
--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2835,13 +2835,10 @@ WbFieldType wb_supervisor_field_get_type(WbFieldRef field) {
 
 int wb_supervisor_field_get_count(WbFieldRef field) {
   if (!check_field(field, __FUNCTION__, WB_NO_FIELD, false, NULL, false, false))
-    return false;
-
-  if (((((WbFieldStruct *)field)->type) & WB_MF) != WB_MF) {
-    if (!robot_is_quitting())
-      fprintf(stderr, "Error: %s() can only be used with multiple fields (MF).\n", __FUNCTION__);
     return -1;
-  }
+
+  if (((((WbFieldStruct *)field)->type) & WB_MF) != WB_MF)
+    return -1;
 
   return ((WbFieldStruct *)field)->count;
 }


### PR DESCRIPTION
Fixes #4356.
This function should not display a warning for SF fields as it may be used to determine if a field is SF or MF. See https://cyberbotics.com/doc/reference/supervisor#wb_supervisor_field_get_count