### PR TITLE
Allow multiple extra projects. Add WEBOTS_EXTRA_PROJECT_PATH env variable

### DIFF
--- a/docs/guide/preferences.md
+++ b/docs/guide/preferences.md
@@ -24,10 +24,12 @@ The default value is `python`.
 It should work on most systems assuming that `python` is installed and available from the command line.
 On some systems, it may be useful to set it to `python3.7` for example if you want to launch the controllers with this specific version of Python.
 Bear in mind that this value may be overridden by the content of a `runtime.ini` file of a Python controller that may redefine a specific Python command to launch that controller.
-- The **Extra projects path** defines the paths to user folders similar to the `WEBOTS_HOME/projects` folder.
-These user folders should contain projects resources that can be used in the current project (such as PROTO nodes, controllers, textures, etc.). Multiple user folders can be added by separating them with `:` (or `;` on Windows).
+- The **Extra project path** defines the paths to user folders similar to the `WEBOTS_HOME/projects` folder.
+These user folders should contain projects resources that can be used in the current project (such as PROTO nodes, controllers, textures, etc.).
+Multiple user folders can be added by separating them with `:` (or `;` on Windows).
 They may contain multiple sub-folders, each one associated to one sub-project (which should respect the [Standard File Hierarchy of a Project](the-standard-file-hierarchy-of-a-project.md)).
-Alternatively, the environment variable `WEBOTS_EXTRA_PROJECT_PATH` can be used. If the `Extra projects path` parameter and the `WEBOTS_EXTRA_PROJECT_PATH` environment variable are set, then both will be considered.
+Alternatively, the environment variable `WEBOTS_EXTRA_PROJECT_PATH` can be used.
+If the `Extra project path` parameter and the `WEBOTS_EXTRA_PROJECT_PATH` environment variable are set, then both will be considered.
 These paths have the priority over the other search paths.
 - The **Warnings: Display save warning only for scene tree edit** checkbox prevents Webots from displaying any warning dialog window when you quit, reload or load a new world after the current world was modified by either changing the viewpoint, dragging, rotating, applying a force or torque to an object, or modifying the world from a controller.
 It will however still display a warning if the world was modified from the scene tree.

--- a/docs/guide/preferences.md
+++ b/docs/guide/preferences.md
@@ -24,11 +24,11 @@ The default value is `python`.
 It should work on most systems assuming that `python` is installed and available from the command line.
 On some systems, it may be useful to set it to `python3.7` for example if you want to launch the controllers with this specific version of Python.
 Bear in mind that this value may be overridden by the content of a `runtime.ini` file of a Python controller that may redefine a specific Python command to launch that controller.
-- The **Extra projects path** defines the path to a user folder similar to the `WEBOTS_HOME/projects` folder.
-This user folder should contain projects resources that can be used in the current project (such as PROTO nodes, controllers, textures, etc.).
-It may contain multiple sub-folders, each one associated to one sub-project (which should respect the [Standard File Hierarchy of a Project](the-standard-file-hierarchy-of-a-project.md)).
-It has the priority over the other search paths.
-This folder may also contain a `default` project that can be used to define generic controllers, textures, sounds, etc.
+- The **Extra projects path** defines the paths to user folders similar to the `WEBOTS_HOME/projects` folder.
+These user folders should contain projects resources that can be used in the current project (such as PROTO nodes, controllers, textures, etc.). Multiple user folders can be added by separating them with `:` (or `;` on Windows).
+They may contain multiple sub-folders, each one associated to one sub-project (which should respect the [Standard File Hierarchy of a Project](the-standard-file-hierarchy-of-a-project.md)).
+Alternatively, the environment variable `WEBOTS_EXTRA_PROJECT_PATH` can be used. If the `Extra projects path` parameter and the `WEBOTS_EXTRA_PROJECT_PATH` environment variable are set, then both will be considered.
+These paths have the priority over the other search paths.
 - The **Warnings: Display save warning only for scene tree edit** checkbox prevents Webots from displaying any warning dialog window when you quit, reload or load a new world after the current world was modified by either changing the viewpoint, dragging, rotating, applying a force or torque to an object, or modifying the world from a controller.
 It will however still display a warning if the world was modified from the scene tree.
 - The **Telemetry: Send technical data to Webots developpers** checkbox allows Webots to send anonymous technical data to Webots developpers in order to help improving the software.

--- a/docs/guide/samples-community-projects.md
+++ b/docs/guide/samples-community-projects.md
@@ -7,7 +7,7 @@ If you want to add the whole Community Projects repository to Webots, you can fo
 
 1. Download or clone the repository to a folder of your choice. 
 
-2. Open Webots and go to `Tools > Preferences > Extra projects path` and add the path to the folder you downloaded. 
+2. Open Webots and go to `Tools > Preferences > Extra project path` and add the path to the folder you downloaded. 
 
 3. Add robots by pressing the `Add new object` button (Ctrl + Shift + A) and selecting `PROTO nodes (Extra Projects)`
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,7 +10,7 @@ Released on XX, XXth, 2022.
     - Added Wizard for the creation of PROTO files ([#4104](https://github.com/cyberbotics/webots/pull/4104)).
     - Added two new Robot API functions, `wb_robot_step_begin` and `wb_robot_step_end`, to optimize computer intensive controllers ([#4107](https://github.com/cyberbotics/webots/pull/4107)).
     - Changed the behavior of `wb_robot_wwi_receive_text` to iterate through the received messages buffer ([#4336](https://github.com/cyberbotics/webots/pull/4336)).
-    - Added the ability to define multiple `Extra Project Paths` through the Preferences menu, and an alternative method by setting the `WEBOTS_EXTRA_PROJECT_PATH` environment variable. ([#4364](https://github.com/cyberbotics/webots/pull/4364)).
+    - Added the ability to define multiple `Extra Project` paths through the Preferences menu, and an alternative method by setting the `WEBOTS_EXTRA_PROJECT_PATH` environment variable. ([#4364](https://github.com/cyberbotics/webots/pull/4364)). **Previously set Extra project paths should be re-set in the preferences menu**
   - New Objects:
     - Added some objects on the hospital theme: hospital bed, drip stand, medicine bottle, hand sanitizer, curtain, photo frame, flower pot, emergency exit sign and a fabric appearance ([#4166](https://github.com/cyberbotics/webots/pull/4166)).
     - Extended the CardboardBox to become a container and added a cardboard appearance ([#4359](https://github.com/cyberbotics/webots/pull/4359)).

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,6 +10,7 @@ Released on XX, XXth, 2022.
     - Added Wizard for the creation of PROTO files ([#4104](https://github.com/cyberbotics/webots/pull/4104)).
     - Added two new Robot API functions, `wb_robot_step_begin` and `wb_robot_step_end`, to optimize computer intensive controllers ([#4107](https://github.com/cyberbotics/webots/pull/4107)).
     - Changed the behavior of `wb_robot_wwi_receive_text` to iterate through the received messages buffer ([#4336](https://github.com/cyberbotics/webots/pull/4336)).
+    - Added the ability to define multiple `Extra Project Paths` through the Preferences menu, and an alternative method by setting the `WEBOTS_EXTRA_PROJECT_PATH` environment variable. ([#4364](https://github.com/cyberbotics/webots/pull/4364)).
   - New Objects:
     - Added some objects on the hospital theme: hospital bed, drip stand, medicine bottle, hand sanitizer, curtain, photo frame, flower pot, emergency exit sign and a fabric appearance ([#4166](https://github.com/cyberbotics/webots/pull/4166)).
     - Extended the CardboardBox to become a container and added a cardboard appearance ([#4359](https://github.com/cyberbotics/webots/pull/4359)).

--- a/resources/translations/wb_de.ts
+++ b/resources/translations/wb_de.ts
@@ -4847,7 +4847,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/wb_es.ts
+++ b/resources/translations/wb_es.ts
@@ -4844,7 +4844,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/wb_fr.ts
+++ b/resources/translations/wb_fr.ts
@@ -4849,7 +4849,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/wb_generic.ts
+++ b/resources/translations/wb_generic.ts
@@ -4844,7 +4844,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/wb_it.ts
+++ b/resources/translations/wb_it.ts
@@ -4864,7 +4864,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation>Progetti extra possono includere PROTO, controllori, plugin, ecc. che puoi usare nel progetto corrente.</translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation>Percorso progetti extra:</translation>
     </message>
     <message>

--- a/resources/translations/wb_ja_JP.ts
+++ b/resources/translations/wb_ja_JP.ts
@@ -4844,7 +4844,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/wb_zh_CN.ts
+++ b/resources/translations/wb_zh_CN.ts
@@ -4844,7 +4844,7 @@ still display a warning if the world was modified from the scene tree.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Extra projects path:</source>
+        <source>Extra project path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/webots/core/WbControllerPlugin.cpp
+++ b/src/webots/core/WbControllerPlugin.cpp
@@ -49,8 +49,8 @@ const QStringList &WbControllerPlugin::defaultList(Type type) {
     QStringList pluginsList;
     WbFileUtil::searchDirectoryNameRecursively(pluginsList, "plugins", WbStandardPaths::projectsPath() + "default/");
     WbFileUtil::searchDirectoryNameRecursively(pluginsList, "plugins", WbStandardPaths::resourcesProjectsPath());
-    if (WbProject::extraDefaultProject())
-      WbFileUtil::searchDirectoryNameRecursively(pluginsList, "plugins", WbProject::extraDefaultProject()->path());
+    foreach (const WbProject *extraProject, *WbProject::extraProjects())
+      WbFileUtil::searchDirectoryNameRecursively(pluginsList, "plugins", extraProject->path());
 
     searchPossibleControllerPlugins(lists[ROBOT_WINDOW], pluginsList, ROBOT_WINDOW);
     lists[ROBOT_WINDOW].sort();

--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -77,9 +77,9 @@ QList<WbProject *> *WbProject::extraProjects() {
     // collect extra project paths in a QSet to avoid duplicate entries
     QSet<QString> projectPaths;
 
-    if (!WbPreferences::instance()->value("General/extraProjectsPath").toString().isEmpty()) {
+    if (!WbPreferences::instance()->value("General/extraProjectPath").toString().isEmpty()) {
       foreach (const QString &path, WbPreferences::instance()
-                                      ->value("General/extraProjectsPath")
+                                      ->value("General/extraProjectPath")
                                       .toString()
                                       .split(QDir::listSeparator(), Qt::SkipEmptyParts))
         projectPaths << path;

--- a/src/webots/core/WbProject.hpp
+++ b/src/webots/core/WbProject.hpp
@@ -20,6 +20,7 @@
 //
 
 #include <QtCore/QDir>
+#include <QtCore/QList>
 #include <QtCore/QString>
 
 class WbProject : public QObject {
@@ -36,8 +37,8 @@ public:
   // the special "default" project: "WEBOTS_HOME/projects/default"
   static WbProject *defaultProject();
 
-  // the special "default" project in the 'extra projects': "EXTRA_PROJECT_PATH/default"
-  static WbProject *extraDefaultProject();
+  // extra projects defined in the preferences or 'WEBOTS_EXTRA_PROJECT_PATH'
+  static QList<WbProject *> *extraProjects();
 
   // e.g. /home/yvan/project/worlds/ghostdog.wbt -> /home/yvan/project
   static QString projectPathFromWorldFile(const QString &fileName, bool &valid);
@@ -85,7 +86,7 @@ private:
 
   static void cleanupCurrentProject();
   static void cleanupDefaultProject();
-  static void cleanupExtraDefaultProject();
+  static void cleanupExtraProjects();
   static void cleanupSystemProject();
 };
 

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -91,7 +91,7 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
     mPythonCommand->setText(prefs->value("General/pythonCommand").toString());
   if (mMatlabCommand)
     mMatlabCommand->setText(prefs->value("General/matlabCommand").toString());
-  mExtraProjectsPath->setText(prefs->value("General/extraProjectsPath").toString());
+  mExtraProjectPath->setText(prefs->value("General/extraProjectPath").toString());
   mTelemetryCheckBox->setChecked(prefs->value("General/telemetry").toBool());
   mCheckWebotsUpdateCheckBox->setChecked(prefs->value("General/checkWebotsUpdateOnStartup").toBool());
   mRenderingCheckBox->setChecked(prefs->value("General/rendering").toBool());
@@ -137,7 +137,7 @@ void WbPreferencesDialog::accept() {
   const QString &languageKey = WbTranslator::instance()->findKey(mLanguageCombo->currentText());
   if (languageKey != prefs->value("General/language") ||
       prefs->value("General/theme").toString() != mValidThemeFilenames.at(mThemeCombo->currentIndex()) ||
-      prefs->value("General/extraProjectsPath").toString() != mExtraProjectsPath->text() ||
+      prefs->value("General/extraProjectPath").toString() != mExtraProjectPath->text() ||
       prefs->value("OpenGL/disableAntiAliasing").toBool() != mDisableAntiAliasingCheckBox->isChecked()) {
     willRestart = WbMessageBox::question(
                     tr("You have changed some settings which require Webots to be restarted. Restart Webots Now?"), this,
@@ -163,7 +163,7 @@ void WbPreferencesDialog::accept() {
     prefs->setValue("General/pythonCommand", mPythonCommand->text());
   if (mMatlabCommand)
     prefs->setValue("General/matlabCommand", mMatlabCommand->text());
-  prefs->setValue("General/extraProjectsPath", mExtraProjectsPath->text());
+  prefs->setValue("General/extraProjectPath", mExtraProjectPath->text());
   prefs->setValue("General/telemetry", mTelemetryCheckBox->isChecked());
   prefs->setValue("General/checkWebotsUpdateOnStartup", mCheckWebotsUpdateCheckBox->isChecked());
   prefs->setValue("General/rendering", mRenderingCheckBox->isChecked());
@@ -281,8 +281,8 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   }
 
   mEditorFontEdit = new WbLineEdit(this);
-  mExtraProjectsPath = new WbLineEdit(this);
-  mExtraProjectsPath->setToolTip(
+  mExtraProjectPath = new WbLineEdit(this);
+  mExtraProjectPath->setToolTip(
     tr("Extra projects may include PROTOs, controllers, plugins, etc. that you can use in your current project."));
 
   // row 0
@@ -333,8 +333,8 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   layout->addWidget(mMatlabCommand = new WbLineEdit(this), 7, 1);
 
   // row 8
-  layout->addWidget(new QLabel(tr("Extra projects path:"), this), 8, 0);
-  layout->addWidget(mExtraProjectsPath, 8, 1);
+  layout->addWidget(new QLabel(tr("Extra project path:"), this), 8, 0);
+  layout->addWidget(mExtraProjectPath, 8, 1);
 
   // row 9
   mDisableSaveWarningCheckBox = new QCheckBox(tr("Display save warning only for scene tree edit"), this);

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -64,7 +64,7 @@ private:
   QDialogButtonBox *mButtonBox;
   QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mAmbientOcclusionCombo, *mTextureQualityCombo,
     *mTextureFilteringCombo;
-  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectsPath, *mHttpProxyHostName, *mHttpProxyPort,
+  WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectPath, *mHttpProxyHostName, *mHttpProxyPort,
     *mHttpProxyUsername, *mHttpProxyPassword, *mUploadUrl, *mBrowserProgram;
   QCheckBox *mDisableSaveWarningCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox, *mDisableShadowsCheckBox,
     *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox, *mNewBrowserWindow;

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -512,8 +512,8 @@ void WbRobot::updateControllerDir() {
     const WbProtoModel *const protoModel = proto();
     if (protoModel)
       path << QDir::cleanPath(protoModelProjectPath() + "/controllers/" + controllerName) + '/';
-    if (WbProject::extraDefaultProject())
-      path << WbProject::extraDefaultProject()->controllersPath() + controllerName + '/';
+    foreach (const WbProject *extraProject, *WbProject::extraProjects())
+      path << extraProject->controllersPath() + controllerName + '/';
     path << WbProject::defaultProject()->controllersPath() + controllerName + '/';
     path << WbProject::system()->controllersPath() + controllerName + '/';
     path.removeDuplicates();

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -67,8 +67,8 @@ QStringList WbUrl::orderedSearchPaths(const WbNode *node) {
   QStringList searchPaths;
   searchPaths << projectPROTOSearchPath;
   searchPaths.append(WbProject::current()->worldsPath());
-  if (WbProject::extraDefaultProject())
-    searchPaths.append(WbProject::extraDefaultProject()->worldsPath());
+  foreach (const WbProject *extraProject, *WbProject::extraProjects())
+    searchPaths.append(extraProject->worldsPath());
   searchPaths << webotsPROTOSearchPath;
   searchPaths.append(WbStandardPaths::projectsPath() + "default/worlds");
   return searchPaths;

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -230,11 +230,10 @@ void WbAddNodeDialog::updateItemInfo() {
           tr("This folder lists all suitable node that were defined (using DEF) above the current line of the Scene Tree."));
         break;
       case PROTO_EXTRA: {
-        QString title("This folder lists all suitable PROTO nodes from the preferences Extra project paths and "
-                      "the 'WEBOTS_EXTRA_PROJECT_PATH' environment variable.\n");
-        foreach (const WbProject *project, *WbProject::extraProjects()) {
+        QString title("This folder lists all suitable PROTO nodes from the preferences Extra project path and "
+                      "the 'WEBOTS_EXTRA_PROJECT_PATH' environment variable:\n");
+        foreach (const WbProject *project, *WbProject::extraProjects())
           title.append(QString("- " + project->path() + "\n"));
-        }
         mInfoText->setPlainText(title);
       } break;
       case PROTO_PROJECT:
@@ -480,7 +479,7 @@ void WbAddNodeDialog::buildTree() {
     mIsAddingLocalProtos = false;
   }
 
-  // add extra PROTO from the 'General/extraProjectsPath' preference and
+  // add extra PROTO from the 'General/extraProjectPath' preference and
   // the environment variable 'WEBOTS_EXTRA_PROJECT_PATH'
   // Multiple paths can be listed if separated by a ":" (or ";" on Windows)
   if (aprotosItem) {

--- a/src/webots/vrml/WbProtoList.cpp
+++ b/src/webots/vrml/WbProtoList.cpp
@@ -17,6 +17,7 @@
 #include "WbNode.hpp"
 #include "WbParser.hpp"
 #include "WbPreferences.hpp"
+#include "WbProject.hpp"
 #include "WbProtoModel.hpp"
 #include "WbStandardPaths.hpp"
 #include "WbTokenizer.hpp"
@@ -110,8 +111,9 @@ void WbProtoList::updateProjectsProtoCache() {
 void WbProtoList::updateExtraProtoCache() {
   gExtraProtoCache.clear();
   QFileInfoList protosInfo;
-  if (!WbPreferences::instance()->value("General/extraProjectsPath").toString().isEmpty())
-    findProtosRecursively(WbPreferences::instance()->value("General/extraProjectsPath").toString(), protosInfo);
+
+  foreach (const WbProject *project, *WbProject::extraProjects()) { findProtosRecursively(project->path(), protosInfo); }
+
   gExtraProtoCache << protosInfo;
 }
 

--- a/src/webots/vrml/WbProtoList.cpp
+++ b/src/webots/vrml/WbProtoList.cpp
@@ -112,7 +112,8 @@ void WbProtoList::updateExtraProtoCache() {
   gExtraProtoCache.clear();
   QFileInfoList protosInfo;
 
-  foreach (const WbProject *project, *WbProject::extraProjects()) { findProtosRecursively(project->path(), protosInfo); }
+  foreach (const WbProject *project, *WbProject::extraProjects())
+    findProtosRecursively(project->path(), protosInfo);
 
   gExtraProtoCache << protosInfo;
 }


### PR DESCRIPTION
**Description**
***Enhancement proposal***
Allows to list and import multiple extra projects defined in the `WEBOTS_EXTRA_PROJECT_PATH` environment variable.
The preferences option `Extra project path` is also enabled with the same functionality. Both can define multiple paths by separating them with `:` (or `;` on Windows)
This will enable the usage of Webots in projects using robots defined in multiple places.

**Additional context**
- Defining each robot in a different place (being packages) is a common pattern when working with ROS, where each robot might have its own package with its definition, the launch files required to spawn the robot, its controller, and so on.
- On the same line, `webots_ros` can be improved to set `WEBOTS_EXTRA_PROJECT_PATH` by using rospack together with the `<export/>` tags in the `package.xml`
- Even more, (and still in `webots_ros`) an spawn (ROS)service to import on runtime the desired robots can be included, easing the migration from other popular simulators where this is a common pattern, allowing the environments to be dynamically generated on runtime (at least in terms of number/position of robots).

