### PR TITLE
fix get_field_by_index (#4363)

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -12,7 +12,7 @@ Released on XX XX, 2022.
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes
-    - Fixed bug in [wb_supervisor_node_get_field_by_index](https://cyberbotics.com/doc/reference/supervisor#wb_supervisor_node_get_field_by_index) and [wb_supervisor_node_get_proto_field_by_index](https://cyberbotics.com/doc/reference/supervisor#wb_supervisor_node_get_proto_field_by_index) API functions ([#4366](https://github.com/cyberbotics/webots/pull/4366)).
+    - Fixed bug in [`wb_supervisor_node_get_field_by_index`](supervisor.md#wb_supervisor_node_get_field_by_index) and [`wb_supervisor_node_get_proto_field_by_index`](supervisor.md#wb_supervisor_node_get_proto_field_by_index) API functions ([#4366](https://github.com/cyberbotics/webots/pull/4366)).
     - Fixed the URDF exportation of [SolidReference](solidreference.md) nodes ([#4102](https://github.com/cyberbotics/webots/pull/4102)).
     - Fixed insufficient value sanity check in Solid's `postPhysicsStep` resulting in exploding [Track](track.md) ([#4133](https://github.com/cyberbotics/webots/pull/4133)).
     - Fixed `wb_supervisor_world_save` behavior when no argument is provided in non-C APIs ([#4140](https://github.com/cyberbotics/webots/pull/4140)).

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -12,6 +12,7 @@ Released on XX XX, 2022.
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
   - Bug fixes
+    - Fixed bug in [wb_supervisor_node_get_field_by_index](https://cyberbotics.com/doc/reference/supervisor#wb_supervisor_node_get_field_by_index) and [wb_supervisor_node_get_proto_field_by_index](https://cyberbotics.com/doc/reference/supervisor#wb_supervisor_node_get_proto_field_by_index) API functions ([#4366](https://github.com/cyberbotics/webots/pull/4366)).
     - Fixed the URDF exportation of [SolidReference](solidreference.md) nodes ([#4102](https://github.com/cyberbotics/webots/pull/4102)).
     - Fixed insufficient value sanity check in Solid's `postPhysicsStep` resulting in exploding [Track](track.md) ([#4133](https://github.com/cyberbotics/webots/pull/4133)).
     - Fixed `wb_supervisor_world_save` behavior when no argument is provided in non-C APIs ([#4140](https://github.com/cyberbotics/webots/pull/4140)).

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2302,7 +2302,7 @@ WbFieldRef wb_supervisor_node_get_field_by_index(WbNodeRef node, int index) {
 
   robot_mutex_lock_step();
   // search if field is already present in field_list
-  WbFieldRef result = find_field_by_id(index, node->id);
+  WbFieldRef result = find_field_by_id(node->id, index);
   if (!result) {
     // otherwise: need to talk to Webots
     WbFieldRef field_list_before = field_list;
@@ -2313,7 +2313,7 @@ WbFieldRef wb_supervisor_node_get_field_by_index(WbNodeRef node, int index) {
     if (field_list != field_list_before)
       result = field_list;
     else
-      result = find_field_by_id(index, node->id);
+      result = find_field_by_id(node->id, index);
     if (result && node->is_proto_internal)
       result->is_proto_internal = true;
   }
@@ -2338,7 +2338,7 @@ WbFieldRef wb_supervisor_node_get_proto_field_by_index(WbNodeRef node, int index
 
   robot_mutex_lock_step();
   // search if field is already present in field_list
-  WbFieldRef result = find_field_by_id(index, node->id);
+  WbFieldRef result = find_field_by_id(node->id, index);
   if (!result) {
     // otherwise: need to talk to Webots
     WbFieldRef field_list_before = field_list;
@@ -2350,7 +2350,7 @@ WbFieldRef wb_supervisor_node_get_proto_field_by_index(WbNodeRef node, int index
     if (field_list != field_list_before)
       result = field_list;
     else
-      result = find_field_by_id(index, node->id);
+      result = find_field_by_id(node->id, index);
     if (result)
       result->is_proto_internal = true;
     allow_search_in_proto = false;

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2344,7 +2344,6 @@ WbFieldRef wb_supervisor_node_get_proto_field_by_index(WbNodeRef node, int index
   robot_mutex_lock_step();
   // search if field is already present in field_list
   WbFieldRef result = find_field_by_id(node->id, index, true);
-  result = 0;
   if (!result) {
     // otherwise: need to talk to Webots
     WbFieldRef field_list_before = field_list;

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -986,10 +986,8 @@ static void supervisor_read_answer(WbDevice *d, WbRequest *r) {
         const bool is_field_get_request = sent_field_get_request && sent_field_get_request->field &&
                                           sent_field_get_request->field->node_unique_id == field_node_id &&
                                           sent_field_get_request->field->id == field_id;
-        const bool is_proto_internal =
-          (sent_field_get_request && sent_field_get_request->field) ? sent_field_get_request->field->is_proto_internal : false;
         WbFieldStruct *f =
-          (is_field_get_request) ? sent_field_get_request->field : find_field_by_id(field_node_id, field_id, is_proto_internal);
+          (is_field_get_request) ? sent_field_get_request->field : find_field_by_id(field_node_id, field_id, false);
         if (f) {
           switch (f->type) {
             case WB_SF_BOOL:

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -174,22 +174,23 @@ static char *supervisor_strdup(const char *src) {
 }
 
 // find field in field_list
-static WbFieldStruct *find_field_by_name(const char *field_name, int node_id) {
+static WbFieldStruct *find_field_by_name(const char *field_name, int node_id, bool is_proto_internal) {
   // TODO: Hash map needed
   WbFieldStruct *field = field_list;
   while (field) {
-    if (field->node_unique_id == node_id && strcmp(field_name, field->name) == 0)
+    if (field->node_unique_id == node_id && strcmp(field_name, field->name) == 0 &&
+        field->is_proto_internal == is_proto_internal)
       return field;
     field = field->next;
   }
   return NULL;
 }
 
-static WbFieldStruct *find_field_by_id(int node_id, int field_id) {
+static WbFieldStruct *find_field_by_id(int node_id, int field_id, bool is_proto_internal) {
   // TODO: Hash map needed
   WbFieldStruct *field = field_list;
   while (field) {
-    if (field->node_unique_id == node_id && field->id == field_id)
+    if (field->node_unique_id == node_id && field->id == field_id && field->is_proto_internal == is_proto_internal)
       return field;
     field = field->next;
   }
@@ -985,8 +986,10 @@ static void supervisor_read_answer(WbDevice *d, WbRequest *r) {
         const bool is_field_get_request = sent_field_get_request && sent_field_get_request->field &&
                                           sent_field_get_request->field->node_unique_id == field_node_id &&
                                           sent_field_get_request->field->id == field_id;
-
-        WbFieldStruct *f = (is_field_get_request) ? sent_field_get_request->field : find_field_by_id(field_node_id, field_id);
+        const bool is_proto_internal =
+          (sent_field_get_request && sent_field_get_request->field) ? sent_field_get_request->field->is_proto_internal : false;
+        WbFieldStruct *f =
+          (is_field_get_request) ? sent_field_get_request->field : find_field_by_id(field_node_id, field_id, is_proto_internal);
         if (f) {
           switch (f->type) {
             case WB_SF_BOOL:
@@ -1067,7 +1070,9 @@ static void supervisor_read_answer(WbDevice *d, WbRequest *r) {
       const char *field_name = request_read_string(r);
       const int field_count = request_read_int32(r);
       if (parent_node_id >= 0) {
-        WbFieldStruct *field = find_field_by_name(field_name, parent_node_id);
+        WbFieldStruct *field = find_field_by_name(field_name, parent_node_id, false);
+        if (field == NULL)
+          field = find_field_by_name(field_name, parent_node_id, true);
         if (field)
           field->count = field_count;
       }
@@ -2302,7 +2307,7 @@ WbFieldRef wb_supervisor_node_get_field_by_index(WbNodeRef node, int index) {
 
   robot_mutex_lock_step();
   // search if field is already present in field_list
-  WbFieldRef result = find_field_by_id(node->id, index);
+  WbFieldRef result = find_field_by_id(node->id, index, false);
   if (!result) {
     // otherwise: need to talk to Webots
     WbFieldRef field_list_before = field_list;
@@ -2313,7 +2318,7 @@ WbFieldRef wb_supervisor_node_get_field_by_index(WbNodeRef node, int index) {
     if (field_list != field_list_before)
       result = field_list;
     else
-      result = find_field_by_id(node->id, index);
+      result = find_field_by_id(node->id, index, false);
     if (result && node->is_proto_internal)
       result->is_proto_internal = true;
   }
@@ -2338,7 +2343,8 @@ WbFieldRef wb_supervisor_node_get_proto_field_by_index(WbNodeRef node, int index
 
   robot_mutex_lock_step();
   // search if field is already present in field_list
-  WbFieldRef result = find_field_by_id(node->id, index);
+  WbFieldRef result = find_field_by_id(node->id, index, true);
+  result = 0;
   if (!result) {
     // otherwise: need to talk to Webots
     WbFieldRef field_list_before = field_list;
@@ -2350,7 +2356,7 @@ WbFieldRef wb_supervisor_node_get_proto_field_by_index(WbNodeRef node, int index
     if (field_list != field_list_before)
       result = field_list;
     else
-      result = find_field_by_id(node->id, index);
+      result = find_field_by_id(node->id, index, true);
     if (result)
       result->is_proto_internal = true;
     allow_search_in_proto = false;
@@ -2376,7 +2382,7 @@ WbFieldRef wb_supervisor_node_get_field(WbNodeRef node, const char *field_name) 
 
   robot_mutex_lock_step();
 
-  WbFieldRef result = find_field_by_name(field_name, node->id);
+  WbFieldRef result = find_field_by_name(field_name, node->id, false);
   if (!result) {
     // otherwise: need to talk to Webots
     requested_field_name = field_name;
@@ -2463,7 +2469,7 @@ WbFieldRef wb_supervisor_node_get_proto_field(WbNodeRef node, const char *field_
   robot_mutex_lock_step();
 
   // search if field is already present in field_list
-  WbFieldRef result = find_field_by_name(field_name, node->id);
+  WbFieldRef result = find_field_by_name(field_name, node->id, true);
   if (!result) {
     // otherwise: need to talk to Webots
     requested_field_name = field_name;

--- a/tests/api/controllers/supervisor_field/supervisor_field.c
+++ b/tests/api/controllers/supervisor_field/supervisor_field.c
@@ -456,13 +456,15 @@ int main(int argc, char **argv) {
   ts_assert_int_equal(proto_fields_count, 18, "Number of PROTO internal fields of MF_FIELDS node is wrong");
   field0 = wb_supervisor_node_get_proto_field_by_index(mfTest, 0);
   ts_assert_string_equal(wb_supervisor_field_get_name(field0), "translation",
-                         "Name of first PROTO internal field of MF_FIELDS node is wrong");
+                         "Name of first PROTO internal field of MF_FIELDS node is wrong: \"%s\" should be \"translation\"",
+                         field0);
   field2 = wb_supervisor_node_get_proto_field_by_index(mfTest, 2);
   ts_assert_string_equal(wb_supervisor_field_get_name(field2), "scale",
-                         "Name of first PROTO internal field of MF_FIELDS node is wrong");
+                         "Name of first PROTO internal field of MF_FIELDS node is wrong: \"%s\" should be \"scale\"", field2);
   field8 = wb_supervisor_node_get_proto_field_by_index(mfTest, fields_count - 1);
-  ts_assert_string_equal(wb_supervisor_field_get_name(field8), "immersionProperties",
-                         "Name of first PROTO internal field of MF_FIELDS node is wrong");
+  ts_assert_string_equal(
+    wb_supervisor_field_get_name(field8), "immersionProperties",
+    "Name of first PROTO internal field of MF_FIELDS node is wrong: \"%s\" should be \"immersionProperties\"", field8);
   fieldInvalid = wb_supervisor_node_get_proto_field_by_index(mfTest, -5);
   ts_assert_pointer_null(fieldInvalid, "It should not be possible to retrieve a PROTO internal field using a negative index");
   fieldInvalid = wb_supervisor_node_get_proto_field_by_index(mfTest, proto_fields_count);


### PR DESCRIPTION
*I*HAVE*NOT*TESTED*THIS*!!! wb_supervisor_node_get_field_by_index was calling find_field_by_id with the node id and index arguments reversed, causing it to return the wrong field if the one with the numbers reversed had been accessed. Similarly for the proto version.