### PR TITLE
Fixed assimp renaming on Windows

### DIFF
--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -1,5 +1,5 @@
 # needed to execute webots-bin.exe (64 bit binary)
-/mingw64/bin/libassimp.dll
+/mingw64/bin/libassimp-5.dll
 /mingw64/bin/libbrotlicommon.dll
 /mingw64/bin/libbrotlidec.dll
 /mingw64/bin/libbz2-1.dll


### PR DESCRIPTION
The nightly builds failed on Windows because of a rename of the libassimp DLL in MSYS2. This PR fixes it.