### PR TITLE
Fix scheduled tests and nightly header

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -49,7 +49,7 @@ jobs:
         sudo scripts/install/linux_optional_compilation_dependencies.sh
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export JAVA_HOME=/usr/lib/jvm/java-${{ matrix.JAVA_VERSION }}-openjdk-amd64
@@ -74,7 +74,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test world update') }}
       with:
@@ -115,7 +115,7 @@ jobs:
       run: |
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
-        xvfb-run --auto-servernum python scripts/packaging/update_urls.py ${{ github.sha }}
+        xvfb-run --auto-servernum python scripts/packaging/update_urls.py $(git log -1 --format='%H')
         export WEBOTS_HOME=$PWD/artifact/webots
         xvfb-run --auto-servernum python tests/test_suite.py
   test-ros:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -42,7 +42,7 @@ jobs:
         sudo scripts/install/linux_optional_compilation_dependencies.sh
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export JAVA_HOME=/usr/lib/jvm/java-${{ matrix.JAVA_VERSION }}-openjdk-amd64
@@ -62,7 +62,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test world update') }}
       with:
@@ -105,7 +105,7 @@ jobs:
       run: |
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
-        xvfb-run --auto-servernum python scripts/packaging/update_urls.py ${{ github.sha }}
+        xvfb-run --auto-servernum python scripts/packaging/update_urls.py $(git log -1 --format='%H')
         export WEBOTS_HOME=$PWD/artifact/webots
         xvfb-run --auto-servernum python tests/test_suite.py
   test-ros:

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -46,7 +46,7 @@ jobs:
         sudo unzip -o -q dependencies/python3.9.zip -d /Library/Frameworks/Python.framework/Versions/3.9
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export JAVA_HOME="$(/usr/libexec/java_home -v 16)"
@@ -64,7 +64,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -42,7 +42,7 @@ jobs:
         sudo unzip -o -q dependencies/python3.9.zip -d /Library/Frameworks/Python.framework/Versions/3.9
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export JAVA_HOME="$(/usr/libexec/java_home -v 16)"
@@ -60,7 +60,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -60,7 +60,7 @@ jobs:
         ./scripts/install/msys64_installer.sh --all
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export WEBOTS_HOME=$GITHUB_WORKSPACE
@@ -78,7 +78,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -56,7 +56,7 @@ jobs:
         ./scripts/install/msys64_installer.sh --all
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
-      run: python scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}
+      run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
     - name: Webots Package Creation
       run: |
         export WEBOTS_HOME=$GITHUB_WORKSPACE
@@ -74,7 +74,7 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         python -m pip install requests PyGithub
-        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=${{ github.sha }} --tag=${{ github.ref }}
+        scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:


### PR DESCRIPTION
**Description**

The failed test revealed a tagging issue with the generation of the nightly.
For reference, the latest master commit is `d45037c` and the latest develop commit is `365d318`. The reason the cache test failed is that the urls of the distribution uploaded as artifact are correct (i.e `365d318`), but when updating the urls to run the test suite (which are not included in the distribution), the assets were tagged with `d45037c`, and in master of course the texture used for the test doesn't exist.

Fundamentally the issue is that the nightly builds and scheduled tests are run from the master branch workflows, so any reference of `${{ github.sha }}` will reference the `d45037c`.
To see this is in fact the case, when checking the headers of the latest nightlies they both mention `d45037c`

![a](https://user-images.githubusercontent.com/44834743/159649632-c7539f87-2b6b-4dc3-98b6-b21e901bbf5f.png)
![b](https://user-images.githubusercontent.com/44834743/159649646-467d6637-ba5f-4dc4-a929-371dc9aa73cc.png)

Given this, I'm not entirely sure why the urls themselves in the distributions end up being correct, but I suspect it's because somehow it gets the right hash here: https://github.com/cyberbotics/webots/blob/d45037c97eeaf46622e2973259e4d0ec582c8567/scripts/packaging/Makefile#L66-L70

Either way, a possible fix is to get the hash from the latest commit, that way whether it's run from the master or develop workflow doesn't really matter.