### PR TITLE
Fix loading of textures and contact properties when the fallback mechanism activates

### DIFF
--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -59,7 +59,8 @@ WbContactProperties::~WbContactProperties() {
 }
 
 void WbContactProperties::downloadAsset(const QString &url, int index) {
-  if (!WbUrl::isWeb(url) || WbNetwork::instance()->isCached(url))
+  const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 
   if (mDownloader[index] != NULL)
@@ -72,7 +73,7 @@ void WbContactProperties::downloadAsset(const QString &url, int index) {
     connect(mDownloader[index], &WbDownloader::complete, this, callback);
   }
 
-  mDownloader[index]->download(QUrl(url));
+  mDownloader[index]->download(QUrl(completeUrl));
 }
 
 void WbContactProperties::downloadAssets() {

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -59,7 +59,7 @@ WbContactProperties::~WbContactProperties() {
 }
 
 void WbContactProperties::downloadAsset(const QString &url, int index) {
-  const QString completeUrl = WbUrl::computePath(this, "url", url, false);
+  const QString &completeUrl = WbUrl::computePath(this, "url", url, false);
   if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -132,12 +132,12 @@ void WbImageTexture::postFinalize() {
 }
 
 bool WbImageTexture::loadTexture() {
-  const QString &url = mUrl->item(0);
-  const bool isWebAsset = WbUrl::isWeb(url);
-  if (isWebAsset && !WbNetwork::instance()->isCached(url))
+  const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0), false);
+  const bool isWebAsset = WbUrl::isWeb(completeUrl);
+  if (isWebAsset && !WbNetwork::instance()->isCached(completeUrl))
     return false;
 
-  const QString filePath = isWebAsset ? WbNetwork::instance()->get(url) : path(true);
+  const QString filePath = isWebAsset ? WbNetwork::instance()->get(completeUrl) : path(true);
   QFile file(filePath);
   if (!file.open(QIODevice::ReadOnly)) {
     warn(tr("Texture file could not be read: '%1'").arg(filePath));


### PR DESCRIPTION
**Description**

Although the fall-back mechanism of attempting to retrieve online an asset that cannot be found locally was working as intended, the internal representation of the url remained unchanged. So, when it came time to load the asset we still attempted to load the `webots://` asset instead of the correctly determined `https://` fallback, which of course failed.

The issue appears to exist only for textures and contact properties, the other assets are handled correctly.

To test it, a nightly should be created:
```
python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
make -j12 distrib
```