### PR TITLE
Fix crash export elevation grid

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -30,6 +30,7 @@ Released on XX XX, 2022.
     - Fixed bug where updating the url of a [Mesh](mesh.md) node resulted in multiple updated being issued ([#4325](https://github.com/cyberbotics/webots/pull/4325)).
     - Fixed perspective (i.e., when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
     - Fixed virtual reality and `get_contact_points` ROS services, and no longer advertise deprecated ones: `get_number_of_contact_points`, `get_contact_point` and `get_contact_point_node` ([#4371](https://github.com/cyberbotics/webots/pull/4371)).
+    - Fixed crash when streaming very large elevation grid ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -30,7 +30,7 @@ Released on XX XX, 2022.
     - Fixed bug where updating the url of a [Mesh](mesh.md) node resulted in multiple updated being issued ([#4325](https://github.com/cyberbotics/webots/pull/4325)).
     - Fixed perspective (i.e., when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
     - Fixed virtual reality and `get_contact_points` ROS services, and no longer advertise deprecated ones: `get_number_of_contact_points`, `get_contact_point` and `get_contact_point_node` ([#4371](https://github.com/cyberbotics/webots/pull/4371)).
-    - Fixed crash when streaming very large elevation grid ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
+    - Fixed crash when streaming very large [ElevationGrid](elevationgrid.md) ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -628,8 +628,8 @@ void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
 
   const int vertexCount = wr_static_mesh_get_vertex_count(mWrenMesh);
   const int indexCount = wr_static_mesh_get_index_count(mWrenMesh);
-  float *vertices = new float [3 * vertexCount];
-  unsigned int *indices = new unsigned int [indexCount];
+  float *vertices = new float[3 * vertexCount];
+  unsigned int *indices = new unsigned int[indexCount];
   wr_static_mesh_read_data(mWrenMesh, vertices, NULL, NULL, indices);
 
   writer << "<Shape>";

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -628,8 +628,8 @@ void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
 
   const int vertexCount = wr_static_mesh_get_vertex_count(mWrenMesh);
   const int indexCount = wr_static_mesh_get_index_count(mWrenMesh);
-  float vertices[3 * vertexCount];
-  unsigned int indices[indexCount];
+  float *vertices = new float [3 * vertexCount];
+  unsigned int *indices = new unsigned int [indexCount];
   wr_static_mesh_read_data(mWrenMesh, vertices, NULL, NULL, indices);
 
   writer << "<Shape>";
@@ -662,4 +662,7 @@ void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
   writer << "'></Coordinate>";
   writer << "</IndexedLineSet>";
   writer << "</Shape>";
+
+  delete vertices;
+  delete indices;
 }

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -663,6 +663,6 @@ void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
   writer << "</IndexedLineSet>";
   writer << "</Shape>";
 
-  delete vertices;
-  delete indices;
+  delete[] vertices;
+  delete[] indices;
 }


### PR DESCRIPTION
Fix #4424 

The arrays were previously allocated on the stack.
For very large elevation grids, it could overload the stack.
So now the arrays are allocated on the heap where there is more room