### PR TITLE
Add Tutorial 6 Wheel Dimensions

### DIFF
--- a/docs/guide/tutorial-6-4-wheels-robot.md
+++ b/docs/guide/tutorial-6-4-wheels-robot.md
@@ -126,7 +126,7 @@ The rotation origin (anchor) and the rotation axis (axis) are defined by the opt
 
 %end
 
-For the first wheel, the [Solid](../reference/solid.md) translation should be defined to `(0.05, 0.06, 0)` in order to define the relative gap between the body and the wheel, and the rotation to `(1 0 0 1.5708)` for the wheel cylinder to be correctly oriented.
+The radius of the wheel is 0.03 and the height is 0.02. For the first wheel, the [Solid](../reference/solid.md) translation should be defined to `(0.05, 0.06, 0)` in order to define the relative gap between the body and the wheel, and the rotation to `(1 0 0 1.5708)` for the wheel cylinder to be correctly oriented.
 The [HingeJointParameters](../reference/hingejointparameters.md) anchor should also be defined to `(0.05, 0.06, 0)` to define the rotation origin (relatively to the body).
 Finally, the [HingeJointParameters](../reference/hingejointparameters.md) axis should define the rotation axis.
 In our case it's along the y-axis (so `(0, 1, 0)`).


### PR DESCRIPTION
**Description**
The wheel size in tutorial 6 is not given explicitly, I add the appropriate size.

**Tasks**
Add the list of tasks of this PR.
  - [x] set the appropriate size of wheel.

**Documentation**
If this pull-request changes the doc, add the link to the related page, 
https://www.cyberbotics.com/doc/guide/tutorial-6-4-wheels-robot?version=lagnx:patch-1


