### PR TITLE
Enhancement animation loading

### DIFF
--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -89,7 +89,7 @@ export default class Animation {
               allPoses.set(poses[j].id, currentIdFields);
             }
           }
-        } else { // Check the previous keyFrames to get missing updates
+        } else { // Check the previous keyFrame to get missing updates
           const poses = this._keyFrames.get(i - 1).poses;
           for (let element of poses) {
             const id = element[0];
@@ -167,17 +167,19 @@ export default class Animation {
           previousPoseStep = this._previousStep;
         else {
           previousPoseStep = (closestKeyFrame + 1) * this.keyFrameStepSize;
-          previousStepIsAKeyFrame = true;
+          if (this._keyFrames.size > 0)
+            previousStepIsAKeyFrame = true;
         }
 
         const completeIds = new Set();
         const appliedFieldsByIds = new Map();
         const appliedLabelsIds = new Set();
 
-        if (previousPoseStep === 0)
-          previousPoseStep--; // We normally do not want to include the previousStep in the loop as its updates are in the keyFrame. However, we need to include the step 0 in the loop as their is no keyFrame for it
+        // We do not want to include the previousPoseStep in the loop as its updates are in the keyFrame. However, we need to include it if their is no keyFrames or if it is the step 0 as their is no keyFrame for it
+        if (previousStepIsAKeyFrame || previousPoseStep !== 0)
+          previousPoseStep++;
 
-        for (let i = this.step; i > previousPoseStep; i--) { // Iterate through each step until the nearest keyFrame is reached or all necessary updates have been applied. Go in decreasing order to minize the number of step.
+        for (let i = this.step; i >= previousPoseStep; i--) { // Iterate through each step until the nearest keyFrame is reached or all necessary updates have been applied. Go in decreasing order to minize the number of step.
           if (this.data.frames[i].poses) {
             for (let j = 0; j < this.data.frames[i].poses.length; j++) { // At each frame, apply all poses
               const id = this.data.frames[i].poses[j].id;

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -6,8 +6,8 @@ import WbWorld from './nodes/WbWorld.js';
 import {changeShadows, changeGtaoLevel, GtaoLevel} from './nodes/wb_preferences.js';
 
 export default class Animation {
-  constructor(url, scene, view, gui, loop) {
-    this._url = url;
+  constructor(jsonPromise, scene, view, gui, loop) {
+    this._jsonPromise = jsonPromise;
     this._scene = scene;
     this._view = view;
     this.gui = typeof gui === 'undefined' || gui === 'play' ? 'real-time' : 'pause';
@@ -23,14 +23,8 @@ export default class Animation {
 
   init(onReady) {
     this._onReady = onReady;
-    var xmlhttp = new XMLHttpRequest();
-    xmlhttp.open('GET', this._url, true);
-    xmlhttp.overrideMimeType('application/json');
-    xmlhttp.onreadystatechange = () => {
-      if (xmlhttp.readyState === 4 && (xmlhttp.status === 200 || xmlhttp.status === 0))
-        this._setup(JSON.parse(xmlhttp.responseText));
-    };
-    xmlhttp.send();
+    this._jsonPromise.then(json => this._setup(json))
+                      .catch(error => console.log(error));
   }
 
   pause() {

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -175,11 +175,11 @@ export default class Animation {
         const appliedFieldsByIds = new Map();
         const appliedLabelsIds = new Set();
 
-        // We do not want to include the previousPoseStep in the loop as its updates are in the keyFrame. However, we need to include it if their is no keyFrames or if it is the step 0 as their is no keyFrame for it
+        // We do not want to include the previousPoseStep in the loop as its updates are in the keyFrame. However, we need to include it if there is no keyFrames or if it is the step 0 as their is no keyFrame for it
         if (previousStepIsAKeyFrame || previousPoseStep !== 0)
           previousPoseStep++;
 
-        for (let i = this.step; i >= previousPoseStep; i--) { // Iterate through each step until the nearest keyFrame is reached or all necessary updates have been applied. Go in decreasing order to minize the number of step.
+        for (let i = this.step; i >= previousPoseStep; i--) { // Iterate through each step until the nearest keyFrame is reached or all necessary updates have been applied. Go in decreasing order to minize the number of steps.
           if (this.data.frames[i].poses) {
             for (let j = 0; j < this.data.frames[i].poses.length; j++) { // At each frame, apply all poses
               const id = this.data.frames[i].poses[j].id;

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -175,7 +175,7 @@ export default class Animation {
         const appliedFieldsByIds = new Map();
         const appliedLabelsIds = new Set();
 
-        // We do not want to include the previousPoseStep in the loop as its updates are in the keyFrame. However, we need to include it if there is no keyFrames or if it is the step 0 as their is no keyFrame for it
+        // We do not want to include the previousPoseStep in the loop as its updates are in the keyFrame. However, we need to include it if there is no keyFrames or if it is the step 0 as there is no keyFrame for it
         if (previousStepIsAKeyFrame || previousPoseStep !== 0)
           previousPoseStep++;
 

--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -24,7 +24,7 @@ export default class Animation {
   init(onReady) {
     this._onReady = onReady;
     this._jsonPromise.then(json => this._setup(json))
-                      .catch(error => console.log(error));
+      .catch(error => console.error(error));
   }
 
   pause() {

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -158,18 +158,16 @@ export default class X3dScene {
     this.render();
   }
 
-  applyPose(pose, appliedFields = []) {
+  applyPose(pose) {
     const id = pose.id;
     if (typeof WbWorld.instance === 'undefined')
-      return appliedFields;
+      return;
 
     const object = WbWorld.instance.nodes.get('n' + id);
     if (typeof object === 'undefined')
       return;
 
-    let fields = [...appliedFields];
-
-    fields = this._applyPoseToObject(pose, object, fields);
+    this._applyPoseToObject(pose, object);
 
     // Update the related USE nodes
     let length = object.useList.length - 1;
@@ -179,26 +177,18 @@ export default class X3dScene {
         // remove a USE node from the list if it has been deleted
         const index = object.useList.indexOf(length);
         this.useList.splice(index, 1);
-      } else {
-        fields = [...appliedFields];
-        fields = this._applyPoseToObject(pose, use, fields);
-      }
+      } else
+        this._applyPoseToObject(pose, use);
 
       --length;
     }
-
-    return fields;
   }
 
-  _applyPoseToObject(pose, object, fields) {
+  _applyPoseToObject(pose, object) {
     for (let key in pose) {
       if (key === 'id')
         continue;
 
-      if (fields.indexOf(key) !== -1)
-        continue;
-
-      let valid = true;
       if (key === 'translation') {
         const translation = convertStringToVec3(pose[key]);
 
@@ -253,11 +243,7 @@ export default class X3dScene {
               shape.updateAppearance();
           }
         }
-      } else
-        valid = false;
-
-      if (valid)
-        fields.push(key);
+      }
     }
 
     if (typeof object.parent !== 'undefined') {
@@ -265,8 +251,6 @@ export default class X3dScene {
       if (typeof parent !== 'undefined' && parent instanceof WbGroup && parent.isPropeller && parent.currentHelix !== object.id && WbWorld.instance.readyForUpdates)
         parent.switchHelix(object.id);
     }
-
-    return fields;
   }
 
   applyLabel(label, view) {

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -105,7 +105,21 @@ webots.View = class View {
       gui = 'play';
     if (typeof loop === 'undefined')
       loop = true;
-    this.animation = new Animation(url, this.x3dScene, this, gui, loop);
+    let jsonPromise = new Promise((resolve, reject) => {
+      let xmlhttp = new XMLHttpRequest();
+      xmlhttp.open('GET', url, true);
+      xmlhttp.overrideMimeType('application/json');
+      xmlhttp.onload = () => {
+        if (xmlhttp.status === 200 || xmlhttp.status === 0)
+          resolve(JSON.parse(xmlhttp.responseText));
+        else {
+          console.log(xmlhttp.readyState)
+          reject(xmlhttp.statusText);
+        }
+      };
+      xmlhttp.send();
+    });
+    this.animation = new Animation(jsonPromise, this.x3dScene, this, gui, loop);
   }
 
   open(url, mode) {

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -112,10 +112,8 @@ webots.View = class View {
       xmlhttp.onload = () => {
         if (xmlhttp.status === 200 || xmlhttp.status === 0)
           resolve(JSON.parse(xmlhttp.responseText));
-        else {
-          console.log(xmlhttp.readyState)
+        else
           reject(xmlhttp.statusText);
-        }
       };
       xmlhttp.send();
     });

--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -440,23 +440,12 @@ void WbAnimationRecorder::stopRecording() {
   const WbWorldInfo *const worldInfo = world->worldInfo();
   const double step = worldInfo->basicTimeStep() * ceil((1000.0 / worldInfo->fps()) / worldInfo->basicTimeStep());
   out << QString(" \"basicTimeStep\":%1,\n").arg(step);
-  out << " \"ids\":\"";
-  bool firstCommand = true;
   QList<WbAnimationCommand *> commandsChangedFromStart;
   foreach (WbAnimationCommand *command, mCommands) {
     // store only ids of nodes that changed during the animation
-    if (command->isChangedFromStart()) {
+    if (command->isChangedFromStart())
       commandsChangedFromStart << command;
-      // cppcheck-suppress knownConditionTrueFalse
-      if (!firstCommand)
-        out << ";";
-      else
-        firstCommand = false;
-      out << command->node()->uniqueId();
-    }
   }
-  out << "\",\n";
-
   out << " \"labelsIds\":\"";
   bool firstLabel = true;
   foreach (QString id, mLabelsIds) {


### PR DESCRIPTION
After seeing the animation generated by Robocup (https://robocup-hlvs.de/GAME_K-GD6-3/public_logs/K-GD6-3.html) , I improved the loading time of the animation by:

- starting the loading of JSON ealier.
- Then I generated some keyframes (think about it like snapshots of the simulation) in order to increase the response time when jumping forward or backward in the replay. The keyframes are generated during the loading.
  - I measured an overhead of 300ms on the Robocup animation for a total loading time of about 16 seconds. It seems acceptable to me knowing that this animation has a JSON file of 400MB.
- I also reordered some loops to minimize the number of iterations
- Finally I made some cleanup.

To test and compare with the original: https://cyberbotics.com/animations/robocup/K-GD6-3.html