### PR TITLE
Fix collada orientation

### DIFF
--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -167,7 +167,8 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
 
   // Assimp fix for up_axis, adapted from https://github.com/assimp/assimp/issues/849
   if (mIsCollada)  // rotate around X by 90° to swap Y and Z axis
-    scene->mRootNode->mTransformation *= aiMatrix4x4(1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1);
+    scene->mRootNode->mTransformation =
+      aiMatrix4x4(1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1) * scene->mRootNode->mTransformation;
 
   // count total number of vertices and faces
   int totalVertices = 0;

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -166,7 +166,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
   }
 
   // Assimp fix for up_axis, adapted from https://github.com/assimp/assimp/issues/849
-  if (mIsCollada)  // rotate around x by 90° to swap Y and Z axis
+  if (mIsCollada)  // rotate around X by 90° to swap Y and Z axis
     scene->mRootNode->mTransformation *= aiMatrix4x4(1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1);
 
   // count total number of vertices and faces

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -114,7 +114,6 @@ bool WbMesh::checkIfNameExists(const aiScene *scene, const QString &name) const 
 }
 
 void WbMesh::updateTriangleMesh(bool issueWarnings) {
-  printf("updateTriangleMesh: %d (%s)\n", mIsCollada, path().toUtf8().constData());
   const QString filePath(path());
   if (filePath.isEmpty())
     return;
@@ -502,7 +501,6 @@ void WbMesh::updateUrl() {
     return;
 
   mIsCollada = (path().mid(path().lastIndexOf('.') + 1).toLower() == "dae");
-  printf("updateUrl: %s %d\n", path().toUtf8().constData(), mIsCollada);
 
   // we want to replace the windows backslash path separators (if any) with cross-platform forward slashes
   const int n = mUrl->size();


### PR DESCRIPTION
**Description**

As surfaced in https://github.com/assimp/assimp/issues/849, importing in assimp non-obj files results in them being rotated 90°. Although the fix proposed in https://github.com/cyberbotics/webots/pull/4172 is technically correct, it ends up overwriting the root transform and therefore any translation & scaling information already present at the root level would end up being overwritten by the fix, which resulted in the behavior shown in the last image of https://github.com/cyberbotics/webots/issues/4447 (coordinate system not centered and scaling issue)

A simpler approach which doesn't suffer from this issue is to simply rotate the root transform by the desired amount.

From this issue also emerged the fact that when loading mesh nodes, the call to `WbTriangleMeshGeometry::preFinalize` builds the mesh prior to having determined whether it's collada or wavefront (which previously only occurred in the function `updateUrl` that comes after), hence `mIsCollada` needs to be defined both before this call and in `updateUrl`) for it to behave correctly.
