### PR TITLE
Fix crash with unsanitized device names

### DIFF
--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -278,11 +278,11 @@ void Ros::fixName() {
 
   mRobotName = mRobot->getName();
   mRobotName += '_' + webotsPID + '_' + webotsHostname;
-  // remove unhautorized symbols ('-', ' ' and '.') for ROS
+  // remove unauthorized symbols ('-', ' ' and '.') for ROS
   mRobotName = Ros::fixedNameString(mRobotName);
 }
 
-// runs accros the list of devices availables and creates the corresponding RosDevices.
+// runs across the list of devices availables and creates the corresponding RosDevices.
 // also stores pointers to sensors to be able to call their publishValues function at each step
 void Ros::setRosDevices(const char **hiddenDevices, int numberHiddenDevices) {
   int nDevices = mRobot->getNumberOfDevices();
@@ -447,7 +447,7 @@ bool Ros::getDeviceListCallback(webots_ros::robot_get_device_list::Request &req,
                                 webots_ros::robot_get_device_list::Response &res) {
   int nDevices = mRobot->getNumberOfDevices();
   for (int j = 0; j < nDevices; ++j)
-    res.list.push_back(Ros::fixedNameString(mRobot->getDeviceByIndex(j)->getName()));
+    res.list.push_back(mRobot->getDeviceByIndex(j)->getName());
   return true;
 }
 

--- a/projects/default/controllers/ros/RosSupervisor.cpp
+++ b/projects/default/controllers/ros/RosSupervisor.cpp
@@ -466,8 +466,12 @@ bool RosSupervisor::getFromDeviceCallback(webots_ros::supervisor_get_from_string
                                           webots_ros::supervisor_get_from_string::Response &res) {
   assert(mSupervisor);
   const Device *device = mRos->getDevice(req.value);
-  res.node = reinterpret_cast<uint64_t>(mSupervisor->getFromDevice(device));
-  return true;
+  if (device) {
+    res.node = reinterpret_cast<uint64_t>(mSupervisor->getFromDevice(device));
+    return true;
+  }
+  ROS_ERROR("ERROR: unkown device %s.", req.value.c_str());
+  return false;
 }
 
 bool RosSupervisor::getSelectedCallback(webots_ros::get_uint64::Request &req, webots_ros::get_uint64::Response &res) {


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/webots/issues/4441

When advertising devices, their name is sanitized (i.e., spaces/dashes replaced by underscores), so for instance a `imu accelerometer` can be enabled with `rosservice call /MyRobot/imu_accelerometer/enable`. 

However, when we call for instance `/MyRobot/robot/get_device_list` a sanitized list of the devices was proposed to the user (in this case `imu_accelerometer` was returned), which if they were subsequently queried, for example to find the noderef of a particular device, resulted in a crash since none could be found with such a name. Since most devices used in the Webots library are unsanitized, I think it makes more sense for them to be accessible in an unsanitized way, otherwise the users need to manually edit the worlds.

