### PR TITLE
Fix nightly issues

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -57,7 +57,6 @@ jobs:
         export LIBGL_ALWAYS_SOFTWARE=true
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
-        ls -la distribution/
     - name: Prepare Webots Controller Deployment
       if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-18.04' }}
       uses: webfactory/ssh-agent@v0.5.3
@@ -75,7 +74,6 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        ls -la distribution/
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test world update') }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -50,7 +50,6 @@ jobs:
         export LIBGL_ALWAYS_SOFTWARE=true
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
         xvfb-run --auto-servernum make distrib -j4
-        ls -la distribution/
     - name: Prepare Webots Controller Deployment
       if: ${{ (github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'deploy libcontroller')) && matrix.os == 'ubuntu-20.04' }}
       uses: webfactory/ssh-agent@v0.5.3
@@ -63,7 +62,6 @@ jobs:
       if: ${{ (github.event_name == 'push' || github.event_name == 'schedule') }}
       run: |
         sudo python -m pip install requests PyGithub
-        ls -la distribution/
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test world update') }}

--- a/scripts/packaging/publish_release.py
+++ b/scripts/packaging/publish_release.py
@@ -172,7 +172,7 @@ for release in repo.get_releases():
                                                release.target_commitish)
         break
 
-if not releaseFound:  # if it does not exists, it should have been created by the script itself
+if not releaseFound:  # if it does not exist, it should have been created by the script itself
     print(f'Error, release "{release.title}" should exist by now but does not.')
 else:
     print('Upload finished.')


### PR DESCRIPTION
**Description**

As far as I can tell from the debug messages, the job that creates the release is always unable to include the distribution files itself created. As tonight's messages have shown, the binaries are indeed available so that's not the problem, therefore I suspect the issue lies with the fact that between [creating the release](https://github.com/cyberbotics/webots/blob/9c87a9d4f7332e764e6bb01947a761444bc488b1/scripts/packaging/publish_release.py#L95) on github and [requesting the list of all releases](https://github.com/cyberbotics/webots/blob/9c87a9d4f7332e764e6bb01947a761444bc488b1/scripts/packaging/publish_release.py#L127) available not enough time passes and therefore no upload occurs since the newly created release is not present (as far as the script is concerned).

I've added an error message and a delay to validate if indeed this is the case, but I suspect so since it's consistent with what we've seen so far