### PR TITLE
Upgrade checkout and attempt fixing discord bot

### DIFF
--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: released 
+        ref: released
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -28,6 +28,7 @@ jobs:
         git config --global user.name ${GITHUB_ACTOR}
         git config --global user.email ${GITHUB_ACTOR}@github.com
         git config --global --add safe.directory /github/workspace
+        git branch -D discord-doc-update
         git checkout -b discord-doc-update
         git add ./docs/discord
         git commit -m "Update discord docs."

--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -27,8 +27,6 @@ jobs:
       run: |
         git config --global user.name ${GITHUB_ACTOR}
         git config --global user.email ${GITHUB_ACTOR}@github.com
-        git config --global --add safe.directory /github/workspace
-        git branch -D discord-doc-update
         git checkout -b discord-doc-update
         git add ./docs/discord
         git commit -m "Update discord docs."

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -35,7 +35,7 @@ jobs:
             ROS_DISTRO: "noetic"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15
@@ -97,7 +97,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
       uses: actions/download-artifact@v2
       with:
@@ -134,7 +134,7 @@ jobs:
             python: 3.6
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
     - name: Download Artifacts
@@ -163,7 +163,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test world update') || github.event_name == 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -27,7 +27,7 @@ jobs:
             ROS_DISTRO: "noetic"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          ref: develop
     - name: Download Artifacts
@@ -121,7 +121,7 @@ jobs:
             python: 3.6
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          ref: develop
@@ -151,7 +151,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test world update') || github.event_name == 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          ref: develop
     - name: Download Artifacts

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -24,7 +24,7 @@ jobs:
         os: [macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15
@@ -79,7 +79,7 @@ jobs:
         os: [macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download Artifacts
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -19,7 +19,7 @@ jobs:
         os: [macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15
@@ -75,7 +75,7 @@ jobs:
         os: [macos-10.15]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          ref: develop
     - name: Download Artifacts

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -34,7 +34,7 @@ jobs:
         install: >-
           git
           openssh
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -29,7 +29,7 @@ jobs:
         install: >-
           git
           openssh
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          submodules: true
          fetch-depth: 15

--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: needs.job-skipper.outputs.should_skip != 'true'
     - name: Set up Python 3.9
       uses: actions/setup-python@v2

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: needs.job-skipper.outputs.should_skip != 'true' && ((matrix.os == 'ubuntu-18.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources'))
     - name: Set up Python ${{ matrix.python }}
       if: needs.job-skipper.outputs.should_skip != 'true' && ((matrix.os == 'ubuntu-18.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources'))


### PR DESCRIPTION
**Description**

Apparently the bot failed again, this time it couldn't push because supposedly its branch was behind the remote one, which doesn't make much sense since it's a fresh clone. There has been an update to the github action "checkout" recently, I haven't found any similar issue on their github but shouldn't hurt to upgrade either. On top of it the PR forces the branch to be recreated. 

It theory it should be sufficient to make a pull before creating the commit, but it really shouldn't be necessary to do so, hence it seems the best approach (or at least, the only I can think of, but I'm open to ideas)