### PR TITLE
WebotsJS: Fix PROTO regeneration and update bugs

### DIFF
--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -715,8 +715,6 @@ export default class Parser {
       geometry = this._parseElevationGrid(node, id);
     else if (node.tagName === 'PointSet')
       geometry = this._parsePointSet(node, id);
-    else
-      console.error('Not a recognized geometry: ' + node.tagName);
 
     if (typeof parentId !== 'undefined' && typeof geometry !== 'undefined')
       geometry.parent = parentId;

--- a/resources/web/wwi/nodes/WbBaseNode.js
+++ b/resources/web/wwi/nodes/WbBaseNode.js
@@ -19,6 +19,9 @@ export default class WbBaseNode {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     this.wrenObjectsCreatedCalled = true;
 
     if (typeof this.parent !== 'undefined')

--- a/resources/web/wwi/nodes/WbBox.js
+++ b/resources/web/wwi/nodes/WbBox.js
@@ -14,6 +14,9 @@ export default class WbBox extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
     super._computeWrenRenderable();
 

--- a/resources/web/wwi/nodes/WbCapsule.js
+++ b/resources/web/wwi/nodes/WbCapsule.js
@@ -18,6 +18,9 @@ export default class WbCapsule extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     if (this.isInBoundingObject() && this.subdivision < WbGeometry.MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)

--- a/resources/web/wwi/nodes/WbCone.js
+++ b/resources/web/wwi/nodes/WbCone.js
@@ -16,6 +16,9 @@ export default class WbCone extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     if (!this.bottom && !this.side)

--- a/resources/web/wwi/nodes/WbCylinder.js
+++ b/resources/web/wwi/nodes/WbCylinder.js
@@ -18,6 +18,9 @@ export default class WbCylinder extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     if (this.isInBoundingObject() && this.subdivision < WbGeometry.MIN_BOUNDING_OBJECT_CIRCLE_SUBDIVISION)

--- a/resources/web/wwi/nodes/WbDirectionalLight.js
+++ b/resources/web/wwi/nodes/WbDirectionalLight.js
@@ -8,6 +8,9 @@ export default class WbDirectionalLight extends WbLight {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     this._wrenLight = _wr_directional_light_new();
     super.createWrenObjects();
 

--- a/resources/web/wwi/nodes/WbElevationGrid.js
+++ b/resources/web/wwi/nodes/WbElevationGrid.js
@@ -19,6 +19,9 @@ export default class WbElevationGrid extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
     this._buildWrenMesh();
   }

--- a/resources/web/wwi/nodes/WbGeometry.js
+++ b/resources/web/wwi/nodes/WbGeometry.js
@@ -81,6 +81,9 @@ export default class WbGeometry extends WbBaseNode {
   }
 
   _computeWrenRenderable() {
+    if (this._wrenRenderable)
+      return;
+
     if (!this.wrenObjectsCreatedCalled)
       super.createWrenObjects();
 

--- a/resources/web/wwi/nodes/WbImageTexture.js
+++ b/resources/web/wwi/nodes/WbImageTexture.js
@@ -78,6 +78,9 @@ export default class WbImageTexture extends WbBaseNode {
   }
 
   preFinalize() {
+    if (this.isPreFinalizeCalled)
+      return;
+
     super.preFinalize();
     this.updateUrl();
     this._updateFiltering();

--- a/resources/web/wwi/nodes/WbIndexedLineSet.js
+++ b/resources/web/wwi/nodes/WbIndexedLineSet.js
@@ -16,6 +16,9 @@ export default class WbIndexedLineSet extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
     this._updateCoord();
     this._buildWrenMesh();

--- a/resources/web/wwi/nodes/WbPlane.js
+++ b/resources/web/wwi/nodes/WbPlane.js
@@ -14,6 +14,9 @@ export default class WbPlane extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     this._computeWrenRenderable();

--- a/resources/web/wwi/nodes/WbPointLight.js
+++ b/resources/web/wwi/nodes/WbPointLight.js
@@ -18,6 +18,9 @@ export default class WbPointLight extends WbLight {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     this._wrenLight = _wr_point_light_new();
     this._attachToUpperTransform();
     super.createWrenObjects();

--- a/resources/web/wwi/nodes/WbPointSet.js
+++ b/resources/web/wwi/nodes/WbPointSet.js
@@ -17,6 +17,9 @@ export default class WbPointSet extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
     _wr_config_enable_point_size(true);
     this._updateCoord();

--- a/resources/web/wwi/nodes/WbShape.js
+++ b/resources/web/wwi/nodes/WbShape.js
@@ -58,11 +58,12 @@ export default class WbShape extends WbBaseNode {
 
   createWrenObjects() {
     super.createWrenObjects();
-    if (typeof this.appearance !== 'undefined')
+    if (typeof this.appearance !== 'undefined' && !this.appearance.wrenObjectsCreatedCalled)
       this.appearance.createWrenObjects();
 
     if (typeof this.geometry !== 'undefined') {
-      this.geometry.createWrenObjects();
+      if (!this.geometry.wrenObjectsCreatedCalled)
+        this.geometry.createWrenObjects();
 
       this.applyMaterialToGeometry();
     }
@@ -127,10 +128,10 @@ export default class WbShape extends WbBaseNode {
   preFinalize() {
     super.preFinalize();
 
-    if (typeof this.appearance !== 'undefined')
+    if (typeof this.appearance !== 'undefined' && !this.appearance.isPreFinalizeCalled)
       this.appearance.preFinalize();
 
-    if (typeof this.geometry !== 'undefined')
+    if (typeof this.geometry !== 'undefined' && !this.geometry.isPreFinalizeCalled)
       this.geometry.preFinalize();
 
     this.updateAppearance();
@@ -139,10 +140,10 @@ export default class WbShape extends WbBaseNode {
   postFinalize() {
     super.postFinalize();
 
-    if (typeof this.appearance !== 'undefined')
+    if (typeof this.appearance !== 'undefined' && !this.appearance.isPostFinalizeCalled)
       this.appearance.postFinalize();
 
-    if (typeof this.geometry !== 'undefined')
+    if (typeof this.geometry !== 'undefined' && !this.geometry.isPostFinalizeCalled)
       this.geometry.postFinalize();
 
     if (!this.isInBoundingObject()) {

--- a/resources/web/wwi/nodes/WbShape.js
+++ b/resources/web/wwi/nodes/WbShape.js
@@ -58,12 +58,11 @@ export default class WbShape extends WbBaseNode {
 
   createWrenObjects() {
     super.createWrenObjects();
-    if (typeof this.appearance !== 'undefined' && !this.appearance.wrenObjectsCreatedCalled)
+    if (typeof this.appearance !== 'undefined')
       this.appearance.createWrenObjects();
 
     if (typeof this.geometry !== 'undefined') {
-      if (!this.geometry.wrenObjectsCreatedCalled)
-        this.geometry.createWrenObjects();
+      this.geometry.createWrenObjects();
 
       this.applyMaterialToGeometry();
     }
@@ -128,10 +127,10 @@ export default class WbShape extends WbBaseNode {
   preFinalize() {
     super.preFinalize();
 
-    if (typeof this.appearance !== 'undefined' && !this.appearance.isPreFinalizeCalled)
+    if (typeof this.appearance !== 'undefined')
       this.appearance.preFinalize();
 
-    if (typeof this.geometry !== 'undefined' && !this.geometry.isPreFinalizeCalled)
+    if (typeof this.geometry !== 'undefined')
       this.geometry.preFinalize();
 
     this.updateAppearance();
@@ -140,10 +139,10 @@ export default class WbShape extends WbBaseNode {
   postFinalize() {
     super.postFinalize();
 
-    if (typeof this.appearance !== 'undefined' && !this.appearance.isPostFinalizeCalled)
+    if (typeof this.appearance !== 'undefined')
       this.appearance.postFinalize();
 
-    if (typeof this.geometry !== 'undefined' && !this.geometry.isPostFinalizeCalled)
+    if (typeof this.geometry !== 'undefined')
       this.geometry.postFinalize();
 
     if (!this.isInBoundingObject()) {

--- a/resources/web/wwi/nodes/WbSphere.js
+++ b/resources/web/wwi/nodes/WbSphere.js
@@ -15,6 +15,9 @@ export default class WbSphere extends WbGeometry {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     this._sanitizeFields();

--- a/resources/web/wwi/nodes/WbSpotLight.js
+++ b/resources/web/wwi/nodes/WbSpotLight.js
@@ -21,6 +21,9 @@ export default class WbSpotLight extends WbLight {
   }
 
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     this._wrenLight = _wr_spot_light_new();
     super.createWrenObjects();
     this._attachToUpperTransform();

--- a/resources/web/wwi/nodes/WbTrack.js
+++ b/resources/web/wwi/nodes/WbTrack.js
@@ -188,7 +188,7 @@ export default class WbTrack extends WbSolid {
 
   postFinalize() {
     super.postFinalize();
-    WbWorld.instance.tracks.push(this);
+    WbWorld.instance.tracks.add(this);
     this.beltElements.forEach(beltElement => beltElement.postFinalize());
   }
 

--- a/resources/web/wwi/nodes/WbTransform.js
+++ b/resources/web/wwi/nodes/WbTransform.js
@@ -44,11 +44,14 @@ export default class WbTransform extends WbGroup {
   }
 
   createWrenObjects() {
-    super.createWrenObjects(true);
-    const transform = _wr_transform_new();
+    if (!this.wrenObjectsCreatedCalled) {
+      super.createWrenObjects(true);
+      const transform = _wr_transform_new();
 
-    _wr_transform_attach_child(this.wrenNode, transform);
-    this.wrenNode = transform;
+      _wr_transform_attach_child(this.wrenNode, transform);
+      this.wrenNode = transform;
+    }
+
     this.children.forEach(child => {
       child.createWrenObjects();
     });

--- a/resources/web/wwi/nodes/WbTriangleMeshGeometry.js
+++ b/resources/web/wwi/nodes/WbTriangleMeshGeometry.js
@@ -8,6 +8,9 @@ import WbWrenShaders from './../wren/WbWrenShaders.js';
 
 export default class WbTriangleMeshGeometry extends WbGeometry {
   createWrenObjects() {
+    if (this.wrenObjectsCreatedCalled)
+      return;
+
     super.createWrenObjects();
 
     this._buildWrenMesh(false);

--- a/resources/web/wwi/nodes/WbWorld.js
+++ b/resources/web/wwi/nodes/WbWorld.js
@@ -10,7 +10,7 @@ export default class WbWorld {
     this.nodes = new Map();
 
     this.billboards = [];
-    this.tracks = [];
+    this.tracks = new Set();
     this.readyForUpdates = false;
     this.robots = [];
   }

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -197,8 +197,9 @@ void WbX3dStreamingServer::propagateNodeDeletion(WbNode *node) {
   if (!isActive() || WbWorld::instance() == NULL)
     return;
 
+  const WbNode *def = static_cast<const WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
   foreach (QWebSocket *client, mWebSocketClients)
-    client->sendTextMessage(QString("delete:%1").arg(node->uniqueId()));
+    client->sendTextMessage(QString("delete:%1").arg(def->uniqueId()));
 }
 
 void WbX3dStreamingServer::generateX3dWorld() {


### PR DESCRIPTION
**Related Issues**
This pull-request fixes issue #1875 

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix crash when replacing an appearance.
  - [x] Fix deleted item ID when inside PROTO.
  - [x] Fix update after PROTO regeneration.

Both the crash and the problem of updates after PROTO regeneration happened because `createWrenObject` was called twice on some objects.

Some objects were not deleted in WebotsJS because the id sent along the `delete:` was not matching the id sent at the world creation.
