### PR TITLE
Fix collision between kinematic robots

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -32,6 +32,7 @@ Released on XX XX, 2022.
     - Fixed perspective (i.e., when the layout is changed) saving logic and camera menu overlay ([#4350](https://github.com/cyberbotics/webots/pull/4350)).
     - Fixed virtual reality and `get_contact_points` ROS services, and no longer advertise deprecated ones: `get_number_of_contact_points`, `get_contact_point` and `get_contact_point_node` ([#4371](https://github.com/cyberbotics/webots/pull/4371)).
     - Fixed crash when streaming very large [ElevationGrid](elevationgrid.md) ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
+    - Fixed collision logic for kinematic robots ([#4509](https://github.com/cyberbotics/webots/pull/4509)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -159,8 +159,8 @@ void WbSimulationCluster::handleKinematicsCollisions() {
 void WbSimulationCluster::collideKinematicRobots(WbKinematicDifferentialWheels *robot, bool collideWithOtherRobot,
                                                  dContact *contact, bool body1) {
   // handle DifferentialWheels robots without physics
-  WbVector2 normal2D(contact[0].geom.normal[0], contact[0].geom.normal[2]);
-  WbVector3 normal3D(contact[0].geom.normal[0], contact[0].geom.normal[1], contact[0].geom.normal[2]);
+  WbVector2 normal2D(contact[0].geom.normal[2], contact[0].geom.normal[1]);
+  WbVector3 normal3D(contact[0].geom.normal[2], contact[0].geom.normal[0], contact[0].geom.normal[1]);
   double depth = fabs(contact[0].geom.depth * (normal2D.length() / normal3D.length()));
 
   // record contact points for graphical and sound rendering

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -159,8 +159,8 @@ void WbSimulationCluster::handleKinematicsCollisions() {
 void WbSimulationCluster::collideKinematicRobots(WbKinematicDifferentialWheels *robot, bool collideWithOtherRobot,
                                                  dContact *contact, bool body1) {
   // handle DifferentialWheels robots without physics
-  WbVector2 normal2D(contact[0].geom.normal[2], contact[0].geom.normal[1]);
-  WbVector3 normal3D(contact[0].geom.normal[2], contact[0].geom.normal[0], contact[0].geom.normal[1]);
+  WbVector2 normal2D(contact[0].geom.normal[0], contact[0].geom.normal[1]);
+  WbVector3 normal3D(contact[0].geom.normal[0], contact[0].geom.normal[2], contact[0].geom.normal[1]);
   double depth = fabs(contact[0].geom.depth * (normal2D.length() / normal3D.length()));
 
   // record contact points for graphical and sound rendering

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -641,6 +641,35 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   if (ts2 && !isRayGeom1)
     ts2->setTouching(true);
 
+  const WbPhysics *const p1 = s1->physics();
+  const WbPhysics *const p2 = s2->physics();
+
+  // kinematic mode
+  if (!p1 || !p2) {
+    WbRobot *const robot1 = dynamic_cast<WbRobot *>(s1);
+    WbRobot *const robot2 = dynamic_cast<WbRobot *>(s2);
+    if (robot1 && !p1 && !isRayGeom2 && robot1->kinematicDifferentialWheels()) {
+      wg1->setColliding();
+      cl->mCollisionedRobots.append(robot1->kinematicDifferentialWheels());
+      if (robot2 && !p2 && robot2->kinematicDifferentialWheels()) {
+        dCollide(o1, o2, 10, &contact[0].geom, sizeof(dContact));  // we want only one contact point
+        wg2->setColliding();
+        cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
+        collideKinematicRobots(robot1->kinematicDifferentialWheels(), true, contact, true);
+        collideKinematicRobots(robot2->kinematicDifferentialWheels(), true, contact, false);
+      } else
+        collideKinematicRobots(robot1->kinematicDifferentialWheels(), false, contact, true);
+      return;
+    }
+    if (robot2 && !p2 && !isRayGeom1 && robot2->kinematicDifferentialWheels()) {
+      dCollide(o1, o2, 10, &contact[0].geom, sizeof(dContact));
+      wg2->setColliding();
+      cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
+      collideKinematicRobots(robot2->kinematicDifferentialWheels(), false, contact, false);
+      return;
+    }
+  }
+
   // Handles the case of ray geometry against a non-ray geometry, i.e. at least one body is null
   if (isRayGeom1) {
     WbDistanceSensor *const ds = dynamic_cast<WbDistanceSensor *>(s1);


### PR DESCRIPTION
**Description**

With the removal of the DifferentialWheels node (R2021b), the logic handling the collision between kinematic robots was also removed by accident. 

Before:

https://user-images.githubusercontent.com/44834743/166713306-27073a2f-cd8f-4cbd-a837-60aef0a304ba.mp4

https://user-images.githubusercontent.com/44834743/166713363-eca16946-0cc8-4a72-adf6-fbd52d9ed089.mp4

After:


https://user-images.githubusercontent.com/44834743/166715245-980f1be1-b5e1-416f-850e-dbe8c863fd4b.mp4


https://user-images.githubusercontent.com/44834743/166715262-70d81d05-9b36-4eb5-8b79-0a2b02b3ca1f.mp4

