### PR TITLE
Fix discord bot yet again

### DIFF
--- a/.github/workflows/discord_updater.yml
+++ b/.github/workflows/discord_updater.yml
@@ -32,7 +32,7 @@ jobs:
         git commit -m "Update discord docs."
         git push origin discord-doc-update
     - name: GitHub Pull Request Action
-      uses: repo-sync/pull-request@v2.2
+      uses: repo-sync/pull-request@v2.6.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         source_branch: discord-doc-update


### PR DESCRIPTION
**Description**

[Apparently](https://github.com/repo-sync/pull-request/pull/85) the reason it still fails might be that the pull-request action itself needs to be upgraded as it relies on checkout as well