### PR TITLE
Fix errors using to python3.10 and update documentation

### DIFF
--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -8,7 +8,7 @@ The Python API is currently composed of a set of about 25 classes having about 2
 The classes are either representations of a node of the scene tree (such as Robot, LED, etc.) or utility classes (such as Motion, ImageRef, etc.).
 A complete description of these functions can be found in the reference guide while the instructions about the common way to program a Python controller can be found in [this chapter](programming-fundamentals.md).
 
-The Python API of Webots supports Python versions 3.7, 3.8 and 3.9.
+The Python API of Webots supports Python versions 3.7, 3.8, 3.9, and 3.10.
 On Ubuntu 18.04 it also supports Python version 3.6.
 
 Alternatively to the Webots built-in editor, [PyCharm](https://www.jetbrains.com/pycharm) can be used to edit and launch Python controllers, see the [Using PyCharm with Webots](using-your-ide.md#pycharm) chapter for a step-by-step procedure.
@@ -20,7 +20,7 @@ As a consequence, it executes the first `python` binary found in the current `PA
 If you want to use a different version of Python, please install it if needed and configure your environment so that it becomes the default `python` version when called from the command line in a terminal.
 Alternatively, you can change the default Python command from the Webots Preferences in the General tab.
 If you set it for example to `python3.8` instead of `python`, this version of Python will be used by default, if available from the command line.
-It is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.9` or `python3.8`, etc.
+It is also possible to set a different version of Python for each robot controller by editing the `[python]` section of the `runtime.ini` file in each robot controller directory and setting the `COMMAND` value to `python3`, `python3.10` or `python3.8`, etc.
 If specified in the `runtime.ini` file of a controller, this Python command will be executed instead of the default one to launch this controller.
 On Linux and macOS, it is also possible to override this value by setting a standard Python shebang header line in your main python controller file, for example:
 
@@ -38,14 +38,14 @@ To check the versions of Python installed on your system, you can type in a term
 
 #### macOS Installation
 
-You can install Python 3.7, 3.8 or 3.9 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
+You can install Python 3.7, 3.8, 3.9 or 3.10 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
 To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python3 --version`, etc.
 
 > **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (e.g. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
 
 #### Windows Installation
 
-You should install the latest 64-bit version of Python 3.9, 3.8 or 3.7 from the official [Python website](https://www.python.org).
+You should install the latest 64-bit version of Python 3.10, 3.9, 3.8 or 3.7 from the official [Python website](https://www.python.org).
 Then, you have to modify your `PATH` environment variable to add the path to the `python.exe` binary which is located in the main installation folder.
 To check this was done properly, you can open a DOS console (`CMD.EXE`) and type `python --version`.
 If it displays the correct Python version, then, everything is setup properly and you should be able to run the Python example provided with Webots in the `WEBOTS_HOME/projects/languages/python/worlds/example.wbt` world file.
@@ -84,7 +84,7 @@ Where `PYTHON_PATH` is the path to the Python installation directory, for exampl
 
 ### Use an Alternative Python Version
 
-As explained above, the Python libraries for Webots are precompiled for the standard versions of Python 3.7, 3.8, 3.9 and on Ubuntu for the default Python 3 version provided with the system.
+As explained above, the Python libraries for Webots are precompiled for the standard versions of Python 3.7, 3.8, 3.9, 3.10 and on Ubuntu for the default Python 3 version provided with the system.
 It is possible however to use another Python version, like Anaconda Python, by recompiling the Webots Python libraries.
 Such a task requires some knowledge in software installation, compilation from sources and Makefile.
 

--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -75,7 +75,7 @@ N/A because Python is interpreted.
     - For Java: `.class` or `.jar`.
 - `SL_PREFIX` is the prefix of a shared library: `lib` on Linux or macOS, and an empty string on Windows.
 - `SL_SUFFIX` is the suffix of a shared library: `.so` on Linux, `.dylib` on macOS and `.dll` on Windows.
-- `PYTHON_VERSION` is your Python version, but concatenated (`27`, `37`, `38`, etc.).
+- `PYTHON_VERSION` is your Python version, but concatenated (`310`, `39`, `38`, etc.).
 
 ---
 

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -75,6 +75,9 @@ endif
 ifeq ($(PYTHON_SHORT_VERSION),39)
 C_FLAGS          += -Wno-deprecated-declarations
 endif
+ifeq ($(PYTHON_SHORT_VERSION),310)
+C_FLAGS          += -Wno-deprecated-declarations
+endif
 ifeq ($(findstring llvm-g++,$(shell ls -lF $(shell which c++ 2> /dev/null))),)
 C_FLAGS        += -Wno-self-assign
 endif

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -172,8 +172,10 @@ const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCo
     if (log)
       WbLog::warning(QObject::tr("\"%1\" was not found.\n").arg(pythonCommand));
     shortVersion = QString();
-  } else
-    shortVersion = QString(version[0][0]) + version[0][2];
+  } else {
+    const QStringList version_numbers(version[0].split("."));
+    shortVersion = QString(version_numbers[0]) + version_numbers[1];
+  }
   return shortVersion;
 }
 #endif

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -174,7 +174,7 @@ const QString WbLanguageTools::checkIfPythonCommandExist(const QString &pythonCo
     shortVersion = QString();
   } else {
     const QStringList version_numbers(version[0].split("."));
-    shortVersion = QString(version_numbers[0]) + version_numbers[1];
+    shortVersion = version_numbers[0] + version_numbers[1];
   }
   return shortVersion;
 }


### PR DESCRIPTION
Fix warning when compiling the Python 3.10 API and errors computing the path to the Python 3.10 API.
I also updated the documentation.