### PR TITLE
Improve deprecation flags and double initialization

### DIFF
--- a/scripts/packaging/Makefile
+++ b/scripts/packaging/Makefile
@@ -45,7 +45,7 @@ ifeq ($(UBUNTU_VERSION),20.04)
 CFLAGS = -DWEBOTS_UBUNTU_20_04
 endif
 ifeq ($(UBUNTU_VERSION),22.04)
-CFLAGS = -DWEBOTS_UBUNTU_22_04
+CFLAGS = -DWEBOTS_UBUNTU_22_04 -Wno-deprecated-declarations
 endif
 endif
 
@@ -106,7 +106,7 @@ install: all
 
 $(WEBOTS_DISTRO_EXE): webots_distro.c
 	+@echo "# compiling webots_distro.c"
-	+@$(CC) $(CFLAGS) -Wno-deprecated-declarations -Wall -o $@ webots_distro.c $(LIBRARIES)
+	+@$(CC) $(CFLAGS) -Wall -o $@ webots_distro.c $(LIBRARIES)
 
 xvfb:
 	+@echo "# starting Xvfb: X Virtual Frame Buffer"

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -33,7 +33,7 @@ from command import Command
 if sys.platform == 'linux':
     result = subprocess.run(['lsb_release', '-sr'], stdout=subprocess.PIPE)
     is_ubuntu_22_04 = result.stdout.decode().strip() == '22.04'
-else
+else:
     is_ubuntu_22_04 = False
 
 # monitor failures

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -30,10 +30,11 @@ import multiprocessing
 
 from command import Command
 
-is_ubuntu_22_04 = False
 if sys.platform == 'linux':
     result = subprocess.run(['lsb_release', '-sr'], stdout=subprocess.PIPE)
     is_ubuntu_22_04 = result.stdout.decode().strip() == '22.04'
+else
+    is_ubuntu_22_04 = False
 
 # monitor failures
 failures = 0


### PR DESCRIPTION
Address comments in #4502.

md5-related functions are deprecated in OpenSSL 3.
For the moment it seems that the new version of OpenSSL is only used on macOS and Ubuntu 22.04 so we need to ignore the warnings only on these platforms.