### PR TITLE
Fix documentation for copying camera image in display

### DIFF
--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -885,7 +885,7 @@ image = wb_camera_get_image(tag)
 *get the image data from a camera*
 
 The `wb_camera_get_image` function reads the last image grabbed by the camera.
-The image is coded as a sequence of three bytes representing the red, green and blue levels of a pixel.
+The image is coded as a sequence of four bytes representing the blue, green, red and alpha levels of a pixel.
 Pixels are stored in horizontal lines ranging from the top left hand side of the image down to bottom right hand side.
 The memory chunk returned by this function must not be freed, as it is handled by the camera itself.
 The size in bytes of this memory chunk can be computed as follows:

--- a/docs/reference/display.md
+++ b/docs/reference/display.md
@@ -757,7 +757,7 @@ int main() {
   while(wb_robot_step(time_step) != -1) {
     const unsigned char *data = wb_camera_get_image(camera);
     if (data) {
-      WbImageRef ir = wb_display_image_new(display, width, height, data, WB_IMAGE_ARGB);
+      WbImageRef ir = wb_display_image_new(display, width, height, data, WB_IMAGE_BGRA);
       wb_display_image_paste(display, ir, 0, 0, false);
       wb_display_image_delete(display, ir);
     }
@@ -790,7 +790,7 @@ int main() {
   while (robot->step(timeStep) != -1) {
     const unsigned char *data = camera->getImage();
     if (data) {
-      ImageRef *ir = display->imageNew(width, height, data, Display::ARGB);
+      ImageRef *ir = display->imageNew(width, height, data, Display::BGRA);
       display->imagePaste(ir, 0, 0, false);
       display->imageDelete(ir);
     }
@@ -818,7 +818,7 @@ display = robot.getDisplay('display');
 while robot.step(32) != -1:
     data = camera.getImage()
     if data:
-        ir = display.imageNew(data, Display.ARGB, width, height)
+        ir = display.imageNew(data, Display.BGRA, width, height)
         display.imagePaste(ir, 0, 0, False)
         display.imageDelete(ir)
 ```
@@ -869,7 +869,7 @@ display = wb_robot_get_device("display");
 while wb_robot_step(time_step) ~= -1
   data = wb_camera_get_image(camera);
   if data
-    ir = wb_display_image_new(display, width, height, data, ARGB);
+    ir = wb_display_image_new(display, width, height, data, BGRA);
     wb_display_image_paste(display, ir, 0, 0, false);
     wb_display_image_delete(display, ir);
   end
@@ -878,4 +878,5 @@ end
 %tab-end
 %end
 
-> **Note**: The `wb_display_image_new` function can display the image returned by the [`wb_camera_get_image`](camera.md#wb_camera_get_image) function directly if the pixel format argument is set to ARGB.
+ **Note**: The Java `Display.imageNew` function can display the image returned by the `Camera.getImage` function directly if the pixel format argument is set to ARGB.
+In the other programming languages the pixel format should be set to BGRA.


### PR DESCRIPTION
It seems there has been issue during branches synchronization and the changes applied to the documentation in PR  #2452 have been overwritten.
However, changes to the code have been applied correctly.