### PR TITLE
Fix crash due to Transform updates in Fuild.boundingObject

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -33,6 +33,7 @@ Released on XX XX, 2022.
     - Fixed virtual reality and `get_contact_points` ROS services, and no longer advertise deprecated ones: `get_number_of_contact_points`, `get_contact_point` and `get_contact_point_node` ([#4371](https://github.com/cyberbotics/webots/pull/4371)).
     - Fixed crash when streaming very large [ElevationGrid](elevationgrid.md) ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
     - Fixed collision logic for kinematic robots ([#4509](https://github.com/cyberbotics/webots/pull/4509)).
+    - Fixed crash moving a [Transform](transform.md) node inserted in a [Fluid.boundingObject](fluid.md) ([#4568](https://github.com/cyberbotics/webots/pull/4568)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2021 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -249,7 +249,8 @@ void WbGeometry::applyToOdeMass() {
   assert(odeGeomData);
   if (mOdeMass->mass > 0.0) {
     WbSolid *const solid = odeGeomData->solid();
-    solid->correctOdeMass(mOdeMass, transformedGeometry());
+    if (solid && solid->physics())
+      solid->correctOdeMass(mOdeMass, transformedGeometry());
   }
 }
 
@@ -578,7 +579,7 @@ int WbGeometry::triangleCount() const {
     return 0;
 }
 
-bool WbGeometry::exportNodeHeader(WbVrmlWriter &writer) const {
+bool WbGeometry::exportNodeHeader(WbWriter &writer) const {
   if (writer.isUrdf())
     return true;
   return WbBaseNode::exportNodeHeader(writer);
@@ -620,49 +621,11 @@ int WbGeometry::constraintType() const {
 // Export //
 ////////////
 
-void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
+void WbGeometry::exportBoundingObjectToX3D(WbWriter &writer) const {
   assert(writer.isX3d());
   assert(isInBoundingObject());
   if (!mWrenMesh)
     return;
 
-  const int vertexCount = wr_static_mesh_get_vertex_count(mWrenMesh);
-  const int indexCount = wr_static_mesh_get_index_count(mWrenMesh);
-  float *vertices = new float[3 * vertexCount];
-  unsigned int *indices = new unsigned int[indexCount];
-  wr_static_mesh_read_data(mWrenMesh, vertices, NULL, NULL, indices);
-
-  writer << "<Shape>";
-  writer << "<Appearance sortType='transparent'><Material emissiveColor='1 1 1'></Material></Appearance>";
-  writer << "<IndexedLineSet coordIndex='";
-
-  for (int i = 0; i < indexCount / 2; ++i)
-    writer << indices[2 * i] << " " << indices[2 * i + 1] << " -1 ";
-  writer << "'>";
-
-  writer << "<Coordinate point='";
-  const float *floatMatrix = wr_transform_get_matrix(mWrenScaleTransform);
-  double doubleMatrix[16];
-  for (int i = 0; i < 16; ++i)
-    doubleMatrix[i] = static_cast<double>(floatMatrix[i]);
-
-  // Extract WREN scaling factors
-  WbMatrix4 meshMatrix;
-  meshMatrix.fromOpenGlMatrix(doubleMatrix);
-  WbVector3 scale = meshMatrix.scale();
-  scale /= absoluteScale();
-
-  for (int i = 0; i < vertexCount; ++i) {
-    const int index = 3 * i;
-    const WbVector3 coord = WbVector3(vertices[index], vertices[index + 1], vertices[index + 2]) * scale;
-    if (i > 0)
-      writer << ", ";
-    writer << coord.toString(WbPrecision::FLOAT_MAX);
-  }
-  writer << "'></Coordinate>";
-  writer << "</IndexedLineSet>";
-  writer << "</Shape>";
-
-  delete[] vertices;
-  delete[] indices;
+  this->write(writer);
 }

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2022 Cyberbotics Ltd.
+// Copyright 1996-2021 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -579,7 +579,7 @@ int WbGeometry::triangleCount() const {
     return 0;
 }
 
-bool WbGeometry::exportNodeHeader(WbWriter &writer) const {
+bool WbGeometry::exportNodeHeader(WbVrmlWriter &writer) const {
   if (writer.isUrdf())
     return true;
   return WbBaseNode::exportNodeHeader(writer);
@@ -621,11 +621,49 @@ int WbGeometry::constraintType() const {
 // Export //
 ////////////
 
-void WbGeometry::exportBoundingObjectToX3D(WbWriter &writer) const {
+void WbGeometry::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
   assert(writer.isX3d());
   assert(isInBoundingObject());
   if (!mWrenMesh)
     return;
 
-  this->write(writer);
+  const int vertexCount = wr_static_mesh_get_vertex_count(mWrenMesh);
+  const int indexCount = wr_static_mesh_get_index_count(mWrenMesh);
+  float *vertices = new float[3 * vertexCount];
+  unsigned int *indices = new unsigned int[indexCount];
+  wr_static_mesh_read_data(mWrenMesh, vertices, NULL, NULL, indices);
+
+  writer << "<Shape>";
+  writer << "<Appearance sortType='transparent'><Material emissiveColor='1 1 1'></Material></Appearance>";
+  writer << "<IndexedLineSet coordIndex='";
+
+  for (int i = 0; i < indexCount / 2; ++i)
+    writer << indices[2 * i] << " " << indices[2 * i + 1] << " -1 ";
+  writer << "'>";
+
+  writer << "<Coordinate point='";
+  const float *floatMatrix = wr_transform_get_matrix(mWrenScaleTransform);
+  double doubleMatrix[16];
+  for (int i = 0; i < 16; ++i)
+    doubleMatrix[i] = static_cast<double>(floatMatrix[i]);
+
+  // Extract WREN scaling factors
+  WbMatrix4 meshMatrix;
+  meshMatrix.fromOpenGlMatrix(doubleMatrix);
+  WbVector3 scale = meshMatrix.scale();
+  scale /= absoluteScale();
+
+  for (int i = 0; i < vertexCount; ++i) {
+    const int index = 3 * i;
+    const WbVector3 coord = WbVector3(vertices[index], vertices[index + 1], vertices[index + 2]) * scale;
+    if (i > 0)
+      writer << ", ";
+    writer << coord.toString(WbPrecision::FLOAT_MAX);
+  }
+  writer << "'></Coordinate>";
+  writer << "</IndexedLineSet>";
+  writer << "</Shape>";
+
+  delete[] vertices;
+  delete[] indices;
 }

--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2021 Cyberbotics Ltd.
+// Copyright 1996-2022 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -373,7 +373,7 @@ void WbTransform::applyToOdeMass(WbGeometry *g, dGeomID geom) {
   assert(odeGeomData);
   WbSolid *const solid = odeGeomData->solid();
   const dMass *odeMass = g->odeMass();
-  if (solid->physics() && odeMass->mass > 0.0)
+  if (solid && solid->physics() && odeMass->mass > 0.0)
     solid->correctOdeMass(odeMass, this);
 }
 
@@ -401,20 +401,26 @@ void WbTransform::showResizeManipulator(bool enabled) {
 // Export //
 ////////////
 
-void WbTransform::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
+void WbTransform::exportBoundingObjectToX3D(WbWriter &writer) const {
   assert(writer.isX3d());
 
-  writer << QString("<Transform translation='%1' rotation='%2'>")
-              .arg(translation().toString(WbPrecision::DOUBLE_MAX))
-              .arg(rotation().toString(WbPrecision::DOUBLE_MAX));
+  if (isUseNode() && defNode())
+    writer << "<" << x3dName() << " role='boundingObject' USE=\'n" + QString::number(defNode()->uniqueId()) + "\'/>";
+  else {
+    writer << QString("<Transform translation='%1' rotation='%2' role='boundingObject'")
+                .arg(translation().toString(WbPrecision::DOUBLE_MAX))
+                .arg(rotation().toString(WbPrecision::DOUBLE_MAX))
+           << " id=\'n" << QString::number(uniqueId()) << "\'>";
+    ;
 
-  WbMFNode::Iterator it(children());
-  while (it.hasNext()) {
-    const WbNode *const childNode = static_cast<WbNode *>(it.next());
-    childNode->exportBoundingObjectToX3D(writer);
+    WbMFNode::Iterator it(children());
+    while (it.hasNext()) {
+      const WbNode *const childNode = static_cast<WbNode *>(it.next());
+      childNode->write(writer);
+    }
+
+    writer << "</Transform>";
   }
-
-  writer << "</Transform>";
 }
 
 QStringList WbTransform::fieldsToSynchronizeWithX3D() const {

--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -1,4 +1,4 @@
-// Copyright 1996-2022 Cyberbotics Ltd.
+// Copyright 1996-2021 Cyberbotics Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -401,26 +401,20 @@ void WbTransform::showResizeManipulator(bool enabled) {
 // Export //
 ////////////
 
-void WbTransform::exportBoundingObjectToX3D(WbWriter &writer) const {
+void WbTransform::exportBoundingObjectToX3D(WbVrmlWriter &writer) const {
   assert(writer.isX3d());
 
-  if (isUseNode() && defNode())
-    writer << "<" << x3dName() << " role='boundingObject' USE=\'n" + QString::number(defNode()->uniqueId()) + "\'/>";
-  else {
-    writer << QString("<Transform translation='%1' rotation='%2' role='boundingObject'")
-                .arg(translation().toString(WbPrecision::DOUBLE_MAX))
-                .arg(rotation().toString(WbPrecision::DOUBLE_MAX))
-           << " id=\'n" << QString::number(uniqueId()) << "\'>";
-    ;
+  writer << QString("<Transform translation='%1' rotation='%2'>")
+              .arg(translation().toString(WbPrecision::DOUBLE_MAX))
+              .arg(rotation().toString(WbPrecision::DOUBLE_MAX));
 
-    WbMFNode::Iterator it(children());
-    while (it.hasNext()) {
-      const WbNode *const childNode = static_cast<WbNode *>(it.next());
-      childNode->write(writer);
-    }
-
-    writer << "</Transform>";
+  WbMFNode::Iterator it(children());
+  while (it.hasNext()) {
+    const WbNode *const childNode = static_cast<WbNode *>(it.next());
+    childNode->exportBoundingObjectToX3D(writer);
   }
+
+  writer << "</Transform>";
 }
 
 QStringList WbTransform::fieldsToSynchronizeWithX3D() const {


### PR DESCRIPTION
Fix #4324.
In case of Fluid objects, the NULL solid pointer was used.