### PR TITLE
Fix support polygon access out of bounds

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -34,6 +34,7 @@ Released on XX XX, 2022.
     - Fixed crash when streaming very large [ElevationGrid](elevationgrid.md) ([#4426](https://github.com/cyberbotics/webots/pull/4426)).
     - Fixed collision logic for kinematic robots ([#4509](https://github.com/cyberbotics/webots/pull/4509)).
     - Fixed crash moving a [Transform](transform.md) node inserted in a [Fluid.boundingObject](fluid.md) ([#4568](https://github.com/cyberbotics/webots/pull/4568)).
+    - Fixed crash with support polygon optional rendering in case of a very high number of contact points ([#4569](https://github.com/cyberbotics/webots/pull/4569)).
 
 ## Webots R2022a
 Released on December 21th, 2022.

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -2458,11 +2458,12 @@ const WbPolygon &WbSolid::supportPolygon() {
   const WbVector3 &eastVector = worldInfo->eastVector();
   const WbVector3 &northVector = worldInfo->northVector();
   // Rules out 4 trivial cases
-  for (int i = 0; i < numberOfContactPoints; ++i) {
-    const WbVector3 &v = mGlobalListOfContactPoints.at(i);
-    mSupportPolygon[i].setXy(v.dot(northVector), v.dot(eastVector));
-  }
   if (numberOfContactPoints <= 3) {
+    assert(mSupportPolygon.size() >= numberOfContactPoints);
+    for (int i = 0; i < numberOfContactPoints; ++i) {
+      const WbVector3 &v = mGlobalListOfContactPoints.at(i);
+      mSupportPolygon[i].setXy(v.dot(northVector), v.dot(eastVector));
+    }
     mSupportPolygon.setActualSize(numberOfContactPoints);
     return mSupportPolygon;
   }
@@ -2513,6 +2514,9 @@ bool WbSolid::showSupportPolygonRepresentation(bool enabled) {
       mSupportPolygonRepresentation = new WbSupportPolygonRepresentation();
       mSupportPolygonNeedsUpdate = true;
     }
+    if (mSupportPolygon.size() < 4)
+      // minimum expected size to rule out trivial cases
+      mSupportPolygon.resize(4);
     connect(WbSimulationState::instance(), &WbSimulationState::physicsStepStarted, this,
             &WbSolid::refreshSupportPolygonRepresentation, Qt::UniqueConnection);
     connect(WbSimulationState::instance(), &WbSimulationState::physicsStepStarted, this,


### PR DESCRIPTION
Fix #4280.
If `numberOfContactPoints` value greater than `mSupportPolygon` size, `mSupportPolygon` was often accessed outside his bounds.
If `numberOfContactPoints` is lower than 32 (default size of the QVarLengthArray `mSupportPolygon`) nothing bad occurs, otherwise we may overwrite other WbSolid structures like the `mJointChildren` vector.