### PR TITLE
Upgrade to Cppcheck 2.8

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-11
             DEPENDENCIES_INSTALLATION: "brew install clang-format@11 cppcheck; ln /usr/local/bin/clang-format-11 /usr/local/bin/clang-format"
           - os: windows-2019
-            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck; choco install -y llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck --version=2.7; choco install -y llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set git to use LF

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-11
             DEPENDENCIES_INSTALLATION: "brew install clang-format@11 cppcheck; ln /usr/local/bin/clang-format-11 /usr/local/bin/clang-format"
           - os: windows-2019
-            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck --version=2.7; choco install -y llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck || true; choco install -y llvm; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set git to use LF

--- a/resources/projects/libraries/qt_utils/core/MainApplication.cpp
+++ b/resources/projects/libraries/qt_utils/core/MainApplication.cpp
@@ -31,7 +31,7 @@ MainApplication::MainApplication() {
   QDir::addSearchPath("icons", StandardPaths::getWebotsHomePath() + "resources/icons/dark");
 
   // init application
-  mMainApplicationPrivate = new MainApplicationPrivate(c, (char **)v);
+  mMainApplicationPrivate = new MainApplicationPrivate(c, const_cast<char **>(v));
   QApplication *app = static_cast<QApplication *>(QApplication::instance());
   app->setWindowIcon(QIcon("icons:webots.png"));
 }

--- a/resources/projects/libraries/qt_utils/core/StandardPaths.cpp
+++ b/resources/projects/libraries/qt_utils/core/StandardPaths.cpp
@@ -45,7 +45,7 @@ const QString &StandardPaths::getCurrentLibraryPath() {
     path = path.replace('\\', '/');
 #else
     Dl_info dl_info;
-    dladdr((void *)foo, &dl_info);
+    dladdr(reinterpret_cast<void *>(foo), &dl_info);
     path = dl_info.dli_fname;
 #endif
     path = path.mid(0, path.lastIndexOf('/') + 1);

--- a/resources/projects/libraries/qt_utils/motion_editor/Pose.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/Pose.cpp
@@ -35,17 +35,17 @@ void Pose::setTimeFromParser(const QString &time) {
     throw tr("Error while parsing time: \"%1\"").arg(time);
 
   bool ok;
-  int minutes = timeTokens[0].toInt(&ok);
+  int min = timeTokens[0].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
-  int seconds = timeTokens[1].toInt(&ok);
+  int sec = timeTokens[1].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
-  int milliseconds = timeTokens[2].toInt(&ok);
+  int ms = timeTokens[2].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
 
-  mTime = milliseconds + 1000 * seconds + 60000 * minutes;
+  mTime = ms + 1000 * sec + 60000 * min;
 
   emit updated();
 }

--- a/resources/projects/libraries/qt_utils/motion_editor/Pose.cpp
+++ b/resources/projects/libraries/qt_utils/motion_editor/Pose.cpp
@@ -35,17 +35,17 @@ void Pose::setTimeFromParser(const QString &time) {
     throw tr("Error while parsing time: \"%1\"").arg(time);
 
   bool ok;
-  int min = timeTokens[0].toInt(&ok);
+  int m = timeTokens[0].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
-  int sec = timeTokens[1].toInt(&ok);
+  int s = timeTokens[1].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
   int ms = timeTokens[2].toInt(&ok);
   if (!ok)
     throw tr("Error while parsing time: \"%1\"").arg(time);
 
-  mTime = ms + 1000 * sec + 60000 * min;
+  mTime = ms + 1000 * s + 60000 * m;
 
   emit updated();
 }

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -41,10 +41,8 @@ static void dynamic_library_print_last_error() {
   LPVOID lpMsgBuf = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
-  if (lpMsgBug != NULL) {
-    fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
-    LocalFree(lpMsgBuf);
-  }
+  fprintf(stderr, "Error: %s (dynamic library)\n", static_cast<const char *>(lpMsgBuf));
+  LocalFree(lpMsgBuf);
 #else
   const char *s = dlerror();
   if (!s)

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -41,8 +41,10 @@ static void dynamic_library_print_last_error() {
   LPVOID lpMsgBuf = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
-  fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
-  LocalFree(lpMsgBuf);
+  if (lpMsgBug) {
+    fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
+    LocalFree(lpMsgBuf);
+  }
 #else
   const char *s = dlerror();
   if (!s)

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -41,7 +41,7 @@ static void dynamic_library_print_last_error() {
   LPVOID lpMsgBuf = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
-  if (lpMsgBug) {
+  if (lpMsgBug != NULL) {
     fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
     LocalFree(lpMsgBuf);
   }

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -38,7 +38,7 @@
 
 static void dynamic_library_print_last_error() {
 #ifdef _WIN32
-  LPVOID lpMsgBuf;
+  LPVOID lpMsgBuf = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
   fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -41,6 +41,7 @@ static void dynamic_library_print_last_error() {
   LPVOID lpMsgBuf = NULL;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
+  // cppcheck-suppress nullPointer
   fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
   LocalFree(lpMsgBuf);
 #else

--- a/src/controller/c/dynamic_library.c
+++ b/src/controller/c/dynamic_library.c
@@ -38,10 +38,10 @@
 
 static void dynamic_library_print_last_error() {
 #ifdef _WIN32
-  LPVOID lpMsgBuf = NULL;
+  LPVOID lpMsgBuf;
   FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
                 GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
-  fprintf(stderr, "Error: %s (dynamic library)\n", static_cast<const char *>(lpMsgBuf));
+  fprintf(stderr, "Error: %s (dynamic library)\n", (const char *)lpMsgBuf);
   LocalFree(lpMsgBuf);
 #else
   const char *s = dlerror();

--- a/src/controller/cpp/GPS.cpp
+++ b/src/controller/cpp/GPS.cpp
@@ -52,6 +52,6 @@ const GPS::CoordinateSystem GPS::getCoordinateSystem() const {
 string GPS::convertToDegreesMinutesSeconds(double decimalDegree) {
   const char *coordinatesString = wb_gps_convert_to_degrees_minutes_seconds(decimalDegree);
   std::string coordinates = string(coordinatesString);
-  free((void *)coordinatesString);
+  free(static_cast<void *>(const_cast<char *>(coordinatesString)));
   return coordinates;
 }

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -185,22 +185,23 @@ QString WbLanguageTools::findWorkingPythonPath(const QString &pythonVersion, QPr
   QString shortVersion;
 
   // look for python from python.org
-  QString pythonCommand = "/Library/Frameworks/Python.framework/Versions/" + pythonVersion + "/bin/python" + pythonVersion;
-  shortVersion = checkIfPythonCommandExist(pythonCommand, env, false);
+  QString pythonCommandString =
+    "/Library/Frameworks/Python.framework/Versions/" + pythonVersion + "/bin/python" + pythonVersion;
+  shortVersion = checkIfPythonCommandExist(pythonCommandString, env, false);
   if (shortVersion.isEmpty()) {
     // look first possible path for python from homebrew
-    pythonCommand = "/usr/local/opt/python@" + pythonVersion + " /bin/python" + pythonVersion;
-    shortVersion = checkIfPythonCommandExist(pythonCommand, env, false);
+    pythonCommandString = "/usr/local/opt/python@" + pythonVersion + " /bin/python" + pythonVersion;
+    shortVersion = checkIfPythonCommandExist(pythonCommandString, env, false);
     if (shortVersion.isEmpty()) {
       // look a second possible path for python from homebrew
-      pythonCommand = "/usr/local/bin/python" + pythonVersion;
-      shortVersion = checkIfPythonCommandExist(pythonCommand, env, log);
+      pythonCommandString = "/usr/local/bin/python" + pythonVersion;
+      shortVersion = checkIfPythonCommandExist(pythonCommandString, env, log);
       if (shortVersion.isEmpty())
-        pythonCommand = "!";
+        pythonCommandString = "!";
     }
   }
 
-  return pythonCommand;
+  return pythonCommandString;
 }
 #endif
 

--- a/src/webots/core/WbApplicationInfo.cpp
+++ b/src/webots/core/WbApplicationInfo.cpp
@@ -41,8 +41,8 @@ const QString &WbApplicationInfo::branch() {
   static QString branchName;
   static bool firstCall = true;
   if (firstCall) {
-    const QString branch("resources/branch.txt");
-    branchName = getInfoFromFile(&branch);
+    const QString branchString("resources/branch.txt");
+    branchName = getInfoFromFile(&branchString);
   }
   return branchName;
 }
@@ -51,8 +51,8 @@ const QString &WbApplicationInfo::repo() {
   static QString repoName;
   static bool firstCall = true;
   if (firstCall) {
-    const QString repo("resources/repo.txt");
-    repoName = getInfoFromFile(&repo);
+    const QString repoString("resources/repo.txt");
+    repoName = getInfoFromFile(&repoString);
   }
   return repoName;
 }

--- a/src/webots/core/WbHttpReply.cpp
+++ b/src/webots/core/WbHttpReply.cpp
@@ -60,12 +60,12 @@ QByteArray WbHttpReply::forgeFileReply(const QString &fileName, const QString &e
     reply.append("etag: ").append(hash.toHex()).append("\r\n");
     reply.append("\r\n");
   } else {
-    const QString mimeType = WbHttpReply::mimeType(fileName, true);
+    const QString mimeTypeString = WbHttpReply::mimeType(fileName, true);
     reply.append("HTTP/1.1 200 OK\r\n");
     reply.append("Access-Control-Allow-Origin: *\r\n");
     reply.append("Cache-Control: public, max-age=3600\r\n");  // Help the browsers to cache the file for 1 hour.
     reply.append("etag: ").append(hash.toHex()).append("\r\n");
-    reply.append(QString("Content-Type: %1\r\n").arg(mimeType).toUtf8());
+    reply.append(QString("Content-Type: %1\r\n").arg(mimeTypeString).toUtf8());
     reply.append(QString("Content-Length: %1\r\n").arg(data.length()).toUtf8());
     reply.append("\r\n");
     reply.append(data);

--- a/src/webots/core/WbLanguage.cpp
+++ b/src/webots/core/WbLanguage.cpp
@@ -827,29 +827,29 @@ WbLanguage *WbLanguage::findByFileName(const QString &fileName) {
   QFileInfo fi(fileName);
   QString ext = fi.suffix().toLower();
 
-  int code = PLAIN_TEXT;
+  int suffixCode = PLAIN_TEXT;
   if (ext == "c" || ext == "h")
-    code = C;
+    suffixCode = C;
   else if (ext == "java")
-    code = JAVA;
+    suffixCode = JAVA;
   else if (ext == "py")
-    code = PYTHON;
+    suffixCode = PYTHON;
   else if (ext == "cpp" || ext == "cc" || ext == "c++" || ext == "hpp" || ext == "hh" || ext == "h++")
-    code = CPP;
+    suffixCode = CPP;
   else if (ext == "m")
-    code = MATLAB;
+    suffixCode = MATLAB;
   else if (ext == "wbt" || ext == "wrl" || ext == "wbo")
-    code = WBT;
+    suffixCode = WBT;
   else if (ext == "proto")
-    code = PROTO;
+    suffixCode = PROTO;
   else if (ext == "lua")
-    code = LUA;
+    suffixCode = LUA;
 
   QString baseName = fi.baseName().toLower();
   if (baseName == "makefile")
-    code = MAKEFILE;
+    suffixCode = MAKEFILE;
 
-  return findByCode(code);
+  return findByCode(suffixCode);
 }
 
 const QStringList &WbLanguage::sourceFileExtensions() {

--- a/src/webots/core/WbMacAddress.cpp
+++ b/src/webots/core/WbMacAddress.cpp
@@ -151,7 +151,7 @@ WbMacAddress::WbMacAddress() {
   memset(&ifr, 0, sizeof(ifr));
   strcpy(ifr.ifr_name, *interface);
   if (ioctl(fd, SIOCGIFHWADDR, &ifr) == 0) {
-    unsigned char *ch = (unsigned char *)ifr.ifr_hwaddr.sa_data;
+    unsigned char *ch = reinterpret_cast<unsigned char *>(ifr.ifr_hwaddr.sa_data);
     for (int i = 0; i < 6; i++)
       mAddress[i] = *ch++;
   }

--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -100,19 +100,19 @@ void WbProject::setCurrent(WbProject *project) {
 QString WbProject::projectPathFromWorldFile(const QString &fileName, bool &valid) {
   QFileInfo info(fileName);
   assert(info.suffix() == "wbt");
-  QDir dir = info.absoluteDir();
-  valid = dir.dirName() == "worlds";
-  dir.cdUp();  // remove "worlds"
-  return dir.absolutePath() + "/";
+  QDir directory = info.absoluteDir();
+  valid = directory.dirName() == "worlds";
+  directory.cdUp();  // remove "worlds"
+  return directory.absolutePath() + "/";
 }
 
 QString WbProject::projectNameFromWorldFile(const QString &fileName) {
   QFileInfo info(fileName);
   assert(info.suffix() == "wbt");
-  QDir dir = info.absoluteDir();
-  if (dir.dirName() == "worlds") {
-    dir.cdUp();  // remove "worlds"
-    return dir.dirName();
+  QDir directory = info.absoluteDir();
+  if (directory.dirName() == "worlds") {
+    directory.cdUp();  // remove "worlds"
+    return directory.dirName();
   }
 
   return "";
@@ -218,17 +218,17 @@ QString WbProject::newWorldFileName() {
 }
 
 bool WbProject::createNewProjectFiles(QString newWorldName) {
-  QDir dir(mPath);
+  QDir directory(mPath);
 
   // create sub dirs
-  bool success = dir.mkpath(WORLDS_DIR);
-  success = success && dir.mkpath(CONTROLLERS_DIR);
-  success = success && dir.mkpath(PROTOS_DIR);
-  success = success && dir.mkpath(PLUGINS_DIR);
-  success = success && dir.mkpath(PHYSICS_PLUGINS_DIR);
-  success = success && dir.mkpath(REMOTE_CONTROL_PLUGINS_DIR);
-  success = success && dir.mkpath(ROBOT_WINDOW_PLUGINS_DIR);
-  success = success && dir.mkpath(LIBRARIES_DIR);
+  bool success = directory.mkpath(WORLDS_DIR);
+  success = success && directory.mkpath(CONTROLLERS_DIR);
+  success = success && directory.mkpath(PROTOS_DIR);
+  success = success && directory.mkpath(PLUGINS_DIR);
+  success = success && directory.mkpath(PHYSICS_PLUGINS_DIR);
+  success = success && directory.mkpath(REMOTE_CONTROL_PLUGINS_DIR);
+  success = success && directory.mkpath(ROBOT_WINDOW_PLUGINS_DIR);
+  success = success && directory.mkpath(LIBRARIES_DIR);
 
   // copy new world file
   QString orig = WbStandardPaths::resourcesProjectsPath() + WORLDS_DIR + "/" + NEW_WORLD_FILE_NAME;

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -187,6 +187,7 @@ const QString &WbSysInfo::platformShortName() {
 #ifdef __linux__
   static QString platformShortName;
   if (platformShortName.isEmpty()) {
+    // cppcheck-suppress knownConditionTrueFalse
     if (WbSysInfo::isPointerSize64bits())
       platformShortName = "linux64";
     else

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -73,21 +73,21 @@ const void WbSysInfo::initializeOpenGlInfo() {
 const QString &WbSysInfo::openGLRenderer() {
   static QString openGLRender;
   if (openGLRender.isEmpty())
-    openGLRender = (const char *)glGetString(GL_RENDERER);
+    openGLRender = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
   return openGLRender;
 }
 
 const QString &WbSysInfo::openGLVendor() {
   static QString openGLVendor;
   if (openGLVendor.isEmpty())
-    openGLVendor = (const char *)glGetString(GL_VENDOR);
+    openGLVendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
   return openGLVendor;
 }
 
 const QString &WbSysInfo::openGLVersion() {
   static QString openGLVersion;
   if (openGLVersion.isEmpty())
-    openGLVersion = (const char *)glGetString(GL_VERSION);
+    openGLVersion = reinterpret_cast<const char *>(glGetString(GL_VERSION));
   return openGLVersion;
 }
 
@@ -340,6 +340,7 @@ bool WbSysInfo::isRootUser() {
 #endif
 
 bool WbSysInfo::isPointerSize32bits() {
+  // cppcheck-suppress knownConditionTrueFalse
   return !WbSysInfo::isPointerSize64bits();
 }
 

--- a/src/webots/core/WbSysInfo.cpp
+++ b/src/webots/core/WbSysInfo.cpp
@@ -144,7 +144,8 @@ const QString &WbSysInfo::sysInfo() {
   sysInfo.append(" ");
 
   SYSTEM_INFO winSysInfo;
-  PGNSI pGetNativeSystemInfo = (PGNSI)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetNativeSystemInfo");
+  PGNSI pGetNativeSystemInfo =
+    reinterpret_cast<PGNSI>(GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "GetNativeSystemInfo"));
   if (NULL != pGetNativeSystemInfo)
     pGetNativeSystemInfo(&winSysInfo);
   else

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -297,13 +297,13 @@ bool WbTemplateEngine::generateJavascript(QHash<QString, QString> tags, const QS
   }
 
   QJSValue generateVrml = module.property("generateVrml");
-  QJSValue res = generateVrml.call();
-  if (res.isError()) {
-    mError = tr("failed to execute JavaScript template: %1").arg(res.property("message").toString());
+  QJSValue r = generateVrml.call();
+  if (r.isError()) {
+    mError = tr("failed to execute JavaScript template: %1").arg(r.property("message").toString());
     return false;
   }
 
-  mResult = res.toString().toUtf8();
+  mResult = r.toString().toUtf8();
 
   // display stream messages
   for (int i = 0; i < jsStdOut.property("length").toInt(); ++i)

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -297,13 +297,13 @@ bool WbTemplateEngine::generateJavascript(QHash<QString, QString> tags, const QS
   }
 
   QJSValue generateVrml = module.property("generateVrml");
-  QJSValue result = generateVrml.call();
-  if (result.isError()) {
-    mError = tr("failed to execute JavaScript template: %1").arg(result.property("message").toString());
+  QJSValue res = generateVrml.call();
+  if (res.isError()) {
+    mError = tr("failed to execute JavaScript template: %1").arg(res.property("message").toString());
     return false;
   }
 
-  mResult = result.toString().toUtf8();
+  mResult = res.toString().toUtf8();
 
   // display stream messages
   for (int i = 0; i < jsStdOut.property("length").toInt(); ++i)

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -141,7 +141,7 @@ const QString &WbTemplateEngine::closingToken() {
 }
 
 bool WbTemplateEngine::generate(QHash<QString, QString> tags, const QString &logHeaderName, const QString &templateLanguage) {
-  bool result;
+  bool output;
 
   if (templateLanguage == "lua") {
     static bool firstLuaCall = true;
@@ -153,7 +153,7 @@ bool WbTemplateEngine::generate(QHash<QString, QString> tags, const QString &log
     gOpeningToken = "%{";
     gClosingToken = "}%";
 
-    result = generateLua(tags, logHeaderName);
+    output = generateLua(tags, logHeaderName);
   } else {
     static bool firstJavaScriptCall = true;
     if (firstJavaScriptCall) {
@@ -164,10 +164,10 @@ bool WbTemplateEngine::generate(QHash<QString, QString> tags, const QString &log
     gOpeningToken = "%<";
     gClosingToken = ">%";
 
-    result = generateJavascript(tags, logHeaderName);
+    output = generateJavascript(tags, logHeaderName);
   }
 
-  return result;
+  return output;
 }
 
 bool WbTemplateEngine::generateJavascript(QHash<QString, QString> tags, const QString &logHeaderName) {

--- a/src/webots/gui/WbDragResizeEvent.hpp
+++ b/src/webots/gui/WbDragResizeEvent.hpp
@@ -68,7 +68,7 @@ protected:
 
   void computeRatio(const QPoint &currentMousePosition);
   WbVector3 computeLocalMousePosition(const QPoint &currentMousePosition);
-  double newSizeValue() const { return mSizeValue; }
+  double sizeValue() const { return mSizeValue; }
 };
 
 // WbRegularResizeEvent class (another abstract layer) : resize spheres, boxes, cylinders, capsules and cones

--- a/src/webots/gui/WbImportWizard.cpp
+++ b/src/webots/gui/WbImportWizard.cpp
@@ -102,15 +102,15 @@ QWizardPage *WbImportWizard::createIntroPage() {
 }
 
 void WbImportWizard::chooseFile() {
-  const QString fileName = QFileDialog::getOpenFileName(this, tr("Choose a File"), mFileEdit->text(),
-                                                        tr("3D Files (*.dae *.DAE *.stl *.STL *.obj *.OBJ);;"
-                                                           "Collada (*.dae *.DAE);;"
-                                                           "STL (*.stl *.STL);;"
-                                                           "Wavefront (*.obj *.OBJ)"));
-  if (fileName.isEmpty())
+  const QString fileNameString = QFileDialog::getOpenFileName(this, tr("Choose a File"), mFileEdit->text(),
+                                                              tr("3D Files (*.dae *.DAE *.stl *.STL *.obj *.OBJ);;"
+                                                                 "Collada (*.dae *.DAE);;"
+                                                                 "STL (*.stl *.STL);;"
+                                                                 "Wavefront (*.obj *.OBJ)"));
+  if (fileNameString.isEmpty())
     return;
-  mFileEdit->setText(fileName);
-  mConclusionLabel->setText(tr("The '%1' file will now be imported at the end of the scene tree.").arg(fileName));
+  mFileEdit->setText(fileNameString);
+  mConclusionLabel->setText(tr("The '%1' file will now be imported at the end of the scene tree.").arg(fileNameString));
 }
 
 QWizardPage *WbImportWizard::createFileSelectionPage() {

--- a/src/webots/gui/WbMultimediaStreamingLimiter.cpp
+++ b/src/webots/gui/WbMultimediaStreamingLimiter.cpp
@@ -35,10 +35,10 @@ void WbMultimediaStreamingLimiter::resetResolution(const QSize &newSize) {
 }
 
 QSize WbMultimediaStreamingLimiter::fullResolution() const {
-  QSize resolution(mResolution);
+  QSize resolutionSize(mResolution);
   for (int i = mResolutionFactor; i > 1; i--)
-    resolution *= 2;
-  return resolution;
+    resolutionSize *= 2;
+  return resolutionSize;
 }
 
 void WbMultimediaStreamingLimiter::recomputeStreamingLimits(int skippedImages) {

--- a/src/webots/gui/WbRecentFilesList.cpp
+++ b/src/webots/gui/WbRecentFilesList.cpp
@@ -110,16 +110,16 @@ void WbRecentFilesList::actionTriggered() {
 // escape all underscores so that they don't get interpreted as hotkeys by Unity
 QString WbRecentFilesList::escapedText(const QString &text) {
   if (qgetenv("XDG_CURRENT_DESKTOP") == "Unity") {
-    QString escapedText(text);
-    return escapedText.replace("_", "__");
+    QString escapedTextString(text);
+    return escapedTextString.replace("_", "__");
   }
   return text;
 }
 
 QString WbRecentFilesList::unescapedText(const QString &text) {
   if (qgetenv("XDG_CURRENT_DESKTOP") == "Unity") {
-    QString escapedText(text);
-    return escapedText.replace("__", "_");
+    QString escapedTextString(text);
+    return escapedTextString.replace("__", "_");
   }
   return text;
 }

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -292,8 +292,8 @@ void WbWrenWindow::flipAndScaleDownImageBuffer(const unsigned char *source, unsi
   // - The `unsigned char *` to `int *` cast is possible assuming that a pixel is coded as four bytes (RGBA)
   //   aligned on an `int *` boundary.
   // - A preliminary `unsigned char *` to `void *` cast is required to by-pass "cast-align" clang warnings.
-  const uint32_t *src = (const uint32_t *)((void *)source);
-  uint32_t *dst = (uint32_t *)((void *)destination);
+  const uint32_t *src = static_cast<const uint32_t *>(static_cast<void *>(const_cast<unsigned char *>(source)));
+  uint32_t *dst = static_cast<uint32_t *>(static_cast<void *>(destination));
 
   for (int y = 0; y < h; y++) {
     for (int x = 0; x < w; x++)
@@ -358,7 +358,7 @@ void WbWrenWindow::processVideoPBO() {
   // Process previously copied pixels
   WrScene *scene = wr_scene_get_instance();
   wr_scene_bind_pixel_buffer(scene, mVideoPBOIds[mVideoPBOIndex]);
-  unsigned char *buffer = (unsigned char *)wr_scene_map_pixel_buffer(scene, GL_READ_ONLY);
+  unsigned char *buffer = static_cast<unsigned char *>(wr_scene_map_pixel_buffer(scene, GL_READ_ONLY));
   if (buffer) {
     emit videoImageReady(buffer);
     wr_scene_unmap_pixel_buffer(scene);

--- a/src/webots/maths/WbAffinePlane.hpp
+++ b/src/webots/maths/WbAffinePlane.hpp
@@ -137,16 +137,16 @@ private:
 };
 
 inline void WbAffinePlane::normalize() {
-  double distance = mA * mA + mB * mB + mC * mC;
-  if (distance == 0.0) {
+  double length = mA * mA + mB * mB + mC * mC;
+  if (length == 0.0) {
     mA = 1.0;
     return;
   }
-  distance = 1.0 / sqrt(distance);
-  mA *= distance;
-  mB *= distance;
-  mC *= distance;
-  mD *= distance;
+  length = 1.0 / sqrt(length);
+  mA *= length;
+  mB *= length;
+  mC *= length;
+  mD *= length;
 }
 
 #endif

--- a/src/webots/maths/WbAffinePlane.hpp
+++ b/src/webots/maths/WbAffinePlane.hpp
@@ -143,10 +143,10 @@ inline void WbAffinePlane::normalize() {
     return;
   }
   dist = 1.0 / sqrt(dist);
-  mA *= d;
-  mB *= d;
-  mC *= d;
-  mD *= d;
+  mA *= dist;
+  mB *= dist;
+  mC *= dist;
+  mD *= dist;
 }
 
 #endif

--- a/src/webots/maths/WbAffinePlane.hpp
+++ b/src/webots/maths/WbAffinePlane.hpp
@@ -137,16 +137,16 @@ private:
 };
 
 inline void WbAffinePlane::normalize() {
-  double dist = mA * mA + mB * mB + mC * mC;
-  if (dist == 0.0) {
+  double distance = mA * mA + mB * mB + mC * mC;
+  if (distance == 0.0) {
     mA = 1.0;
     return;
   }
-  dist = 1.0 / sqrt(dist);
-  mA *= dist;
-  mB *= dist;
-  mC *= dist;
-  mD *= dist;
+  distance = 1.0 / sqrt(distance);
+  mA *= distance;
+  mB *= distance;
+  mC *= distance;
+  mD *= distance;
 }
 
 #endif

--- a/src/webots/maths/WbAffinePlane.hpp
+++ b/src/webots/maths/WbAffinePlane.hpp
@@ -137,12 +137,12 @@ private:
 };
 
 inline void WbAffinePlane::normalize() {
-  double d = mA * mA + mB * mB + mC * mC;
-  if (d == 0.0) {
+  double dist = mA * mA + mB * mB + mC * mC;
+  if (dist == 0.0) {
     mA = 1.0;
     return;
   }
-  d = 1.0 / sqrt(d);
+  dist = 1.0 / sqrt(dist);
   mA *= d;
   mB *= d;
   mC *= d;

--- a/src/webots/maths/WbImage.cpp
+++ b/src/webots/maths/WbImage.cpp
@@ -29,7 +29,7 @@ WbImage *WbImage::downscale(int width, int height, int xBlurRadius, int yBlurRad
   const int channels = 4;
   const int dstSize = width * height * channels;
   const int srcSize = mWidth * mHeight * channels;
-  unsigned char *pixels = (unsigned char *)malloc(dstSize);
+  unsigned char *pixels = static_cast<unsigned char *>(malloc(dstSize));
 
   // downscale and apply the convolution matrix.
   for (int j = 0; j < height; ++j) {

--- a/src/webots/nodes/WbAbstractTransform.cpp
+++ b/src/webots/nodes/WbAbstractTransform.cpp
@@ -333,29 +333,29 @@ void WbAbstractTransform::updateConstrainedHandleMaterials() {
 // Apply to WREN
 
 void WbAbstractTransform::applyTranslationToWren() {
-  float translation[3];
-  mTranslation->value().toFloatArray(translation);
-  wr_transform_set_position(mBaseNode->wrenNode(), translation);
+  float newTranslation[3];
+  mTranslation->value().toFloatArray(newTranslation);
+  wr_transform_set_position(mBaseNode->wrenNode(), newTranslation);
 }
 
 void WbAbstractTransform::applyRotationToWren() {
-  float rotation[4];
-  mRotation->value().toFloatArray(rotation);
-  wr_transform_set_orientation(mBaseNode->wrenNode(), rotation);
+  float newRotation[4];
+  mRotation->value().toFloatArray(newRotation);
+  wr_transform_set_orientation(mBaseNode->wrenNode(), newRotation);
 }
 
 void WbAbstractTransform::applyScaleToWren() {
-  float scale[3];
-  mScale->value().toFloatArray(scale);
-  wr_transform_set_scale(mBaseNode->wrenNode(), scale);
+  float newScale[3];
+  mScale->value().toFloatArray(newScale);
+  wr_transform_set_scale(mBaseNode->wrenNode(), newScale);
 }
 
 void WbAbstractTransform::applyTranslationAndRotationToWren() {  // for performance optimization
-  float translation[3];
-  mTranslation->value().toFloatArray(translation);
-  float rotation[4];
-  mRotation->value().toFloatArray(rotation);
-  wr_transform_set_position_and_orientation(mBaseNode->wrenNode(), translation, rotation);
+  float newTranslation[3];
+  mTranslation->value().toFloatArray(newTranslation);
+  float newRotation[4];
+  mRotation->value().toFloatArray(newRotation);
+  wr_transform_set_position_and_orientation(mBaseNode->wrenNode(), newTranslation, newRotation);
 }
 
 // Matrix 4-by-4

--- a/src/webots/nodes/WbAppearance.cpp
+++ b/src/webots/nodes/WbAppearance.cpp
@@ -86,12 +86,12 @@ void WbAppearance::postFinalize() {
 void WbAppearance::reset(const QString &id) {
   WbAbstractAppearance::reset(id);
 
-  WbNode *const material = mMaterial->value();
-  if (material)
-    material->reset(id);
-  WbNode *const texture = mTexture->value();
-  if (texture)
-    texture->reset(id);
+  WbNode *const mat = mMaterial->value();
+  if (mat)
+    mat->reset(id);
+  WbNode *const tex = mTexture->value();
+  if (tex)
+    tex->reset(id);
 }
 
 void WbAppearance::updateMaterial() {

--- a/src/webots/nodes/WbAppearance.cpp
+++ b/src/webots/nodes/WbAppearance.cpp
@@ -86,12 +86,12 @@ void WbAppearance::postFinalize() {
 void WbAppearance::reset(const QString &id) {
   WbAbstractAppearance::reset(id);
 
-  WbNode *const mat = mMaterial->value();
-  if (mat)
-    mat->reset(id);
-  WbNode *const tex = mTexture->value();
-  if (tex)
-    tex->reset(id);
+  WbNode *const m = mMaterial->value();
+  if (m)
+    m->reset(id);
+  WbNode *const t = mTexture->value();
+  if (t)
+    t->reset(id);
 }
 
 void WbAppearance::updateMaterial() {

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -554,12 +554,12 @@ bool WbBackground::loadIrradianceTexture(int i) {
     delete mDownloader[k];
     mDownloader[k] = NULL;
   }
-  float *data = stbi_loadf_from_memory((const unsigned char *)content.constData(), content.size(), &mIrradianceWidth,
-                                       &mIrradianceHeight, &components, 0);
+  float *data = stbi_loadf_from_memory(reinterpret_cast<const unsigned char *>(content.constData()), content.size(),
+                                       &mIrradianceWidth, &mIrradianceHeight, &components, 0);
   const int rotate = gCoordinateSystemRotate(i);
   // FIXME: this texture rotation should be performed by OpenGL or in the shader to get a better performance
   if (rotate != 0) {
-    float *rotated = (float *)stbi__malloc(sizeof(float) * mIrradianceWidth * mIrradianceHeight * components);
+    float *rotated = static_cast<float *>(stbi__malloc(sizeof(float) * mIrradianceWidth * mIrradianceHeight * components));
     if (rotate == 90) {
       for (int x = 0; x < mIrradianceWidth; x++) {
         for (int y = 0; y < mIrradianceHeight; y++) {

--- a/src/webots/nodes/WbBaseNode.cpp
+++ b/src/webots/nodes/WbBaseNode.cpp
@@ -258,6 +258,7 @@ bool WbBaseNode::exportNodeHeader(WbVrmlWriter &writer) const {
 
   if (isUseNode() && defNode()) {  // export referred DEF node id
     const WbNode *def = defNode();
+    // cppcheck-suppress knownConditionTrueFalse
     if (def && def->isProtoParameterNode())
       def = static_cast<const WbBaseNode *>(def)->getFirstFinalizedProtoInstance();
     assert(def != NULL);

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -294,18 +294,18 @@ WbSolid *WbBasicJoint::solidEndPoint() const {
       if (solid)
         return solid;
 
-      WbSolidReference *solidReference = childrenSlot->solidReferenceEndPoint();
-      if (solidReference)
-        return solidReference->solid();
+      WbSolidReference *solidRef = childrenSlot->solidReferenceEndPoint();
+      if (solidRef)
+        return solidRef->solid();
     }
   } else {
     WbSolid *solid = dynamic_cast<WbSolid *>(mEndPoint->value());
     if (solid)
       return solid;
 
-    const WbSolidReference *const solidReference = dynamic_cast<WbSolidReference *>(mEndPoint->value());
-    if (solidReference)
-      return solidReference->solid();
+    const WbSolidReference *const solidRef = dynamic_cast<WbSolidReference *>(mEndPoint->value());
+    if (solidRef)
+      return solidRef->solid();
   }
 
   return NULL;

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -294,18 +294,18 @@ WbSolid *WbBasicJoint::solidEndPoint() const {
       if (solid)
         return solid;
 
-      WbSolidReference *solidRef = childrenSlot->solidReferenceEndPoint();
-      if (solidRef)
-        return solidRef->solid();
+      WbSolidReference *s= childrenSlot->solidReferenceEndPoint();
+      if (s)
+        return s->solid();
     }
   } else {
     WbSolid *solid = dynamic_cast<WbSolid *>(mEndPoint->value());
     if (solid)
       return solid;
 
-    const WbSolidReference *const solidRef = dynamic_cast<WbSolidReference *>(mEndPoint->value());
-    if (solidRef)
-      return solidRef->solid();
+    const WbSolidReference *const s= dynamic_cast<WbSolidReference *>(mEndPoint->value());
+    if (s)
+      return s->solid();
   }
 
   return NULL;

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -294,7 +294,7 @@ WbSolid *WbBasicJoint::solidEndPoint() const {
       if (solid)
         return solid;
 
-      WbSolidReference *s= childrenSlot->solidReferenceEndPoint();
+      WbSolidReference *s = childrenSlot->solidReferenceEndPoint();
       if (s)
         return s->solid();
     }
@@ -303,7 +303,7 @@ WbSolid *WbBasicJoint::solidEndPoint() const {
     if (solid)
       return solid;
 
-    const WbSolidReference *const s= dynamic_cast<WbSolidReference *>(mEndPoint->value());
+    const WbSolidReference *const s = dynamic_cast<WbSolidReference *>(mEndPoint->value());
     if (s)
       return s->solid();
   }

--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -105,8 +105,8 @@ void WbBox::createResizeManipulator() {
 }
 
 bool WbBox::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const size = findField("size", true);
-  return WbNodeUtilities::isVisible(size) && !WbNodeUtilities::isTemplateRegeneratorField(size);
+  const WbField *const sizeField = findField("size", true);
+  return WbNodeUtilities::isVisible(sizeField) && !WbNodeUtilities::isTemplateRegeneratorField(sizeField);
 }
 
 void WbBox::setSize(const WbVector3 &size) {
@@ -201,8 +201,8 @@ void WbBox::checkFluidBoundingObjectOrientation() {
 }
 
 dGeomID WbBox::createOdeGeom(dSpaceID space) {
-  const WbVector3 &size = mSize->value();
-  if (size.x() <= 0.0 || size.y() <= 0.0 || size.z() <= 0.0) {
+  const WbVector3 &sizeVec = mSize->value();
+  if (sizeVec.x() <= 0.0 || sizeVec.y() <= 0.0 || sizeVec.z() <= 0.0) {
     parsingWarn(tr("'size' must be positive: construction of the Box in 'boundingObject' failed."));
     return NULL;
   }
@@ -218,10 +218,10 @@ void WbBox::applyToOdeData(bool correctSolidMass) {
   if (mOdeGeom == NULL)
     return;
 
-  WbVector3 size = mSize->value();
-  size *= absoluteScale().abs();
+  WbVector3 sizeVec = mSize->value();
+  sizeVec *= absoluteScale().abs();
   assert(dGeomGetClass(mOdeGeom) == dBoxClass);
-  dGeomBoxSetLengths(mOdeGeom, size.x(), size.y(), size.z());
+  dGeomBoxSetLengths(mOdeGeom, sizeVec.x(), sizeVec.y(), sizeVec.z());
 
   WbOdeGeomData *const odeGeomData = static_cast<WbOdeGeomData *>(dGeomGetData(mOdeGeom));
   assert(odeGeomData);
@@ -280,51 +280,51 @@ WbVector2 WbBox::computeTextureCoordinate(const WbVector3 &minBound, const WbVec
     intersectedFace = findIntersectedFace(minBound, maxBound, point);
 
   WbVector3 vertex = point - minBound;
-  WbVector3 size = maxBound - minBound;
+  WbVector3 sizeVec = maxBound - minBound;
   switch (intersectedFace) {
     case TOP_FACE:
-      u = vertex.x() / size.x();
-      v = 1 - vertex.y() / size.y();
+      u = vertex.x() / sizeVec.x();
+      v = 1 - vertex.y() / sizeVec.y();
       if (nonRecursive) {
         u = 0.25 * u + 0.50;
         v = 0.50 * v;
       }
       break;
     case BOTTOM_FACE:
-      u = vertex.x() / size.x();
-      v = vertex.y() / size.y();
+      u = vertex.x() / sizeVec.x();
+      v = vertex.y() / sizeVec.y();
       if (nonRecursive) {
         u = 0.25 * u;
         v = 0.50 * v;
       }
       break;
     case FRONT_FACE:
-      u = vertex.y() / size.y();
-      v = 1 - vertex.z() / size.z();
+      u = vertex.y() / sizeVec.y();
+      v = 1 - vertex.z() / sizeVec.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.75;
         v = 0.50 * v + 0.50;
       }
       break;
     case BACK_FACE:
-      u = 1 - vertex.y() / size.y();
-      v = 1 - vertex.z() / size.z();
+      u = 1 - vertex.y() / sizeVec.y();
+      v = 1 - vertex.z() / sizeVec.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.25;
         v = 0.50 * v + 0.50;
       }
       break;
     case LEFT_FACE:
-      u = 1 - vertex.x() / size.x();
-      v = 1 - vertex.z() / size.z();
+      u = 1 - vertex.x() / sizeVec.x();
+      v = 1 - vertex.z() / sizeVec.z();
       if (nonRecursive) {
         u = 0.25 * u;
         v = 0.50 * v + 0.50;
       }
       break;
     case RIGHT_FACE:
-      u = vertex.x() / size.x();
-      v = 1 - vertex.z() / size.z();
+      u = vertex.x() / sizeVec.x();
+      v = 1 - vertex.z() / sizeVec.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.50;
         v = 0.50 * v + 0.50;

--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -201,8 +201,8 @@ void WbBox::checkFluidBoundingObjectOrientation() {
 }
 
 dGeomID WbBox::createOdeGeom(dSpaceID space) {
-  const WbVector3 &sizeVec = mSize->value();
-  if (sizeVec.x() <= 0.0 || sizeVec.y() <= 0.0 || sizeVec.z() <= 0.0) {
+  const WbVector3 &s= mSize->value();
+  if (s.x() <= 0.0 || s.y() <= 0.0 || s.z() <= 0.0) {
     parsingWarn(tr("'size' must be positive: construction of the Box in 'boundingObject' failed."));
     return NULL;
   }
@@ -218,10 +218,10 @@ void WbBox::applyToOdeData(bool correctSolidMass) {
   if (mOdeGeom == NULL)
     return;
 
-  WbVector3 sizeVec = mSize->value();
-  sizeVec *= absoluteScale().abs();
+  WbVector3 s= mSize->value();
+  s *= absoluteScale().abs();
   assert(dGeomGetClass(mOdeGeom) == dBoxClass);
-  dGeomBoxSetLengths(mOdeGeom, sizeVec.x(), sizeVec.y(), sizeVec.z());
+  dGeomBoxSetLengths(mOdeGeom, s.x(), s.y(), s.z());
 
   WbOdeGeomData *const odeGeomData = static_cast<WbOdeGeomData *>(dGeomGetData(mOdeGeom));
   assert(odeGeomData);
@@ -280,51 +280,51 @@ WbVector2 WbBox::computeTextureCoordinate(const WbVector3 &minBound, const WbVec
     intersectedFace = findIntersectedFace(minBound, maxBound, point);
 
   WbVector3 vertex = point - minBound;
-  WbVector3 sizeVec = maxBound - minBound;
+  WbVector3 s = maxBound - minBound;
   switch (intersectedFace) {
     case TOP_FACE:
-      u = vertex.x() / sizeVec.x();
-      v = 1 - vertex.y() / sizeVec.y();
+      u = vertex.x() / s.x();
+      v = 1 - vertex.y() / s.y();
       if (nonRecursive) {
         u = 0.25 * u + 0.50;
         v = 0.50 * v;
       }
       break;
     case BOTTOM_FACE:
-      u = vertex.x() / sizeVec.x();
-      v = vertex.y() / sizeVec.y();
+      u = vertex.x() / s.x();
+      v = vertex.y() / s.y();
       if (nonRecursive) {
         u = 0.25 * u;
         v = 0.50 * v;
       }
       break;
     case FRONT_FACE:
-      u = vertex.y() / sizeVec.y();
-      v = 1 - vertex.z() / sizeVec.z();
+      u = vertex.y() / s.y();
+      v = 1 - vertex.z() / s.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.75;
         v = 0.50 * v + 0.50;
       }
       break;
     case BACK_FACE:
-      u = 1 - vertex.y() / sizeVec.y();
-      v = 1 - vertex.z() / sizeVec.z();
+      u = 1 - vertex.y() / s.y();
+      v = 1 - vertex.z() / s.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.25;
         v = 0.50 * v + 0.50;
       }
       break;
     case LEFT_FACE:
-      u = 1 - vertex.x() / sizeVec.x();
-      v = 1 - vertex.z() / sizeVec.z();
+      u = 1 - vertex.x() / s.x();
+      v = 1 - vertex.z() / s.z();
       if (nonRecursive) {
         u = 0.25 * u;
         v = 0.50 * v + 0.50;
       }
       break;
     case RIGHT_FACE:
-      u = vertex.x() / sizeVec.x();
-      v = 1 - vertex.z() / sizeVec.z();
+      u = vertex.x() / s.x();
+      v = 1 - vertex.z() / s.z();
       if (nonRecursive) {
         u = 0.25 * u + 0.50;
         v = 0.50 * v + 0.50;

--- a/src/webots/nodes/WbBox.cpp
+++ b/src/webots/nodes/WbBox.cpp
@@ -201,8 +201,8 @@ void WbBox::checkFluidBoundingObjectOrientation() {
 }
 
 dGeomID WbBox::createOdeGeom(dSpaceID space) {
-  const WbVector3 &s= mSize->value();
-  if (s.x() <= 0.0 || s.y() <= 0.0 || s.z() <= 0.0) {
+  const WbVector3 &s1 = mSize->value();
+  if (s1.x() <= 0.0 || s1.y() <= 0.0 || s1.z() <= 0.0) {
     parsingWarn(tr("'size' must be positive: construction of the Box in 'boundingObject' failed."));
     return NULL;
   }
@@ -210,15 +210,15 @@ dGeomID WbBox::createOdeGeom(dSpaceID space) {
   if (WbNodeUtilities::findUpperMatter(this)->nodeType() == WB_NODE_FLUID)
     checkFluidBoundingObjectOrientation();
 
-  const WbVector3 s = scaledSize();
-  return dCreateBox(space, s.x(), s.y(), s.z());
+  const WbVector3 s2 = scaledSize();
+  return dCreateBox(space, s2.x(), s2.y(), s2.z());
 }
 
 void WbBox::applyToOdeData(bool correctSolidMass) {
   if (mOdeGeom == NULL)
     return;
 
-  WbVector3 s= mSize->value();
+  WbVector3 s = mSize->value();
   s *= absoluteScale().abs();
   assert(dGeomGetClass(mOdeGeom) == dBoxClass);
   dGeomBoxSetLengths(mOdeGeom, s.x(), s.y(), s.z());

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -115,10 +115,10 @@ void WbCapsule::createResizeManipulator() {
 }
 
 bool WbCapsule::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const height = findField("height", true);
-  const WbField *const radius = findField("radius", true);
-  return WbNodeUtilities::isVisible(height) && WbNodeUtilities::isVisible(radius) &&
-         !WbNodeUtilities::isTemplateRegeneratorField(height) && !WbNodeUtilities::isTemplateRegeneratorField(radius);
+  const WbField *const heightField = findField("height", true);
+  const WbField *const radiusField = findField("radius", true);
+  return WbNodeUtilities::isVisible(heightField) && WbNodeUtilities::isVisible(radiusField) &&
+         !WbNodeUtilities::isTemplateRegeneratorField(heightField) && !WbNodeUtilities::isTemplateRegeneratorField(radiusField);
 }
 
 bool WbCapsule::sanitizeFields() {
@@ -482,7 +482,7 @@ void WbCapsule::recomputeBoundingSphere() const {
   const bool side = mSide->value();
   const bool bottom = mBottom->value();
   const double halfHeight = scaledHeight() / 2.0;
-  const double radius = scaledRadius();
+  const double rad = scaledRadius();
 
   if (!top && !side && !bottom) {  // it is empty
     mBoundingSphere->empty();
@@ -491,18 +491,18 @@ void WbCapsule::recomputeBoundingSphere() const {
 
   if (top + side + bottom == 1) {
     if (top || bottom)
-      mBoundingSphere->set(WbVector3(0, 0, top ? halfHeight : -halfHeight), radius);
+      mBoundingSphere->set(WbVector3(0, 0, top ? halfHeight : -halfHeight), rad);
     else  // side
-      mBoundingSphere->set(WbVector3(), WbVector3(radius, 0, halfHeight).length());
+      mBoundingSphere->set(WbVector3(), WbVector3(rad, 0, halfHeight).length());
   } else if (top != bottom) {  // we have 'top and side' or 'side and bottom'
-    const double maxZ = top ? halfHeight + radius : halfHeight;
-    const double minZ = bottom ? -halfHeight - radius : -halfHeight;
+    const double maxZ = top ? halfHeight + rad : halfHeight;
+    const double minZ = bottom ? -halfHeight - rad : -halfHeight;
     const double totalHeight = (maxZ - minZ);
-    const double newRadius = totalHeight / 2.0 + radius * radius / (2 * totalHeight);
+    const double newRadius = totalHeight / 2.0 + rad * rad / (2 * totalHeight);
     const double offsetZ = top ? (maxZ - newRadius) : (minZ + newRadius);
     mBoundingSphere->set(WbVector3(0, 0, offsetZ), newRadius);
   } else  // complete capsule
-    mBoundingSphere->set(WbVector3(), halfHeight + radius);
+    mBoundingSphere->set(WbVector3(), halfHeight + rad);
 }
 
 void WbCapsule::write(WbVrmlWriter &writer) const {

--- a/src/webots/nodes/WbCapsule.cpp
+++ b/src/webots/nodes/WbCapsule.cpp
@@ -482,7 +482,7 @@ void WbCapsule::recomputeBoundingSphere() const {
   const bool side = mSide->value();
   const bool bottom = mBottom->value();
   const double halfHeight = scaledHeight() / 2.0;
-  const double rad = scaledRadius();
+  const double r = scaledRadius();
 
   if (!top && !side && !bottom) {  // it is empty
     mBoundingSphere->empty();
@@ -491,18 +491,18 @@ void WbCapsule::recomputeBoundingSphere() const {
 
   if (top + side + bottom == 1) {
     if (top || bottom)
-      mBoundingSphere->set(WbVector3(0, 0, top ? halfHeight : -halfHeight), rad);
+      mBoundingSphere->set(WbVector3(0, 0, top ? halfHeight : -halfHeight), r);
     else  // side
-      mBoundingSphere->set(WbVector3(), WbVector3(rad, 0, halfHeight).length());
+      mBoundingSphere->set(WbVector3(), WbVector3(r, 0, halfHeight).length());
   } else if (top != bottom) {  // we have 'top and side' or 'side and bottom'
-    const double maxZ = top ? halfHeight + rad : halfHeight;
-    const double minZ = bottom ? -halfHeight - rad : -halfHeight;
+    const double maxZ = top ? halfHeight + r : halfHeight;
+    const double minZ = bottom ? -halfHeight - r : -halfHeight;
     const double totalHeight = (maxZ - minZ);
-    const double newRadius = totalHeight / 2.0 + rad * rad / (2 * totalHeight);
+    const double newRadius = totalHeight / 2.0 + r * r / (2 * totalHeight);
     const double offsetZ = top ? (maxZ - newRadius) : (minZ + newRadius);
     mBoundingSphere->set(WbVector3(0, 0, offsetZ), newRadius);
   } else  // complete capsule
-    mBoundingSphere->set(WbVector3(), halfHeight + rad);
+    mBoundingSphere->set(WbVector3(), halfHeight + r);
 }
 
 void WbCapsule::write(WbVrmlWriter &writer) const {

--- a/src/webots/nodes/WbCone.cpp
+++ b/src/webots/nodes/WbCone.cpp
@@ -375,14 +375,14 @@ double WbCone::computeLocalCollisionPoint(WbVector3 &point, const WbRay &ray) co
 void WbCone::recomputeBoundingSphere() const {
   assert(mBoundingSphere);
   const bool side = mSide->value();
-  const double rad = scaledBottomRadius();
+  const double r = scaledBottomRadius();
   const double h = scaledHeight();
   const double halfHeight = h / 2.0;
 
-  if (!side || h <= rad)  // consider it as disk
-    mBoundingSphere->set(WbVector3(0, -halfHeight, 0), rad);
+  if (!side || h <= r)  // consider it as disk
+    mBoundingSphere->set(WbVector3(0, -halfHeight, 0), r);
   else {
-    const double newRadius = halfHeight + rad * rad / (2 * h);
+    const double newRadius = halfHeight + r * r / (2 * h);
     mBoundingSphere->set(WbVector3(0, halfHeight - newRadius, 0), newRadius);
   }
 }

--- a/src/webots/nodes/WbCone.cpp
+++ b/src/webots/nodes/WbCone.cpp
@@ -98,10 +98,10 @@ void WbCone::createResizeManipulator() {
 }
 
 bool WbCone::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const height = findField("height", true);
-  const WbField *const radius = findField("bottomRadius", true);
-  return WbNodeUtilities::isVisible(height) && WbNodeUtilities::isVisible(radius) &&
-         !WbNodeUtilities::isTemplateRegeneratorField(height) && !WbNodeUtilities::isTemplateRegeneratorField(radius);
+  const WbField *const heightField = findField("height", true);
+  const WbField *const radiusField = findField("bottomRadius", true);
+  return WbNodeUtilities::isVisible(heightField) && WbNodeUtilities::isVisible(radiusField) &&
+         !WbNodeUtilities::isTemplateRegeneratorField(heightField) && !WbNodeUtilities::isTemplateRegeneratorField(radiusField);
 }
 
 void WbCone::exportNodeFields(WbVrmlWriter &writer) const {
@@ -375,14 +375,14 @@ double WbCone::computeLocalCollisionPoint(WbVector3 &point, const WbRay &ray) co
 void WbCone::recomputeBoundingSphere() const {
   assert(mBoundingSphere);
   const bool side = mSide->value();
-  const double radius = scaledBottomRadius();
-  const double height = scaledHeight();
-  const double halfHeight = height / 2.0;
+  const double rad = scaledBottomRadius();
+  const double h = scaledHeight();
+  const double halfHeight = h / 2.0;
 
-  if (!side || height <= radius)  // consider it as disk
-    mBoundingSphere->set(WbVector3(0, -halfHeight, 0), radius);
+  if (!side || h <= rad)  // consider it as disk
+    mBoundingSphere->set(WbVector3(0, -halfHeight, 0), rad);
   else {
-    const double newRadius = halfHeight + radius * radius / (2 * height);
+    const double newRadius = halfHeight + rad * rad / (2 * h);
     mBoundingSphere->set(WbVector3(0, halfHeight - newRadius, 0), newRadius);
   }
 }

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -119,10 +119,10 @@ void WbCylinder::createResizeManipulator() {
 }
 
 bool WbCylinder::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const height = findField("height", true);
-  const WbField *const radius = findField("radius", true);
-  return WbNodeUtilities::isVisible(height) && WbNodeUtilities::isVisible(radius) &&
-         !WbNodeUtilities::isTemplateRegeneratorField(height) && !WbNodeUtilities::isTemplateRegeneratorField(radius);
+  const WbField *const heightField = findField("height", true);
+  const WbField *const radiusField = findField("radius", true);
+  return WbNodeUtilities::isVisible(heightField) && WbNodeUtilities::isVisible(radiusField) &&
+         !WbNodeUtilities::isTemplateRegeneratorField(heightField) && !WbNodeUtilities::isTemplateRegeneratorField(radiusField);
 }
 
 void WbCylinder::exportNodeFields(WbVrmlWriter &writer) const {
@@ -443,8 +443,8 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
     origin /= absoluteScale();
   }
 
-  double radius = scaledRadius();
-  double radius2 = radius * radius;
+  double rad = scaledRadius();
+  double rad2 = rad * rad;
   double h = scaledHeight();
   double d = std::numeric_limits<double>::infinity();
   faceIndex = -1;
@@ -453,7 +453,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
   if (mSide->value()) {
     double a = direction.x() * direction.x() + direction.y() * direction.y();
     double b = 2 * (origin.x() * direction.x() + origin.y() * direction.y());
-    double c = origin.x() * origin.x() + origin.y() * origin.y() - radius2;
+    double c = origin.x() * origin.x() + origin.y() * origin.y() - rad2;
     double discriminant = b * b - 4 * a * c;
 
     // if c < 0: ray origin is inside cylinder body
@@ -480,7 +480,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
       WbRay(origin, direction).intersects(WbAffinePlane(WbVector3(0, 0, 1), WbVector3(0, 0, h / 2)), true);
     if (intersection.first && intersection.second > 0 && intersection.second < d) {
       WbVector3 p = origin + intersection.second * direction;
-      if (p.x() * p.x() + p.y() * p.y() <= radius2) {
+      if (p.x() * p.x() + p.y() * p.y() <= rad2) {
         d = intersection.second;
         faceIndex = 1;
       }
@@ -493,7 +493,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
       WbRay(origin, direction).intersects(WbAffinePlane(WbVector3(0, 0, -1), WbVector3(0, 0, -h / 2)), true);
     if (intersection.first && intersection.second > 0 && intersection.second < d) {
       WbVector3 p = origin + intersection.second * direction;
-      if (p.x() * p.x() + p.y() * p.y() <= radius2) {
+      if (p.x() * p.x() + p.y() * p.y() <= rad2) {
         d = intersection.second;
         faceIndex = 2;
       }
@@ -513,15 +513,15 @@ void WbCylinder::recomputeBoundingSphere() const {
   const bool side = mSide->value();
   const bool bottom = mBottom->value();
   const double halfHeight = scaledHeight() / 2.0;
-  const double radius = scaledRadius();
+  const double rad = scaledRadius();
 
   if ((top + side + bottom) == 0)  // it is empty
     mBoundingSphere->empty();
   else if ((top + side + bottom) == 1 && !side) {  // just one disk
     const double center = top ? halfHeight : -halfHeight;
-    mBoundingSphere->set(WbVector3(0, center, 0), radius);
+    mBoundingSphere->set(WbVector3(0, center, 0), rad);
   } else
-    mBoundingSphere->set(WbVector3(), WbVector3(radius, halfHeight, 0).length());
+    mBoundingSphere->set(WbVector3(), WbVector3(rad, halfHeight, 0).length());
 }
 
 // if a cylinder has nothing to draw, then it shouldn't be exported to X3D

--- a/src/webots/nodes/WbCylinder.cpp
+++ b/src/webots/nodes/WbCylinder.cpp
@@ -443,8 +443,8 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
     origin /= absoluteScale();
   }
 
-  double rad = scaledRadius();
-  double rad2 = rad * rad;
+  double r = scaledRadius();
+  double r2 = r * r;
   double h = scaledHeight();
   double d = std::numeric_limits<double>::infinity();
   faceIndex = -1;
@@ -453,7 +453,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
   if (mSide->value()) {
     double a = direction.x() * direction.x() + direction.y() * direction.y();
     double b = 2 * (origin.x() * direction.x() + origin.y() * direction.y());
-    double c = origin.x() * origin.x() + origin.y() * origin.y() - rad2;
+    double c = origin.x() * origin.x() + origin.y() * origin.y() - r2;
     double discriminant = b * b - 4 * a * c;
 
     // if c < 0: ray origin is inside cylinder body
@@ -480,7 +480,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
       WbRay(origin, direction).intersects(WbAffinePlane(WbVector3(0, 0, 1), WbVector3(0, 0, h / 2)), true);
     if (intersection.first && intersection.second > 0 && intersection.second < d) {
       WbVector3 p = origin + intersection.second * direction;
-      if (p.x() * p.x() + p.y() * p.y() <= rad2) {
+      if (p.x() * p.x() + p.y() * p.y() <= r2) {
         d = intersection.second;
         faceIndex = 1;
       }
@@ -493,7 +493,7 @@ double WbCylinder::computeLocalCollisionPoint(WbVector3 &point, int &faceIndex, 
       WbRay(origin, direction).intersects(WbAffinePlane(WbVector3(0, 0, -1), WbVector3(0, 0, -h / 2)), true);
     if (intersection.first && intersection.second > 0 && intersection.second < d) {
       WbVector3 p = origin + intersection.second * direction;
-      if (p.x() * p.x() + p.y() * p.y() <= rad2) {
+      if (p.x() * p.x() + p.y() * p.y() <= r2) {
         d = intersection.second;
         faceIndex = 2;
       }
@@ -513,15 +513,15 @@ void WbCylinder::recomputeBoundingSphere() const {
   const bool side = mSide->value();
   const bool bottom = mBottom->value();
   const double halfHeight = scaledHeight() / 2.0;
-  const double rad = scaledRadius();
+  const double r = scaledRadius();
 
   if ((top + side + bottom) == 0)  // it is empty
     mBoundingSphere->empty();
   else if ((top + side + bottom) == 1 && !side) {  // just one disk
     const double center = top ? halfHeight : -halfHeight;
-    mBoundingSphere->set(WbVector3(0, center, 0), rad);
+    mBoundingSphere->set(WbVector3(0, center, 0), r);
   } else
-    mBoundingSphere->set(WbVector3(), WbVector3(rad, halfHeight, 0).length());
+    mBoundingSphere->set(WbVector3(), WbVector3(r, halfHeight, 0).length());
 }
 
 // if a cylinder has nothing to draw, then it shouldn't be exported to X3D

--- a/src/webots/nodes/WbDirectionalLight.cpp
+++ b/src/webots/nodes/WbDirectionalLight.cpp
@@ -98,8 +98,8 @@ void WbDirectionalLight::applyLightShadowsToWren() {
 }
 
 void WbDirectionalLight::applyLightDirectionToWren() {
-  float dir[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()), static_cast<float>(mDirection->z())};
-  wr_directional_light_set_direction(mWrenLight, dir);
+  float d[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()), static_cast<float>(mDirection->z())};
+  wr_directional_light_set_direction(mWrenLight, d);
 }
 
 const WbVector3 &WbDirectionalLight::direction() const {

--- a/src/webots/nodes/WbDirectionalLight.cpp
+++ b/src/webots/nodes/WbDirectionalLight.cpp
@@ -98,9 +98,8 @@ void WbDirectionalLight::applyLightShadowsToWren() {
 }
 
 void WbDirectionalLight::applyLightDirectionToWren() {
-  float direction[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()),
-                       static_cast<float>(mDirection->z())};
-  wr_directional_light_set_direction(mWrenLight, direction);
+  float dir[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()), static_cast<float>(mDirection->z())};
+  wr_directional_light_set_direction(mWrenLight, dir);
 }
 
 const WbVector3 &WbDirectionalLight::direction() const {

--- a/src/webots/nodes/WbElevationGrid.cpp
+++ b/src/webots/nodes/WbElevationGrid.cpp
@@ -380,10 +380,11 @@ void WbElevationGrid::setResizeManipulatorDimensions() {
 }
 
 bool WbElevationGrid::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const xSpacing = findField("xSpacing", true);
-  const WbField *const ySpacing = findField("ySpacing", true);
-  return WbNodeUtilities::isVisible(xSpacing) && WbNodeUtilities::isVisible(ySpacing) &&
-         !WbNodeUtilities::isTemplateRegeneratorField(xSpacing) && !WbNodeUtilities::isTemplateRegeneratorField(ySpacing);
+  const WbField *const xSpacingField = findField("xSpacing", true);
+  const WbField *const ySpacingField = findField("ySpacing", true);
+  return WbNodeUtilities::isVisible(xSpacingField) && WbNodeUtilities::isVisible(ySpacingField) &&
+         !WbNodeUtilities::isTemplateRegeneratorField(xSpacingField) &&
+         !WbNodeUtilities::isTemplateRegeneratorField(ySpacingField);
 }
 
 /////////////////

--- a/src/webots/nodes/WbEmitter.cpp
+++ b/src/webots/nodes/WbEmitter.cpp
@@ -190,17 +190,17 @@ void WbEmitter::writeAnswer(QDataStream &stream) {
 void WbEmitter::handleMessage(QDataStream &stream) {
   unsigned char command;
   unsigned int size;
-  int channel;
-  double range;
+  int newChannel;
+  double newRange;
   char *data;
 
   stream >> command;
   switch (command) {
     case C_EMITTER_SEND:
-      stream >> channel;
-      mChannel->setValue(channel);
-      stream >> range;
-      mRange->setValue(range);
+      stream >> newChannel;
+      mChannel->setValue(newChannel);
+      stream >> newRange;
+      mRange->setValue(newRange);
       stream >> size;
       data = new char[size];
       stream.readRawData(data, size);
@@ -209,13 +209,13 @@ void WbEmitter::handleMessage(QDataStream &stream) {
       return;
 
     case C_EMITTER_SET_CHANNEL:
-      stream >> channel;
-      mChannel->setValue(channel);
+      stream >> newChannel;
+      mChannel->setValue(newChannel);
       return;
 
     case C_EMITTER_SET_RANGE:
-      stream >> range;
-      mRange->setValue(range);
+      stream >> newRange;
+      mRange->setValue(newRange);
       return;
 
     default:

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -596,9 +596,9 @@ WbMatrix4 WbGeometry::matrix() const {
   if (!ut->isInBoundingObject())
     return ut->matrix();
   else {
-    const WbMatrix4 &matrix = ut->vrmlMatrix();
+    const WbMatrix4 &matrix4 = ut->vrmlMatrix();
     ut = ut->upperTransform();
-    return ut->matrix() * matrix;
+    return ut->matrix() * matrix4;
   }
 }
 

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -266,14 +266,14 @@ void WbGroup::insertChildFromSlotOrJoint(WbBaseNode *decendant) {
 }
 
 void WbGroup::insertChildPrivate(int index) {
-  WbBaseNode *child = static_cast<WbBaseNode *>(mChildren->item(index));
-  if (child->isPostFinalizedCalled() && mBoundingSphere)
-    mBoundingSphere->addSubBoundingSphere(child->boundingSphere());
-  emit childAdded(child);
-  descendantNodeInserted(child);
+  WbBaseNode *childNode = static_cast<WbBaseNode *>(mChildren->item(index));
+  if (childNode->isPostFinalizedCalled() && mBoundingSphere)
+    mBoundingSphere->addSubBoundingSphere(childNode->boundingSphere());
+  emit childAdded(childNode);
+  descendantNodeInserted(childNode);
 
   if (isPostFinalizedCalled())
-    connect(child, &WbBaseNode::finalizationCompleted, this, &WbGroup::monitorChildFinalization);
+    connect(childNode, &WbBaseNode::finalizationCompleted, this, &WbGroup::monitorChildFinalization);
 }
 
 void WbGroup::monitorChildFinalization(WbBaseNode *child) {
@@ -304,9 +304,9 @@ void WbGroup::save(const QString &id) {
 void WbGroup::forwardJerk() {
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
-    WbGroup *const child = dynamic_cast<WbGroup *>(it.next());
-    if (child)
-      child->forwardJerk();
+    WbGroup *const childGroup = dynamic_cast<WbGroup *>(it.next());
+    if (childGroup)
+      childGroup->forwardJerk();
   }
 }
 
@@ -314,9 +314,9 @@ QList<const WbBaseNode *> WbGroup::findClosestDescendantNodesWithDedicatedWrenNo
   QList<const WbBaseNode *> list;
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
-    const WbBaseNode *const child = static_cast<WbBaseNode *>(it.next());
-    assert(child);
-    list << child->findClosestDescendantNodesWithDedicatedWrenNode();
+    const WbBaseNode *const childNode = static_cast<WbBaseNode *>(it.next());
+    assert(childNode);
+    list << childNode->findClosestDescendantNodesWithDedicatedWrenNode();
   }
   return list;
 }

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -155,24 +155,24 @@ bool WbImageTexture::loadTextureData(QIODevice *device) {
   QSize textureSize = imageReader.size();
   const int imageWidth = textureSize.width();
   const int imageHeight = textureSize.height();
-  int width = WbMathsUtilities::nextPowerOf2(imageWidth);
-  int height = WbMathsUtilities::nextPowerOf2(imageHeight);
-  if (width != imageWidth || height != imageHeight)
+  int w = WbMathsUtilities::nextPowerOf2(imageWidth);
+  int h = WbMathsUtilities::nextPowerOf2(imageHeight);
+  if (w != imageWidth || h != imageHeight)
     warn(tr("Texture image size of '%1' is not a power of two: rescaling it from %2x%3 to %4x%5.")
            .arg(path())
            .arg(imageWidth)
            .arg(imageHeight)
-           .arg(width)
-           .arg(height));
+           .arg(w)
+           .arg(h));
 
   const int quality = WbPreferences::instance()->value("OpenGL/textureQuality", 2).toInt();
   const int divider = 4 * pow(0.5, quality);      // 0: 4, 1: 2, 2: 1
   const int maxResolution = pow(2, 9 + quality);  // 0: 512, 1: 1024, 2: 2048
   if (divider != 1) {
-    if (width >= maxResolution)
-      width /= divider;
-    if (height >= maxResolution)
-      height /= divider;
+    if (w >= maxResolution)
+      w /= divider;
+    if (h >= maxResolution)
+      h /= divider;
   }
 
   mImage = new QImage();
@@ -189,15 +189,14 @@ bool WbImageTexture::loadTextureData(QIODevice *device) {
     mImage->swap(tmp);
   }
 
-  if (mImage->width() != width || mImage->height() != height) {
+  if (mImage->width() != w || mImage->height() != h) {
     // Qt::SmoothTransformation alterates the alpha channel.
     // Qt::FastTransformation creates ugly aliasing effects.
     // A custom scale with gaussian blur is the best tradeoff found between quality and loading performance.
-    WbImage *image = new WbImage((unsigned char *)mImage->constBits(), mImage->width(), mImage->height());
-    WbImage *downscaledImage =
-      image->downscale(width, height, qMax(0, mImage->width() / width - 1), qMax(0, mImage->height() / height - 1));
+    WbImage *image = new WbImage(const_cast<unsigned char *>(mImage->constBits()), mImage->width(), mImage->height());
+    WbImage *downscaledImage = image->downscale(w, h, qMax(0, mImage->width() / w - 1), qMax(0, mImage->height() / h - 1));
     delete image;
-    QImage tmp(downscaledImage->data(), width, height, mImage->format());
+    QImage tmp(downscaledImage->data(), w, h, mImage->format());
     delete downscaledImage;
     mImage->swap(tmp);
 

--- a/src/webots/nodes/WbJoint.cpp
+++ b/src/webots/nodes/WbJoint.cpp
@@ -151,9 +151,9 @@ void WbJoint::addDevice(int index) {
     WbBaseNode *decendant = dynamic_cast<WbBaseNode *>(mDevice->item(index));
     r->descendantNodeInserted(decendant);
   }
-  WbBrake *brake = dynamic_cast<WbBrake *>(mDevice->item(index));
-  if (brake)
-    connect(brake, &WbBrake::brakingChanged, this, &WbJoint::updateSpringAndDampingConstants, Qt::UniqueConnection);
+  WbBrake *b = dynamic_cast<WbBrake *>(mDevice->item(index));
+  if (b)
+    connect(b, &WbBrake::brakingChanged, this, &WbJoint::updateSpringAndDampingConstants, Qt::UniqueConnection);
 }
 
 void WbJoint::updateParameters() {

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -175,7 +175,7 @@ void WbLidar::initializeImageSharedMemory() {
     // initialize the shared memory with a black image
     float *im = lidarImage();
     const int s = actualHorizontalResolution() * actualNumberOfLayers();
-    for (int i = 0; i < s ; i++)
+    for (int i = 0; i < s; i++)
       im[i] = 0.0f;
   }
   mTemporaryImage = new float[actualHorizontalResolution() * height()];

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -174,8 +174,8 @@ void WbLidar::initializeImageSharedMemory() {
   if (mImageShm) {
     // initialize the shared memory with a black image
     float *im = lidarImage();
-    const int im_size = actualHorizontalResolution() * actualNumberOfLayers();
-    for (int i = 0; i < im_size; i++)
+    const int s = actualHorizontalResolution() * actualNumberOfLayers();
+    for (int i = 0; i < s ; i++)
       im[i] = 0.0f;
   }
   mTemporaryImage = new float[actualHorizontalResolution() * height()];

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -174,8 +174,8 @@ void WbLidar::initializeImageSharedMemory() {
   if (mImageShm) {
     // initialize the shared memory with a black image
     float *im = lidarImage();
-    const int size = actualHorizontalResolution() * actualNumberOfLayers();
-    for (int i = 0; i < size; i++)
+    const int im_size = actualHorizontalResolution() * actualNumberOfLayers();
+    for (int i = 0; i < im_size; i++)
       im[i] = 0.0f;
   }
   mTemporaryImage = new float[actualHorizontalResolution() * height()];

--- a/src/webots/nodes/WbMaterial.cpp
+++ b/src/webots/nodes/WbMaterial.cpp
@@ -154,19 +154,19 @@ void WbMaterial::modifyWrenMaterial(WrMaterial *wrenMaterial, bool textured) {
     shininess = mShininess->value();
   }
 
-  const float ambientColor[] = {static_cast<float>(ambient.red()), static_cast<float>(ambient.green()),
-                                static_cast<float>(ambient.blue())};
+  const float ambColor[] = {static_cast<float>(ambient.red()), static_cast<float>(ambient.green()),
+                            static_cast<float>(ambient.blue())};
 
-  const float diffuseColor[] = {static_cast<float>(diffuse.red()), static_cast<float>(diffuse.green()),
-                                static_cast<float>(diffuse.blue())};
+  const float diffColor[] = {static_cast<float>(diffuse.red()), static_cast<float>(diffuse.green()),
+                             static_cast<float>(diffuse.blue())};
 
-  const float specularColor[] = {static_cast<float>(specular.red()), static_cast<float>(specular.green()),
-                                 static_cast<float>(specular.blue())};
+  const float specColor[] = {static_cast<float>(specular.red()), static_cast<float>(specular.green()),
+                             static_cast<float>(specular.blue())};
 
-  const float emissiveColor[] = {static_cast<float>(emissive.red()), static_cast<float>(emissive.green()),
-                                 static_cast<float>(emissive.blue())};
+  const float emiColor[] = {static_cast<float>(emissive.red()), static_cast<float>(emissive.green()),
+                            static_cast<float>(emissive.blue())};
 
-  wr_phong_material_set_all_parameters(wrenMaterial, ambientColor, diffuseColor, specularColor, emissiveColor, shininess,
+  wr_phong_material_set_all_parameters(wrenMaterial, ambColor, diffColor, specColor, emiColor, shininess,
                                        mTransparency->value());
 }
 

--- a/src/webots/nodes/WbMaterial.cpp
+++ b/src/webots/nodes/WbMaterial.cpp
@@ -155,19 +155,19 @@ void WbMaterial::modifyWrenMaterial(WrMaterial *wrenMaterial, bool textured) {
   }
 
   const float newAmbientColor[] = {static_cast<float>(ambient.red()), static_cast<float>(ambient.green()),
-                            static_cast<float>(ambient.blue())};
+                                   static_cast<float>(ambient.blue())};
 
   const float newDiffuseColor[] = {static_cast<float>(diffuse.red()), static_cast<float>(diffuse.green()),
-                             static_cast<float>(diffuse.blue())};
+                                   static_cast<float>(diffuse.blue())};
 
   const float newSpecularColor[] = {static_cast<float>(specular.red()), static_cast<float>(specular.green()),
-                             static_cast<float>(specular.blue())};
+                                    static_cast<float>(specular.blue())};
 
   const float newEmissiveColor[] = {static_cast<float>(emissive.red()), static_cast<float>(emissive.green()),
-                            static_cast<float>(emissive.blue())};
+                                    static_cast<float>(emissive.blue())};
 
-  wr_phong_material_set_all_parameters(wrenMaterial, newAmbientColor, newDiffuseColor, newSpecularColor, newEmissiveColor, shininess,
-                                       mTransparency->value());
+  wr_phong_material_set_all_parameters(wrenMaterial, newAmbientColor, newDiffuseColor, newSpecularColor, newEmissiveColor,
+                                       shininess, mTransparency->value());
 }
 
 QStringList WbMaterial::fieldsToSynchronizeWithX3D() const {

--- a/src/webots/nodes/WbMaterial.cpp
+++ b/src/webots/nodes/WbMaterial.cpp
@@ -154,19 +154,19 @@ void WbMaterial::modifyWrenMaterial(WrMaterial *wrenMaterial, bool textured) {
     shininess = mShininess->value();
   }
 
-  const float ambColor[] = {static_cast<float>(ambient.red()), static_cast<float>(ambient.green()),
+  const float newAmbientColor[] = {static_cast<float>(ambient.red()), static_cast<float>(ambient.green()),
                             static_cast<float>(ambient.blue())};
 
-  const float diffColor[] = {static_cast<float>(diffuse.red()), static_cast<float>(diffuse.green()),
+  const float newDiffuseColor[] = {static_cast<float>(diffuse.red()), static_cast<float>(diffuse.green()),
                              static_cast<float>(diffuse.blue())};
 
-  const float specColor[] = {static_cast<float>(specular.red()), static_cast<float>(specular.green()),
+  const float newSpecularColor[] = {static_cast<float>(specular.red()), static_cast<float>(specular.green()),
                              static_cast<float>(specular.blue())};
 
-  const float emiColor[] = {static_cast<float>(emissive.red()), static_cast<float>(emissive.green()),
+  const float newEmissiveColor[] = {static_cast<float>(emissive.red()), static_cast<float>(emissive.green()),
                             static_cast<float>(emissive.blue())};
 
-  wr_phong_material_set_all_parameters(wrenMaterial, ambColor, diffColor, specColor, emiColor, shininess,
+  wr_phong_material_set_all_parameters(wrenMaterial, newAmbientColor, newDiffuseColor, newSpecularColor, newEmissiveColor, shininess,
                                        mTransparency->value());
 }
 

--- a/src/webots/nodes/WbMatter.cpp
+++ b/src/webots/nodes/WbMatter.cpp
@@ -240,9 +240,9 @@ dSpaceID WbMatter::groupSpace() const {
 
 dSpaceID WbMatter::upperSpace() const {
   assert(areOdeObjectsCreated());
-  dSpaceID space = groupSpace();
-  if (space)
-    return space;
+  dSpaceID s = groupSpace();
+  if (s)
+    return s;
 
   return odeGeom() ? dGeomGetSpace(odeGeom()) : WbOdeContext::instance()->space();
 }

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -97,12 +97,12 @@ WbMotor::~WbMotor() {
 }
 
 void WbMotor::downloadAssets() {
-  const QString &sound = mSound->value();
-  if (WbUrl::isWeb(sound)) {
+  const QString &soundString = mSound->value();
+  if (WbUrl::isWeb(soundString)) {
     mDownloader = new WbDownloader(this);
     if (isPostFinalizedCalled())
       connect(mDownloader, &WbDownloader::complete, this, &WbMotor::updateSound);
-    mDownloader->download(QUrl(sound));
+    mDownloader->download(QUrl(soundString));
   }
 }
 
@@ -278,17 +278,17 @@ void WbMotor::updateControlPID() {
 }
 
 void WbMotor::updateSound() {
-  const QString &sound = mSound->value();
-  if (sound.isEmpty())
+  const QString &soundString = mSound->value();
+  if (soundString.isEmpty())
     mSoundClip = NULL;
-  else if (isPostFinalizedCalled() && WbUrl::isWeb(sound) && mDownloader == NULL) {
+  else if (isPostFinalizedCalled() && WbUrl::isWeb(soundString) && mDownloader == NULL) {
     downloadAssets();
     return;
   } else if (!mDownloader)
-    mSoundClip = WbSoundEngine::sound(WbUrl::computePath(this, "sound", sound));
+    mSoundClip = WbSoundEngine::sound(WbUrl::computePath(this, "sound", soundString));
   else {
     if (mDownloader->error().isEmpty())
-      mSoundClip = WbSoundEngine::sound(sound, mDownloader->device());
+      mSoundClip = WbSoundEngine::sound(soundString, mDownloader->device());
     else {
       mSoundClip = NULL;
       warn(mDownloader->error());
@@ -686,27 +686,27 @@ void WbMotor::handleMessage(QDataStream &stream) {
 
   switch (command) {
     case C_MOTOR_SET_POSITION: {
-      double position;
-      stream >> position;
-      setTargetPosition(position);
+      double pos;
+      stream >> pos;
+      setTargetPosition(pos);
       // relay target position to coupled motors, if any
       for (int i = 0; i < mCoupledMotors.size(); ++i)
-        mCoupledMotors[i]->setTargetPosition(position);
+        mCoupledMotors[i]->setTargetPosition(pos);
       break;
     }
     case C_MOTOR_SET_VELOCITY: {
-      double velocity;
-      stream >> velocity;
-      setVelocity(velocity);
+      double vel;
+      stream >> vel;
+      setVelocity(vel);
       // relay target velocity to coupled motors, if any
       for (int i = 0; i < mCoupledMotors.size(); ++i)
-        mCoupledMotors[i]->setVelocity(velocity);
+        mCoupledMotors[i]->setVelocity(vel);
       break;
     }
     case C_MOTOR_SET_ACCELERATION: {
-      double acceleration;
-      stream >> acceleration;
-      setAcceleration(acceleration);
+      double acc;
+      stream >> acc;
+      setAcceleration(acc);
       break;
     }
     case C_MOTOR_SET_FORCE: {

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -686,27 +686,27 @@ void WbMotor::handleMessage(QDataStream &stream) {
 
   switch (command) {
     case C_MOTOR_SET_POSITION: {
-      double pos;
-      stream >> pos;
-      setTargetPosition(pos);
+      double p;
+      stream >> p;
+      setTargetPosition(p);
       // relay target position to coupled motors, if any
       for (int i = 0; i < mCoupledMotors.size(); ++i)
-        mCoupledMotors[i]->setTargetPosition(pos);
+        mCoupledMotors[i]->setTargetPosition(p);
       break;
     }
     case C_MOTOR_SET_VELOCITY: {
-      double vel;
-      stream >> vel;
-      setVelocity(vel);
+      double v;
+      stream >> v;
+      setVelocity(v);
       // relay target velocity to coupled motors, if any
       for (int i = 0; i < mCoupledMotors.size(); ++i)
-        mCoupledMotors[i]->setVelocity(vel);
+        mCoupledMotors[i]->setVelocity(v);
       break;
     }
     case C_MOTOR_SET_ACCELERATION: {
-      double acc;
-      stream >> acc;
-      setAcceleration(acc);
+      double a;
+      stream >> a;
+      setAcceleration(a);
       break;
     }
     case C_MOTOR_SET_FORCE: {

--- a/src/webots/nodes/WbPbrAppearance.cpp
+++ b/src/webots/nodes/WbPbrAppearance.cpp
@@ -296,11 +296,11 @@ WrMaterial *WbPbrAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
   wr_material_set_texture_enable_mip_maps(wrenMaterial, false, 5);
   wr_material_set_texture_enable_interpolation(wrenMaterial, false, 5);
 
-  const float baseColor[] = {static_cast<float>(mBaseColor->red()), static_cast<float>(mBaseColor->green()),
-                             static_cast<float>(mBaseColor->blue())};
+  const float baseCol[] = {static_cast<float>(mBaseColor->red()), static_cast<float>(mBaseColor->green()),
+                           static_cast<float>(mBaseColor->blue())};
 
-  const float emissiveColor[] = {static_cast<float>(mEmissiveColor->red()), static_cast<float>(mEmissiveColor->green()),
-                                 static_cast<float>(mEmissiveColor->blue())};
+  const float emissiveCol[] = {static_cast<float>(mEmissiveColor->red()), static_cast<float>(mEmissiveColor->green()),
+                               static_cast<float>(mEmissiveColor->blue())};
 
   float backgroundColor[] = {0.0, 0.0, 0.0};
 
@@ -312,9 +312,9 @@ WrMaterial *WbPbrAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
   }
 
   // set material properties
-  wr_pbr_material_set_all_parameters(wrenMaterial, backgroundColor, baseColor, mTransparency->value(), mRoughness->value(),
+  wr_pbr_material_set_all_parameters(wrenMaterial, backgroundColor, baseCol, mTransparency->value(), mRoughness->value(),
                                      mMetalness->value(), backgroundLuminosity * mIblStrength->value(),
-                                     mNormalMapFactor->value(), mOcclusionMapStrength->value(), emissiveColor,
+                                     mNormalMapFactor->value(), mOcclusionMapStrength->value(), emissiveCol,
                                      mEmissiveIntensity->value());
 
   return wrenMaterial;

--- a/src/webots/nodes/WbPbrAppearance.cpp
+++ b/src/webots/nodes/WbPbrAppearance.cpp
@@ -300,7 +300,7 @@ WrMaterial *WbPbrAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
                                 static_cast<float>(mBaseColor->blue())};
 
   const float newEmissiveColor[] = {static_cast<float>(mEmissiveColor->red()), static_cast<float>(mEmissiveColor->green()),
-                                   static_cast<float>(mEmissiveColor->blue())};
+                                    static_cast<float>(mEmissiveColor->blue())};
 
   float backgroundColor[] = {0.0, 0.0, 0.0};
 

--- a/src/webots/nodes/WbPbrAppearance.cpp
+++ b/src/webots/nodes/WbPbrAppearance.cpp
@@ -296,11 +296,11 @@ WrMaterial *WbPbrAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
   wr_material_set_texture_enable_mip_maps(wrenMaterial, false, 5);
   wr_material_set_texture_enable_interpolation(wrenMaterial, false, 5);
 
-  const float baseCol[] = {static_cast<float>(mBaseColor->red()), static_cast<float>(mBaseColor->green()),
-                           static_cast<float>(mBaseColor->blue())};
+  const float newBaseColor[] = {static_cast<float>(mBaseColor->red()), static_cast<float>(mBaseColor->green()),
+                                static_cast<float>(mBaseColor->blue())};
 
-  const float emissiveCol[] = {static_cast<float>(mEmissiveColor->red()), static_cast<float>(mEmissiveColor->green()),
-                               static_cast<float>(mEmissiveColor->blue())};
+  const float newEmissiveColor[] = {static_cast<float>(mEmissiveColor->red()), static_cast<float>(mEmissiveColor->green()),
+                                   static_cast<float>(mEmissiveColor->blue())};
 
   float backgroundColor[] = {0.0, 0.0, 0.0};
 
@@ -312,9 +312,9 @@ WrMaterial *WbPbrAppearance::modifyWrenMaterial(WrMaterial *wrenMaterial) {
   }
 
   // set material properties
-  wr_pbr_material_set_all_parameters(wrenMaterial, backgroundColor, baseCol, mTransparency->value(), mRoughness->value(),
+  wr_pbr_material_set_all_parameters(wrenMaterial, backgroundColor, newBaseColor, mTransparency->value(), mRoughness->value(),
                                      mMetalness->value(), backgroundLuminosity * mIblStrength->value(),
-                                     mNormalMapFactor->value(), mOcclusionMapStrength->value(), emissiveCol,
+                                     mNormalMapFactor->value(), mOcclusionMapStrength->value(), newEmissiveColor,
                                      mEmissiveIntensity->value());
 
   return wrenMaterial;

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -84,8 +84,8 @@ void WbPlane::setY(double y) {
 }
 
 const WbVector2 WbPlane::scaledSize() const {
-  const WbVector2 &s1= mSize->value();
-  const WbVector3 &s2= absoluteScale();
+  const WbVector2 &s1 = mSize->value();
+  const WbVector3 &s2 = absoluteScale();
   return WbVector2(fabs(s2.x() * s1.x()), fabs(s2.y() * s1.y()));
 }
 

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -84,9 +84,9 @@ void WbPlane::setY(double y) {
 }
 
 const WbVector2 WbPlane::scaledSize() const {
-  const WbVector2 &size = mSize->value();
-  const WbVector3 &scale = absoluteScale();
-  return WbVector2(fabs(scale.x() * size.x()), fabs(scale.y() * size.y()));
+  const WbVector2 &sizeVec = mSize->value();
+  const WbVector3 &scaleVec = absoluteScale();
+  return WbVector2(fabs(scaleVec.x() * sizeVec.x()), fabs(scaleVec.y() * sizeVec.y()));
 }
 
 void WbPlane::write(WbVrmlWriter &writer) const {
@@ -184,8 +184,8 @@ void WbPlane::setResizeManipulatorDimensions() {
 }
 
 bool WbPlane::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const size = findField("size", true);
-  return WbNodeUtilities::isVisible(size) && !WbNodeUtilities::isTemplateRegeneratorField(size);
+  const WbField *const sizeField = findField("size", true);
+  return WbNodeUtilities::isVisible(sizeField) && !WbNodeUtilities::isTemplateRegeneratorField(sizeField);
 }
 
 bool WbPlane::sanitizeFields() {

--- a/src/webots/nodes/WbPlane.cpp
+++ b/src/webots/nodes/WbPlane.cpp
@@ -84,9 +84,9 @@ void WbPlane::setY(double y) {
 }
 
 const WbVector2 WbPlane::scaledSize() const {
-  const WbVector2 &sizeVec = mSize->value();
-  const WbVector3 &scaleVec = absoluteScale();
-  return WbVector2(fabs(scaleVec.x() * sizeVec.x()), fabs(scaleVec.y() * sizeVec.y()));
+  const WbVector2 &s1= mSize->value();
+  const WbVector3 &s2= absoluteScale();
+  return WbVector2(fabs(s2.x() * s1.x()), fabs(s2.y() * s1.y()));
 }
 
 void WbPlane::write(WbVrmlWriter &writer) const {

--- a/src/webots/nodes/WbPointSet.cpp
+++ b/src/webots/nodes/WbPointSet.cpp
@@ -149,22 +149,22 @@ int WbPointSet::computeCoordsAndColorData(float *coordsData, float *colorData) {
   if (colorData) {
     WbMFColor::Iterator colorIt(color()->color());
     while (coordsIt.hasNext() && colorIt.hasNext()) {
-      WbVector3 coord = coordsIt.next();
-      WbRgb color = colorIt.next();
-      coordsData[3 * count] = coord.x();
-      coordsData[3 * count + 1] = coord.y();
-      coordsData[3 * count + 2] = coord.z();
-      colorData[3 * count] = color.red();
-      colorData[3 * count + 1] = color.green();
-      colorData[3 * count + 2] = color.blue();
+      WbVector3 coordVec = coordsIt.next();
+      WbRgb colorCode = colorIt.next();
+      coordsData[3 * count] = coordVec.x();
+      coordsData[3 * count + 1] = coordVec.y();
+      coordsData[3 * count + 2] = coordVec.z();
+      colorData[3 * count] = colorCode.red();
+      colorData[3 * count + 1] = colorCode.green();
+      colorData[3 * count + 2] = colorCode.blue();
       count++;
     }
   } else {
     while (coordsIt.hasNext()) {
-      WbVector3 coord = coordsIt.next();
-      coordsData[3 * count] = coord.x();
-      coordsData[3 * count + 1] = coord.y();
-      coordsData[3 * count + 2] = coord.z();
+      WbVector3 coordVec = coordsIt.next();
+      coordsData[3 * count] = coordVec.x();
+      coordsData[3 * count + 1] = coordVec.y();
+      coordsData[3 * count + 2] = coordVec.z();
       count++;
     }
   }

--- a/src/webots/nodes/WbPointSet.cpp
+++ b/src/webots/nodes/WbPointSet.cpp
@@ -149,22 +149,22 @@ int WbPointSet::computeCoordsAndColorData(float *coordsData, float *colorData) {
   if (colorData) {
     WbMFColor::Iterator colorIt(color()->color());
     while (coordsIt.hasNext() && colorIt.hasNext()) {
-      WbVector3 coordVec = coordsIt.next();
-      WbRgb colorCode = colorIt.next();
-      coordsData[3 * count] = coordVec.x();
-      coordsData[3 * count + 1] = coordVec.y();
-      coordsData[3 * count + 2] = coordVec.z();
-      colorData[3 * count] = colorCode.red();
-      colorData[3 * count + 1] = colorCode.green();
-      colorData[3 * count + 2] = colorCode.blue();
+      WbVector3 v = coordsIt.next();
+      WbRgb c = colorIt.next();
+      coordsData[3 * count] = v.x();
+      coordsData[3 * count + 1] = v.y();
+      coordsData[3 * count + 2] = v.z();
+      colorData[3 * count] = c.red();
+      colorData[3 * count + 1] = c.green();
+      colorData[3 * count + 2] = c.blue();
       count++;
     }
   } else {
     while (coordsIt.hasNext()) {
-      WbVector3 coordVec = coordsIt.next();
-      coordsData[3 * count] = coordVec.x();
-      coordsData[3 * count + 1] = coordVec.y();
-      coordsData[3 * count + 2] = coordVec.z();
+      WbVector3 v = coordsIt.next();
+      coordsData[3 * count] = v.x();
+      coordsData[3 * count + 1] = v.y();
+      coordsData[3 * count + 2] = v.z();
       count++;
     }
   }

--- a/src/webots/nodes/WbPropeller.cpp
+++ b/src/webots/nodes/WbPropeller.cpp
@@ -96,13 +96,13 @@ void WbPropeller::preFinalize() {
   if (d && !d->isPreFinalizedCalled())
     d->preFinalize();
 
-  WbBaseNode *helix = static_cast<WbBaseNode *>(mFastHelix->value());
-  if (helix && !helix->isPreFinalizedCalled())
-    helix->preFinalize();
+  WbBaseNode *hel = static_cast<WbBaseNode *>(mFastHelix->value());
+  if (hel && !hel->isPreFinalizedCalled())
+    hel->preFinalize();
 
-  helix = static_cast<WbBaseNode *>(mSlowHelix->value());
-  if (helix && !helix->isPreFinalizedCalled())
-    helix->preFinalize();
+  hel = static_cast<WbBaseNode *>(mSlowHelix->value());
+  if (hel && !hel->isPreFinalizedCalled())
+    hel->preFinalize();
 
   updateShaftAxis();
   updateDevice();
@@ -115,13 +115,13 @@ void WbPropeller::postFinalize() {
   if (d && !d->isPostFinalizedCalled())
     d->postFinalize();
 
-  WbBaseNode *helix = static_cast<WbBaseNode *>(mFastHelix->value());
-  if (helix && !helix->isPostFinalizedCalled())
-    helix->postFinalize();
+  WbBaseNode *hel = static_cast<WbBaseNode *>(mFastHelix->value());
+  if (hel && !hel->isPostFinalizedCalled())
+    hel->postFinalize();
 
-  helix = static_cast<WbBaseNode *>(mSlowHelix->value());
-  if (helix && !helix->isPostFinalizedCalled())
-    helix->postFinalize();
+  hel = static_cast<WbBaseNode *>(mSlowHelix->value());
+  if (hel && !hel->isPostFinalizedCalled())
+    hel->postFinalize();
 
   updateHelix(0.0);
 
@@ -238,9 +238,9 @@ void WbPropeller::prePhysicsStep(double ms) {
 
     // Applies thrust and torque
     const WbMatrix3 &m3 = ut->rotationMatrix();
-    const WbVector3 &axis = m3 * mNormalizedAxis;
-    const WbVector3 &thrustVector = mCurrentThrust * axis;
-    const WbVector3 &torqueVector = -mCurrentTorque * axis;
+    const WbVector3 &axisVector = m3 * mNormalizedAxis;
+    const WbVector3 &thrustVector = mCurrentThrust * axisVector;
+    const WbVector3 &torqueVector = -mCurrentTorque * axisVector;
     if (sm && !sm->isBodyArtificiallyDisabled())
       dBodyEnable(b);
     dBodyAddForceAtPos(b, thrustVector.x(), thrustVector.y(), thrustVector.z(), cot.x(), cot.y(), cot.z());
@@ -320,14 +320,14 @@ void WbPropeller::updateShaftAxisRepresentation() {
   wr_static_mesh_delete(mMesh);
 
   const float scaling = 0.5f * wr_config_get_line_scale();
-  const WbVector3 &centerOfThrust = mCenterOfThrust->value();
-  const WbVector3 axis(scaling * mNormalizedAxis);
-  const WbVector3 vMinus(centerOfThrust - axis);
-  const WbVector3 vPlus(centerOfThrust + axis);
+  const WbVector3 &centerOfThrustVector = mCenterOfThrust->value();
+  const WbVector3 axisVector(scaling * mNormalizedAxis);
+  const WbVector3 vMinusVector(centerOfThrustVector - axisVector);
+  const WbVector3 vPlusVector(centerOfThrustVector + axisVector);
 
   float vertices[6];
-  vMinus.toFloatArray(vertices);
-  vPlus.toFloatArray(vertices + 3);
+  vMinusVector.toFloatArray(vertices);
+  vPlusVector.toFloatArray(vertices + 3);
 
   mMesh = wr_static_mesh_line_set_new(2, vertices, NULL);
   wr_renderable_set_mesh(mRenderable, WR_MESH(mMesh));
@@ -399,9 +399,9 @@ void WbPropeller::write(WbVrmlWriter &writer) const {
 void WbPropeller::reset(const QString &id) {
   WbBaseNode::reset(id);
 
-  WbNode *const device = mDevice->value();
-  if (device)
-    device->reset(id);
+  WbNode *const dev = mDevice->value();
+  if (dev)
+    dev->reset(id);
   WbNode *const fastHelix = mFastHelix->value();
   if (fastHelix)
     fastHelix->reset(id);

--- a/src/webots/nodes/WbPropeller.cpp
+++ b/src/webots/nodes/WbPropeller.cpp
@@ -96,13 +96,13 @@ void WbPropeller::preFinalize() {
   if (d && !d->isPreFinalizedCalled())
     d->preFinalize();
 
-  WbBaseNode *hel = static_cast<WbBaseNode *>(mFastHelix->value());
-  if (hel && !hel->isPreFinalizedCalled())
-    hel->preFinalize();
+  WbBaseNode *h = static_cast<WbBaseNode *>(mFastHelix->value());
+  if (h && !h->isPreFinalizedCalled())
+    h->preFinalize();
 
-  hel = static_cast<WbBaseNode *>(mSlowHelix->value());
-  if (hel && !hel->isPreFinalizedCalled())
-    hel->preFinalize();
+  h = static_cast<WbBaseNode *>(mSlowHelix->value());
+  if (h && !h->isPreFinalizedCalled())
+    h->preFinalize();
 
   updateShaftAxis();
   updateDevice();
@@ -115,13 +115,13 @@ void WbPropeller::postFinalize() {
   if (d && !d->isPostFinalizedCalled())
     d->postFinalize();
 
-  WbBaseNode *hel = static_cast<WbBaseNode *>(mFastHelix->value());
-  if (hel && !hel->isPostFinalizedCalled())
-    hel->postFinalize();
+  WbBaseNode *h = static_cast<WbBaseNode *>(mFastHelix->value());
+  if (h && !h->isPostFinalizedCalled())
+    h->postFinalize();
 
-  hel = static_cast<WbBaseNode *>(mSlowHelix->value());
-  if (hel && !hel->isPostFinalizedCalled())
-    hel->postFinalize();
+  h = static_cast<WbBaseNode *>(mSlowHelix->value());
+  if (h && !h->isPostFinalizedCalled())
+    h->postFinalize();
 
   updateHelix(0.0);
 
@@ -399,9 +399,9 @@ void WbPropeller::write(WbVrmlWriter &writer) const {
 void WbPropeller::reset(const QString &id) {
   WbBaseNode::reset(id);
 
-  WbNode *const dev = mDevice->value();
-  if (dev)
-    dev->reset(id);
+  WbNode *const d = mDevice->value();
+  if (d)
+    d->reset(id);
   WbNode *const fastHelix = mFastHelix->value();
   if (fastHelix)
     fastHelix->reset(id);

--- a/src/webots/nodes/WbRadio.cpp
+++ b/src/webots/nodes/WbRadio.cpp
@@ -285,11 +285,11 @@ static struct WebotsRadioEvent *radio_event_duplicate(const struct WebotsRadioEv
   struct WebotsRadioEvent *copy = new struct WebotsRadioEvent;
   copy->type = orig->type;
   copy->data = new char[orig->data_size];
-  memcpy((void *)copy->data, orig->data, orig->data_size);
+  memcpy(static_cast<void *>(const_cast<char *>(copy->data)), orig->data, orig->data_size);
   copy->data_size = orig->data_size;
   int len = strlen(orig->from) + 1;
   copy->from = new char[len];
-  strncpy((char *)copy->from, orig->from, len);
+  strncpy(const_cast<char *>(copy->from), orig->from, len);
   copy->rssi = orig->rssi;
   return copy;
 }

--- a/src/webots/nodes/WbRangeFinder.cpp
+++ b/src/webots/nodes/WbRangeFinder.cpp
@@ -80,8 +80,8 @@ void WbRangeFinder::initializeImageSharedMemory() {
   if (mImageShm) {
     // initialize the shared memory with a black image
     float *im = rangeFinderImage();
-    const int size = width() * height();
-    for (int i = 0; i < size; i++)
+    const int im_size = width() * height();
+    for (int i = 0; i < im_size; i++)
       im[i] = 0.0f;
   }
 }

--- a/src/webots/nodes/WbRangeFinder.cpp
+++ b/src/webots/nodes/WbRangeFinder.cpp
@@ -80,8 +80,8 @@ void WbRangeFinder::initializeImageSharedMemory() {
   if (mImageShm) {
     // initialize the shared memory with a black image
     float *im = rangeFinderImage();
-    const int im_size = width() * height();
-    for (int i = 0; i < im_size; i++)
+    const int s = width() * height();
+    for (int i = 0; i < s; i++)
       im[i] = 0.0f;
   }
 }

--- a/src/webots/nodes/WbRenderingDevice.cpp
+++ b/src/webots/nodes/WbRenderingDevice.cpp
@@ -178,10 +178,10 @@ WbRenderingDevice *WbRenderingDevice::fromMousePosition(int x, int y) {
   int size = cRenderingDevices.size();
 
   for (int i = 0; i < size; i++) {
-    const WbWrenTextureOverlay *overlay = cRenderingDevices.at(i)->overlay();
-    if (overlay && overlay->isVisible()) {
-      int currentZorder = overlay->zOrder();
-      if (overlay->isInside(x, y) && currentZorder > maxZorder) {
+    const WbWrenTextureOverlay *textureOverlay = cRenderingDevices.at(i)->overlay();
+    if (textureOverlay && textureOverlay->isVisible()) {
+      int currentZorder = textureOverlay->zOrder();
+      if (textureOverlay->isInside(x, y) && currentZorder > maxZorder) {
         iMax = i;
         maxZorder = currentZorder;
       }

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -116,9 +116,9 @@ void WbShape::reset(const QString &id) {
   if (baseNode)
     baseNode->reset(id);
 
-  WbNode *const geometry = mGeometry->value();
-  if (geometry)
-    geometry->reset(id);
+  WbNode *const geometryNode = mGeometry->value();
+  if (geometryNode)
+    geometryNode->reset(id);
 }
 
 WbAppearance *WbShape::appearance() const {

--- a/src/webots/nodes/WbSolidReference.cpp
+++ b/src/webots/nodes/WbSolidReference.cpp
@@ -55,15 +55,15 @@ void WbSolidReference::postFinalize() {
 void WbSolidReference::updateName() {
   WbSolid *const ts = topSolid();
   assert(ts);
-  const QString &name = mName->value();
-  const bool linkToStaticEnvironment = name == STATIC_ENVIRONMENT;
+  const QString &nameString = mName->value();
+  const bool linkToStaticEnvironment = nameString == STATIC_ENVIRONMENT;
   if (!linkToStaticEnvironment)
-    mSolid = QPointer<WbSolid>(ts->findSolid(name, upperSolid()));
+    mSolid = QPointer<WbSolid>(ts->findSolid(nameString, upperSolid()));
   else
     mSolid.clear();
-  if (!name.isEmpty() && !linkToStaticEnvironment && mSolid.isNull())
+  if (!nameString.isEmpty() && !linkToStaticEnvironment && mSolid.isNull())
     parsingWarn(
-      tr("SolidReference has an invalid '%1' name or refers to its closest upper solid, which is prohibited.").arg(name));
+      tr("SolidReference has an invalid '%1' name or refers to its closest upper solid, which is prohibited.").arg(nameString));
 }
 
 QList<const WbBaseNode *> WbSolidReference::findClosestDescendantNodesWithDedicatedWrenNode() const {

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -294,7 +294,7 @@ void WbSphere::updateScale() {
   if (!sanitizeFields())
     return;
 
-  const float s= static_cast<float>(mRadius->value());
+  const float s = static_cast<float>(mRadius->value());
   const float scale[] = {s, s, s};
   wr_transform_set_scale(wrenNode(), scale);
 }

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -172,11 +172,11 @@ void WbSphere::exportNodeSubNodes(WbVrmlWriter &writer) const {
   writer.increaseIndent();
   writer.indent();
   writer << "point [ ";
-  const double rad = mRadius->value();
+  const double r = mRadius->value();
   for (int i = 0; i < vertexCount; i++) {
-    writer << QString::number(vertices[i * 3] * rad, 'f', precision) << " "
-           << QString::number(vertices[i * 3 + 1] * rad, 'f', precision) << " "
-           << QString::number(vertices[i * 3 + 2] * rad, 'f', precision) << " ";
+    writer << QString::number(vertices[i * 3] * r, 'f', precision) << " "
+           << QString::number(vertices[i * 3 + 1] * r, 'f', precision) << " "
+           << QString::number(vertices[i * 3 + 2] * r, 'f', precision) << " ";
   }
   writer << " ]\n";
   writer.decreaseIndent();
@@ -285,8 +285,8 @@ void WbSphere::updateLineScale() {
     return;
 
   const float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
-  const float scaledRad = static_cast<float>(mRadius->value() * (1.0 + offset));
-  const float scale[] = {scaledRad, scaledRad, scaledRad};
+  const float s = static_cast<float>(mRadius->value() * (1.0 + offset));
+  const float scale[] = {s, s, s};
   wr_transform_set_scale(wrenNode(), scale);
 }
 
@@ -294,8 +294,8 @@ void WbSphere::updateScale() {
   if (!sanitizeFields())
     return;
 
-  const float scaledRad = static_cast<float>(mRadius->value());
-  const float scale[] = {scaledRad, scaledRad, scaledRad};
+  const float s= static_cast<float>(mRadius->value());
+  const float scale[] = {s, s, s};
   wr_transform_set_scale(wrenNode(), scale);
 }
 
@@ -395,10 +395,10 @@ bool WbSphere::computeCollisionPoint(WbVector3 &point, const WbRay &ray) const {
   const WbTransform *const transform = upperTransform();
   if (transform)
     center = transform->matrix().translation();
-  double rad = scaledRadius();
+  const double r = scaledRadius();
 
   // distance from sphere
-  const std::pair<bool, double> result = ray.intersects(center, rad, true);
+  const std::pair<bool, double> result = ray.intersects(center, r, true);
 
   point = ray.origin() + result.second * ray.direction();
   return result.first;

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -111,8 +111,8 @@ void WbSphere::createResizeManipulator() {
 }
 
 bool WbSphere::areSizeFieldsVisibleAndNotRegenerator() const {
-  const WbField *const radius = findField("radius", true);
-  return WbNodeUtilities::isVisible(radius) && !WbNodeUtilities::isTemplateRegeneratorField(radius);
+  const WbField *const radiusField = findField("radius", true);
+  return WbNodeUtilities::isVisible(radiusField) && !WbNodeUtilities::isTemplateRegeneratorField(radiusField);
 }
 
 void WbSphere::write(WbVrmlWriter &writer) const {
@@ -172,11 +172,11 @@ void WbSphere::exportNodeSubNodes(WbVrmlWriter &writer) const {
   writer.increaseIndent();
   writer.indent();
   writer << "point [ ";
-  const double radius = mRadius->value();
+  const double rad = mRadius->value();
   for (int i = 0; i < vertexCount; i++) {
-    writer << QString::number(vertices[i * 3] * radius, 'f', precision) << " "
-           << QString::number(vertices[i * 3 + 1] * radius, 'f', precision) << " "
-           << QString::number(vertices[i * 3 + 2] * radius, 'f', precision) << " ";
+    writer << QString::number(vertices[i * 3] * rad, 'f', precision) << " "
+           << QString::number(vertices[i * 3 + 1] * rad, 'f', precision) << " "
+           << QString::number(vertices[i * 3 + 2] * rad, 'f', precision) << " ";
   }
   writer << " ]\n";
   writer.decreaseIndent();
@@ -285,8 +285,8 @@ void WbSphere::updateLineScale() {
     return;
 
   const float offset = wr_config_get_line_scale() / LINE_SCALE_FACTOR;
-  const float scaledRadius = static_cast<float>(mRadius->value() * (1.0 + offset));
-  const float scale[] = {scaledRadius, scaledRadius, scaledRadius};
+  const float scaledRad = static_cast<float>(mRadius->value() * (1.0 + offset));
+  const float scale[] = {scaledRad, scaledRad, scaledRad};
   wr_transform_set_scale(wrenNode(), scale);
 }
 
@@ -294,8 +294,8 @@ void WbSphere::updateScale() {
   if (!sanitizeFields())
     return;
 
-  const float scaledRadius = static_cast<float>(mRadius->value());
-  const float scale[] = {scaledRadius, scaledRadius, scaledRadius};
+  const float scaledRad = static_cast<float>(mRadius->value());
+  const float scale[] = {scaledRad, scaledRad, scaledRad};
   wr_transform_set_scale(wrenNode(), scale);
 }
 
@@ -395,10 +395,10 @@ bool WbSphere::computeCollisionPoint(WbVector3 &point, const WbRay &ray) const {
   const WbTransform *const transform = upperTransform();
   if (transform)
     center = transform->matrix().translation();
-  double radius = scaledRadius();
+  double rad = scaledRadius();
 
   // distance from sphere
-  const std::pair<bool, double> result = ray.intersects(center, radius, true);
+  const std::pair<bool, double> result = ray.intersects(center, rad, true);
 
   point = ray.origin() + result.second * ray.direction();
   return result.first;

--- a/src/webots/nodes/WbSpotLight.cpp
+++ b/src/webots/nodes/WbSpotLight.cpp
@@ -268,9 +268,9 @@ void WbSpotLight::applyBillboardVisibilityToWren() {
 }
 
 void WbSpotLight::applyLightDirectionToWren() {
-  const float dir[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()),
-                       static_cast<float>(mDirection->z())};
-  wr_spot_light_set_direction(mWrenLight, dir);
+  const float d[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()),
+                     static_cast<float>(mDirection->z())};
+  wr_spot_light_set_direction(mWrenLight, d);
   mLightRepresentation->setDirection(mDirection->value());
 }
 

--- a/src/webots/nodes/WbSpotLight.cpp
+++ b/src/webots/nodes/WbSpotLight.cpp
@@ -268,9 +268,9 @@ void WbSpotLight::applyBillboardVisibilityToWren() {
 }
 
 void WbSpotLight::applyLightDirectionToWren() {
-  const float direction[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()),
-                             static_cast<float>(mDirection->z())};
-  wr_spot_light_set_direction(mWrenLight, direction);
+  const float dir[] = {static_cast<float>(mDirection->x()), static_cast<float>(mDirection->y()),
+                       static_cast<float>(mDirection->z())};
+  wr_spot_light_set_direction(mWrenLight, dir);
   mLightRepresentation->setDirection(mDirection->value());
 }
 

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -523,29 +523,29 @@ void WbTrack::updateAnimatedGeometries() {
       clearAnimatedGeometries();
       return;
     }
-    float pos[3];
-    float rot[4];
-    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(pos);
-    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rot);
+    float p[3];
+    float r[4];
+    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(p);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(r);
 
     WrTransform *transform = wr_transform_new();
-    wr_transform_set_position(transform, pos);
-    wr_transform_set_orientation(transform, rot);
+    wr_transform_set_position(transform, p);
+    wr_transform_set_orientation(transform, r);
 
     for (int j = 0; j < mAnimatedObjectList.size(); ++j) {
       WbGeometry *geom = mAnimatedObjectList[j]->geometry;
 
       WbMatrix4 geomMatrix = geom->matrix() * invMatrix;
 
-      geomMatrix.translation().toFloatArray(pos);
+      geomMatrix.translation().toFloatArray(p);
       float scale[3];
       geomMatrix.scale().toFloatArray(scale);
-      WbRotation(geomMatrix.extracted3x3Matrix()).toFloatArray(rot);
+      WbRotation(geomMatrix.extracted3x3Matrix()).toFloatArray(r);
 
       WrTransform *meshTransform = wr_transform_new();
-      wr_transform_set_position(meshTransform, pos);
+      wr_transform_set_position(meshTransform, p);
       wr_transform_set_scale(meshTransform, scale);
-      wr_transform_set_orientation(meshTransform, rot);
+      wr_transform_set_orientation(meshTransform, r);
 
       WrRenderable *renderable = wr_renderable_new();
       wr_renderable_set_material(renderable, mAnimatedObjectList[j]->material, NULL);
@@ -651,13 +651,13 @@ void WbTrack::animateMesh() {
       return;
     }
 
-    float pos[3];
-    float rot[4];
-    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(pos);
-    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rot);
+    float p[3];
+    float r[4];
+    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(p);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(r);
 
-    wr_transform_set_position(mBeltElements[i], pos);
-    wr_transform_set_orientation(mBeltElements[i], rot);
+    wr_transform_set_position(mBeltElements[i], p);
+    wr_transform_set_orientation(mBeltElements[i], r);
 
     if (i == 0) {
       mFirstGeometryPosition = beltPosition;

--- a/src/webots/nodes/WbTrack.cpp
+++ b/src/webots/nodes/WbTrack.cpp
@@ -395,12 +395,12 @@ QVector<WbLogicalDevice *> WbTrack::devices() const {
 }
 
 WbPositionSensor *WbTrack::positionSensor() const {
-  WbPositionSensor *sensor = NULL;
+  WbPositionSensor *s = NULL;
   WbMFNode::Iterator it(*mDeviceField);
   while (it.hasNext()) {
-    sensor = dynamic_cast<WbPositionSensor *>(it.next());
-    if (sensor)
-      return sensor;
+    s = dynamic_cast<WbPositionSensor *>(it.next());
+    if (s)
+      return s;
   }
   return NULL;
 }
@@ -411,9 +411,9 @@ WbLinearMotor *WbTrack::motor() const {
 
   WbMFNode::Iterator it(*mDeviceField);
   while (it.hasNext()) {
-    WbLinearMotor *motor = dynamic_cast<WbLinearMotor *>(it.next());
-    if (motor)
-      return motor;
+    WbLinearMotor *m = dynamic_cast<WbLinearMotor *>(it.next());
+    if (m)
+      return m;
   }
   return NULL;
 }
@@ -424,9 +424,9 @@ WbBrake *WbTrack::brake() const {
 
   WbMFNode::Iterator it(*mDeviceField);
   while (it.hasNext()) {
-    WbBrake *brake = dynamic_cast<WbBrake *>(it.next());
-    if (brake)
-      return brake;
+    WbBrake *b = dynamic_cast<WbBrake *>(it.next());
+    if (b)
+      return b;
   }
   return NULL;
 }
@@ -523,29 +523,29 @@ void WbTrack::updateAnimatedGeometries() {
       clearAnimatedGeometries();
       return;
     }
-    float position[3];
-    float rotation[4];
-    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(position);
-    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rotation);
+    float pos[3];
+    float rot[4];
+    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(pos);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rot);
 
     WrTransform *transform = wr_transform_new();
-    wr_transform_set_position(transform, position);
-    wr_transform_set_orientation(transform, rotation);
+    wr_transform_set_position(transform, pos);
+    wr_transform_set_orientation(transform, rot);
 
     for (int j = 0; j < mAnimatedObjectList.size(); ++j) {
       WbGeometry *geom = mAnimatedObjectList[j]->geometry;
 
       WbMatrix4 geomMatrix = geom->matrix() * invMatrix;
 
-      geomMatrix.translation().toFloatArray(position);
+      geomMatrix.translation().toFloatArray(pos);
       float scale[3];
       geomMatrix.scale().toFloatArray(scale);
-      WbRotation(geomMatrix.extracted3x3Matrix()).toFloatArray(rotation);
+      WbRotation(geomMatrix.extracted3x3Matrix()).toFloatArray(rot);
 
       WrTransform *meshTransform = wr_transform_new();
-      wr_transform_set_position(meshTransform, position);
+      wr_transform_set_position(meshTransform, pos);
       wr_transform_set_scale(meshTransform, scale);
-      wr_transform_set_orientation(meshTransform, rotation);
+      wr_transform_set_orientation(meshTransform, rot);
 
       WrRenderable *renderable = wr_renderable_new();
       wr_renderable_set_material(renderable, mAnimatedObjectList[j]->material, NULL);
@@ -651,13 +651,13 @@ void WbTrack::animateMesh() {
       return;
     }
 
-    float position[3];
-    float rotation[4];
-    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(position);
-    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rotation);
+    float pos[3];
+    float rot[4];
+    WbVector3(beltPosition.position.x(), 0.0, beltPosition.position.y()).toFloatArray(pos);
+    WbRotation(0.0, 1.0, 0.0, beltPosition.rotation).toFloatArray(rot);
 
-    wr_transform_set_position(mBeltElements[i], position);
-    wr_transform_set_orientation(mBeltElements[i], rotation);
+    wr_transform_set_position(mBeltElements[i], pos);
+    wr_transform_set_orientation(mBeltElements[i], rot);
 
     if (i == 0) {
       mFirstGeometryPosition = beltPosition;
@@ -896,23 +896,24 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
     parsingWarn(tr("Track field 'animatedGeometry' must have a DEF name for exportation. One have been generated."));
   }
 
-  QString position = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.x(), WbPrecision::DOUBLE_MAX)) +
-                     " 0 " +
-                     QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.y(), WbPrecision::DOUBLE_MAX));
-  QString rotation = QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[0].rotation, WbPrecision::DOUBLE_MAX));
+  QString positionString =
+    QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.x(), WbPrecision::DOUBLE_MAX)) + " 0 " +
+    QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[0].position.y(), WbPrecision::DOUBLE_MAX));
+  QString rotationString =
+    QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[0].rotation, WbPrecision::DOUBLE_MAX));
 
   if (writer.isX3d()) {
     writer << "<Transform ";
-    writer << "translation='" << position << "' ";
-    writer << "rotation='" << rotation << "'>";
+    writer << "translation='" << positionString << "' ";
+    writer << "rotation='" << rotationString << "'>";
   } else {
     writer.indent();
     writer << "Transform {\n";
     writer.increaseIndent();
     writer.indent();
-    writer << "translation " << position << "\n";
+    writer << "translation " << positionString << "\n";
     writer.indent();
-    writer << "rotation " << rotation << "\n";
+    writer << "rotation " << rotationString << "\n";
     writer.indent();
     writer << "children [\n";
     writer.increaseIndent();
@@ -932,14 +933,15 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
   }
 
   for (int i = 1; i < mGeometriesCountField->value(); ++i) {
-    position = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.x(), WbPrecision::DOUBLE_MAX)) + " 0 " +
-               QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.y(), WbPrecision::DOUBLE_MAX));
-    rotation = QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[i].rotation, WbPrecision::DOUBLE_MAX));
+    positionString = QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.x(), WbPrecision::DOUBLE_MAX)) +
+                     " 0 " +
+                     QString("%1").arg(WbPrecision::doubleToString(mBeltPositions[i].position.y(), WbPrecision::DOUBLE_MAX));
+    rotationString = QString("0 1 0 %1").arg(WbPrecision::doubleToString(mBeltPositions[i].rotation, WbPrecision::DOUBLE_MAX));
 
     if (writer.isX3d()) {
       writer << "<Transform ";
-      writer << "translation='" << position << "' ";
-      writer << "rotation='" << rotation << "'>";
+      writer << "translation='" << positionString << "' ";
+      writer << "rotation='" << rotationString << "'>";
       writer << "<Group USE='" << QString::number(node->uniqueId()) << "'></Group>";
       writer << "</Transform>";
     } else {
@@ -947,9 +949,9 @@ void WbTrack::exportAnimatedGeometriesMesh(WbVrmlWriter &writer) const {
       writer << "Transform {\n";
       writer.increaseIndent();
       writer.indent();
-      writer << "translation " << position << "\n";
+      writer << "translation " << positionString << "\n";
       writer.indent();
-      writer << "rotation " << rotation << "\n";
+      writer << "rotation " << rotationString << "\n";
       writer.indent();
       writer << "children [\n";
       writer.increaseIndent();

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -714,9 +714,9 @@ void WbViewpoint::updateFollow() {
     return;
 
   if (!mFollow->value().isEmpty()) {
-    WbSolid *fSolid = WbSolid::findSolidFromUniqueName(mFollow->value());
-    if (fSolid) {
-      startFollowUp(fSolid, false);
+    WbSolid *s = WbSolid::findSolidFromUniqueName(mFollow->value());
+    if (s) {
+      startFollowUp(s, false);
       emit followInvalidated(true);  // checks the follow object action at the WbView3D level
       return;
     }
@@ -865,8 +865,8 @@ void WbViewpoint::applyPositionToWren() {
     mVirtualRealityHeadset->setPosition(mPosition->value());
 #endif
 
-  float pos[] = {static_cast<float>(mPosition->x()), static_cast<float>(mPosition->y()), static_cast<float>(mPosition->z())};
-  wr_camera_set_position(mWrenCamera, pos);
+  float p[] = {static_cast<float>(mPosition->x()), static_cast<float>(mPosition->y()), static_cast<float>(mPosition->z())};
+  wr_camera_set_position(mWrenCamera, p);
 }
 
 void WbViewpoint::applyNearToWren() {

--- a/src/webots/nodes/WbViewpoint.cpp
+++ b/src/webots/nodes/WbViewpoint.cpp
@@ -373,9 +373,9 @@ WbLensFlare *WbViewpoint::lensFlare() const {
 }
 
 void WbViewpoint::startFollowUpFromField() {
-  WbSolid *followedSolid = WbSolid::findSolidFromUniqueName(mFollow->value());
-  if (followedSolid != NULL)
-    startFollowUp(followedSolid, false);
+  WbSolid *solid = WbSolid::findSolidFromUniqueName(mFollow->value());
+  if (solid != NULL)
+    startFollowUp(solid, false);
 }
 
 void WbViewpoint::setFollowType(int followType) {
@@ -714,9 +714,9 @@ void WbViewpoint::updateFollow() {
     return;
 
   if (!mFollow->value().isEmpty()) {
-    WbSolid *followedSolid = WbSolid::findSolidFromUniqueName(mFollow->value());
-    if (followedSolid) {
-      startFollowUp(followedSolid, false);
+    WbSolid *fSolid = WbSolid::findSolidFromUniqueName(mFollow->value());
+    if (fSolid) {
+      startFollowUp(fSolid, false);
       emit followInvalidated(true);  // checks the follow object action at the WbView3D level
       return;
     }
@@ -865,9 +865,8 @@ void WbViewpoint::applyPositionToWren() {
     mVirtualRealityHeadset->setPosition(mPosition->value());
 #endif
 
-  float position[] = {static_cast<float>(mPosition->x()), static_cast<float>(mPosition->y()),
-                      static_cast<float>(mPosition->z())};
-  wr_camera_set_position(mWrenCamera, position);
+  float pos[] = {static_cast<float>(mPosition->x()), static_cast<float>(mPosition->y()), static_cast<float>(mPosition->z())};
+  wr_camera_set_position(mWrenCamera, pos);
 }
 
 void WbViewpoint::applyNearToWren() {

--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -376,15 +376,15 @@ static QString forgeHtmlEscapedString(const QString &s) {
 
 void WbWorldInfo::exportNodeFields(WbVrmlWriter &writer) const {
   if (writer.isX3d()) {
-    QString title = forgeHtmlEscapedString(mTitle->toString());
-    if (title.size() > 2)  // at least 2 double quotes
-      writer << " title=" << title;
+    QString titleString = forgeHtmlEscapedString(mTitle->toString());
+    if (titleString.size() > 2)  // at least 2 double quotes
+      writer << " title=" << titleString;
 
     if (mInfo->size() > 0) {
       writer << " info='";
       for (int i = 0; i < mInfo->size(); ++i) {
-        QString info = forgeHtmlEscapedString(mInfo->itemToString(i));
-        writer << info;
+        QString infoString = forgeHtmlEscapedString(mInfo->itemToString(i));
+        writer << infoString;
         if (i != mInfo->size() - 1)
           writer << " ";
       }

--- a/src/webots/nodes/utils/WbJoystickInterface.cpp
+++ b/src/webots/nodes/utils/WbJoystickInterface.cpp
@@ -79,10 +79,10 @@ void WbJoystickInterface::init() {
     return;
   }
 
-  int numberOfAxes = mJoystick->getNumberOfComponents(OIS::OIS_Axis);
-  int numberOfPovs = mJoystick->getNumberOfComponents(OIS::OIS_POV);
-  int numberOfButtons = mJoystick->getNumberOfComponents(OIS::OIS_Button);
-  mListener = new WbJoystickListener(numberOfAxes, numberOfButtons, numberOfPovs);
+  int nbAxes = mJoystick->getNumberOfComponents(OIS::OIS_Axis);
+  int nbPovs = mJoystick->getNumberOfComponents(OIS::OIS_POV);
+  int nbButtons = mJoystick->getNumberOfComponents(OIS::OIS_Button);
+  mListener = new WbJoystickListener(nbAxes, nbButtons, nbPovs);
   connect(mListener, &WbJoystickListener::changed, this, &WbJoystickInterface::changed);
   mJoystick->setEventCallback(mListener);
 

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -69,9 +69,9 @@ void WbObjectDetection::deleteRay() {
 }
 
 void WbObjectDetection::setCollided(double depth) {
-  double distance = dGeomRayGetLength(mGeom) - depth;
-  if (mCollisionDepth < distance)
-    mCollisionDepth = distance;
+  double dist = dGeomRayGetLength(mGeom) - depth;
+  if (mCollisionDepth < dist)
+    mCollisionDepth = dist;
 }
 
 bool WbObjectDetection::recomputeRayDirection(WbSolid *device, const WbVector3 &devicePosition, const WbMatrix3 &deviceRotation,
@@ -322,12 +322,12 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
     // Note: this sort of detection is only adapted for a field of view smaller than PI. If a larger FoV is desirable, the logic
     // should be changed by having two separate frustums, more details here: https://github.com/cyberbotics/webots/pull/3960
     for (int j = 0; j < 4; ++j) {
-      const double distance = frustumPlanes[j].distance(objectPosition);
+      const double dist = frustumPlanes[j].distance(objectPosition);
       const int objectAxis = j % 2 + 1;
-      if (distance < -objectSize[objectAxis] / 2.0)  // the object is completely outside
+      if (dist < -objectSize[objectAxis] / 2.0)  // the object is completely outside
         return false;
-      else if (distance < objectSize[objectAxis] / 2.0)  // a part of the object is outside
-        outsidePart[j] = objectSize[objectAxis] / 2.0 - distance;
+      else if (dist < objectSize[objectAxis] / 2.0)  // a part of the object is outside
+        outsidePart[j] = objectSize[objectAxis] / 2.0 - dist;
     }
     objectSize.setY(objectSize.y() - outsidePart[RIGHT] - outsidePart[LEFT]);
     objectSize.setZ(objectSize.z() - outsidePart[BOTTOM] - outsidePart[TOP]);

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -69,9 +69,9 @@ void WbObjectDetection::deleteRay() {
 }
 
 void WbObjectDetection::setCollided(double depth) {
-  double dist = dGeomRayGetLength(mGeom) - depth;
-  if (mCollisionDepth < dist)
-    mCollisionDepth = dist;
+  const double d = dGeomRayGetLength(mGeom) - depth;
+  if (mCollisionDepth < d)
+    mCollisionDepth = d;
 }
 
 bool WbObjectDetection::recomputeRayDirection(WbSolid *device, const WbVector3 &devicePosition, const WbMatrix3 &deviceRotation,

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -322,12 +322,12 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
     // Note: this sort of detection is only adapted for a field of view smaller than PI. If a larger FoV is desirable, the logic
     // should be changed by having two separate frustums, more details here: https://github.com/cyberbotics/webots/pull/3960
     for (int j = 0; j < 4; ++j) {
-      const double dist = frustumPlanes[j].distance(objectPosition);
+      const double d = frustumPlanes[j].distance(objectPosition);
       const int objectAxis = j % 2 + 1;
-      if (dist < -objectSize[objectAxis] / 2.0)  // the object is completely outside
+      if (d < -objectSize[objectAxis] / 2.0)  // the object is completely outside
         return false;
-      else if (dist < objectSize[objectAxis] / 2.0)  // a part of the object is outside
-        outsidePart[j] = objectSize[objectAxis] / 2.0 - dist;
+      else if (d < objectSize[objectAxis] / 2.0)  // a part of the object is outside
+        outsidePart[j] = objectSize[objectAxis] / 2.0 - d;
     }
     objectSize.setY(objectSize.y() - outsidePart[RIGHT] - outsidePart[LEFT]);
     objectSize.setZ(objectSize.z() - outsidePart[BOTTOM] - outsidePart[TOP]);

--- a/src/webots/nodes/utils/WbSolidMerger.cpp
+++ b/src/webots/nodes/utils/WbSolidMerger.cpp
@@ -141,7 +141,7 @@ void WbSolidMerger::updateCenterOfMass() {
   MCI end = mMergedSolids.constEnd();
 
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    const WbSolid *s= it.key();
+    const WbSolid *s = it.key();
     const WbVector3 &com = s->matrix() * s->centerOfMass();
     const double m = s->mass();
     mAbsoluteCenterOfMass += m * com;
@@ -164,7 +164,7 @@ void WbSolidMerger::setGeomOffsetPositions() {
   typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
   MCI end = mMergedSolids.constEnd();
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    WbSolid *s= it.key();
+    WbSolid *s = it.key();
     s->updateOdeGeomPosition();
   }
 }
@@ -307,9 +307,9 @@ void WbSolidMerger::setOdeDamping() {
 
   // We average collected solids'damping weighted by the volume of their bounding objects
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    const WbSolid *const thisSolid = it.key();
-    const WbDamping *damping = thisSolid->physics()->damping();
-    const double v = thisSolid->referenceMass()->mass;
+    const WbSolid *const s = it.key();
+    const WbDamping *damping = s->physics()->damping();
+    const double v = s->referenceMass()->mass;
     if (damping) {
       ld += v * damping->linear();
       ad += v * damping->angular();
@@ -372,9 +372,9 @@ void WbSolidMerger::setGeomAndBodyPositions(bool zeroVelocities, bool resetJoint
     typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
     MCI end = mMergedSolids.constEnd();
     for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-      WbSolid *const thisSolid = it.key();
-      if (thisSolid->mergerIsSet())
-        thisSolid->resetJointsToLinkedSolids();
+      WbSolid *const s = it.key();
+      if (s->mergerIsSet())
+        s->resetJointsToLinkedSolids();
     }
   }
 }

--- a/src/webots/nodes/utils/WbSolidMerger.cpp
+++ b/src/webots/nodes/utils/WbSolidMerger.cpp
@@ -351,9 +351,9 @@ void WbSolidMerger::setGeomAndBodyPositions(bool zeroVelocities, bool resetJoint
   dBodySetPosition(mBody, mAbsoluteCenterOfMass.x(), mAbsoluteCenterOfMass.y(), mAbsoluteCenterOfMass.z());
   // Rotates ODE body
   WbMatrix4 m44 = mSolid->matrix();
-  const double s = 1.0 / mSolid->absoluteScale().x();
+  const double s1 = 1.0 / mSolid->absoluteScale().x();
   dMatrix3 m;
-  m44.extract3x4Matrix(m, s);
+  m44.extract3x4Matrix(m, s1);
   dBodySetRotation(mBody, m);
   // Sets the offset position (with respect to the ODE dBody) of every ODE dGeom in the boundingObject
   setGeomOffsetPositions();
@@ -372,9 +372,9 @@ void WbSolidMerger::setGeomAndBodyPositions(bool zeroVelocities, bool resetJoint
     typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
     MCI end = mMergedSolids.constEnd();
     for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-      WbSolid *const s = it.key();
-      if (s->mergerIsSet())
-        s->resetJointsToLinkedSolids();
+      WbSolid *const s2 = it.key();
+      if (s2->mergerIsSet())
+        s2->resetJointsToLinkedSolids();
     }
   }
 }

--- a/src/webots/nodes/utils/WbSolidMerger.cpp
+++ b/src/webots/nodes/utils/WbSolidMerger.cpp
@@ -99,10 +99,10 @@ void WbSolidMerger::reserveSpace() {
 
 void WbSolidMerger::addGeomToSpace(dGeomID g) {
   assert(g);
-  dSpaceID space = dGeomGetSpace(g);
+  dSpaceID spaceId = dGeomGetSpace(g);
 
-  if (space)
-    dSpaceRemove(space, g);
+  if (spaceId)
+    dSpaceRemove(spaceId, g);
 
   reserveSpace();
 
@@ -141,9 +141,9 @@ void WbSolidMerger::updateCenterOfMass() {
   MCI end = mMergedSolids.constEnd();
 
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    const WbSolid *solid = it.key();
-    const WbVector3 &com = solid->matrix() * solid->centerOfMass();
-    const double m = solid->mass();
+    const WbSolid *thisSolid = it.key();
+    const WbVector3 &com = thisSolid->matrix() * thisSolid->centerOfMass();
+    const double m = thisSolid->mass();
     mAbsoluteCenterOfMass += m * com;
     mass += m;
   }
@@ -164,8 +164,8 @@ void WbSolidMerger::setGeomOffsetPositions() {
   typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
   MCI end = mMergedSolids.constEnd();
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    WbSolid *solid = it.key();
-    solid->updateOdeGeomPosition();
+    WbSolid *thisSolid = it.key();
+    thisSolid->updateOdeGeomPosition();
   }
 }
 
@@ -307,9 +307,9 @@ void WbSolidMerger::setOdeDamping() {
 
   // We average collected solids'damping weighted by the volume of their bounding objects
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    const WbSolid *const solid = it.key();
-    const WbDamping *damping = solid->physics()->damping();
-    const double v = solid->referenceMass()->mass;
+    const WbSolid *const thisSolid = it.key();
+    const WbDamping *damping = thisSolid->physics()->damping();
+    const double v = thisSolid->referenceMass()->mass;
     if (damping) {
       ld += v * damping->linear();
       ad += v * damping->angular();
@@ -372,9 +372,9 @@ void WbSolidMerger::setGeomAndBodyPositions(bool zeroVelocities, bool resetJoint
     typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
     MCI end = mMergedSolids.constEnd();
     for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-      WbSolid *const solid = it.key();
-      if (solid->mergerIsSet())
-        solid->resetJointsToLinkedSolids();
+      WbSolid *const thisSolid = it.key();
+      if (thisSolid->mergerIsSet())
+        thisSolid->resetJointsToLinkedSolids();
     }
   }
 }
@@ -411,13 +411,13 @@ void WbSolidMerger::setOdeAutoDisable() {
 
 // Sets the merger body into placeable ODE dGeoms
 void WbSolidMerger::attachGeomsToBody(dGeomID g) {
-  dSpaceID space = WbSolidUtilities::dynamicCastInSpaceID(g);
-  if (space) {
-    const int n = dSpaceGetNumGeoms(space);
+  dSpaceID spaceId = WbSolidUtilities::dynamicCastInSpaceID(g);
+  if (spaceId) {
+    const int n = dSpaceGetNumGeoms(spaceId);
     // we need to store the geoms since dGeomSetBody() changes the way they are sorted in their common space
     dGeomID geoms[n];
     for (int i = 0; i < n; ++i)
-      geoms[i] = dSpaceGetGeom(space, i);
+      geoms[i] = dSpaceGetGeom(spaceId, i);
 
     for (int i = 0; i < n; ++i)
       attachGeomsToBody(geoms[i]);

--- a/src/webots/nodes/utils/WbSolidMerger.cpp
+++ b/src/webots/nodes/utils/WbSolidMerger.cpp
@@ -141,9 +141,9 @@ void WbSolidMerger::updateCenterOfMass() {
   MCI end = mMergedSolids.constEnd();
 
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    const WbSolid *thisSolid = it.key();
-    const WbVector3 &com = thisSolid->matrix() * thisSolid->centerOfMass();
-    const double m = thisSolid->mass();
+    const WbSolid *s= it.key();
+    const WbVector3 &com = s->matrix() * s->centerOfMass();
+    const double m = s->mass();
     mAbsoluteCenterOfMass += m * com;
     mass += m;
   }
@@ -164,8 +164,8 @@ void WbSolidMerger::setGeomOffsetPositions() {
   typedef QMap<WbSolid *, dMass *>::const_iterator MCI;
   MCI end = mMergedSolids.constEnd();
   for (MCI it = mMergedSolids.constBegin(); it != end; ++it) {
-    WbSolid *thisSolid = it.key();
-    thisSolid->updateOdeGeomPosition();
+    WbSolid *s= it.key();
+    s->updateOdeGeomPosition();
   }
 }
 

--- a/src/webots/nodes/utils/WbSolidUtilities.cpp
+++ b/src/webots/nodes/utils/WbSolidUtilities.cpp
@@ -71,11 +71,11 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
   // The WbTransform case must come before the WbGroup case
   const WbTransform *const transform = dynamic_cast<WbTransform *>(node);
   if (transform) {
-    WbGeometry *geometry = transform->geometry();
+    WbGeometry *g = transform->geometry();
 
     // Computes the total mass
-    if (geometry && geometry->odeGeom())
-      addMass(&m, geometry, density, warning);
+    if (g && g->odeGeom())
+      addMass(&m, g, density, warning);
     else
       // invalid geometry
       return;
@@ -92,7 +92,7 @@ void WbSolidUtilities::addMass(dMass *const mass, WbNode *const node, double den
     dMassTranslate(&m, t.x(), t.y(), t.z());
     dMassAdd(mass, &m);
 
-    geometry->setOdeMass(&m);
+    g->setOdeMass(&m);
     return;
   }
 
@@ -234,9 +234,9 @@ bool WbSolidUtilities::checkBoundingObject(WbNode *const node) {
       return false;
     }
 
-    const WbGeometry *const geometry = dynamic_cast<WbGeometry *>(child);
+    const WbGeometry *const g = dynamic_cast<WbGeometry *>(child);
     // cppcheck-suppress knownConditionTrueFalse
-    if (geometry)
+    if (g)
       return true;
 
     const WbShape *const shape = dynamic_cast<WbShape *>(child);

--- a/src/webots/nodes/utils/WbTriangleMesh.cpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.cpp
@@ -260,17 +260,17 @@ void WbTriangleMesh::indicesPass(const WbMFVector3 *coord, const WbMFInt *coordI
 
   for (int i = 0; i < coordIndexSize; ++i) {
     // get the current index
-    const int j = coordIndex->item(i);
+    const int id = coordIndex->item(i);
 
     // special case: last index not equal to -1
     // -> add a current index to the current face
     //    in order to have consistent data
-    if (j != -1 && i == coordIndexSize - 1)
-      currentFaceIndices.append(QVector<int>() << j << (mNormalsValid ? normalIndex->item(i) : 0)
+    if (id != -1 && i == coordIndexSize - 1)
+      currentFaceIndices.append(QVector<int>() << id << (mNormalsValid ? normalIndex->item(i) : 0)
                                                << (mTextureCoordinatesValid ? texCoordIndex->item(i) : 0));
     const int cfiSize = currentFaceIndices.size();
     // add the current face
-    if (j == -1 || i == coordIndexSize - 1) {
+    if (id == -1 || i == coordIndexSize - 1) {
       // check the validity of the current face
       // by checking if the range of the new face indices is valid
       bool currentFaceValidity = true;
@@ -409,7 +409,7 @@ void WbTriangleMesh::indicesPass(const WbMFVector3 *coord, const WbMFInt *coordI
     }
     // add a coordIndex to the currentFace
     else
-      currentFaceIndices.append(QVector<int>() << j << (mNormalsValid ? normalIndex->item(i) : 0)
+      currentFaceIndices.append(QVector<int>() << id << (mNormalsValid ? normalIndex->item(i) : 0)
                                                << (mTextureCoordinatesValid ? texCoordIndex->item(i) : 0));
   }
 
@@ -678,8 +678,8 @@ void WbTriangleMesh::finalPass(const WbMFVector3 *coord, const WbMFVector3 *norm
         const WbVector3 **linkedTriangleNormals = new const WbVector3 *[ltSize];
         int creasedLinkedTriangleNumber = 0;
         int linkedTriangleNormalsIndex = 0;
-        for (int i = 0; i < ltSize; ++i) {
-          const int linkedTriangleIndex = linkedTriangles.at(i);
+        for (int j = 0; j < ltSize; ++j) {
+          const int linkedTriangleIndex = linkedTriangles.at(j);
           if (linkedTriangleIndex >= 0 && linkedTriangleIndex < mNTriangles) {
             const WbVector3 &linkedTriangleNormal = mTmpTriangleNormals[linkedTriangleIndex];
             // perform the creaseAngle check

--- a/src/webots/nodes/utils/WbTriangleMesh.cpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.cpp
@@ -260,17 +260,17 @@ void WbTriangleMesh::indicesPass(const WbMFVector3 *coord, const WbMFInt *coordI
 
   for (int i = 0; i < coordIndexSize; ++i) {
     // get the current index
-    const int idx = coordIndex->item(i);
+    const int j = coordIndex->item(i);
 
     // special case: last index not equal to -1
     // -> add a current index to the current face
     //    in order to have consistent data
-    if (idx != -1 && i == coordIndexSize - 1)
-      currentFaceIndices.append(QVector<int>() << idx << (mNormalsValid ? normalIndex->item(i) : 0)
+    if (j != -1 && i == coordIndexSize - 1)
+      currentFaceIndices.append(QVector<int>() << j << (mNormalsValid ? normalIndex->item(i) : 0)
                                                << (mTextureCoordinatesValid ? texCoordIndex->item(i) : 0));
     const int cfiSize = currentFaceIndices.size();
     // add the current face
-    if (idx == -1 || i == coordIndexSize - 1) {
+    if (j == -1 || i == coordIndexSize - 1) {
       // check the validity of the current face
       // by checking if the range of the new face indices is valid
       bool currentFaceValidity = true;
@@ -409,7 +409,7 @@ void WbTriangleMesh::indicesPass(const WbMFVector3 *coord, const WbMFInt *coordI
     }
     // add a coordIndex to the currentFace
     else
-      currentFaceIndices.append(QVector<int>() << idx << (mNormalsValid ? normalIndex->item(i) : 0)
+      currentFaceIndices.append(QVector<int>() << j << (mNormalsValid ? normalIndex->item(i) : 0)
                                                << (mTextureCoordinatesValid ? texCoordIndex->item(i) : 0));
   }
 
@@ -550,12 +550,12 @@ QString WbTriangleMesh::tmpNormalsPass(const WbMFVector3 *coord, const WbMFVecto
   // 2. compute the map coordIndex->triangleIndex
   for (int t = 0; t < mNTriangles; ++t) {
     const int k = 3 * t;
-    int idx = mCoordIndices[k];
-    mTmpVertexToTriangle.insert(idx, t);
-    idx = mCoordIndices[k + 1];
-    mTmpVertexToTriangle.insert(idx, t);
-    idx = mCoordIndices[k + 2];
-    mTmpVertexToTriangle.insert(idx, t);
+    int j = mCoordIndices[k];
+    mTmpVertexToTriangle.insert(j, t);
+    j = mCoordIndices[k + 1];
+    mTmpVertexToTriangle.insert(j, t);
+    j = mCoordIndices[k + 2];
+    mTmpVertexToTriangle.insert(j, t);
   }
   return "";
 }
@@ -579,12 +579,12 @@ void WbTriangleMesh::setDefaultTextureCoordinates(const WbMFVector3 *coord) {
 
   assert(longestDimension >= 0 && secondLongestDimension >= 0);
 
-  int idx = 0;
+  int i = 0;
   WbVector3 vertices[3];
   for (int t = 0; t < mNTriangles; ++t) {  // foreach triangle
-    vertices[0] = coord->item(mCoordIndices[idx]);
-    vertices[1] = coord->item(mCoordIndices[idx + 1]);
-    vertices[2] = coord->item(mCoordIndices[idx + 2]);
+    vertices[0] = coord->item(mCoordIndices[i]);
+    vertices[1] = coord->item(mCoordIndices[i + 1]);
+    vertices[2] = coord->item(mCoordIndices[i + 2]);
 
     // compute face center and normal
     const WbVector3 edge1(vertices[1] - vertices[0]);

--- a/src/webots/nodes/utils/WbTriangleMesh.cpp
+++ b/src/webots/nodes/utils/WbTriangleMesh.cpp
@@ -589,16 +589,16 @@ void WbTriangleMesh::setDefaultTextureCoordinates(const WbMFVector3 *coord) {
     // compute face center and normal
     const WbVector3 edge1(vertices[1] - vertices[0]);
     const WbVector3 edge2(vertices[2] - vertices[0]);
-    WbVector3 normalVec(edge1.cross(edge2));
-    normalVec.normalize();
+    WbVector3 normalVector(edge1.cross(edge2));
+    normalVector.normalize();
     const WbVector3 origin((vertices[0] + vertices[1] + vertices[2]) / 3.0);
 
     // compute intersection with the bounding box
-    const WbRay faceNormal(origin, normalVec);
+    const WbRay faceNormal(origin, normalVector);
     double tmin, tmax;
     const std::pair<bool, double> result = faceNormal.intersects(minBound, maxBound, tmin, tmax);
     assert(result.first);
-    const int faceIndex = WbBox::findIntersectedFace(minBound, maxBound, origin + result.second * normalVec);
+    const int faceIndex = WbBox::findIntersectedFace(minBound, maxBound, origin + result.second * normalVector);
 
     for (int v = 0; v < 3; ++v) {  // foreach vertex
       // compute default texture mapping
@@ -612,7 +612,7 @@ void WbTriangleMesh::setDefaultTextureCoordinates(const WbMFVector3 *coord) {
       mNonRecursiveTextureCoordinates.append(uv.y());
     }
 
-    idx += 3;
+    i += 3;
   }
 }
 
@@ -629,29 +629,29 @@ void WbTriangleMesh::finalPass(const WbMFVector3 *coord, const WbMFVector3 *norm
   const int coordSize = coord->size();
 
   // populate the vertex array
-  WbVector3 vertexVec = coord->item(0);
-  mMax[X] = vertexVec.x();
-  mMax[Y] = vertexVec.y();
-  mMax[Z] = vertexVec.z();
+  WbVector3 vertexVector = coord->item(0);
+  mMax[X] = vertexVector.x();
+  mMax[Y] = vertexVector.y();
+  mMax[Z] = vertexVector.z();
   mMin[X] = mMax[X];
   mMin[Y] = mMax[Y];
   mMin[Z] = mMax[Z];
   for (int i = 0; i < coordSize; ++i) {
-    vertexVec = coord->item(i);
+    vertexVector = coord->item(i);
 
-    const double x = vertexVec.x();
+    const double x = vertexVector.x();
     if (mMax[X] < x)
       mMax[X] = x;
     else if (mMin[X] > x)
       mMin[X] = x;
 
-    const double y = vertexVec.y();
+    const double y = vertexVector.y();
     if (mMax[Y] < y)
       mMax[Y] = y;
     else if (mMin[Y] > y)
       mMin[Y] = y;
 
-    const double z = vertexVec.z();
+    const double z = vertexVector.z();
     if (mMax[Z] < z)
       mMax[Z] = z;
     else if (mMin[Z] > z)
@@ -665,8 +665,8 @@ void WbTriangleMesh::finalPass(const WbMFVector3 *coord, const WbMFVector3 *norm
   for (int t = 0; t < mNTriangles; ++t) {  // foreach triangle
     const int k = 3 * t;
     for (int v = 0; v < 3; ++v) {  // foreach vertex
-      const int idx = k + v;
-      const int indexCoord = mCoordIndices[idx];
+      const int i = k + v;
+      const int indexCoord = mCoordIndices[i];
 
       // compute the normal per vertex (from normal per triangle)
       if (!mNormalsValid || !mNormalPerVertex) {
@@ -717,7 +717,7 @@ void WbTriangleMesh::finalPass(const WbMFVector3 *coord, const WbMFVector3 *norm
         mNormals.append(triangleNormal[Z]);
         mIsNormalCreased.append(creasedLinkedTriangleNumber == ltSize);
       } else {  // normal already defined per vertex
-        const int indexNormal = mTmpNormalIndices[idx];
+        const int indexNormal = mTmpNormalIndices[i];
         if (indexNormal >= 0 && indexNormal < normalSize) {
           const WbVector3 nor(normal->item(indexNormal));
           mNormals.append(nor.x());
@@ -728,7 +728,7 @@ void WbTriangleMesh::finalPass(const WbMFVector3 *coord, const WbMFVector3 *norm
       }
 
       if (mTextureCoordinatesValid) {
-        const int indexTex = mTmpTexIndices[idx];
+        const int indexTex = mTmpTexIndices[i];
         if (indexTex >= 0 && indexTex < texCoordSize) {
           const WbVector2 tex(texCoord->item(indexTex));
           mTextureCoordinates.append(tex.x());
@@ -795,11 +795,11 @@ int WbTriangleMesh::estimateNumberOfTriangles(const WbMFInt *coordIndex) {
   int nTriangles = 0;
   int currentFaceIndicesCounter = 0;
   while (coordIndexIt.hasNext()) {
-    const int idx = coordIndexIt.next();
-    if (idx != -1 && !coordIndexIt.hasNext())
+    const int i = coordIndexIt.next();
+    if (i != -1 && !coordIndexIt.hasNext())
       ++currentFaceIndicesCounter;
 
-    if (idx == -1 || !coordIndexIt.hasNext()) {
+    if (i == -1 || !coordIndexIt.hasNext()) {
       int nCurrentFaceTriangle = qMax(0, currentFaceIndicesCounter - 2);
       nTriangles += nCurrentFaceTriangle;
       currentFaceIndicesCounter = 0;

--- a/src/webots/plugins/WbRadioPlugin.hpp
+++ b/src/webots/plugins/WbRadioPlugin.hpp
@@ -28,25 +28,28 @@ public:
   static void cleanupAndUnload();
 
   // user implemented functions in shared library
-  void init() { (*((void (*)())mFunctions[0]))(); }
-  void cleanup() { (*((void (*)())mFunctions[1]))(); }
-  int newRadio() { return (*((int (*)())mFunctions[2]))(); }
-  void deleteRadio(int id) { (*((void (*)(int))mFunctions[3]))(id); }
-  void setProtocol(int id, const char *prot) { (*((void (*)(int, const char *))mFunctions[4]))(id, prot); }
-  void setAddress(int id, const char *addr) { (*((void (*)(int, const char *))mFunctions[5]))(id, addr); }
-  void setFrequency(int id, double hz) { (*((void (*)(int, double))mFunctions[6]))(id, hz); }
-  void setChannel(int id, int channel) { (*((void (*)(int, int))mFunctions[7]))(id, channel); }
-  void setBitrate(int id, double baud) { (*((void (*)(int, double))mFunctions[8]))(id, baud); }
-  void setRxSensitivity(int id, double dBm) { (*((void (*)(int, double))mFunctions[9]))(id, dBm); }
-  void setTxPower(int id, double dBm) { (*((void (*)(int, double))mFunctions[10]))(id, dBm); }
-  void move(int id, double x, double y, double z) { (*((void (*)(int, double, double, double))mFunctions[11]))(id, x, y, z); }
+  void init() { (*(reinterpret_cast<void (*)()>(mFunctions[0])))(); }
+  void cleanup() { (*(reinterpret_cast<void (*)()>(mFunctions[1])))(); }
+  int newRadio() { return (*(reinterpret_cast<int (*)()>(mFunctions[2])))(); }
+  void deleteRadio(int id) { (*(reinterpret_cast<void (*)(int)>(mFunctions[3])))(id); }
+  void setProtocol(int id, const char *prot) { (*(reinterpret_cast<void (*)(int, const char *)>(mFunctions[4])))(id, prot); }
+  void setAddress(int id, const char *addr) { (*(reinterpret_cast<void (*)(int, const char *)>(mFunctions[5])))(id, addr); }
+  void setFrequency(int id, double hz) { (*(reinterpret_cast<void (*)(int, double)>(mFunctions[6])))(id, hz); }
+  void setChannel(int id, int channel) { (*(reinterpret_cast<void (*)(int, int)>(mFunctions[7])))(id, channel); }
+  void setBitrate(int id, double baud) { (*(reinterpret_cast<void (*)(int, double)>(mFunctions[8])))(id, baud); }
+  void setRxSensitivity(int id, double dBm) { (*(reinterpret_cast<void (*)(int, double)>(mFunctions[9])))(id, dBm); }
+  void setTxPower(int id, double dBm) { (*(reinterpret_cast<void (*)(int, double)>(mFunctions[10])))(id, dBm); }
+  void move(int id, double x, double y, double z) {
+    (*(reinterpret_cast<void (*)(int, double, double, double)>(mFunctions[11])))(id, x, y, z);
+  }
   void send(int id, const char *dest, const void *data, int size, double delay) {
-    (*((void (*)(int, const char *, const void *, int, double))mFunctions[12]))(id, dest, data, size, delay);
+    (*(reinterpret_cast<void (*)(int, const char *, const void *, int, double)>(mFunctions[12])))(id, dest, data, size, delay);
   }
   void setCallback(int id, void *userData, void (*callback)(int, const struct WebotsRadioEvent *)) {
-    (*((void (*)(int, void *, void (*)(int, const struct WebotsRadioEvent *)))mFunctions[13]))(id, userData, callback);
+    (*(reinterpret_cast<void (*)(int, void *, void (*)(int, const struct WebotsRadioEvent *))>(mFunctions[13])))(id, userData,
+                                                                                                                 callback);
   }
-  void run(double sec) { (*((void (*)(double))mFunctions[14]))(sec); }
+  void run(double sec) { (*(reinterpret_cast<void (*)(double)>(mFunctions[14])))(sec); }
 
   // constructor & destructor
   // name: name of the plugin, e.g. "omnet"

--- a/src/webots/scene_tree/WbSceneTreeModel.cpp
+++ b/src/webots/scene_tree/WbSceneTreeModel.cpp
@@ -204,10 +204,10 @@ QModelIndex WbSceneTreeModel::itemToIndex(const WbTreeItem *item) const {
 
   // create a path from the root item to the specified item
   QList<const WbTreeItem *> ancestors;
-  const WbTreeItem *parent = item;
-  while (parent) {
-    ancestors.prepend(parent);
-    parent = parent->parent();
+  const WbTreeItem *parentItem = item;
+  while (parentItem) {
+    ancestors.prepend(parentItem);
+    parentItem = parentItem->parent();
   }
 
   // traverse the model from the root index, using the above path
@@ -241,8 +241,8 @@ void WbSceneTreeModel::updateData() {
   }
 
   item->setDataRefreshNeeded(false);
-  QModelIndex index = itemToIndex(item);
-  emit dataChanged(index, index);
+  QModelIndex modelIndex = itemToIndex(item);
+  emit dataChanged(modelIndex, modelIndex);
 
   // Without the following line, some values such as MFVector2
   // were not updated correctly when modified from editor
@@ -270,9 +270,9 @@ void WbSceneTreeModel::updateItemAndChildren(WbNode *node, bool createChildren) 
 
 void WbSceneTreeModel::removeItems(int row, int count) {
   const WbTreeItem *const item = static_cast<WbTreeItem *>(sender());
-  const QModelIndex &index = itemToIndex(item);
-  emit rowsAboutToBeRemovedSoon(index, row, row + count - 1);
-  removeRows(row, count, index);
+  const QModelIndex &modelIndex = itemToIndex(item);
+  emit rowsAboutToBeRemovedSoon(modelIndex, row, row + count - 1);
+  removeRows(row, count, modelIndex);
 }
 
 bool WbSceneTreeModel::removeRows(int row, int count, const QModelIndex &parent) {
@@ -291,8 +291,8 @@ bool WbSceneTreeModel::removeRows(int row, int count, const QModelIndex &parent)
 
 void WbSceneTreeModel::insertItems(int position, int count) {
   const WbTreeItem *const item = static_cast<WbTreeItem *>(sender());
-  const QModelIndex &index = itemToIndex(item);
-  insertRows(position, count, index);
+  const QModelIndex &modelIndex = itemToIndex(item);
+  insertRows(position, count, modelIndex);
 }
 
 bool WbSceneTreeModel::insertRows(int row, int count, const QModelIndex &parent) {
@@ -353,9 +353,9 @@ QModelIndex WbSceneTreeModel::findModelIndexFromNode(WbNode *node, WbTreeItem *c
 
   const int nChild = current->childCount();
   for (int i = 0; i < nChild; ++i) {
-    QModelIndex index = findModelIndexFromNode(node, current->child(i));
-    if (index.isValid())
-      return index;
+    QModelIndex modelIndex = findModelIndexFromNode(node, current->child(i));
+    if (modelIndex.isValid())
+      return modelIndex;
   }
 
   return QModelIndex();
@@ -397,9 +397,9 @@ QModelIndex WbSceneTreeModel::findModelIndexFromField(WbField *field, WbTreeItem
 
   const int nChild = current->childCount();
   for (int i = 0; i < nChild; ++i) {
-    QModelIndex index = findModelIndexFromField(field, current->child(i));
-    if (index.isValid())
-      return index;
+    QModelIndex modelIndex = findModelIndexFromField(field, current->child(i));
+    if (modelIndex.isValid())
+      return modelIndex;
   }
 
   return QModelIndex();
@@ -412,13 +412,13 @@ QModelIndex WbSceneTreeModel::findModelIndexFromField(WbField *field, WbTreeItem
 int WbSceneTreeModel::itemToTreeIndex(WbTreeItem *item) const {
   WbTreeItem *const targetItem = item;
   bool itemFound = false;
-  int index = 0;
+  int itemIndex = 0;
   const int n = mRootItem->childCount();
 
   for (int i = 0; !itemFound && i < n; ++i)
-    treeIndex(mRootItem->child(i), targetItem, itemFound, index);
+    treeIndex(mRootItem->child(i), targetItem, itemFound, itemIndex);
 
-  return index;
+  return itemIndex;
 }
 
 void WbSceneTreeModel::treeIndex(const WbTreeItem *const currentItem, const WbTreeItem *const targetItem, bool &itemFound,
@@ -436,12 +436,12 @@ void WbSceneTreeModel::treeIndex(const WbTreeItem *const currentItem, const WbTr
 }
 
 WbTreeItem *WbSceneTreeModel::treeIndexToItem(int targetIndex) const {
-  int index = targetIndex;
+  int itemIndex = targetIndex;
   const int n = mRootItem->childCount();
 
-  for (int i = 0; (index > 0) && i < n; ++i) {
-    WbTreeItem *currentItem = treeIndexToItem(mRootItem->child(i), index);
-    if (index == 0)
+  for (int i = 0; (itemIndex > 0) && i < n; ++i) {
+    WbTreeItem *currentItem = treeIndexToItem(mRootItem->child(i), itemIndex);
+    if (itemIndex == 0)
       return currentItem;
   }
 

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -438,7 +438,7 @@ void WbTreeItem::deleteAllChildren() {
 void WbTreeItem::sfnodeChanged() {
   assert(mType == FIELD);
   WbSFNode *sfnode = static_cast<WbSFNode *>(mField->value());
-  WbNode *node = sfnode->value();
+  WbNode *nodeObject = sfnode->value();
 
   // delete previous children items
   int count = 0;
@@ -447,7 +447,7 @@ void WbTreeItem::sfnodeChanged() {
   if (count)
     emit childrenNeedDeletion(0, count);
 
-  if (node != NULL)
+  if (nodeObject != NULL)
     emit rowsInserted(0, 1);
 }
 

--- a/src/webots/sound/WbMicrosoftTextToSpeech.cpp
+++ b/src/webots/sound/WbMicrosoftTextToSpeech.cpp
@@ -107,7 +107,7 @@ qint16 *WbMicrosoftTextToSpeech::generateBufferFromText(const QString &text, int
   ULONG bytesRead = 0;
   LARGE_INTEGER zero;
   zero.QuadPart = 0;
-  char *pBuffer = (char *)malloc(sSize);
+  char *pBuffer = static_cast<char *>(malloc(sSize));
   gBaseStream->Seek(zero, STREAM_SEEK_SET, NULL);
   gBaseStream->Read(pBuffer, sSize, &bytesRead);
   gBaseStream->Seek(zero, STREAM_SEEK_SET, NULL);

--- a/src/webots/sound/WbPicoTextToSpeech.cpp
+++ b/src/webots/sound/WbPicoTextToSpeech.cpp
@@ -103,7 +103,7 @@ static void releaseSgResource() {
 static void releaseVoices() {
   if (gPicoSystem) {
     for (int i = 0; i < N_LANGUAGES; ++i)
-      pico_releaseVoiceDefinition(gPicoSystem, (pico_Char *)gLanguages[i]);
+      pico_releaseVoiceDefinition(gPicoSystem, reinterpret_cast<pico_Char *>(const_cast<char *>(gLanguages[i])));
   }
 }
 
@@ -128,7 +128,7 @@ static void createEngine(int languageIndex) {
   assert(languageIndex < N_LANGUAGES);
   int ret = 0;
   pico_Retstring outMessage;
-  if ((ret = pico_newEngine(gPicoSystem, (const pico_Char *)gLanguages[languageIndex], &gPicoEngine))) {
+  if ((ret = pico_newEngine(gPicoSystem, reinterpret_cast<const pico_Char *>(gLanguages[languageIndex]), &gPicoEngine))) {
     pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
     gError = QString("Cannot create a new pico engine (%1): %2").arg(ret).arg(outMessage);
     releaseEngine();
@@ -143,7 +143,7 @@ static void init() {
   int ret = 0;
 
   gPicoMemArea = new char[PICO_MEM_SIZE];
-  if ((ret = pico_initialize((void *)gPicoMemArea, PICO_MEM_SIZE, &gPicoSystem))) {
+  if ((ret = pico_initialize(static_cast<void *>(gPicoMemArea), PICO_MEM_SIZE, &gPicoSystem))) {
     pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
     gError = QString("Cannot initialize pico (%1): %2").arg(ret).arg(outMessage);
     terminate();
@@ -153,8 +153,8 @@ static void init() {
   // Load the text analysis Lingware resource file.
   for (int i = 0; i < N_LANGUAGES; ++i) {
     gPicoTaFileNames[i] = new pico_Char[PICO_MAX_DATAPATH_NAME_SIZE + PICO_MAX_FILE_NAME_SIZE];
-    strcpy((char *)gPicoTaFileNames[i], WbStandardPaths::resourcesPicoPath().toStdString().c_str());
-    strcat((char *)gPicoTaFileNames[i], (const char *)gPicoTaLingwares[i]);
+    strcpy(reinterpret_cast<char *>(gPicoTaFileNames[i]), WbStandardPaths::resourcesPicoPath().toStdString().c_str());
+    strcat(reinterpret_cast<char *>(gPicoTaFileNames[i]), (const char *)gPicoTaLingwares[i]);
     if ((ret = pico_loadResource(gPicoSystem, gPicoTaFileNames[i], &gPicoTaResources[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot load text analysis resource file (%1): %2").arg(ret).arg(outMessage);
@@ -164,8 +164,8 @@ static void init() {
 
     // Load the signal generation Lingware resource file.
     gPicoSgFileNames[i] = new pico_Char[PICO_MAX_DATAPATH_NAME_SIZE + PICO_MAX_FILE_NAME_SIZE];
-    strcpy((char *)gPicoSgFileNames[i], WbStandardPaths::resourcesPicoPath().toStdString().c_str());
-    strcat((char *)gPicoSgFileNames[i], (const char *)gPicoSgLingwares[i]);
+    strcpy(reinterpret_cast<char *>(gPicoSgFileNames[i]), WbStandardPaths::resourcesPicoPath().toStdString().c_str());
+    strcat(reinterpret_cast<char *>(gPicoSgFileNames[i]), (const char *)gPicoSgLingwares[i]);
     if ((ret = pico_loadResource(gPicoSystem, gPicoSgFileNames[i], &gPicoSgResources[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot load signal generation Lingware resource file (%1): %2").arg(ret).arg(outMessage);
@@ -175,7 +175,7 @@ static void init() {
 
     // Get the text analysis resource name.
     gPicoTaResourceNames[i] = new pico_Char[PICO_MAX_RESOURCE_NAME_SIZE];
-    if ((ret = pico_getResourceName(gPicoSystem, gPicoTaResources[i], (char *)gPicoTaResourceNames[i]))) {
+    if ((ret = pico_getResourceName(gPicoSystem, gPicoTaResources[i], reinterpret_cast<char *>(gPicoTaResourceNames[i])))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot get the text analysis resource name (%1): %2").arg(ret).arg(outMessage);
       cleanup();
@@ -184,7 +184,7 @@ static void init() {
 
     // Get the signal generation resource name.
     gPicoSgResourceNames[i] = new pico_Char[PICO_MAX_RESOURCE_NAME_SIZE];
-    if ((ret = pico_getResourceName(gPicoSystem, gPicoSgResources[i], (char *)gPicoSgResourceNames[i]))) {
+    if ((ret = pico_getResourceName(gPicoSystem, gPicoSgResources[i], reinterpret_cast<char *>(gPicoSgResourceNames[i])))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot get the signal generation resource name (%1): %2").arg(ret).arg(outMessage);
       cleanup();
@@ -192,7 +192,7 @@ static void init() {
     }
 
     // Create a voice definition.
-    if ((ret = pico_createVoiceDefinition(gPicoSystem, (const pico_Char *)gLanguages[i]))) {
+    if ((ret = pico_createVoiceDefinition(gPicoSystem, reinterpret_cast<const pico_Char *>(gLanguages[i])))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot create voice definition (%1): %2").arg(ret).arg(outMessage);
       cleanup();
@@ -200,7 +200,8 @@ static void init() {
     }
 
     // Add the text analysis resource to the voice.
-    if ((ret = pico_addResourceToVoiceDefinition(gPicoSystem, (const pico_Char *)gLanguages[i], gPicoTaResourceNames[i]))) {
+    if ((ret = pico_addResourceToVoiceDefinition(gPicoSystem, reinterpret_cast<const pico_Char *>(gLanguages[i]),
+                                                 gPicoTaResourceNames[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot add the text analysis resource to the voice (%1): %2").arg(ret).arg(outMessage);
       cleanup();
@@ -208,7 +209,8 @@ static void init() {
     }
 
     // Add the signal generation resource to the voice.
-    if ((ret = pico_addResourceToVoiceDefinition(gPicoSystem, (const pico_Char *)gLanguages[i], gPicoSgResourceNames[i]))) {
+    if ((ret = pico_addResourceToVoiceDefinition(gPicoSystem, reinterpret_cast<const pico_Char *>(gLanguages[i]),
+                                                 gPicoSgResourceNames[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot add the signal generation resource to the voice (%1): %2").arg(ret).arg(outMessage);
       cleanup();
@@ -325,7 +327,7 @@ qint16 *WbPicoTextToSpeech::generateBufferFromText(const QString &text, int *siz
   int status;
   QString t = toSsml(text);
   const QByteArray textUtf8 = t.toUtf8();  // seems vital: may be related to deep copy (see #4471)
-  const pico_Char *remainingTextToSent = (const pico_Char *)(textUtf8.constData());
+  const pico_Char *remainingTextToSent = reinterpret_cast<const pico_Char *>((textUtf8.constData()));
   pico_Int16 bytesSent, bytesReceived, outDataType, remainingText = textUtf8.size() + 1;
   pico_Retstring outMessage;
 
@@ -348,14 +350,14 @@ qint16 *WbPicoTextToSpeech::generateBufferFromText(const QString &text, int *siz
       while (bufferIndex + PICO_BLOCK_SIZE > bufferSize) {
         bufferSize += 1024 * 1024;  // 1 MB
         qint16 *previousBuffer = buffer;
-        buffer = (qint16 *)realloc(buffer, bufferSize);
+        buffer = static_cast<qint16 *>(realloc(buffer, bufferSize));
         if (!buffer) {  // re-allocation failed, this is required otherwise CppCheck raises an error
           free(previousBuffer);
           gError = QString("Cannot re-allocate buffer.");
           return NULL;
         }
       }
-      char *bufferPointer = ((char *)buffer) + bufferIndex;
+      char *bufferPointer = (reinterpret_cast<char *>(buffer)) + bufferIndex;
       status = pico_getData(gPicoEngine, bufferPointer, PICO_BLOCK_SIZE, &bytesReceived, &outDataType);
       if (status != PICO_STEP_BUSY && status != PICO_STEP_IDLE) {
         free(buffer);
@@ -369,7 +371,7 @@ qint16 *WbPicoTextToSpeech::generateBufferFromText(const QString &text, int *siz
   }
   gError.clear();
   *size = bufferIndex / sizeof(qint16);
-  buffer = (qint16 *)realloc(buffer, bufferIndex);  // reduce the size of the buffer to the minimum
+  buffer = static_cast<qint16 *>(realloc(buffer, bufferIndex));  // reduce the size of the buffer to the minimum
   return buffer;
 }
 

--- a/src/webots/sound/WbPicoTextToSpeech.cpp
+++ b/src/webots/sound/WbPicoTextToSpeech.cpp
@@ -154,7 +154,7 @@ static void init() {
   for (int i = 0; i < N_LANGUAGES; ++i) {
     gPicoTaFileNames[i] = new pico_Char[PICO_MAX_DATAPATH_NAME_SIZE + PICO_MAX_FILE_NAME_SIZE];
     strcpy(reinterpret_cast<char *>(gPicoTaFileNames[i]), WbStandardPaths::resourcesPicoPath().toStdString().c_str());
-    strcat(reinterpret_cast<char *>(gPicoTaFileNames[i]), (const char *)gPicoTaLingwares[i]);
+    strcat(reinterpret_cast<char *>(gPicoTaFileNames[i]), static_cast<const char *>(gPicoTaLingwares[i]));
     if ((ret = pico_loadResource(gPicoSystem, gPicoTaFileNames[i], &gPicoTaResources[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot load text analysis resource file (%1): %2").arg(ret).arg(outMessage);
@@ -165,7 +165,7 @@ static void init() {
     // Load the signal generation Lingware resource file.
     gPicoSgFileNames[i] = new pico_Char[PICO_MAX_DATAPATH_NAME_SIZE + PICO_MAX_FILE_NAME_SIZE];
     strcpy(reinterpret_cast<char *>(gPicoSgFileNames[i]), WbStandardPaths::resourcesPicoPath().toStdString().c_str());
-    strcat(reinterpret_cast<char *>(gPicoSgFileNames[i]), (const char *)gPicoSgLingwares[i]);
+    strcat(reinterpret_cast<char *>(gPicoSgFileNames[i]), static_cast<const char *>(gPicoSgLingwares[i]));
     if ((ret = pico_loadResource(gPicoSystem, gPicoSgFileNames[i], &gPicoSgResources[i]))) {
       pico_getSystemStatusMessage(gPicoSystem, ret, outMessage);
       gError = QString("Cannot load signal generation Lingware resource file (%1): %2").arg(ret).arg(outMessage);

--- a/src/webots/user_commands/WbActionManager.cpp
+++ b/src/webots/user_commands/WbActionManager.cpp
@@ -63,686 +63,686 @@ QString WbActionManager::mapControlKey() {
 }
 
 void WbActionManager::populateActions() {
-  QAction *action;
+  QAction *newAction;
   QIcon icon;
 
   /* WORLD and SIMULATION ACTIONS */
-  action = new QAction(this);
-  action->setText(tr("&New World"));
-  action->setStatusTip(tr("Create a new simulation world. (%1+Shift+N)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_N);
-  mActions[NEW_WORLD] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&New World"));
+  newAction->setStatusTip(tr("Create a new simulation world. (%1+Shift+N)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_N);
+  mActions[NEW_WORLD] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:open_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:open_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Open World..."));
-  action->setStatusTip(tr("Open an existing world file. (%1+Shift+O)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_O);
-  action->setIcon(icon);
-  mActions[OPEN_WORLD] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Open World..."));
+  newAction->setStatusTip(tr("Open an existing world file. (%1+Shift+O)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_O);
+  newAction->setIcon(icon);
+  mActions[OPEN_WORLD] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Open Sample World..."));
-  action->setStatusTip(tr("Open a sample world."));
-  action->setToolTip(action->statusTip());
-  mActions[OPEN_SAMPLE_WORLD] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Open Sample World..."));
+  newAction->setStatusTip(tr("Open a sample world."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[OPEN_SAMPLE_WORLD] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:save_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:save_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Save World"));
-  action->setStatusTip(tr("Save the current world file. (%1+Shift+S)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_S);
-  action->setIcon(icon);
-  mActions[SAVE_WORLD] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Save World"));
+  newAction->setStatusTip(tr("Save the current world file. (%1+Shift+S)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_S);
+  newAction->setIcon(icon);
+  mActions[SAVE_WORLD] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Save World &As..."));
-  action->setStatusTip(tr("Save the current world file with a new name."));
-  action->setToolTip(action->statusTip());
-  mActions[SAVE_WORLD_AS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Save World &As..."));
+  newAction->setStatusTip(tr("Save the current world file with a new name."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[SAVE_WORLD_AS] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:reload_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:reload_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Reload World"));
-  action->setStatusTip(
+  newAction = new QAction(this);
+  newAction->setText(tr("&Reload World"));
+  newAction->setStatusTip(
     tr("Reload World.\nReload the current world file and restart the simulation. (%1+Shift+R)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_R);
-  mActions[RELOAD_WORLD] = action;
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_R);
+  mActions[RELOAD_WORLD] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:reset_simulation_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:reset_simulation_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("Reset Simulation"));
-  action->setStatusTip(tr("Reset Simulation.\nRestore initial state of the simulation. (%1+Shift+T)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_T);
-  action->setIcon(icon);
-  mActions[RESET_SIMULATION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Reset Simulation"));
+  newAction->setStatusTip(tr("Reset Simulation.\nRestore initial state of the simulation. (%1+Shift+T)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_T);
+  newAction->setIcon(icon);
+  mActions[RESET_SIMULATION] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:real_time_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:real_time_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("Real-&time"));
-  action->setStatusTip(tr("Run the simulation in real-time. (%1+2)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_2);
-  action->setIcon(icon);
-  mActions[REAL_TIME] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Real-&time"));
+  newAction->setStatusTip(tr("Run the simulation in real-time. (%1+2)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_2);
+  newAction->setIcon(icon);
+  mActions[REAL_TIME] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:pause_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:pause_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Pause"));
-  action->setStatusTip(tr("Pause the simulation. (%1+0)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_0);
-  action->setIcon(icon);
-  mActions[PAUSE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Pause"));
+  newAction->setStatusTip(tr("Pause the simulation. (%1+0)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_0);
+  newAction->setIcon(icon);
+  mActions[PAUSE] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:step_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:step_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("St&ep"));
-  action->setStatusTip(tr("Execute one simulation step. (%1+1)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_1);
-  action->setIcon(icon);
-  mActions[STEP] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("St&ep"));
+  newAction->setStatusTip(tr("Execute one simulation step. (%1+1)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_1);
+  newAction->setIcon(icon);
+  mActions[STEP] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:fast_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:fast_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Fast"));
-  action->setStatusTip(tr("Run the simulation as fast as possible. (%1+3)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_3);
-  action->setIcon(icon);
-  mActions[FAST] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Fast"));
+  newAction->setStatusTip(tr("Run the simulation as fast as possible. (%1+3)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_3);
+  newAction->setIcon(icon);
+  mActions[FAST] = newAction;
 
-  action = new QAction(this);
-  action->setCheckable(true);
-  action->setShortcut(Qt::CTRL + Qt::Key_4);
-  action->setText(tr("&Rendering"));
-  mActions[RENDERING] = action;
+  newAction = new QAction(this);
+  newAction->setCheckable(true);
+  newAction->setShortcut(Qt::CTRL + Qt::Key_4);
+  newAction->setText(tr("&Rendering"));
+  mActions[RENDERING] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Unmute sound"));
-  action->setStatusTip(tr("Unmute the sound on the main audio device of the computer."));
-  action->setToolTip(action->statusTip());
+  newAction = new QAction(this);
+  newAction->setText(tr("&Unmute sound"));
+  newAction->setStatusTip(tr("Unmute the sound on the main audio device of the computer."));
+  newAction->setToolTip(newAction->statusTip());
   // the icon is inverted there to respect the other applications behavior
-  action->setIcon(QIcon("enabledIcons:sound_mute_button.png"));
-  mActions[SOUND_UNMUTE] = action;
+  newAction->setIcon(QIcon("enabledIcons:sound_mute_button.png"));
+  mActions[SOUND_UNMUTE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Mute sound"));
-  action->setStatusTip(tr("Mute the sound on the main audio device of the computer."));
-  action->setToolTip(action->statusTip());
+  newAction = new QAction(this);
+  newAction->setText(tr("&Mute sound"));
+  newAction->setStatusTip(tr("Mute the sound on the main audio device of the computer."));
+  newAction->setToolTip(newAction->statusTip());
   // the icon is inverted there to respect the other applications behavior
-  action->setIcon(QIcon("enabledIcons:sound_unmute_button.png"));
-  mActions[SOUND_MUTE] = action;
+  newAction->setIcon(QIcon("enabledIcons:sound_unmute_button.png"));
+  mActions[SOUND_MUTE] = newAction;
 
-  action = new QAction(this);
-  mActions[ANIMATION] = action;
+  newAction = new QAction(this);
+  mActions[ANIMATION] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Take Screenshot..."));
-  action->setStatusTip(tr("Save the current image of the simulation. (%1 + SHIFT + P)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_P);
-  action->setIcon(QIcon("enabledIcons:screenshot_button.png"));
-  mActions[TAKE_SCREENSHOT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Take Screenshot..."));
+  newAction->setStatusTip(tr("Save the current image of the simulation. (%1 + SHIFT + P)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_P);
+  newAction->setIcon(QIcon("enabledIcons:screenshot_button.png"));
+  mActions[TAKE_SCREENSHOT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Perspective Projection"));
-  action->setStatusTip(tr("Perspective viewing projection."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::Key_F9);
-  action->setCheckable(true);
-  mActions[PERSPECTIVE_PROJECTION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Perspective Projection"));
+  newAction->setStatusTip(tr("Perspective viewing projection."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::Key_F9);
+  newAction->setCheckable(true);
+  mActions[PERSPECTIVE_PROJECTION] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Orthographic Projection"));
-  action->setStatusTip(tr("Orthographic viewing projection."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::Key_F10);
-  action->setCheckable(true);
-  mActions[ORTHOGRAPHIC_PROJECTION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Orthographic Projection"));
+  newAction->setStatusTip(tr("Orthographic viewing projection."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::Key_F10);
+  newAction->setCheckable(true);
+  mActions[ORTHOGRAPHIC_PROJECTION] = newAction;
 
   QActionGroup *actionGroup = new QActionGroup(this);
   actionGroup->addAction(mActions[PERSPECTIVE_PROJECTION]);
   actionGroup->addAction(mActions[ORTHOGRAPHIC_PROJECTION]);
 
-  action = new QAction(this);
-  action->setText(tr("&Plain Rendering"));
-  action->setStatusTip(tr("Plain OpenGL rendering."));
-  action->setToolTip(action->statusTip());
+  newAction = new QAction(this);
+  newAction->setText(tr("&Plain Rendering"));
+  newAction->setStatusTip(tr("Plain OpenGL rendering."));
+  newAction->setToolTip(newAction->statusTip());
 #ifdef __APPLE__
-  action->setShortcut(Qt::SHIFT + Qt::Key_P);
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_P);
 #else
-  action->setShortcut(Qt::Key_F11);
+  newAction->setShortcut(Qt::Key_F11);
 #endif
-  action->setCheckable(true);
-  mActions[PLAIN_RENDERING] = action;
+  newAction->setCheckable(true);
+  mActions[PLAIN_RENDERING] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Wireframe Rendering"));
-  action->setStatusTip(tr("Rendering only the segments between the vertices."));
-  action->setToolTip(action->statusTip());
+  newAction = new QAction(this);
+  newAction->setText(tr("&Wireframe Rendering"));
+  newAction->setStatusTip(tr("Rendering only the segments between the vertices."));
+  newAction->setToolTip(newAction->statusTip());
 #ifdef __APPLE__
-  action->setShortcut(Qt::SHIFT + Qt::Key_W);
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_W);
 #else
-  action->setShortcut(Qt::Key_F12);
+  newAction->setShortcut(Qt::Key_F12);
 #endif
-  action->setCheckable(true);
-  mActions[WIREFRAME_RENDERING] = action;
+  newAction->setCheckable(true);
+  mActions[WIREFRAME_RENDERING] = newAction;
 
   actionGroup = new QActionGroup(this);
   actionGroup->addAction(mActions[PLAIN_RENDERING]);
   actionGroup->addAction(mActions[WIREFRAME_RENDERING]);
 
   // ----- optional rendering -----
-  action = new QAction(this);
-  action->setText(tr("Show &Coordinate System"));
-  action->setStatusTip(tr("Show coordinate system."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F1);
-  action->setCheckable(true);
-  mActions[COORDINATE_SYSTEM] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &Coordinate System"));
+  newAction->setStatusTip(tr("Show coordinate system."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F1);
+  newAction->setCheckable(true);
+  mActions[COORDINATE_SYSTEM] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show All &Bounding Objects"));
-  action->setStatusTip(tr("Show all bounding objects."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F2);
-  action->setCheckable(true);
-  mActions[BOUNDING_OBJECT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show All &Bounding Objects"));
+  newAction->setStatusTip(tr("Show all bounding objects."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F2);
+  newAction->setCheckable(true);
+  mActions[BOUNDING_OBJECT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Contact &Points"));
-  action->setStatusTip(tr("Show contact points and polygons."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F3);
-  action->setCheckable(true);
-  mActions[CONTACT_POINTS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Contact &Points"));
+  newAction->setStatusTip(tr("Show contact points and polygons."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F3);
+  newAction->setCheckable(true);
+  mActions[CONTACT_POINTS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Connector &Axes"));
-  action->setStatusTip(tr("Show connector axes."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F4);
-  action->setCheckable(true);
-  mActions[CONNECTOR_AXES] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Connector &Axes"));
+  newAction->setStatusTip(tr("Show connector axes."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F4);
+  newAction->setCheckable(true);
+  mActions[CONNECTOR_AXES] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show &Joint Axes"));
-  action->setStatusTip(tr("Show joint axes."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F5);
-  action->setCheckable(true);
-  mActions[JOINT_AXES] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &Joint Axes"));
+  newAction->setStatusTip(tr("Show joint axes."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F5);
+  newAction->setCheckable(true);
+  mActions[JOINT_AXES] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Range&Finder Frustums"));
-  action->setStatusTip(tr("Show range-finder frustums."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F6);
-  action->setCheckable(true);
-  mActions[RANGE_FINDER_FRUSTUMS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Range&Finder Frustums"));
+  newAction->setStatusTip(tr("Show range-finder frustums."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F6);
+  newAction->setCheckable(true);
+  mActions[RANGE_FINDER_FRUSTUMS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Lidar &Ray Paths"));
-  action->setStatusTip(tr("Show lidar rays paths."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F7);
-  action->setCheckable(true);
-  mActions[LIDAR_RAYS_PATH] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Lidar &Ray Paths"));
+  newAction->setStatusTip(tr("Show lidar rays paths."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F7);
+  newAction->setCheckable(true);
+  mActions[LIDAR_RAYS_PATH] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Lidar Point Cl&oud"));
-  action->setStatusTip(tr("Show lidar point cloud."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F8);
-  action->setCheckable(true);
-  mActions[LIDAR_POINT_CLOUD] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Lidar Point Cl&oud"));
+  newAction->setStatusTip(tr("Show lidar point cloud."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F8);
+  newAction->setCheckable(true);
+  mActions[LIDAR_POINT_CLOUD] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show &Camera Frustums"));
-  action->setStatusTip(tr("Show camera frustums."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F9);
-  action->setCheckable(true);
-  mActions[CAMERA_FRUSTUM] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &Camera Frustums"));
+  newAction->setStatusTip(tr("Show camera frustums."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F9);
+  newAction->setCheckable(true);
+  mActions[CAMERA_FRUSTUM] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show &DistanceSensor Rays"));
-  action->setStatusTip(tr("Show distance sensors rays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F10);
-  action->setCheckable(true);
-  mActions[DISTANCE_SENSOR_RAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &DistanceSensor Rays"));
+  newAction->setStatusTip(tr("Show distance sensors rays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F10);
+  newAction->setCheckable(true);
+  mActions[DISTANCE_SENSOR_RAYS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show &LightSensor Rays"));
-  action->setStatusTip(tr("Show light sensors rays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F11);
-  action->setCheckable(true);
-  mActions[LIGHT_SENSOR_RAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &LightSensor Rays"));
+  newAction->setStatusTip(tr("Show light sensors rays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F11);
+  newAction->setCheckable(true);
+  mActions[LIGHT_SENSOR_RAYS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show L&ight Positions"));
-  action->setStatusTip(tr("Show position of light sources."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F12);
-  action->setCheckable(true);
-  mActions[LIGHT_POSITIONS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show L&ight Positions"));
+  newAction->setStatusTip(tr("Show position of light sources."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F12);
+  newAction->setCheckable(true);
+  mActions[LIGHT_POSITIONS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Center of Buo&yancy"));
-  action->setStatusTip(tr("Show the center of buoyancy of a solid."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F3);
-  action->setCheckable(true);
-  mActions[CENTER_OF_BUOYANCY] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Center of Buo&yancy"));
+  newAction->setStatusTip(tr("Show the center of buoyancy of a solid."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F3);
+  newAction->setCheckable(true);
+  mActions[CENTER_OF_BUOYANCY] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show &Pen Painting Rays"));
-  action->setStatusTip(tr("Show pen painting rays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F1);
-  action->setCheckable(true);
-  mActions[PEN_PAINTING_RAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show &Pen Painting Rays"));
+  newAction->setStatusTip(tr("Show pen painting rays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F1);
+  newAction->setCheckable(true);
+  mActions[PEN_PAINTING_RAYS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Center of &Mass"));
-  action->setStatusTip(tr("Show the center of mass of a solid."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F2);
-  action->setCheckable(true);
-  mActions[CENTER_OF_MASS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Center of &Mass"));
+  newAction->setStatusTip(tr("Show the center of mass of a solid."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F2);
+  newAction->setCheckable(true);
+  mActions[CENTER_OF_MASS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show S&upport Polygon"));
-  action->setStatusTip(tr("Show the center of mass and the support polygon of a solid."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F4);
-  action->setCheckable(true);
-  mActions[SUPPORT_POLYGON] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show S&upport Polygon"));
+  newAction->setStatusTip(tr("Show the center of mass and the support polygon of a solid."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F4);
+  newAction->setCheckable(true);
+  mActions[SUPPORT_POLYGON] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show S&kin Skeleton"));
-  action->setStatusTip(tr("Turn on visual representation of skeleton used by the Skin device."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F9);
-  action->setCheckable(true);
-  mActions[SKIN_SKELETON] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show S&kin Skeleton"));
+  newAction->setStatusTip(tr("Turn on visual representation of skeleton used by the Skin device."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F9);
+  newAction->setCheckable(true);
+  mActions[SKIN_SKELETON] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Radar Frustums"));
-  action->setStatusTip(tr("Show radar frustums."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F6);
-  action->setCheckable(true);
-  mActions[RADAR_FRUSTUMS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Radar Frustums"));
+  newAction->setStatusTip(tr("Show radar frustums."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F6);
+  newAction->setCheckable(true);
+  mActions[RADAR_FRUSTUMS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Normals"));
-  action->setStatusTip(tr("Show IndexedFaceSet and Mesh nodes normals."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F5);
-  action->setCheckable(true);
-  mActions[NORMALS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Normals"));
+  newAction->setStatusTip(tr("Show IndexedFaceSet and Mesh nodes normals."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F5);
+  newAction->setCheckable(true);
+  mActions[NORMALS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Physics Clusters"));
-  action->setStatusTip(tr("Show visual representation of ODE clusters."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[PHYSICS_CLUSTERS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Physics Clusters"));
+  newAction->setStatusTip(tr("Show visual representation of ODE clusters."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[PHYSICS_CLUSTERS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Show Bounding Sphere"));
-  action->setStatusTip(tr("Show visual representaton of the selected node's bounding sphere."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[BOUNDING_SPHERE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Show Bounding Sphere"));
+  newAction->setStatusTip(tr("Show visual representaton of the selected node's bounding sphere."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[BOUNDING_SPHERE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Lock Viewpoint"));
-  action->setStatusTip(tr("Disable Viewpoint translation and rotation from 3D view."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[LOCK_VIEWPOINT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Lock Viewpoint"));
+  newAction->setStatusTip(tr("Disable Viewpoint translation and rotation from 3D view."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[LOCK_VIEWPOINT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Disable Selection"));
-  action->setStatusTip(tr("Disable selection change from 3D view."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[DISABLE_SELECTION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Disable Selection"));
+  newAction->setStatusTip(tr("Disable selection change from 3D view."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[DISABLE_SELECTION] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Disable 3D View Context Menu"));
-  action->setStatusTip(tr("Disable opening the context menu clicking on the 3D view."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[DISABLE_3D_VIEW_CONTEXT_MENU] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Disable 3D View Context Menu"));
+  newAction->setStatusTip(tr("Disable opening the context menu clicking on the 3D view."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[DISABLE_3D_VIEW_CONTEXT_MENU] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Disable Object Move"));
-  action->setStatusTip(tr("Disable moving objects from 3D view."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[DISABLE_OBJECT_MOVE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Disable Object Move"));
+  newAction->setStatusTip(tr("Disable moving objects from 3D view."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[DISABLE_OBJECT_MOVE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Disable Applying Force and Torque"));
-  action->setStatusTip(tr("Disable applying force and torque to objects from 3D view."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[DISABLE_FORCE_AND_TORQUE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Disable Applying Force and Torque"));
+  newAction->setStatusTip(tr("Disable applying force and torque to objects from 3D view."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[DISABLE_FORCE_AND_TORQUE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Disable Rendering"));
-  action->setStatusTip(tr("Disable activating the rendering."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[DISABLE_RENDERING] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Disable Rendering"));
+  newAction->setStatusTip(tr("Disable activating the rendering."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[DISABLE_RENDERING] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:insert_after_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:insert_after_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setEnabled(false);
-  action->setText(tr("&Add New"));
-  action->setStatusTip(tr("Add a new object or import an object. (%1+Shift+A)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  action->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_A);
-  mActions[ADD_NEW] = action;
+  newAction = new QAction(this);
+  newAction->setEnabled(false);
+  newAction->setText(tr("&Add New"));
+  newAction->setStatusTip(tr("Add a new object or import an object. (%1+Shift+A)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  newAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_A);
+  mActions[ADD_NEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:delete_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:delete_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setEnabled(false);
-  action->setText(tr("&Delete"));
-  action->setStatusTip(tr("Delete the selected object. (Del)"));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::Key_Delete);
-  action->setIcon(icon);
-  action->setProperty("kind", DEL);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[DEL] = action;
+  newAction = new QAction(this);
+  newAction->setEnabled(false);
+  newAction->setText(tr("&Delete"));
+  newAction->setStatusTip(tr("Delete the selected object. (Del)"));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::Key_Delete);
+  newAction->setIcon(icon);
+  newAction->setProperty("kind", DEL);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[DEL] = newAction;
 
   /* GENERAL ACTIONS  */
   icon = QIcon();
   icon.addFile("enabledIcons:cut_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:cut_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setEnabled(false);
-  action->setText(tr("C&ut"));
-  action->setStatusTip(tr("Cut object at the selected line. (%1+X)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcuts(QKeySequence::Cut);
-  action->setIcon(icon);
-  action->setProperty("kind", CUT);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[CUT] = action;
+  newAction = new QAction(this);
+  newAction->setEnabled(false);
+  newAction->setText(tr("C&ut"));
+  newAction->setStatusTip(tr("Cut object at the selected line. (%1+X)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcuts(QKeySequence::Cut);
+  newAction->setIcon(icon);
+  newAction->setProperty("kind", CUT);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[CUT] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:copy_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:copy_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setEnabled(false);
-  action->setText(tr("&Copy"));
-  action->setStatusTip(tr("Copy object at the selected line. (%1+C)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcuts(QKeySequence::Copy);
-  action->setIcon(icon);
-  action->setProperty("kind", COPY);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[COPY] = action;
+  newAction = new QAction(this);
+  newAction->setEnabled(false);
+  newAction->setText(tr("&Copy"));
+  newAction->setStatusTip(tr("Copy object at the selected line. (%1+C)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcuts(QKeySequence::Copy);
+  newAction->setIcon(icon);
+  newAction->setProperty("kind", COPY);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[COPY] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:paste_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:paste_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setEnabled(false);
-  action->setText(tr("&Paste"));
-  action->setStatusTip(tr("Paste or insert the clipboard object. (%1+V)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcuts(QKeySequence::Paste);
-  action->setIcon(icon);
-  action->setProperty("kind", PASTE);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[PASTE] = action;
+  newAction = new QAction(this);
+  newAction->setEnabled(false);
+  newAction->setText(tr("&Paste"));
+  newAction->setStatusTip(tr("Paste or insert the clipboard object. (%1+V)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcuts(QKeySequence::Paste);
+  newAction->setIcon(icon);
+  newAction->setProperty("kind", PASTE);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[PASTE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Select &All"));
-  action->setStatusTip(tr("Select all text. (%1+A)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(QKeySequence::SelectAll);
-  action->setProperty("kind", SELECT_ALL);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[SELECT_ALL] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Select &All"));
+  newAction->setStatusTip(tr("Select all text. (%1+A)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(QKeySequence::SelectAll);
+  newAction->setProperty("kind", SELECT_ALL);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[SELECT_ALL] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Undo"));
-  action->setStatusTip(tr("Undo manual modification to the simulation world and edited text. (%1+Z)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcuts(QKeySequence::Undo);
-  action->setProperty("kind", UNDO);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[UNDO] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Undo"));
+  newAction->setStatusTip(tr("Undo manual modification to the simulation world and edited text. (%1+Z)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcuts(QKeySequence::Undo);
+  newAction->setProperty("kind", UNDO);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[UNDO] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Redo"));
-  action->setStatusTip(tr("Redo manual modification to the simulation world and edited text. (%1+Y)").arg(mapControlKey()));
-  action->setToolTip(action->statusTip());
-  action->setShortcuts(QKeySequence::Redo);
-  action->setProperty("kind", REDO);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[REDO] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Redo"));
+  newAction->setStatusTip(tr("Redo manual modification to the simulation world and edited text. (%1+Y)").arg(mapControlKey()));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcuts(QKeySequence::Redo);
+  newAction->setProperty("kind", REDO);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[REDO] = newAction;
 
   /* TEXT EDIT ACTIONS  */
 
   icon = QIcon();
   icon.addFile("enabledIcons:new_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:new_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&New Text File"));
-  action->setStatusTip(tr("Create a new text file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_N);
-  action->setIcon(icon);
-  mActions[NEW_FILE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&New Text File"));
+  newAction->setStatusTip(tr("Create a new text file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_N);
+  newAction->setIcon(icon);
+  mActions[NEW_FILE] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:open_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:open_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Open Text File..."));
-  action->setStatusTip(tr("Open an existing text file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_O);
-  action->setIcon(icon);
-  mActions[OPEN_FILE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Open Text File..."));
+  newAction->setStatusTip(tr("Open an existing text file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_O);
+  newAction->setIcon(icon);
+  mActions[OPEN_FILE] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:save_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:save_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Save Text File"));
-  action->setStatusTip(tr("Save the current text file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_S);
-  action->setIcon(icon);
-  mActions[SAVE_FILE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Save Text File"));
+  newAction->setStatusTip(tr("Save the current text file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_S);
+  newAction->setIcon(icon);
+  mActions[SAVE_FILE] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:save_as_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:save_as_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("Save Text File &As..."));
-  action->setStatusTip(tr("Save the current text file with a new name."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  mActions[SAVE_FILE_AS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Save Text File &As..."));
+  newAction->setStatusTip(tr("Save the current text file with a new name."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  mActions[SAVE_FILE_AS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Save All Text Files"));
-  action->setStatusTip(tr("Save all the opened text files."));
-  action->setToolTip(action->statusTip());
-  mActions[SAVE_ALL_FILES] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Save All Text Files"));
+  newAction->setStatusTip(tr("Save all the opened text files."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[SAVE_ALL_FILES] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:reload_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:reload_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Revert Text File"));
-  action->setStatusTip(tr("Revert the current text file."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  action->setShortcut(Qt::CTRL + Qt::Key_R);
-  mActions[REVERT_FILE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Revert Text File"));
+  newAction->setStatusTip(tr("Revert the current text file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  newAction->setShortcut(Qt::CTRL + Qt::Key_R);
+  mActions[REVERT_FILE] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:find_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:find_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Find..."));
-  action->setStatusTip(tr("Find text in current file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_F);
-  action->setIcon(icon);
-  action->setProperty("kind", FIND);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[FIND] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Find..."));
+  newAction->setStatusTip(tr("Find text in current file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_F);
+  newAction->setIcon(icon);
+  newAction->setProperty("kind", FIND);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[FIND] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Find &Next"));
-  action->setStatusTip(tr("Find next occurence of search string in current file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_G);
-  action->setProperty("kind", FIND_NEXT);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[FIND_NEXT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Find &Next"));
+  newAction->setStatusTip(tr("Find next occurence of search string in current file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_G);
+  newAction->setProperty("kind", FIND_NEXT);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[FIND_NEXT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Find &Previous"));
-  action->setStatusTip(tr("Find previous occurence of search string in current file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_G);
-  action->setProperty("kind", FIND_PREVIOUS);
-  connect(action, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
-  mActions[FIND_PREVIOUS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Find &Previous"));
+  newAction->setStatusTip(tr("Find previous occurence of search string in current file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_G);
+  newAction->setProperty("kind", FIND_PREVIOUS);
+  connect(newAction, &QAction::triggered, this, &WbActionManager::dispatchUserCommand);
+  mActions[FIND_PREVIOUS] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:replace_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:replace_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Replace..."));
-  action->setStatusTip(tr("Replace text in current file."));
-  action->setToolTip(action->statusTip());
+  newAction = new QAction(this);
+  newAction->setText(tr("&Replace..."));
+  newAction->setStatusTip(tr("Replace text in current file."));
+  newAction->setToolTip(newAction->statusTip());
 #ifdef __APPLE__  // on Mac, CTRL+H is a system shortcut to hide the window
-  action->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_F);
+  newAction->setShortcut(Qt::CTRL + Qt::ALT + Qt::Key_F);
 #else
-  action->setShortcut(Qt::CTRL + Qt::Key_H);
+  newAction->setShortcut(Qt::CTRL + Qt::Key_H);
 #endif
-  action->setIcon(icon);
-  mActions[REPLACE] = action;
+  newAction->setIcon(icon);
+  mActions[REPLACE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Go to line..."));
-  action->setStatusTip(tr("Go to specified line number."));
-  action->setToolTip(action->statusTip());
-  mActions[GO_TO_LINE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Go to line..."));
+  newAction->setStatusTip(tr("Go to specified line number."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[GO_TO_LINE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Toggle Line Comment") + "    ");  // add spaces because the spacing between the menu text
+  newAction = new QAction(this);
+  newAction->setText(tr("&Toggle Line Comment") + "    ");  // add spaces because the spacing between the menu text
   // and the hotkey text does not expand to adjust for the text length
-  action->setStatusTip(tr("Toggle comment of selected lines."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_Slash);
-  mActions[TOGGLE_LINE_COMMENT] = action;
+  newAction->setStatusTip(tr("Toggle comment of selected lines."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_Slash);
+  mActions[TOGGLE_LINE_COMMENT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Print..."));
-  action->setStatusTip(tr("Print text file."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_P);
-  mActions[PRINT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Print..."));
+  newAction->setStatusTip(tr("Print text file."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_P);
+  mActions[PRINT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Print Preview..."));
-  action->setStatusTip(tr("Preview of printed text file."));
-  action->setToolTip(action->statusTip());
-  mActions[PRINT_PREVIEW] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Print Preview..."));
+  newAction->setStatusTip(tr("Preview of printed text file."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[PRINT_PREVIEW] = newAction;
 
   /* CONSOLE ACTIONS */
-  action = new QAction(this);
-  action->setText(tr("&Clear All Consoles"));
-  action->setStatusTip(tr("Clears all the Consoles."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_K);
-  mActions[CLEAR_CONSOLE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Clear All Consoles"));
+  newAction->setStatusTip(tr("Clears all the Consoles."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_K);
+  mActions[CLEAR_CONSOLE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&New Console"));
-  action->setStatusTip(tr("Opens a new Console."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::CTRL + Qt::Key_N);
-  mActions[NEW_CONSOLE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&New Console"));
+  newAction->setStatusTip(tr("Opens a new Console."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::CTRL + Qt::Key_N);
+  mActions[NEW_CONSOLE] = newAction;
 
   /* VIEWPOINT ACTIONS */
 
-  action = new QAction(this);
-  action->setText(tr("&None"));
-  action->setStatusTip(tr("Do not follow the object."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[FOLLOW_NONE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&None"));
+  newAction->setStatusTip(tr("Do not follow the object."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[FOLLOW_NONE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Tracking Shot"));
-  action->setStatusTip(tr("Translate the camera to follow the object."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::Key_F5);
-  action->setCheckable(true);
-  mActions[FOLLOW_TRACKING] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Tracking Shot"));
+  newAction->setStatusTip(tr("Translate the camera to follow the object."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::Key_F5);
+  newAction->setCheckable(true);
+  mActions[FOLLOW_TRACKING] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Mounted Shot"));
-  action->setStatusTip(tr("Translate and rotate the camera to follow the object."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F5);
-  action->setCheckable(true);
-  mActions[FOLLOW_MOUNTED] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Mounted Shot"));
+  newAction->setStatusTip(tr("Translate and rotate the camera to follow the object."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F5);
+  newAction->setCheckable(true);
+  mActions[FOLLOW_MOUNTED] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Pan and Tilt Shot"));
-  action->setStatusTip(tr("Rotate the camera to always look at the object center."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F7);
-  action->setCheckable(true);
-  mActions[FOLLOW_PAN_AND_TILT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Pan and Tilt Shot"));
+  newAction->setStatusTip(tr("Rotate the camera to always look at the object center."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F7);
+  newAction->setCheckable(true);
+  mActions[FOLLOW_PAN_AND_TILT] = newAction;
 
   actionGroup->addAction(mActions[FOLLOW_NONE]);
   actionGroup->addAction(mActions[FOLLOW_TRACKING]);
@@ -752,278 +752,278 @@ void WbActionManager::populateActions() {
   icon = QIcon();
   icon.addFile("enabledIcons:move_viewpoint_to_object_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:move_viewpoint_to_object_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Move Viewpoint to Object"));
+  newAction = new QAction(this);
+  newAction->setText(tr("&Move Viewpoint to Object"));
 #ifdef __APPLE__  // on Mac, CTRL+H is a system shortcut to hide the window
-  action->setStatusTip(tr("Move viewpoint to selected object. (CTRL + ALT + 5)"));
+  newAction->setStatusTip(tr("Move viewpoint to selected object. (CTRL + ALT + 5)"));
 #else
-  action->setStatusTip(tr("Move viewpoint to selected object. (ALT + 5)"));
+  newAction->setStatusTip(tr("Move viewpoint to selected object. (ALT + 5)"));
 #endif
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_5);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_5);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_5);
+  newAction->setShortcut(Qt::ALT + Qt::Key_5);
 #endif
-  mActions[MOVE_VIEWPOINT_TO_OBJECT] = action;
+  mActions[MOVE_VIEWPOINT_TO_OBJECT] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:front_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:front_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Change View"));
-  action->setStatusTip(tr("Open standard Viewpoint positions menu."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  mActions[VIEW_MENU] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Change View"));
+  newAction->setStatusTip(tr("Open standard Viewpoint positions menu."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  mActions[VIEW_MENU] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:restore_viewpoint_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:restore_viewpoint_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("Restore &Viewpoint"));
-  action->setStatusTip(tr("Restore the initial Viewpoint position and orientation. (CTRL + SHIFT + V)"));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  action->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_V);
-  mActions[RESTORE_VIEWPOINT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Restore &Viewpoint"));
+  newAction->setStatusTip(tr("Restore the initial Viewpoint position and orientation. (CTRL + SHIFT + V)"));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  newAction->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_V);
+  mActions[RESTORE_VIEWPOINT] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:front_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:front_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Front View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the front."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Front View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the front."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_2);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_2);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_2);
+  newAction->setShortcut(Qt::ALT + Qt::Key_2);
 #endif
-  mActions[FRONT_VIEW] = action;
+  mActions[FRONT_VIEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:back_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:back_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Back View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the back."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Back View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the back."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_8);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_8);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_8);
+  newAction->setShortcut(Qt::ALT + Qt::Key_8);
 #endif
-  mActions[BACK_VIEW] = action;
+  mActions[BACK_VIEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:left_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:left_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Left View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the left."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Left View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the left."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_4);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_4);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_4);
+  newAction->setShortcut(Qt::ALT + Qt::Key_4);
 #endif
-  mActions[LEFT_VIEW] = action;
+  mActions[LEFT_VIEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:right_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:right_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Right View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the right."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Right View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the right."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_6);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_6);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_6);
+  newAction->setShortcut(Qt::ALT + Qt::Key_6);
 #endif
-  mActions[RIGHT_VIEW] = action;
+  mActions[RIGHT_VIEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:top_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:top_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Top View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the top."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Top View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the top."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_1);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_1);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_1);
+  newAction->setShortcut(Qt::ALT + Qt::Key_1);
 #endif
-  mActions[TOP_VIEW] = action;
+  mActions[TOP_VIEW] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:bottom_view.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:bottom_view.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Bottom View"));
-  action->setStatusTip(tr("Move Viewpoint to see object from the bottom."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
+  newAction = new QAction(this);
+  newAction->setText(tr("&Bottom View"));
+  newAction->setStatusTip(tr("Move Viewpoint to see object from the bottom."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
 #ifdef __APPLE__
-  action->setShortcut(Qt::META + Qt::ALT + Qt::Key_7);
+  newAction->setShortcut(Qt::META + Qt::ALT + Qt::Key_7);
 #else
-  action->setShortcut(Qt::ALT + Qt::Key_7);
+  newAction->setShortcut(Qt::ALT + Qt::Key_7);
 #endif
-  mActions[BOTTOM_VIEW] = action;
+  mActions[BOTTOM_VIEW] = newAction;
 
   /* OVERLAY ACTIONS */
-  action = new QAction(this);
-  action->setText(tr("Hide All &Camera Overlays"));
-  action->setStatusTip(tr("Hide all camera overlays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F10);
-  action->setCheckable(true);
-  mActions[HIDE_ALL_CAMERA_OVERLAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Hide All &Camera Overlays"));
+  newAction->setStatusTip(tr("Hide all camera overlays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F10);
+  newAction->setCheckable(true);
+  mActions[HIDE_ALL_CAMERA_OVERLAYS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Hide All &RangeFinder Overlays"));
-  action->setStatusTip(tr("Hide all range-finder overlays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F11);
-  action->setCheckable(true);
-  mActions[HIDE_ALL_RANGE_FINDER_OVERLAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Hide All &RangeFinder Overlays"));
+  newAction->setStatusTip(tr("Hide all range-finder overlays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F11);
+  newAction->setCheckable(true);
+  mActions[HIDE_ALL_RANGE_FINDER_OVERLAYS] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Hide All &Display Overlays"));
-  action->setStatusTip(tr("Hide all display overlays."));
-  action->setToolTip(action->statusTip());
-  action->setShortcut(Qt::SHIFT + Qt::Key_F12);
-  action->setCheckable(true);
-  mActions[HIDE_ALL_DISPLAY_OVERLAYS] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Hide All &Display Overlays"));
+  newAction->setStatusTip(tr("Hide all display overlays."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setShortcut(Qt::SHIFT + Qt::Key_F12);
+  newAction->setCheckable(true);
+  mActions[HIDE_ALL_DISPLAY_OVERLAYS] = newAction;
 
   /* VIRTUAL REALITY HEADSET */
-  action = new QAction(this);
-  action->setText(tr("&Enable"));
-  action->setStatusTip(tr("View simulation in a virtual reality headset."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_ENABLE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Enable"));
+  newAction->setStatusTip(tr("View simulation in a virtual reality headset."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_ENABLE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Track headset &position"));
-  action->setStatusTip(tr("Enable virtual reality headset position tracking."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_POSITION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Track headset &position"));
+  newAction->setStatusTip(tr("Enable virtual reality headset position tracking."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_POSITION] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Track headset &orientation"));
-  action->setStatusTip(tr("Enable virtual reality headset orientation tracking."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_ORIENTATION] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Track headset &orientation"));
+  newAction->setStatusTip(tr("Enable virtual reality headset orientation tracking."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_ORIENTATION] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("View left eye"));
-  action->setStatusTip(tr("View the left eye image in the main 3D window."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_LEFT_EYE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("View left eye"));
+  newAction->setStatusTip(tr("View the left eye image in the main 3D window."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_LEFT_EYE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("View right eye"));
-  action->setStatusTip(tr("View the right eye image in the main 3D window."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_RIGHT_EYE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("View right eye"));
+  newAction->setStatusTip(tr("View the right eye image in the main 3D window."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_RIGHT_EYE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Empty view"));
-  action->setStatusTip(tr("View nothing in the main 3D window."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_NO_EYE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Empty view"));
+  newAction->setStatusTip(tr("View nothing in the main 3D window."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_NO_EYE] = newAction;
 
   actionGroup = new QActionGroup(this);
   actionGroup->addAction(mActions[VIRTUAL_REALITY_HEADSET_LEFT_EYE]);
   actionGroup->addAction(mActions[VIRTUAL_REALITY_HEADSET_RIGHT_EYE]);
   actionGroup->addAction(mActions[VIRTUAL_REALITY_HEADSET_NO_EYE]);
 
-  action = new QAction(this);
-  action->setText(tr("Anti-aliasing"));
-  action->setStatusTip(tr("Enable the anti-aliasing."));
-  action->setToolTip(action->statusTip());
-  action->setCheckable(true);
-  mActions[VIRTUAL_REALITY_HEADSET_ANTI_ALIASING] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Anti-aliasing"));
+  newAction->setStatusTip(tr("Enable the anti-aliasing."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setCheckable(true);
+  mActions[VIRTUAL_REALITY_HEADSET_ANTI_ALIASING] = newAction;
 
   /* ROBOT ACTIONS */
-  action = new QAction(tr("Edit &Controller"), this);
-  action->setShortcut(Qt::ALT + Qt::Key_C);
-  action->setStatusTip(tr("Edit controller source code."));
-  action->setToolTip(action->statusTip());
-  mActions[EDIT_CONTROLLER] = action;
+  newAction = new QAction(tr("Edit &Controller"), this);
+  newAction->setShortcut(Qt::ALT + Qt::Key_C);
+  newAction->setStatusTip(tr("Edit controller source code."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[EDIT_CONTROLLER] = newAction;
 
-  action = new QAction(tr("Show Robot &Window"), this);
-  action->setStatusTip(tr("Show the related robot window."));
-  action->setToolTip(action->statusTip());
-  mActions[SHOW_ROBOT_WINDOW] = action;
+  newAction = new QAction(tr("Show Robot &Window"), this);
+  newAction->setStatusTip(tr("Show the related robot window."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[SHOW_ROBOT_WINDOW] = newAction;
 
   /* NODE/FIELD ACTIONS */
   icon = QIcon();
   icon.addFile("enabledIcons:help_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:help_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Help..."));
-  action->setStatusTip(tr("Open &documentation for this node."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  mActions[OPEN_HELP] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Help..."));
+  newAction->setStatusTip(tr("Open &documentation for this node."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  mActions[OPEN_HELP] = newAction;
 
   icon = QIcon();
   icon.addFile("enabledIcons:reset_button.png", QSize(), QIcon::Normal);
   icon.addFile("disabledIcons:reset_button.png", QSize(), QIcon::Disabled);
-  action = new QAction(this);
-  action->setText(tr("&Reset to Default Value"));
-  action->setStatusTip(tr("Reset to default value."));
-  action->setToolTip(action->statusTip());
-  action->setIcon(icon);
-  action->setEnabled(false);
-  mActions[RESET_VALUE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Reset to Default Value"));
+  newAction->setStatusTip(tr("Reset to default value."));
+  newAction->setToolTip(newAction->statusTip());
+  newAction->setIcon(icon);
+  newAction->setEnabled(false);
+  mActions[RESET_VALUE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Export"));
-  action->setStatusTip(tr("Export this scene object."));
-  action->setToolTip(action->statusTip());
-  mActions[EXPORT_NODE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Export"));
+  newAction->setStatusTip(tr("Export this scene object."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[EXPORT_NODE] = newAction;
 
   /* PROTO ACTIONS */
 
-  action = new QAction(this);
-  action->setText(tr("&View PROTO Source"));
-  action->setStatusTip(tr("Open the PROTO file in Text Editor."));
-  action->setToolTip(action->statusTip());
-  mActions[SHOW_PROTO_SOURCE] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&View PROTO Source"));
+  newAction->setStatusTip(tr("Open the PROTO file in Text Editor."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[SHOW_PROTO_SOURCE] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("View Generated &PROTO Node"));
-  action->setStatusTip(tr("Open the temporary file generated by the template engine in Text Editor."));
-  action->setToolTip(action->statusTip());
-  mActions[SHOW_PROTO_RESULT] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("View Generated &PROTO Node"));
+  newAction->setStatusTip(tr("Open the temporary file generated by the template engine in Text Editor."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[SHOW_PROTO_RESULT] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("&Convert to Base Node(s)"));
-  action->setStatusTip(tr("Convert this PROTO node (and nested PROTO nodes) into the equivalent base node(s)."));
-  action->setToolTip(action->statusTip());
-  mActions[CONVERT_TO_BASE_NODES] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("&Convert to Base Node(s)"));
+  newAction->setStatusTip(tr("Convert this PROTO node (and nested PROTO nodes) into the equivalent base node(s)."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[CONVERT_TO_BASE_NODES] = newAction;
 
-  action = new QAction(this);
-  action->setText(tr("Convert &Root to Base Node(s)"));
-  action->setStatusTip(tr("Convert this PROTO node into the equivalent base node(s)."));
-  action->setToolTip(action->statusTip());
-  mActions[CONVERT_ROOT_TO_BASE_NODES] = action;
+  newAction = new QAction(this);
+  newAction->setText(tr("Convert &Root to Base Node(s)"));
+  newAction->setStatusTip(tr("Convert this PROTO node into the equivalent base node(s)."));
+  newAction->setToolTip(newAction->statusTip());
+  mActions[CONVERT_ROOT_TO_BASE_NODES] = newAction;
 
   assert(NACTIONS == mActions.size());
 }
@@ -1096,11 +1096,11 @@ void WbActionManager::dispatchUserCommand() {
   if (!senderAction)
     return;
 
-  QObject *focusObject = mFocusObject;
-  if (focusObject == NULL)
+  QObject *currentFocusObject = mFocusObject;
+  if (currentFocusObject == NULL)
     return;
 
-  const QString focusObjectName = focusObject->objectName();
+  const QString focusObjectName = currentFocusObject->objectName();
   WbActionKind actionKind = (WbActionKind)senderAction->property("kind").toInt();
   if (focusObjectName.isEmpty())
     return;

--- a/src/webots/vrml/WbFieldModel.cpp
+++ b/src/webots/vrml/WbFieldModel.cpp
@@ -177,7 +177,7 @@ WbValue *WbFieldModel::createValueForVrmlType(const QString &type, WbTokenizer *
 }
 
 QList<WbVariant> WbFieldModel::getAcceptedValues(const QString &type, WbTokenizer *tokenizer, const QString &worldPath) {
-  QList<WbVariant> acceptedValues;
+  QList<WbVariant> values;
   while (tokenizer->nextWord() != '}') {
     tokenizer->ungetToken();
     const WbSingleValue *singleValue =
@@ -192,10 +192,10 @@ QList<WbVariant> WbFieldModel::getAcceptedValues(const QString &type, WbTokenize
       QObject::connect(&variant, &QObject::destroyed, copy, &QObject::deleteLater);
     }
 
-    acceptedValues << variant;
+    values << variant;
     delete singleValue;
   }
-  return acceptedValues;
+  return values;
 }
 
 bool WbFieldModel::isValueAccepted(const WbValue *value, int *refusedIndex) const {

--- a/src/webots/vrml/WbFieldModel.hpp
+++ b/src/webots/vrml/WbFieldModel.hpp
@@ -94,8 +94,8 @@ private:
 
   mutable int mRefCount;
 
-  WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
-  QList<WbVariant> getAcceptedValues(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
+  static WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
+  static QList<WbVariant> getAcceptedValues(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
 };
 
 #endif

--- a/src/webots/vrml/WbFieldModel.hpp
+++ b/src/webots/vrml/WbFieldModel.hpp
@@ -94,7 +94,7 @@ private:
 
   mutable int mRefCount;
 
-  WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
+  static WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
   QList<WbVariant> getAcceptedValues(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
 };
 

--- a/src/webots/vrml/WbFieldModel.hpp
+++ b/src/webots/vrml/WbFieldModel.hpp
@@ -94,7 +94,7 @@ private:
 
   mutable int mRefCount;
 
-  static WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
+  WbValue *createValueForVrmlType(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
   QList<WbVariant> getAcceptedValues(const QString &type, WbTokenizer *tokenizer, const QString &worldPath);
 };
 

--- a/src/webots/vrml/WbMFDouble.cpp
+++ b/src/webots/vrml/WbMFDouble.cpp
@@ -56,9 +56,9 @@ void WbMFDouble::setItem(int index, double value) {
 }
 
 void WbMFDouble::setAllItems(const double *values) {
-  const int size = mVector.size();
+  const int vectorSize = mVector.size();
   bool vectorHasChanged = false;
-  for (int index = 0; index < size; index++) {
+  for (int index = 0; index < vectorSize; index++) {
     if (mVector[index] != values[index]) {
       mVector[index] = values[index];
       emit itemChanged(index);
@@ -74,8 +74,8 @@ void WbMFDouble::multiplyAllItems(double factor) {
   if (factor == 1.0)
     return;
 
-  const int size = mVector.size();
-  for (int index = 0; index < size; index++) {
+  const int vectorSize = mVector.size();
+  for (int index = 0; index < vectorSize; index++) {
     const double previousValue = mVector[index];
     if (previousValue != 0.0) {
       mVector[index] = factor * previousValue;

--- a/src/webots/vrml/WbMFNode.cpp
+++ b/src/webots/vrml/WbMFNode.cpp
@@ -167,8 +167,8 @@ bool WbMFNode::operator==(const WbMFNode &other) const {
   if (size() != other.size())
     return false;
 
-  const int size = mVector.size();
-  for (int i = 0; i < size; ++i) {
+  const int vectorSize = mVector.size();
+  for (int i = 0; i < vectorSize; ++i) {
     const WbNode *const n1 = mVector[i];
     const WbNode *const n2 = other.mVector[i];
     if (*n1 != *n2)
@@ -194,8 +194,8 @@ void WbMFNode::writeItem(WbVrmlWriter &writer, int index) const {
 }
 
 void WbMFNode::defHasChanged() {
-  const int size = mVector.size();
-  for (int i = 0; i < size; ++i)
+  const int vectorSize = mVector.size();
+  for (int i = 0; i < vectorSize; ++i)
     mVector[i]->defHasChanged();
 }
 
@@ -208,8 +208,8 @@ int WbMFNode::nodeIndex(const WbNode *node) const {
 void WbMFNode::write(WbVrmlWriter &writer) const {
   writer.writeMFStart();
   int c = 0;
-  const int size = mVector.size();
-  for (int i = 0; i < size; ++i) {
+  const int vectorSize = mVector.size();
+  for (int i = 0; i < vectorSize; ++i) {
     if (writer.isWebots() || writer.isUrdf() || mVector[i]->shallExport()) {
       if (!writer.isX3d())
         writer.writeMFSeparator(c == 0, smallSeparator(i));

--- a/src/webots/vrml/WbMFVector3.cpp
+++ b/src/webots/vrml/WbMFVector3.cpp
@@ -60,9 +60,9 @@ void WbMFVector3::rescale(const WbVector3 &scale) {
   if (sx == 1.0 && sy == 1.0 && sz == 1.0)
     return;
 
-  const int size = mVector.size();
+  const int vectorSize = mVector.size();
 
-  for (int index = 0; index < size; index++) {
+  for (int index = 0; index < vectorSize; index++) {
     const WbVector3 &previousValue = mVector[index];
     mVector[index].setXyz(sx * previousValue.x(), sy * previousValue.y(), sz * previousValue.z());
     emit itemChanged(index);
@@ -77,8 +77,8 @@ void WbMFVector3::rescaleAndTranslate(int coordinate, double scale, double trans
     return;
   }
 
-  const int size = mVector.size();
-  for (int index = 0; index < size; index++) {
+  const int vectorSize = mVector.size();
+  for (int index = 0; index < vectorSize; index++) {
     mVector[index][coordinate] = scale * mVector[index][coordinate] + translation;
     emit itemChanged(index);
   }
@@ -99,9 +99,9 @@ void WbMFVector3::rescaleAndTranslate(const WbVector3 &scale, const WbVector3 &t
   double tx = translation.x();
   double ty = translation.y();
   double tz = translation.z();
-  const int size = mVector.size();
+  const int vectorSize = mVector.size();
 
-  for (int index = 0; index < size; index++) {
+  for (int index = 0; index < vectorSize; index++) {
     const WbVector3 &previousValue = mVector[index];
     mVector[index].setXyz(sx * previousValue.x() + tx, sy * previousValue.y() + ty, sz * previousValue.z() + tz);
     emit itemChanged(index);
@@ -114,8 +114,8 @@ void WbMFVector3::translate(int coordinate, double translation) {
   if (translation == 0.0)
     return;
 
-  const int size = mVector.size();
-  for (int index = 0; index < size; index++) {
+  const int vectorSize = mVector.size();
+  for (int index = 0; index < vectorSize; index++) {
     mVector[index][coordinate] = mVector[index][coordinate] + translation;
     emit itemChanged(index);
   }
@@ -131,9 +131,9 @@ void WbMFVector3::translate(const WbVector3 &translation) {
   if (x == 0.0 && y == 0.0 && z == 0.0)
     return;
 
-  const int size = mVector.size();
+  const int vectorSize = mVector.size();
 
-  for (int index = 0; index < size; index++) {
+  for (int index = 0; index < vectorSize; index++) {
     const WbVector3 &previousValue = mVector[index];
     mVector[index].setXyz(previousValue.x() + x, previousValue.y() + y, previousValue.z() + z);
     emit itemChanged(index);

--- a/src/webots/vrml/WbSFRotation.cpp
+++ b/src/webots/vrml/WbSFRotation.cpp
@@ -20,11 +20,11 @@
 
 void WbSFRotation::readSFRotation(WbTokenizer *tokenizer, const QString &worldPath) {
   try {
-    double x = tokenizer->nextToken()->toDouble();
-    double y = tokenizer->nextToken()->toDouble();
-    double z = tokenizer->nextToken()->toDouble();
-    double angle = tokenizer->nextToken()->toDouble();
-    mValue.setAxisAngle(x, y, z, angle);
+    double xCoordinate = tokenizer->nextToken()->toDouble();
+    double yCoordinate = tokenizer->nextToken()->toDouble();
+    double zCoordinate = tokenizer->nextToken()->toDouble();
+    double angleValue = tokenizer->nextToken()->toDouble();
+    mValue.setAxisAngle(xCoordinate, yCoordinate, zCoordinate, angleValue);
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());
     tokenizer->ungetToken();  // unexpected token: keep the tokenizer coherent

--- a/src/webots/vrml/WbSFVector2.cpp
+++ b/src/webots/vrml/WbSFVector2.cpp
@@ -18,9 +18,9 @@
 
 void WbSFVector2::readSFVector2(WbTokenizer *tokenizer, const QString &worldPath) {
   try {
-    double x = tokenizer->nextToken()->toDouble();
-    double y = tokenizer->nextToken()->toDouble();
-    mValue.setXy(x, y);
+    double xCoordinate = tokenizer->nextToken()->toDouble();
+    double yCoordinate = tokenizer->nextToken()->toDouble();
+    mValue.setXy(xCoordinate, yCoordinate);
     mValue.clamp();
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());

--- a/src/webots/vrml/WbSFVector3.cpp
+++ b/src/webots/vrml/WbSFVector3.cpp
@@ -18,10 +18,10 @@
 
 void WbSFVector3::readSFVector3(WbTokenizer *tokenizer, const QString &worldPath) {
   try {
-    double x = tokenizer->nextToken()->toDouble();
-    double y = tokenizer->nextToken()->toDouble();
-    double z = tokenizer->nextToken()->toDouble();
-    mValue.setXyz(x, y, z);
+    double xCoordinate = tokenizer->nextToken()->toDouble();
+    double yCoordinate = tokenizer->nextToken()->toDouble();
+    double zCoordinate = tokenizer->nextToken()->toDouble();
+    mValue.setXyz(xCoordinate, yCoordinate, zCoordinate);
     mValue.clamp();
   } catch (...) {
     tokenizer->reportError(tr("Expected floating point value, found %1").arg(tokenizer->lastWord()), tokenizer->lastToken());

--- a/src/webots/wren/WbTesselator.cpp
+++ b/src/webots/wren/WbTesselator.cpp
@@ -84,8 +84,9 @@ static void tessError(GLenum errorCode) {
   if (errorCode == GLU_TESS_NEED_COMBINE_CALLBACK)
     errorString = QObject::tr("Tessellation Error: the contour of a face must not self-intersect.");
   else
-    errorString =
-      QObject::tr("Tessellation Error (%1): \"%2\".").arg((int)errorCode).arg((const char *)gluErrorString(errorCode));
+    errorString = QObject::tr("Tessellation Error (%1): \"%2\".")
+                    .arg((int)errorCode)
+                    .arg(reinterpret_cast<const char *>(gluErrorString(errorCode)));
 }
 
 QString WbTesselator::tesselate(const QList<QVector<int>> &indexes, const QList<WbVector3> &vertices,

--- a/src/webots/wren/WbTranslateRotateManipulator.cpp
+++ b/src/webots/wren/WbTranslateRotateManipulator.cpp
@@ -384,10 +384,10 @@ void WbTranslateRotateManipulator::updateRotationLine(const WbVector3 &begin, co
 }
 
 WbVector3 WbTranslateRotateManipulator::relativeHandlePosition(int handleNumber) const {
-  int coordinate = handleNumber % 3;
-  WbVector3 position = STANDARD_COORDINATE_VECTORS[coordinate];
+  int axis = handleNumber % 3;
+  WbVector3 position = STANDARD_COORDINATE_VECTORS[axis];
   if (handleNumber > 2)
-    position[coordinate] -= 0.1f;
+    position[axis] -= 0.1f;
 
   return position * mScale;
 }

--- a/src/webots/wren/WbWrenPostProcessingEffects.cpp
+++ b/src/webots/wren/WbWrenPostProcessingEffects.cpp
@@ -83,15 +83,15 @@ WrPostProcessingEffect *WbWrenPostProcessingEffects::lensFlare(float width, floa
 
   wr_post_processing_effect_set_drawing_index(lensFlareEffect, WbWrenRenderingContext::PP_LENS_FLARE);
 
-  WrPostProcessingEffectPass *passThrough = wr_post_processing_effect_pass_new();
-  wr_post_processing_effect_pass_set_name(passThrough, "LensFlarePassToBlend");
-  wr_post_processing_effect_pass_set_program(passThrough, WbWrenShaders::passThroughShader());
-  wr_post_processing_effect_pass_set_output_size(passThrough, width, height);
-  wr_post_processing_effect_pass_set_alpha_blending(passThrough, false);
-  wr_post_processing_effect_pass_set_input_texture_count(passThrough, 1);
-  wr_post_processing_effect_pass_set_output_texture_count(passThrough, 1);
-  wr_post_processing_effect_pass_set_output_texture_format(passThrough, 0, WR_TEXTURE_INTERNAL_FORMAT_RGBA8);
-  wr_post_processing_effect_append_pass(lensFlareEffect, passThrough);
+  WrPostProcessingEffectPass *throughPass = wr_post_processing_effect_pass_new();
+  wr_post_processing_effect_pass_set_name(throughPass, "LensFlarePassToBlend");
+  wr_post_processing_effect_pass_set_program(throughPass, WbWrenShaders::passThroughShader());
+  wr_post_processing_effect_pass_set_output_size(throughPass, width, height);
+  wr_post_processing_effect_pass_set_alpha_blending(throughPass, false);
+  wr_post_processing_effect_pass_set_input_texture_count(throughPass, 1);
+  wr_post_processing_effect_pass_set_output_texture_count(throughPass, 1);
+  wr_post_processing_effect_pass_set_output_texture_format(throughPass, 0, WR_TEXTURE_INTERNAL_FORMAT_RGBA8);
+  wr_post_processing_effect_append_pass(lensFlareEffect, throughPass);
 
   WrPostProcessingEffectPass *lensFlarePass = wr_post_processing_effect_pass_new();
   wr_post_processing_effect_pass_set_name(lensFlarePass, "LensFlare");
@@ -126,7 +126,7 @@ WrPostProcessingEffect *WbWrenPostProcessingEffects::lensFlare(float width, floa
   wr_post_processing_effect_connect(lensFlareEffect, blurPass, 0, blurPass, 1);
 
   wr_post_processing_effect_connect(lensFlareEffect, blurPass, 0, blendPass, 1);
-  wr_post_processing_effect_connect(lensFlareEffect, passThrough, 0, blendPass, 0);
+  wr_post_processing_effect_connect(lensFlareEffect, throughPass, 0, blendPass, 0);
 
   wr_post_processing_effect_set_result_program(lensFlareEffect, WbWrenShaders::passThroughShader());
 
@@ -326,15 +326,15 @@ WrPostProcessingEffect *WbWrenPostProcessingEffects::smaa(float width, float hei
   WrPostProcessingEffect *smaaEffect = wr_post_processing_effect_new();
   wr_post_processing_effect_set_drawing_index(smaaEffect, WbWrenRenderingContext::PP_SMAA);
 
-  WrPostProcessingEffectPass *passThrough = wr_post_processing_effect_pass_new();
-  wr_post_processing_effect_pass_set_name(passThrough, "LensFlarePassToBlend");
-  wr_post_processing_effect_pass_set_program(passThrough, WbWrenShaders::passThroughShader());
-  wr_post_processing_effect_pass_set_output_size(passThrough, width, height);
-  wr_post_processing_effect_pass_set_input_texture_count(passThrough, 1);
-  wr_post_processing_effect_pass_set_alpha_blending(passThrough, false);
-  wr_post_processing_effect_pass_set_output_texture_count(passThrough, 1);
-  wr_post_processing_effect_pass_set_output_texture_format(passThrough, 0, WR_TEXTURE_INTERNAL_FORMAT_RGBA8);
-  wr_post_processing_effect_append_pass(smaaEffect, passThrough);
+  WrPostProcessingEffectPass *throughPass = wr_post_processing_effect_pass_new();
+  wr_post_processing_effect_pass_set_name(throughPass, "LensFlarePassToBlend");
+  wr_post_processing_effect_pass_set_program(throughPass, WbWrenShaders::passThroughShader());
+  wr_post_processing_effect_pass_set_output_size(throughPass, width, height);
+  wr_post_processing_effect_pass_set_input_texture_count(throughPass, 1);
+  wr_post_processing_effect_pass_set_alpha_blending(throughPass, false);
+  wr_post_processing_effect_pass_set_output_texture_count(throughPass, 1);
+  wr_post_processing_effect_pass_set_output_texture_format(throughPass, 0, WR_TEXTURE_INTERNAL_FORMAT_RGBA8);
+  wr_post_processing_effect_append_pass(smaaEffect, throughPass);
 
   WrPostProcessingEffectPass *edgeDetection = wr_post_processing_effect_pass_new();
   wr_post_processing_effect_pass_set_name(edgeDetection, "EdgeDetect");
@@ -376,7 +376,7 @@ WrPostProcessingEffect *WbWrenPostProcessingEffects::smaa(float width, float hei
   wr_post_processing_effect_pass_set_output_texture_format(finalBlend, 0, WR_TEXTURE_INTERNAL_FORMAT_RGB8);
   wr_post_processing_effect_append_pass(smaaEffect, finalBlend);
 
-  wr_post_processing_effect_connect(smaaEffect, passThrough, 0, finalBlend, 0);
+  wr_post_processing_effect_connect(smaaEffect, throughPass, 0, finalBlend, 0);
   wr_post_processing_effect_connect(smaaEffect, edgeDetection, 0, weightCalculation, 0);
   wr_post_processing_effect_connect(smaaEffect, weightCalculation, 0, finalBlend, 1);
 

--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -268,22 +268,22 @@ WrTexture2d *WbWrenTextureOverlay::createIconTexture(QString filePath) {
   assert(QFileInfo(filePath).isFile());
 
   // don't read the image from disk if it's already in the cache
-  WrTexture2d *texture = wr_texture_2d_copy_from_cache(filePath.toUtf8().constData());
-  if (texture)
-    return texture;
+  WrTexture2d *imageTexture = wr_texture_2d_copy_from_cache(filePath.toUtf8().constData());
+  if (imageTexture)
+    return imageTexture;
 
   QImageReader imageReader(filePath);
   QImage image = imageReader.read().mirrored(false, true);  // account for inverted Y axis in OpenGL
   const bool isTranslucent = image.pixelFormat().alphaUsage() == QPixelFormat::UsesAlpha;
 
-  texture = wr_texture_2d_new();
-  wr_texture_set_size(WR_TEXTURE(texture), image.width(), image.height());
-  wr_texture_set_translucent(WR_TEXTURE(texture), isTranslucent);
-  wr_texture_2d_set_data(texture, reinterpret_cast<const char *>(image.bits()));
-  wr_texture_2d_set_file_path(texture, filePath.toUtf8().constData());
-  wr_texture_setup(WR_TEXTURE(texture));
+  imageTexture = wr_texture_2d_new();
+  wr_texture_set_size(WR_TEXTURE(imageTexture), image.width(), image.height());
+  wr_texture_set_translucent(WR_TEXTURE(imageTexture), isTranslucent);
+  wr_texture_2d_set_data(imageTexture, reinterpret_cast<const char *>(image.bits()));
+  wr_texture_2d_set_file_path(imageTexture, filePath.toUtf8().constData());
+  wr_texture_setup(WR_TEXTURE(imageTexture));
 
-  return texture;
+  return imageTexture;
 }
 
 void WbWrenTextureOverlay::copyDataToTexture(void *data, TextureType type, int x, int y, int width, int height) {
@@ -317,21 +317,21 @@ void WbWrenTextureOverlay::copyDataToTexture(void *data, TextureType type, int x
 void WbWrenTextureOverlay::allocateBlackImageIntoData() {
   assert(!mData);
 
-  int size = mWidth * mHeight;
+  int imageSize = mWidth * mHeight;
   switch (mTextureType) {
     case TEXTURE_TYPE_BGRA: {
-      mData = malloc(4 * size);
+      mData = malloc(4 * imageSize);
 
-      int *dataInt = (int *)mData;
-      for (int i = 0; i < size; i++)
+      int *dataInt = static_cast<int *>(mData);
+      for (int i = 0; i < imageSize; i++)
         dataInt[i] = 0xFF000000;
       break;
     }
     case TEXTURE_TYPE_DEPTH: {
-      mData = malloc(sizeof(float) * size);
+      mData = malloc(sizeof(float) * imageSize);
 
-      float *dataFloat = (float *)mData;
-      for (int i = 0; i < size; i++)
+      float *dataFloat = static_cast<float *>(mData);
+      for (int i = 0; i < imageSize; i++)
         dataFloat[i] = 0.0f;
       break;
     }
@@ -476,16 +476,16 @@ QStringList WbWrenTextureOverlay::perspective() const {
 void WbWrenTextureOverlay::restorePerspective(QStringList &perspective, bool globalOverlaysEnabled) {
   assert(perspective.size() >= 4);
 
-  bool isVisible = perspective.takeFirst() == "1";
+  bool visible = perspective.takeFirst() == "1";
   // cppcheck-suppress duplicateAssignExpression
-  double pixelSize = perspective.takeFirst().toDouble();
+  double pixelsSize = perspective.takeFirst().toDouble();
   // cppcheck-suppress duplicateAssignExpression
   double x = perspective.takeFirst().toDouble();
   // cppcheck-suppress duplicateAssignExpression
   double y = perspective.takeFirst().toDouble();
-  resize(pixelSize);
+  resize(pixelsSize);
   updatePercentagePosition(x, y);
-  setVisible(isVisible, globalOverlaysEnabled);
+  setVisible(visible, globalOverlaysEnabled);
 }
 
 /////////////////////////////////////////////////

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -22,8 +22,8 @@
 namespace wren {
 
   Font::Font() : mFaceIsInitialized(false), mError(WR_FONT_ERROR_NONE), mFontSize(0) {
-    FT_Error error = FT_Init_FreeType(&mLibrary);
-    if (error)
+    FT_Error fontError = FT_Init_FreeType(&mLibrary);
+    if (fontError)
       mError = WR_FONT_ERROR_FREETYPE_LOADING;
   }
 
@@ -36,13 +36,13 @@ namespace wren {
   unsigned char *Font::generateCharBuffer(unsigned long character, bool antiAliasing, int *width, int *rows,
                                           int *verticalOffset, int *horizontalOffset, int *transparencyFactor,
                                           int *horizontalAdvance, int *pitch) {
-    FT_Error error;
+    FT_Error fontError;
     if (antiAliasing)
-      error = FT_Load_Char(mFace, character, FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL);
+      fontError = FT_Load_Char(mFace, character, FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL);
     else
-      error = FT_Load_Char(mFace, character, FT_LOAD_RENDER | FT_LOAD_TARGET_MONO);
+      fontError = FT_Load_Char(mFace, character, FT_LOAD_RENDER | FT_LOAD_TARGET_MONO);
 
-    if (error) {
+    if (fontError) {
       mError = WR_FONT_ERROR_CHARACTER_LOADING;
       return NULL;
     }
@@ -66,10 +66,10 @@ namespace wren {
     if (mFaceIsInitialized)
       FT_Done_Face(mFace);
 
-    FT_Error error = FT_New_Face(mLibrary, filename, 0, &mFace);
-    if (error == FT_Err_Unknown_File_Format)
+    FT_Error fontError = FT_New_Face(mLibrary, filename, 0, &mFace);
+    if (fontError == FT_Err_Unknown_File_Format)
       mError = WR_FONT_ERROR_UNKNOWN_FILE_FORMAT;
-    else if (error)
+    else if (fontError)
       mError = WR_FONT_ERROR_FONT_LOADING;
 
     mFaceIsInitialized = true;
@@ -79,8 +79,8 @@ namespace wren {
     mFontSize = size;
 
     // Size is multiplied by 64 because FreeType measures font sizes in 1/64 of pixels
-    FT_Error error = FT_Set_Char_Size(mFace, mFontSize << 6, 0, 72, 0);
-    if (error)
+    FT_Error fontError = FT_Set_Char_Size(mFace, mFontSize << 6, 0, 72, 0);
+    if (fontError)
       mError = WR_FONT_ERROR_FONT_SIZE;
   }
 

--- a/src/wren/FrameBuffer.cpp
+++ b/src/wren/FrameBuffer.cpp
@@ -211,7 +211,7 @@ namespace wren {
     glReadPixels(x, (flipY ? mHeight - 1 - y : y), 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, data);
 #endif
     if (config::requiresDepthBufferDistortion()) {
-      GLfloat *fData = (GLfloat *)data;
+      GLfloat *fData = static_cast<GLfloat *>(data);
       fData[0] = fData[0] * fData[0];
     }
     glstate::bindReadFrameBuffer(currentReadFrameBuffer);

--- a/src/wren/Frustum.cpp
+++ b/src/wren/Frustum.cpp
@@ -47,8 +47,8 @@ namespace wren {
       primitive::Plane(glm::vec3(matrix[0][3] - matrix[0][2], matrix[1][3] - matrix[1][2], matrix[2][3] - matrix[2][2]),
                        matrix[3][3] - matrix[3][2]);
 
-    for (primitive::Plane &plane : mPlanes)
-      plane.normalize();
+    for (primitive::Plane &planePrimitive : mPlanes)
+      planePrimitive.normalize();
 
     computeCornersFromInverseMatrix(glm::inverse(matrix));
     computeAabb();
@@ -67,8 +67,8 @@ namespace wren {
   }
 
   bool Frustum::isInside(const primitive::Aabb &aabb) const {
-    for (const primitive::Plane &plane : mPlanes) {
-      if (!primitive::isAabbAbovePlane(plane, aabb))
+    for (const primitive::Plane &planePrimitive : mPlanes) {
+      if (!primitive::isAabbAbovePlane(planePrimitive, aabb))
         return false;
     }
 
@@ -76,8 +76,8 @@ namespace wren {
   }
 
   bool Frustum::isInside(const primitive::Sphere &sphere) const {
-    for (const primitive::Plane &plane : mPlanes) {
-      if (!primitive::isSphereAbovePlane(plane, sphere))
+    for (const primitive::Plane &planePrimitive : mPlanes) {
+      if (!primitive::isSphereAbovePlane(planePrimitive, sphere))
         return false;
     }
 

--- a/src/wren/PostProcessingEffect.cpp
+++ b/src/wren/PostProcessingEffect.cpp
@@ -46,9 +46,9 @@ namespace wren {
     mFrameBuffer->setSize(mOutputWidth, mOutputHeight);
 
     for (size_t i = 0; i < mOutputTextureFormat.size(); ++i) {
-      TextureRtt *outputTexture = TextureRtt::createTextureRtt();
-      outputTexture->setInternalFormat(mOutputTextureFormat[i]);
-      mFrameBuffer->appendOutputTexture(outputTexture);
+      TextureRtt *texture = TextureRtt::createTextureRtt();
+      texture->setInternalFormat(mOutputTextureFormat[i]);
+      mFrameBuffer->appendOutputTexture(texture);
     }
 
     // If during a shader invocation a texture is sampled and written to at the same time,
@@ -230,11 +230,11 @@ namespace wren {
     if (mInputFrameBuffer)
       mPasses.front()->setInputTexture(0, mInputFrameBuffer->outputTexture(0));
 
-    for (Pass *pass : mPasses)
-      pass->setup();
+    for (Pass *p : mPasses)
+      p->setup();
 
-    for (Pass *pass : mPasses)
-      pass->processConnections();
+    for (Pass *p : mPasses)
+      p->processConnections();
 
     printPasses();
   }
@@ -264,8 +264,8 @@ namespace wren {
     mDrawingIndex(0) {}
 
   PostProcessingEffect::~PostProcessingEffect() {
-    for (Pass *pass : mPasses)
-      Pass::deletePass(pass);
+    for (Pass *p : mPasses)
+      Pass::deletePass(p);
 
     StaticMesh::deleteMesh(mMesh);
   }

--- a/src/wren/Scene.hpp
+++ b/src/wren/Scene.hpp
@@ -110,11 +110,11 @@ namespace wren {
 
     RenderQueueIterator partitionByVisibility(RenderQueueIterator first, RenderQueueIterator last);
     RenderQueueIterator partitionByViewability(RenderQueueIterator first, RenderQueueIterator last);
-    RenderQueueIterator partitionByTranslucency(RenderQueueIterator first, RenderQueueIterator last);
-    RenderQueueIterator partitionByUseMaterial(RenderQueueIterator first, RenderQueueIterator last);
-    RenderQueueIterator partitionByStencilProgram(RenderQueueIterator first, RenderQueueIterator last);
-    RenderQueueIterator partitionByShadowReceiving(RenderQueueIterator first, RenderQueueIterator last);
-    RenderQueueIterator partitionByZOrder(RenderQueueIterator first, RenderQueueIterator last);
+    static RenderQueueIterator partitionByTranslucency(RenderQueueIterator first, RenderQueueIterator last);
+    static RenderQueueIterator partitionByUseMaterial(RenderQueueIterator first, RenderQueueIterator last);
+    static RenderQueueIterator partitionByStencilProgram(RenderQueueIterator first, RenderQueueIterator last);
+    static RenderQueueIterator partitionByShadowReceiving(RenderQueueIterator first, RenderQueueIterator last);
+    static RenderQueueIterator partitionByZOrder(RenderQueueIterator first, RenderQueueIterator last);
 
     ShadowVolumeIterator partitionShadowsByVisibility(ShadowVolumeIterator first, ShadowVolumeIterator last, LightNode *light);
 

--- a/src/wren/Skeleton.cpp
+++ b/src/wren/Skeleton.cpp
@@ -46,13 +46,13 @@ namespace wren {
   }
 
   glm::mat4 Skeleton::vertexMatrix(DynamicMesh *mesh, unsigned int vertexIndex) {
-    glm::mat4 vertMatrix(0.0f);
+    glm::mat4 m(0.0f);
     for (unsigned int boneIndex : mVertexBones[mesh][vertexIndex]) {
       SkeletonBone *bone = mBones[boneIndex];
       const float weight = bone->vertexWeight(mesh, vertexIndex);
-      vertMatrix += weight * bone->finalTransform();
+      m += weight * bone->finalTransform();
     }
-    return vertMatrix;
+    return m;
   }
 
   glm::mat4 Skeleton::matrix() const {

--- a/src/wren/Skeleton.cpp
+++ b/src/wren/Skeleton.cpp
@@ -46,13 +46,13 @@ namespace wren {
   }
 
   glm::mat4 Skeleton::vertexMatrix(DynamicMesh *mesh, unsigned int vertexIndex) {
-    glm::mat4 matrix(0.0f);
+    glm::mat4 vertMatrix(0.0f);
     for (unsigned int boneIndex : mVertexBones[mesh][vertexIndex]) {
       SkeletonBone *bone = mBones[boneIndex];
       const float weight = bone->vertexWeight(mesh, vertexIndex);
-      matrix += weight * bone->finalTransform();
+      vertMatrix += weight * bone->finalTransform();
     }
-    return matrix;
+    return vertMatrix;
   }
 
   glm::mat4 Skeleton::matrix() const {

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -61,11 +61,11 @@ namespace wren {
       if (StaticMesh::createOrRetrieveFromCache(&mesh, key))
         return mesh;
 
-      const int vertexCount = 8;
-      const int indexCount = 24;
+      const int vertexCounter = 8;
+      const int indexCounter = 24;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       mesh->addCoord(glm::vec3(0.5f, 0.5f, 0.5f));
       mesh->addCoord(glm::vec3(0.5f, 0.5f, -0.5f));
@@ -107,11 +107,11 @@ namespace wren {
       if (StaticMesh::createOrRetrieveFromCache(&mesh, key))
         return mesh;
 
-      const int vertexCount = 24;
-      const int indexCount = 36;
+      const int vertexCounter = 24;
+      const int indexCounter = 36;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       // left
       mesh->addCoord(glm::vec3(-0.5f, 0.5f, 0.5f));
@@ -225,7 +225,7 @@ namespace wren {
       mesh->addUnwrappedTexCoord(glm::vec2(0.5f, 0.5f));
 
       unsigned int i = 0;
-      while (i < vertexCount) {
+      while (i < vertexCounter) {
         mesh->addIndex(i + 0);
         mesh->addIndex(i + 1);
         mesh->addIndex(i + 2);
@@ -270,20 +270,20 @@ namespace wren {
     const float invSub = 1.0f / subdivision;
     const float k = invSub * glm::pi<float>() * 2.0f;
 
-    int vertexCount = 0;
+    int vertexCounter = 0;
     if (hasSide)
-      vertexCount += 2 * sub1;
+      vertexCounter += 2 * sub1;
     if (hasBottom)
-      vertexCount += sub1 + 1;  // circle + center
+      vertexCounter += sub1 + 1;  // circle + center
 
-    int indexCount = 0;
+    int indexCounter = 0;
     if (hasSide)
-      indexCount += subdivision * 3;
+      indexCounter += subdivision * 3;
     if (hasBottom)
-      indexCount += subdivision * 3;
+      indexCounter += subdivision * 3;
 
-    mesh->estimateVertexCount(vertexCount);
-    mesh->estimateIndexCount(indexCount);
+    mesh->estimateVertexCount(vertexCounter);
+    mesh->estimateIndexCount(indexCounter);
 
     if (hasSide) {
       float hh = 0.5f;
@@ -384,13 +384,13 @@ namespace wren {
       return mesh;
 
     if (outline) {
-      const int vertexCount = subdivision * 2;
-      const int indexCount = subdivision * 3;
+      const int vertexCounter = subdivision * 2;
+      const int indexCounter = subdivision * 3;
       const double h = 0.5;
       const double k = (2.0 * glm::pi<float>()) / subdivision;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       for (int i = 0; i < subdivision + 1; ++i) {
         const double x = glm::sin(i * k + glm::pi<float>());
@@ -404,7 +404,7 @@ namespace wren {
         mesh->addIndex(index + 1);
       }
 
-      for (int i = 0; i < vertexCount; ++i) {
+      for (int i = 0; i < vertexCounter; ++i) {
         mesh->addIndex(i);
         mesh->addIndex(i + 2);
       }
@@ -413,24 +413,24 @@ namespace wren {
       const int sub1 = subdivision + 1;
       const float h = 0.5f;
 
-      int vertexCount = 0;
+      int vertexCounter = 0;
       if (hasSide)
-        vertexCount += 2 * sub1;
+        vertexCounter += 2 * sub1;
       if (hasTop)
-        vertexCount += sub1 + 1;  // circle + center
+        vertexCounter += sub1 + 1;  // circle + center
       if (hasBottom)
-        vertexCount += sub1 + 1;  // circle + center
+        vertexCounter += sub1 + 1;  // circle + center
 
-      int indexCount = 0;
+      int indexCounter = 0;
       if (hasSide)
-        indexCount += subdivision * 6;
+        indexCounter += subdivision * 6;
       if (hasTop)
-        indexCount += subdivision * 3;
+        indexCounter += subdivision * 3;
       if (hasBottom)
-        indexCount += subdivision * 3;
+        indexCounter += subdivision * 3;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       if (hasSide) {
         // define points around cylinder
@@ -874,21 +874,21 @@ namespace wren {
       glm::uvec3(7, 10, 3), glm::uvec3(7, 6, 10), glm::uvec3(7, 11, 6), glm::uvec3(11, 0, 6), glm::uvec3(0, 1, 6),
       glm::uvec3(6, 1, 10), glm::uvec3(9, 0, 11), glm::uvec3(9, 11, 2), glm::uvec3(9, 2, 5),  glm::uvec3(7, 2, 11)};
 
-    int vertexCount;
+    int vertexCounter;
     if (subdivision == 0)
-      vertexCount = 60;
+      vertexCounter = 60;
     else
-      vertexCount = 60 * (4 << (2 * (subdivision - 1)));
+      vertexCounter = 60 * (4 << (2 * (subdivision - 1)));
 
-    mesh->estimateVertexCount(vertexCount);
-    mesh->estimateIndexCount(vertexCount);
+    mesh->estimateVertexCount(vertexCounter);
+    mesh->estimateIndexCount(vertexCounter);
 
     // iterate over all faces and apply a subdivison with the given value
     for (int i = 0; i < 20; ++i)
       subdividePolyhedronFace(mesh, &gVertices[gIndices[i].x], &gVertices[gIndices[i].y], &gVertices[gIndices[i].z],
                               subdivision);
 
-    for (int i = 0; i < vertexCount; ++i)
+    for (int i = 0; i < vertexCounter; ++i)
       mesh->addIndex(i);
 
     // bounding volumes
@@ -914,9 +914,9 @@ namespace wren {
       return mesh;
 
     const int rowSize = subdivision + 1;
-    const int vertexCount = rowSize * rowSize;
-    mesh->estimateVertexCount(vertexCount);
-    mesh->estimateIndexCount(3 * (vertexCount - 1));
+    const int vertexCounter = rowSize * rowSize;
+    mesh->estimateVertexCount(vertexCounter);
+    mesh->estimateIndexCount(3 * (vertexCounter - 1));
 
     int r, s;
     const float latitudeUnitAngle = glm::pi<float>() / subdivision;
@@ -951,7 +951,7 @@ namespace wren {
 
     // indices
     if (outline) {
-      const int lastRingIndex = vertexCount - subdivision - 1;
+      const int lastRingIndex = vertexCounter - subdivision - 1;
       for (s = 0; s < subdivision; ++s) {
         // top
         mesh->addIndex(0);
@@ -1051,18 +1051,18 @@ namespace wren {
     const float bottom = 1.0f / 3.0f;
 
     if (outline) {
-      int vertexCount = 2 + subdivision * 2;
-      vertexCount += subdivision * 2 * (sub4 - 1);
+      int vertexCounter = 2 + subdivision * 2;
+      vertexCounter += subdivision * 2 * (sub4 - 1);
 
-      int indexCount = 0;
+      int indexCounter = 0;
       // Top & bottom
-      indexCount += subdivision * 2 + ((sub4 - 1) * subdivision * 2);
-      indexCount *= 2;
+      indexCounter += subdivision * 2 + ((sub4 - 1) * subdivision * 2);
+      indexCounter *= 2;
       // Sides
-      indexCount += subdivision * 2 + subdivision * 4;
+      indexCounter += subdivision * 2 + subdivision * 4;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       const float factor = 2.0f * glm::pi<float>() / subdivision;
       float x[sub1];
@@ -1184,26 +1184,26 @@ namespace wren {
       delete[] idx;
 
     } else {
-      int vertexCount = 0;
+      int vertexCounter = 0;
       if (hasTop || hasBottom) {
-        vertexCount += sub1 * sub5;
+        vertexCounter += sub1 * sub5;
         if (hasBottom && hasTop)
-          vertexCount *= 2;
+          vertexCounter *= 2;
       }
       if (hasSide)
-        vertexCount += 2 * sub1;
+        vertexCounter += 2 * sub1;
 
-      int indexCount = 0;
+      int indexCounter = 0;
       if (hasTop || hasBottom) {
-        indexCount += subdivision * ((sub4 - 1) * 6 + 3);
+        indexCounter += subdivision * ((sub4 - 1) * 6 + 3);
         if (hasBottom && hasTop)
-          indexCount *= 2;
+          indexCounter *= 2;
       }
       if (hasSide)
-        indexCount += 6 * subdivision;
+        indexCounter += 6 * subdivision;
 
-      mesh->estimateVertexCount(vertexCount);
-      mesh->estimateIndexCount(indexCount);
+      mesh->estimateVertexCount(vertexCounter);
+      mesh->estimateIndexCount(indexCounter);
 
       if (hasSide) {
         // define points around capsule
@@ -1959,31 +1959,32 @@ namespace wren {
     // Check whether prepareGl has been called
     // (it is very unlikely that the condition will be met, but it has to be checked).
     if (mCoords.size() > 0) {
-      const int vertexCount = mCoords.size();
-      const int indexCount = mIndices.size();
+      const int vertexCounter = mCoords.size();
+      const int indexCounter = mIndices.size();
 
       if (coordData)
-        memcpy(coordData, &mCoords[0], vertexCount * sizeof(glm::vec3));
+        memcpy(coordData, &mCoords[0], vertexCounter * sizeof(glm::vec3));
       if (normalData)
-        memcpy(normalData, &mNormals[0], vertexCount * sizeof(glm::vec3));
+        memcpy(normalData, &mNormals[0], vertexCounter * sizeof(glm::vec3));
       if (texCoordData)
-        memcpy(texCoordData, &mTexCoords[0], vertexCount * sizeof(glm::vec2));
+        memcpy(texCoordData, &mTexCoords[0], vertexCounter * sizeof(glm::vec2));
       if (indexData)
-        memcpy(indexData, &mIndices[0], indexCount * sizeof(unsigned int));
+        memcpy(indexData, &mIndices[0], indexCounter * sizeof(unsigned int));
     } else {
-      const int vertexCount = mCacheData->mVertexCount;
-      const int indexCount = mCacheData->mIndexCount;
+      const int vertexCounter = mCacheData->mVertexCount;
+      const int indexCounter = mCacheData->mIndexCount;
 
       bind();
 
       if (indexData)
-        copyFromBuffer(GL_ELEMENT_ARRAY_BUFFER, mCacheData->mGlNameBufferIndices, indexCount * sizeof(unsigned int), indexData);
+        copyFromBuffer(GL_ELEMENT_ARRAY_BUFFER, mCacheData->mGlNameBufferIndices, indexCounter * sizeof(unsigned int),
+                       indexData);
       if (coordData)
-        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferCoords, vertexCount * sizeof(glm::vec3), coordData);
+        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferCoords, vertexCounter * sizeof(glm::vec3), coordData);
       if (normalData)
-        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferNormals, vertexCount * sizeof(glm::vec3), normalData);
+        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferNormals, vertexCounter * sizeof(glm::vec3), normalData);
       if (texCoordData)
-        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferTexCoords, vertexCount * sizeof(glm::vec2), texCoordData);
+        copyFromBuffer(GL_ARRAY_BUFFER, mCacheData->mGlNameBufferTexCoords, vertexCounter * sizeof(glm::vec2), texCoordData);
 
       glBindBuffer(GL_ARRAY_BUFFER, 0);
 

--- a/src/wren/Texture.cpp
+++ b/src/wren/Texture.cpp
@@ -69,11 +69,11 @@ namespace wren {
   }
 
   unsigned int Texture::generateNewTexture() {
-    unsigned int glName;
-    glGenTextures(1, &glName);
+    unsigned int glTextureName;
+    glGenTextures(1, &glTextureName);
     glstate::checkError();
-    glstate::initializeTextureParams(glName);
-    return glName;
+    glstate::initializeTextureParams(glTextureName);
+    return glTextureName;
   }
 
   void Texture::deleteTexture(Texture *texture) {

--- a/src/wren/TextureCubeMapBaker.cpp
+++ b/src/wren/TextureCubeMapBaker.cpp
@@ -98,11 +98,11 @@ namespace wren {
         // link vertex attributes
         glstate::bindVertexArrayObject(cubeVAO);
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void *)0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), reinterpret_cast<void *>(0));
         glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void *)(3 * sizeof(float)));
+        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), reinterpret_cast<void *>(3 * sizeof(float)));
         glEnableVertexAttribArray(2);
-        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void *)(6 * sizeof(float)));
+        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), reinterpret_cast<void *>(6 * sizeof(float)));
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glstate::releaseVertexArrayObject(cubeVAO);
       }
@@ -128,9 +128,9 @@ namespace wren {
         glBindBuffer(GL_ARRAY_BUFFER, quadVBO);
         glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices, GL_STATIC_DRAW);
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void *)0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), reinterpret_cast<void *>(0));
         glEnableVertexAttribArray(1);
-        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void *)(3 * sizeof(float)));
+        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), reinterpret_cast<void *>(3 * sizeof(float)));
         glBindBuffer(GL_ARRAY_BUFFER, 0);
         glstate::releaseVertexArrayObject(quadVAO);
       }

--- a/src/wren/TransformNode.cpp
+++ b/src/wren/TransformNode.cpp
@@ -82,10 +82,10 @@ namespace wren {
 
   const glm::mat4 TransformNode::relativeMatrix() const {
     glm::mat4 m;
-    m= glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z,
-                   0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
+    m = glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z, 0.0f,
+                  0.0f, 0.0f, 0.0f, 1.0f);
 
-    m= glm::mat4_cast(mOrientationRelative) * m;
+    m = glm::mat4_cast(mOrientationRelative) * m;
 
     m[3][0] = mPositionRelative.x;
     m[3][1] = mPositionRelative.y;

--- a/src/wren/TransformNode.cpp
+++ b/src/wren/TransformNode.cpp
@@ -81,17 +81,17 @@ namespace wren {
   }
 
   const glm::mat4 TransformNode::relativeMatrix() const {
-    glm::mat4 relMatrix;
-    relMatrix = glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z,
-                          0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
+    glm::mat4 m;
+    m= glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z,
+                   0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
 
-    relMatrix = glm::mat4_cast(mOrientationRelative) * relMatrix;
+    m= glm::mat4_cast(mOrientationRelative) * m;
 
-    relMatrix[3][0] = mPositionRelative.x;
-    relMatrix[3][1] = mPositionRelative.y;
-    relMatrix[3][2] = mPositionRelative.z;
+    m[3][0] = mPositionRelative.x;
+    m[3][1] = mPositionRelative.y;
+    m[3][2] = mPositionRelative.z;
 
-    return relMatrix;
+    return m;
   }
 
   TransformNode::TransformNode() :

--- a/src/wren/TransformNode.cpp
+++ b/src/wren/TransformNode.cpp
@@ -81,17 +81,17 @@ namespace wren {
   }
 
   const glm::mat4 TransformNode::relativeMatrix() const {
-    glm::mat4 matrix;
-    matrix = glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z,
-                       0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
+    glm::mat4 relMatrix;
+    relMatrix = glm::mat4(mScaleRelative.x, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.y, 0.0f, 0.0f, 0.0f, 0.0f, mScaleRelative.z,
+                          0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
 
-    matrix = glm::mat4_cast(mOrientationRelative) * matrix;
+    relMatrix = glm::mat4_cast(mOrientationRelative) * relMatrix;
 
-    matrix[3][0] = mPositionRelative.x;
-    matrix[3][1] = mPositionRelative.y;
-    matrix[3][2] = mPositionRelative.z;
+    relMatrix[3][0] = mPositionRelative.x;
+    relMatrix[3][1] = mPositionRelative.y;
+    relMatrix[3][2] = mPositionRelative.z;
 
-    return matrix;
+    return relMatrix;
   }
 
   TransformNode::TransformNode() :

--- a/src/wren/demo/default.cpp
+++ b/src/wren/demo/default.cpp
@@ -57,7 +57,7 @@ static void create_wren_scene() {
   WrTexture2d *texture = wr_texture_2d_new();
   wr_texture_2d_set_file_path(texture, "dummy.jpg");
   wr_texture_set_size(WR_TEXTURE(texture), 256, 256);
-  char *data = (char *)malloc(256 * 256 * 4);
+  char *data = static_cast<char *>(malloc(256 * 256 * 4));
   for (unsigned int d = 0; d < (256 * 256); ++d) {
     data[4 * d] = (d) % 0xff;
     data[4 * d + 1] = (d + d) % 0xff;


### PR DESCRIPTION
**Description**
Cppcheck has been upgraded to version 2.8.
On Windows, it now requires a reboot after installation, thus the source test is always failing. This PR adds a way to still continue the test despite the reboot requirement.
This PR also fixes new style and shadow function errors detected by the new version.


