### PR TITLE
Fixed compilation warning on Windows

### DIFF
--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -552,6 +552,7 @@ OTHER_SOURCES = \
   WbTriangleMesh.cpp \
   WbTriangleMeshCache.cpp \
   WbUrl.cpp \
+  WbVector3.cpp \
   WbVector4.cpp \
   WbVersion.cpp \
   WbWaveFile.cpp \

--- a/src/webots/maths/WbVector3.cpp
+++ b/src/webots/maths/WbVector3.cpp
@@ -1,0 +1,19 @@
+// Copyright 1996-2022 Cyberbotics Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "WbVector3.hpp"
+
+const double *WbVector3::ptr() const {
+  return &mX;
+}

--- a/src/webots/maths/WbVector3.hpp
+++ b/src/webots/maths/WbVector3.hpp
@@ -46,7 +46,7 @@ public:
   }
 
   // pointer representation
-  const double *ptr() const { return &mX; }
+  const double *ptr() const;
 
   // getters
   double x() const { return mX; }


### PR DESCRIPTION
I was getting this compilation warning on Windows:
```
nodes/WbConnector.cpp: In member function 'void WbConnector::snapOrigins(WbConnector*)':
nodes/WbConnector.cpp:377:44: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  377 |     dBodySetPosition(b1, d1[0] + h[0], d1[1] + h[1], d1[2] + h[2]);
      |                                        ~~~~^
nodes/WbConnector.cpp:365:69: note: unnamed temporary defined here
  365 |   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~^~
nodes/WbConnector.cpp:377:58: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  377 |     dBodySetPosition(b1, d1[0] + h[0], d1[1] + h[1], d1[2] + h[2]);
      |                                                      ~~~~^
nodes/WbConnector.cpp:365:69: note: unnamed temporary defined here
  365 |   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~^~
nodes/WbConnector.cpp:377:30: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  377 |     dBodySetPosition(b1, d1[0] + h[0], d1[1] + h[1], d1[2] + h[2]);
      |                          ~~~~^
nodes/WbConnector.cpp:365:69: note: unnamed temporary defined here
  365 |   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~^~
nodes/WbConnector.cpp:379:44: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  379 |     dBodySetPosition(b2, d2[0] - h[0], d2[1] - h[1], d2[2] - h[2]);
      |                                        ~~~~^
nodes/WbConnector.cpp:366:76: note: unnamed temporary defined here
  366 |   const dReal *d2 = b2 ? dBodyGetPosition(b2) : other->matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
nodes/WbConnector.cpp:379:58: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  379 |     dBodySetPosition(b2, d2[0] - h[0], d2[1] - h[1], d2[2] - h[2]);
      |                                                      ~~~~^
nodes/WbConnector.cpp:366:76: note: unnamed temporary defined here
  366 |   const dReal *d2 = b2 ? dBodyGetPosition(b2) : other->matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
nodes/WbConnector.cpp:379:30: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  379 |     dBodySetPosition(b2, d2[0] - h[0], d2[1] - h[1], d2[2] - h[2]);
      |                          ~~~~^
nodes/WbConnector.cpp:366:76: note: unnamed temporary defined here
  366 |   const dReal *d2 = b2 ? dBodyGetPosition(b2) : other->matrix().translation().ptr();
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

This PR fixes it.