### PR TITLE
Fix SWIG deprecation warning with Python 3.10 on Windows

### DIFF
--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -48,6 +48,9 @@ C_FLAGS         = -c -O -Wall -Wno-maybe-uninitialized
 ifeq ($(PYTHON_SHORT_VERSION),39)
 C_FLAGS          += -Wno-deprecated-declarations
 endif
+ifeq ($(PYTHON_SHORT_VERSION),310)
+C_FLAGS          += -Wno-deprecated-declarations
+endif
 LD_FLAGS        = -shared
 LIBS            = -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION) -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController -lCppController
 LIBOUT          = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/_,$(INTERFACE:.i=.pyd))


### PR DESCRIPTION
When compiling the python 3.10 controller on the CI on Windows the following warning is printed in the log:
```
# Python 3.10 controller library (release)
#
# generating D:/a/webots/webots/lib/controller/python310/controller.py
# generating controller310.cpp
# compiling controller310.cpp
controller310.cpp: In function 'PyObject* PyInit__controller()':
controller310.cpp:984:64: warning: 'void PyEval_InitThreads()' is deprecated [-Wdeprecated-declarations]
  984 | #     define SWIG_PYTHON_INITIALIZE_THREADS  PyEval_InitThreads()
      |                                              ~~~~~~~~~~~~~~~~~~^~
controller310.cpp:27471:3: note: in expansion of macro 'SWIG_PYTHON_INITIALIZE_THREADS'
27471 |   SWIG_PYTHON_INITIALIZE_THREADS;
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from C:/hostedtoolcache/windows/Python/3.10.4/x64/include/Python.h:130,
                 from controller310.cpp:182:
C:/hostedtoolcache/windows/Python/3.10.4/x64/include/ceval.h:122:37: note: declared here
  122 | Py_DEPRECATED(3.9) PyAPI_FUNC(void) PyEval_InitThreads(void);
      |                                     ^~~~~~~~~~~~~~~~~~
# linking D:/a/webots/webots/lib/controller/python310/_controller.pyd
#
```