### PR TITLE
Fix compilation on Windows CI

### DIFF
--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -372,9 +372,9 @@ void WbConnector::snapOrigins(WbConnector *other) {
       h[i] /= 2.0;
   }
 
-// gcc 12.1.0 on Windows is raising a false positive warning here about dangling pointers
+// gcc 12.1.0 is raising a false positive warning here about dangling pointers
 #pragma GCC diagnostic push
-#ifdef _WIN32
+#if __GNUC__ == 12 && __GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ == 0
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
   // shift bodies


### PR DESCRIPTION
It seems the buggy `-Wdangling-pointer` warning was introduced in [gcc 12.1.0](https://gcc.gnu.org/onlinedocs/gcc-12.1.0/gcc/Warning-Options.html) as compared to [gcc 11.3.0](https://gcc.gnu.org/onlinedocs/gcc-11.3.0/gcc/Warning-Options.html#Warning-Options) which is not yet present on the Windows CI machines. I prefer to make a strict test on gcc 12.1.0 to be able to detect when we can get rid of these pragmas after a gcc update.