### PR TITLE
Trigger release only on nightly and release tags

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -7,7 +7,8 @@ on:
     - cron:  '0 23 * * *'
   push:
     tags:
-      - '*'
+      - nightly_*
+      - r20*
 
 defaults:
   run:

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -7,7 +7,8 @@ on:
     - cron:  '0 23 * * *'
   push:
     tags:
-      - '*'
+      - nightly_*
+      - r20*
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -7,7 +7,8 @@ on:
     - cron:  '0 23 * * *'
   push:
     tags:
-      - '*'
+      - nightly_*
+      - r20*
 
 defaults:
   run:


### PR DESCRIPTION
This is done to allow other tags to be created without publishing a release

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags