### PR TITLE
Fix path to appdmg.json file

### DIFF
--- a/scripts/packaging/mac_distro.py
+++ b/scripts/packaging/mac_distro.py
@@ -155,7 +155,7 @@ class MacWebotsPackage(WebotsPackage):
                   f"{self.distribution_path}/{self.application_name_lowercase_and_dashes}-{self.package_version}.dmg")
 
         # clear distribution folder
-        remove_force('appdmg.json')
+        remove_force(f"{self.distribution_path}/appdmg.json")
 
         print('Done.\n')
 


### PR DESCRIPTION
Fix remove of `appdmg.json` linking to the wrong path.
After correctly removing it, the `appdmg.json` should no longer appear in the release page.

https://github.com/cyberbotics/webots/releases/tag/nightly_6_6_2022