### PR TITLE
Fix cadshape with .mtl spaced name

### DIFF
--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -285,8 +285,8 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
       if (!cleanLine.startsWith("mtllib"))
         continue;
 
-      cleanLine = cleanLine.replace("mtllib", "");
-      materials << cleanLine.split(' ', Qt::SkipEmptyParts);
+      cleanLine = cleanLine.replace("mtllib ", "");
+      materials << cleanLine;
     }
   } else
     warn(tr("File '%1' cannot be read.").arg(url));

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -286,6 +286,7 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
         continue;
 
       cleanLine = cleanLine.replace("mtllib ", "").trimmed();
+      cleanLine = cleanLine.replace("\"", "");
       materials << cleanLine.split(".mtl ", Qt::SkipEmptyParts);
       for (int i = 0; i < materials.size() - 1; i++)  // the last item still have '.mtl'
         materials[i] += ".mtl";

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -286,8 +286,8 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
         continue;
 
       cleanLine = cleanLine.replace("mtllib ", "");
-      materials << cleanLine.split(".mtl", Qt::SkipEmptyParts);
-      for (int i = 0; i < materials.size(); i++)
+      materials << cleanLine.split(".mtl ", Qt::SkipEmptyParts);
+      for (int i = 0; i < materials.size() - 1; i++)  // the last item still have '.mtl'
         materials[i] += ".mtl";
     }
   } else

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -286,7 +286,9 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
         continue;
 
       cleanLine = cleanLine.replace("mtllib ", "");
-      materials << cleanLine;
+      materials << cleanLine.split(".mtl", Qt::SkipEmptyParts);
+      for (int i = 0; i < materials.size(); i++)
+        materials[i] += ".mtl";
     }
   } else
     warn(tr("File '%1' cannot be read.").arg(url));

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -285,7 +285,7 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
       if (!cleanLine.startsWith("mtllib"))
         continue;
 
-      cleanLine = cleanLine.replace("mtllib ", "");
+      cleanLine = cleanLine.replace("mtllib ", "").trimmed();
       materials << cleanLine.split(".mtl ", Qt::SkipEmptyParts);
       for (int i = 0; i < materials.size() - 1; i++)  // the last item still have '.mtl'
         materials[i] += ".mtl";


### PR DESCRIPTION
**Description**
if we had an `.obj` with:
```
mtllib Cat 3D Model.mtl
```
CadShape believe there was 3 `.mtl` files. So I had to modifiy a bit how it was split