### PR TITLE
Remove i686 code (libController 32 bits on Windows)

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -39,9 +39,7 @@ msys64: $(TARGET_PATH) \
 	$(TARGET_PATH)/zlib1.dll \
 	$(TARGET_PATH)/libjpeg-8.dll \
 	$(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest \
-	$(WEBOTS_HOME_PATH)/msys64/mingw64/lib \
-	$(WEBOTS_HOME_PATH)/msys64/mingw32/bin \
-	$(WEBOTS_HOME_PATH)/msys64/mingw32/lib
+	$(WEBOTS_HOME_PATH)/msys64/mingw64/lib
 
 $(TARGET_PATH)/zlib1.dll: $(TARGET_PATH)
 	@cp /mingw64/bin/zlib1.dll $(TARGET_PATH)/
@@ -54,12 +52,6 @@ $(TARGET_PATH)/Cyberbotics.Webots.Mingw64.Libraries.manifest: $(TARGET_PATH)
 
 $(WEBOTS_HOME_PATH)/msys64/mingw64/lib:
 	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw64/lib
-
-$(WEBOTS_HOME_PATH)/msys64/mingw32/bin:
-	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/bin
-
-$(WEBOTS_HOME_PATH)/msys64/mingw32/lib:
-	@mkdir -p $(WEBOTS_HOME_PATH)/msys64/mingw32/lib
 
 $(TARGET_PATH):
 	@mkdir -p $(TARGET_PATH)

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -32,6 +32,7 @@ Released on XX, XXth, 2022.
     - Added rendering of anchors in joints ([#4256](https://github.com/cyberbotics/webots/pull/4256)).
     - The ColladaShapes PROTO was replaced by the [CadShape](cadshape.md) node ([#4285](https://github.com/cyberbotics/webots/pull/4285)).
   - Cleanup
+    - Windows: removed the old i686 binary version of the libController.dll ([#4617](https://github.com/cyberbotics/webots/pull/4617)).
     - Removed the deprecated lua-gd library ([#4543](https://github.com/cyberbotics/webots/pull/4543)).
     - New controller and plugin specifications ([#4501](https://github.com/cyberbotics/webots/pull/4501)).
     - 3D model import menu option was removed as with the introduction of the [CadShape](cadshape.md) node it no longer serves a purpose ([#4285](https://github.com/cyberbotics/webots/pull/4285)).

--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -456,15 +456,12 @@ ifdef MAIN_TARGET
 MAIN_TARGET_WINDOWS_LIB = $(MAIN_TARGET:.dll=.lib)
 ifdef WEBOTS_LIBRARY
 MAIN_TARGET_COPY = "$(subst $(space),\ ,$(WEBOTS_CONTROLLER_LIB_PATH))/$(MAIN_TARGET)"
-MAIN_TARGET_WINDOWS32_LIB = $(WEBOTS_HOME_PATH)/msys64/mingw32/lib/$(MAIN_TARGET_WINDOWS_LIB)
 MAIN_TARGET_WINDOWS64_LIB = $(WEBOTS_CONTROLLER_LIB_PATH)/$(MAIN_TARGET_WINDOWS_LIB)
 else
 MAIN_TARGET_COPY ?= $(MAIN_TARGET)
-MAIN_TARGET_WINDOWS32_LIB = $(MAIN_TARGET:.dll=.lib)
 MAIN_TARGET_WINDOWS64_LIB = $(MAIN_TARGET:.dll=.lib)
 endif
 ifeq ($(OSTYPE),windows)
-FILES_TO_REMOVE += $(MAIN_TARGET_WINDOWS32_LIB)
 FILES_TO_REMOVE += $(MAIN_TARGET_WINDOWS64_LIB)
 endif
 
@@ -497,8 +494,6 @@ ifdef VS_DEF_NAME
 	@# if the .def file is existing.
 	@if [ -f $(VS_DEF_NAME) ]; then \
 		if [ -d "$(VISUAL_STUDIO_PATH)" ]; then \
-			PATH="$(VISUAL_STUDIO_PATH)/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64":$PATH lib /machine:X86 /def:$(VS_DEF_NAME) /out:out.lib > /dev/null; \
-			mv out.lib $(MAIN_TARGET_WINDOWS32_LIB); \
 			PATH="$(VISUAL_STUDIO_PATH)/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64":$PATH lib /machine:X64 /def:$(VS_DEF_NAME) /out:out.lib > /dev/null; \
 			mv out.lib $(MAIN_TARGET_WINDOWS64_LIB); \
 			rm -f *.exp; \

--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -31,7 +31,6 @@ declare -a OPTIONAL_PACKAGES=(
   "mingw-w64-x86_64-libzip"   # Robotis OP2 robot window
   "mingw-w64-x86_64-boost"    # to recompile ROS controller
   "mingw-w64-x86_64-cmake"    # Thymio II dashel library
-  "mingw-w64-i686-gcc"        # libController (32 bit)
 )
 
 declare -a DEVELOPMENT_PACKAGES=(

--- a/scripts/packaging/windows_distro.py
+++ b/scripts/packaging/windows_distro.py
@@ -264,12 +264,11 @@ class WindowsWebotsPackage(WebotsPackage):
         dependencies = list(set(  # use a set to make sure to avoid duplication
             list_dependencies('make') +
             list_dependencies('coreutils') +
-            list_dependencies('mingw-w64-x86_64-gcc') +
-            list_dependencies('mingw-w64-i686-gcc')
+            list_dependencies('mingw-w64-x86_64-gcc')
         ))
 
         # add specific folder dependencies needed by Webots
-        folders = ['/tmp', '/mingw32', '/mingw32/bin', '/mingw32/lib', '/mingw64', '/mingw64/bin', '/mingw64/bin/cpp',
+        folders = ['/tmp', '/mingw64', '/mingw64/bin', '/mingw64/bin/cpp',
                    '/mingw64/include',
                    '/mingw64/include/libssh',
                    '/mingw64/lib', '/mingw64/share',

--- a/src/controller/c/Makefile
+++ b/src/controller/c/Makefile
@@ -59,9 +59,6 @@ LD_FLAGS    = -shared -mwindows --def Controller.def -lws2_32
 PLATFORM    = win32
 CC          = gcc
 TARGET      = $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.dll $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.lib
-ifneq (,$(wildcard /mingw32/bin/gcc))
-TARGET     += $(WEBOTS_HOME_PATH)/msys64/mingw32/bin/Controller.dll $(WEBOTS_HOME_PATH)/msys64/mingw32/lib/Controller.lib
-endif
 endif
 
 ifeq ($(MAKECMDGOALS),debug)
@@ -80,9 +77,6 @@ endif
 OBJDIR = build/$(MAKECMDGOALS)
 ifneq (,$(findstring $(MAKECMDGOALS),debug profile release))
 BUILD_PATH_SETUP := $(shell mkdir -p $(OBJDIR))
-ifeq ($(OSTYPE),windows)
-BUILD_PATH_SETUP := $(shell mkdir -p $(OBJDIR)/mingw32)
-endif
 ifeq ($(OSTYPE),darwin)
 BUILD_PATH_SETUP := $(shell mkdir -p $(OBJDIR)/x86_64 $(OBJDIR)/arm64)
 endif
@@ -125,15 +119,11 @@ debug profile release: $(TARGET)
 ifeq ($(OSTYPE),windows)
 
 MINGW64_OBJECTS = $(addprefix $(OBJDIR)/, $(OBJECTS))
-MINGW32_OBJECTS = $(addprefix $(OBJDIR)/mingw32/, $(OBJECTS))
 
 $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.dll: $(MINGW64_OBJECTS) Controller.def
 	@echo "# linking  "$@
 	@echo "# linking  "$(WEBOTS_CONTROLLER_LIB_PATH)"/libController.a"
 	@$(CC) -o $@ $(addprefix $(OBJDIR)/, $(OBJECTS)) $(LD_FLAGS) -Wl,--out-implib,$(WEBOTS_CONTROLLER_LIB_PATH)/libController.a
-ifeq ($(NO_GCC32),1)
-	@echo -e "# \033[0;33mmissing 32 bit gcc or dependencies, skipping 32 bit version of Controller.dll\033[0m"
-endif
 
 $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.lib: $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.dll Controller.def
 ifeq ($(VISUAL_STUDIO_PATH),)
@@ -143,21 +133,6 @@ else
 	@PATH="$(VISUAL_STUDIO_PATH)/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64":$PATH lib /machine:X64 /def:Controller.def /out:Controller.lib > /dev/null
 	@mv Controller.lib "$(WEBOTS_CONTROLLER_LIB_PATH)"
 	@rm Controller.exp
-endif
-
-$(WEBOTS_HOME_PATH)/msys64/mingw32/bin/Controller.dll: $(MINGW32_OBJECTS) Controller.def
-	@echo "# linking  "$@" (32 bit)"
-	@echo "# linking  "$(WEBOTS_HOME_PATH)"/msys64/mingw32/lib/libController.a (32 bit)"
-	@PATH=/mingw32/bin $(CC) -o $@ $(addprefix $(OBJDIR)/mingw32/, $(OBJECTS)) -L/mingw32/lib $(LD_FLAGS) -Wl,--out-implib,$(WEBOTS_HOME_PATH)/msys64/mingw32/lib/libController.a
-
-$(WEBOTS_HOME_PATH)/msys64/mingw32/lib/Controller.lib: $(WEBOTS_HOME_PATH)/msys64/mingw32/bin/Controller.dll Controller.def
-ifeq ($(VISUAL_STUDIO_PATH),)
-	@echo -e "# \033[0;33m'VISUAL_STUDIO_PATH' not set, skipping Controller.lib (32 bit)\033[0m"
-else
-	@echo "# creating "$@" (32 bit)"
-	@PATH="$(VISUAL_STUDIO_PATH)/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64":$PATH lib /machine:X86 /def:Controller.def /out:Controller32.lib > /dev/null
-	@mv Controller32.lib "$(WEBOTS_HOME_PATH)/msys64/mingw32/lib/Controller.lib"
-	@rm Controller32.exp
 endif
 
 endif
@@ -195,10 +170,6 @@ $(OBJDIR)/%.o:%.c
 	@echo "# compiling "$<
 	@$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) $< -o $@
 
-$(OBJDIR)/mingw32/%o:%c
-	@echo "# compiling "$<" (32 bit)"
-	@PATH=/mingw32/bin $(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) $< -o $(OBJDIR)/mingw32/$(notdir $@)
-
 $(OBJDIR)/arm64/%o:%c
 	@echo "# compiling "$<" (arm64)"
 	@$(CC) -c -target arm64-apple-macos11 $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) $< -o $(OBJDIR)/arm64/$(notdir $@)
@@ -216,6 +187,3 @@ $(OBJDIR)/%.d:%.c
 FILES_TO_REMOVE = $(TARGET)
 FILES_TO_REMOVE += $(WEBOTS_CONTROLLER_LIB_PATH)/libController.a
 FILES_TO_REMOVE += $(WEBOTS_CONTROLLER_LIB_PATH)/libController.lib
-FILES_TO_REMOVE += $(WEBOTS_HOME_PATH)/msys64/mingw32/bin/Controller.dll
-FILES_TO_REMOVE += $(WEBOTS_HOME_PATH)/msys64/mingw32/lib/libController.a
-FILES_TO_REMOVE += $(WEBOTS_HOME_PATH)/msys64/mingw32/lib/Controller.lib


### PR DESCRIPTION
This code was used for building controller programs linked against libraries that are available only for i686 architecture. This was the case for the Nao simulator SDK libraries and some old versions of MATLAB, Python, Java, etc. Hopefully, this is not needed any more.

Thanks to this PR, the size of the installation setup will shrink from 453 to 341 MB.