### PR TITLE
Closed-loop kinematics detection in webots convert URDF

### DIFF
--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -134,7 +134,11 @@ void WbSingleTaskApplication::convertProto() const {
   WbNode *node = WbNode::regenerateProtoInstanceFromParameters(model, fields, true, "");
   for (WbNode *subNode : node->subNodes(true)) {
     if (type == "URDF" && dynamic_cast<WbSolidReference *>(subNode))
-      cout << tr("Warning: Exporting a Joint node with a SolidReference endpoint (%1) to URDF is not supported.").arg(static_cast<WbSolidReference *>(subNode)->name()).toUtf8().constData() << endl;
+      cout << tr("Warning: Exporting a Joint node with a SolidReference endpoint (%1) to URDF is not supported.")
+                .arg(static_cast<WbSolidReference *>(subNode)->name())
+                .toUtf8()
+                .constData()
+           << endl;
     if (dynamic_cast<WbSolid *>(subNode))
       static_cast<WbSolid *>(subNode)->updateChildren();
     if (dynamic_cast<WbBasicJoint *>(subNode)) {

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -20,6 +20,8 @@
 #include "WbProtoCachedInfo.hpp"
 #include "WbProtoList.hpp"
 #include "WbProtoModel.hpp"
+#include "WbSolid.hpp"
+#include "WbSolidReference.hpp"
 #include "WbSoundEngine.hpp"
 #include "WbSysInfo.hpp"
 #include "WbTokenizer.hpp"
@@ -130,9 +132,18 @@ void WbSingleTaskApplication::convertProto() const {
   // Generate a node structure
   WbNode::setInstantiateMode(true);
   WbNode *node = WbNode::regenerateProtoInstanceFromParameters(model, fields, true, "");
-  for (WbNode *subNode : node->subNodes(true))
-    if (dynamic_cast<WbBasicJoint *>(subNode))
+  for (WbNode *subNode : node->subNodes(true)) {
+    if (type == QString("URDF") && dynamic_cast<WbSolidReference *>(subNode))
+      cout << tr("Warning: Exporting a Joint node with a SolidReference endpoint (").toUtf8().constData()
+           << static_cast<WbSolidReference *>(subNode)->name().toStdString()
+           << tr(") to URDF is not supported.").toUtf8().constData() << endl;
+    if (dynamic_cast<WbSolid *>(subNode))
+      static_cast<WbSolid *>(subNode)->updateChildren();
+    if (dynamic_cast<WbBasicJoint *>(subNode)) {
+      static_cast<WbBasicJoint *>(subNode)->updateEndPoint();
       static_cast<WbBasicJoint *>(subNode)->updateEndPointZeroTranslationAndRotation();
+    }
+  }
 
   // Export
   QString output;

--- a/src/webots/gui/WbSingleTaskApplication.cpp
+++ b/src/webots/gui/WbSingleTaskApplication.cpp
@@ -133,10 +133,8 @@ void WbSingleTaskApplication::convertProto() const {
   WbNode::setInstantiateMode(true);
   WbNode *node = WbNode::regenerateProtoInstanceFromParameters(model, fields, true, "");
   for (WbNode *subNode : node->subNodes(true)) {
-    if (type == QString("URDF") && dynamic_cast<WbSolidReference *>(subNode))
-      cout << tr("Warning: Exporting a Joint node with a SolidReference endpoint (").toUtf8().constData()
-           << static_cast<WbSolidReference *>(subNode)->name().toStdString()
-           << tr(") to URDF is not supported.").toUtf8().constData() << endl;
+    if (type == "URDF" && dynamic_cast<WbSolidReference *>(subNode))
+      cout << tr("Warning: Exporting a Joint node with a SolidReference endpoint (%1) to URDF is not supported.").arg(static_cast<WbSolidReference *>(subNode)->name()).toUtf8().constData() << endl;
     if (dynamic_cast<WbSolid *>(subNode))
       static_cast<WbSolid *>(subNode)->updateChildren();
     if (dynamic_cast<WbBasicJoint *>(subNode)) {

--- a/src/webots/nodes/WbJoint.cpp
+++ b/src/webots/nodes/WbJoint.cpp
@@ -323,7 +323,7 @@ const QString WbJoint::urdfName() const {
 void WbJoint::writeExport(WbVrmlWriter &writer) const {
   if (writer.isUrdf() && solidEndPoint()) {
     if (dynamic_cast<WbSolidReference *>(mEndPoint->value())) {
-      this->warn("Exporting a Joint node with a SolidRefernce endpoint to URDF is not supported.");
+      this->warn("Exporting a Joint node with a SolidReference endpoint to URDF is not supported.");
       return;
     }
 

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -243,6 +243,7 @@ public slots:
   void updateGlobalCenterOfMass();
   void updateGraphicalGlobalCenterOfMass();
   void resetPhysicsIfRequired(bool changedFromSupervisor);
+  virtual void updateChildren();
 
 protected:
   // this constructor is reserved for derived classes only
@@ -289,7 +290,6 @@ protected slots:
   void updateRotation() override;
   void updateScale(bool warning = false) override;
   void updateLineScale() override;
-  virtual void updateChildren();
   virtual void updateIsLinearVelocityNull();
   virtual void updateIsAngularVelocityNull();
 


### PR DESCRIPTION
Fixes #4332.

The crash was already fixed in PR #4102. Therefore robot.getUrdf() is now displaying a warning if the robot contains closed-loop kinematics.

However, this is not the case when using `webots convert` command line for an URDF conversion. The parsing of the PROTO isn't updating the solid children and solid end point references. Therefore, the closed-loop is not detected and no warning is displayed. This PR adds the references update, as well as the warnings for a better user experience.
