### PR TITLE
Hotfix CORS new tab

### DIFF
--- a/resources/web/templates/x3d_playback.html
+++ b/resources/web/templates/x3d_playback.html
@@ -18,7 +18,7 @@
       <p><strong>Description:</strong><br><br>%description%</p>
     </div>
     <div class="bottom-container">
-      <p>If the animation is not loading correctly, please refer to the <a target:'_blank' href='https://cyberbotics.com/doc/guide/web-scene#remarks-on-the-used-technologies-and-their-limitations'>User Guide</a>
+      <p>If the animation is not loading correctly, please refer to the <a target='_blank' href='https://cyberbotics.com/doc/guide/web-scene#remarks-on-the-used-technologies-and-their-limitations'>User Guide</a>
         it could be that your browser prevents local files CORS requests.</p>
     </div>
   </body>


### PR DESCRIPTION
Link did not open in new tab because `:` should have been `=`.