### PR TITLE
Fixed warning on Ubuntu 22.04

### DIFF
--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -73,6 +73,10 @@ export LD_LIBRARY_PATH="$webots_home/lib/webots":$LD_LIBRARY_PATH
 
 export QT_ENABLE_HIGHDPI_SCALING=1
 
+# Fixes warning on Ubuntu 22.04
+unset XDG_SESSION_TYPE
+unset WAYLAND_DISPLAY
+
 # execute the real Webots binary in a child process
 if command -v primusrun >/dev/null 2>&1; then
   primusrun "$webots_home/bin/webots-bin" "$@" &


### PR DESCRIPTION
Starting Webots on Ubuntu 22.04 is raising the following warning in the console:
```
Info: Warning: Ignoring WAYLAND_DISPLAY on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
```
This PR fixes it.