### PR TITLE
Enhancement share reset and thumbnail robustness

### DIFF
--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -67,6 +67,7 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("General/numberOfThreads", WbSysInfo::coreCount());
   setDefault("General/checkWebotsUpdateOnStartup", true);
   setDefault("General/disableSaveWarning", false);
+  setDefault("General/thumbnail", true);
   setDefault("Sound/mute", true);
   setDefault("Sound/volume", 80);
   setDefault("OpenGL/disableShadows", false);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1503,7 +1503,7 @@ void WbMainWindow::resetWorldFromGui() {
     WbWorld::instance()->reset(true);
 
   if (mAnimationRecordingTimer->isActive())
-    WbLog::info(tr("HTML5 recording canceled, locally stored files will still be available."));
+    WbLog::info(tr("HTML recording canceled, locally stored files will still be available."));
 
   resetGui(true);
 }

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1612,7 +1612,9 @@ void WbMainWindow::upload() {
   if (QFileInfo(WbStandardPaths::webotsTmpPath() + "cloud_export.json").exists() && mUploadType == 'A')
     filenames << "cloud_export.json";
   filenames << "cloud_export.x3d";
-  filenames << "cloud_export.jpg";
+  if (WbPreferences::instance()->value("General/thumbnail").toBool() &&
+      QFileInfo(WbStandardPaths::webotsTmpPath() + "cloud_export.jpg").exists())
+    filenames << "cloud_export.jpg";
 
   // add files content
   QMap<QString, QString> map;

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -97,6 +97,7 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
   mCheckWebotsUpdateCheckBox->setChecked(prefs->value("General/checkWebotsUpdateOnStartup").toBool());
   mRenderingCheckBox->setChecked(prefs->value("General/rendering").toBool());
   mDisableSaveWarningCheckBox->setChecked(prefs->value("General/disableSaveWarning").toBool());
+  mThumnailCheckBox->setChecked(prefs->value("General/thumbnail").toBool());
 
   // openGL tab
   mAmbientOcclusionCombo->setCurrentIndex(prefs->value("OpenGL/GTAO", 2).toInt());
@@ -179,6 +180,7 @@ void WbPreferencesDialog::accept() {
   prefs->setValue("General/checkWebotsUpdateOnStartup", mCheckWebotsUpdateCheckBox->isChecked());
   prefs->setValue("General/rendering", mRenderingCheckBox->isChecked());
   prefs->setValue("General/disableSaveWarning", mDisableSaveWarningCheckBox->isChecked());
+  prefs->setValue("General/thumbnail", mThumnailCheckBox->isChecked());
 
   // openGL
   prefs->setValue("OpenGL/GTAO", mAmbientOcclusionCombo->currentIndex());
@@ -413,21 +415,28 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   layout->addWidget(mDisableSaveWarningCheckBox, 10, 1);
 
   // row 11
+  mThumnailCheckBox = new QCheckBox(tr("Capture thumbnail on world save or share."), this);
+  mThumnailCheckBox->setToolTip(tr("If this option is enabled, Webots will take and store a 768px by 432px (16:9)\nscreenshot "
+                                   "of the world in .jpg format when the it is saved, shared or exported."));
+  layout->addWidget(new QLabel(tr("Thumbnail:"), this), 11, 0);
+  layout->addWidget(mThumnailCheckBox, 11, 1);
+
+  // row 12
   mTelemetryCheckBox = new QCheckBox(tr("Send technical data to Webots developers"), this);
   mTelemetryCheckBox->setToolTip(tr("We need your help to continue to improve Webots: more information at:\n"
                                     "https://cyberbotics.com/doc/guide/telemetry"));
   QLabel *label =
     new QLabel(tr("Telemetry (<a style='color: #5DADE2;' href='https://cyberbotics.com/doc/guide/telemetry'>info</a>):"), this);
   connect(label, &QLabel::linkActivated, &WbDesktopServices::openUrl);
-  layout->addWidget(label, 11, 0);
-  layout->addWidget(mTelemetryCheckBox, 11, 1);
+  layout->addWidget(label, 12, 0);
+  layout->addWidget(mTelemetryCheckBox, 12, 1);
 
-  // row 12
+  // row 13
   mCheckWebotsUpdateCheckBox = new QCheckBox(tr("Check for Webots updates on startup"), this);
   mCheckWebotsUpdateCheckBox->setToolTip(tr("If this option is enabled, Webots will check if a new version is available for "
                                             "download\nat every startup. If available, it will inform you about it."));
-  layout->addWidget(new QLabel(tr("Update policy:"), this), 12, 0);
-  layout->addWidget(mCheckWebotsUpdateCheckBox, 12, 1);
+  layout->addWidget(new QLabel(tr("Update policy:"), this), 13, 0);
+  layout->addWidget(mCheckWebotsUpdateCheckBox, 13, 1);
 
   setTabOrder(mStartupModeCombo, mEditorFontEdit);
   setTabOrder(mEditorFontEdit, chooseFontButton);

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -70,8 +70,8 @@ private:
     *mTextureFilteringCombo;
   WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectPath, *mHttpProxyHostName, *mHttpProxyPort,
     *mHttpProxyUsername, *mHttpProxyPassword, *mUploadUrl, *mBrowserProgram;
-  QCheckBox *mDisableSaveWarningCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox, *mDisableShadowsCheckBox,
-    *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox, *mNewBrowserWindow;
+  QCheckBox *mDisableSaveWarningCheckBox, *mThumnailCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox,
+    *mDisableShadowsCheckBox, *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox, *mNewBrowserWindow;
   QSpinBox *mCacheSize;
   QListWidget *mAllowedIps;
   QLabel *mCacheSizeLabel;

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -770,7 +770,7 @@ void WbSimulationView::writeScreenshotForThumbnail() {
 }
 
 void WbSimulationView::restoreViewAfterThumbnail() {
-  disconnect(this, &WbSimulationView::screenshotWritten,this, &WbSimulationView::restoreViewAfterThumbnail);
+  disconnect(this, &WbSimulationView::screenshotWritten, this, &WbSimulationView::restoreViewAfterThumbnail);
   mView3D->restoreOptionalRenderingAndOverLays();
   enableView3DFixedSize(mSizeBeforeThumbnail);
   disableView3DFixedSize();

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -746,6 +746,11 @@ void WbSimulationView::takeScreenshot() {
 }
 
 void WbSimulationView::takeThumbnail(const QString &fileName) {
+  if (!WbPreferences::instance()->value("General/thumbnail").toBool()) {
+    emit thumbnailTaken();
+    return;
+  }
+
   mThumbnailFileName = fileName;
   mSizeBeforeThumbnail.setWidth(mView3DContainer->width());
   mSizeBeforeThumbnail.setHeight(mView3DContainer->height());

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -663,6 +663,8 @@ void WbSimulationView::writeScreenshot() {
     mainWindow->showMinimized();
     mWasMinimized = false;
   }
+
+  emit screenshotWritten();
 }
 
 void WbSimulationView::takeScreenshotAndSaveAs(const QString &fileName, int quality) {
@@ -763,7 +765,12 @@ void WbSimulationView::takeScreesnhotForThumbnail() {
 
 void WbSimulationView::writeScreenshotForThumbnail() {
   disconnect(mView3D, &WbView3D::screenshotReady, this, &WbSimulationView::writeScreenshotForThumbnail);
+  connect(this, &WbSimulationView::screenshotWritten, this, &WbSimulationView::restoreViewAfterThumbnail);
   takeScreenshotAndSaveAs(mThumbnailFileName);
+}
+
+void WbSimulationView::restoreViewAfterThumbnail() {
+  disconnect(this, &WbSimulationView::screenshotWritten,this, &WbSimulationView::restoreViewAfterThumbnail);
   mView3D->restoreOptionalRenderingAndOverLays();
   enableView3DFixedSize(mSizeBeforeThumbnail);
   disableView3DFixedSize();

--- a/src/webots/gui/WbSimulationView.hpp
+++ b/src/webots/gui/WbSimulationView.hpp
@@ -92,7 +92,8 @@ signals:
   void needsMinimize();
   void requestOpenUrl(const QString &fileName, const QString &message, const QString &title);
 
-  // signal called when thumbnail is taken
+  // signals for screenshots and thumbnails
+  void screenshotWritten();
   void thumbnailTaken();
 
 public slots:
@@ -117,6 +118,7 @@ private slots:
   void takeScreenshotAndSaveAs(const QString &fileName, int quality = -1);
   void takeScreenshot();
   void takeScreesnhotForThumbnail();
+  void restoreViewAfterThumbnail();
   void pause();
   void step();
   void realTime();


### PR DESCRIPTION
**Description**

- Improves usability of animation and scene sharing by pausing when the dialog is displayed and resuming afterwards (+ code cleanup)
- Gives a more clear indication of what is happening on simulation reset during animation recording with an info log message .
- Improves thumbnail robustness by only resizing back to original size once screenshot is written thanks to a new signal.
- Add checkbox to preferences to disable thumbnails if wanted