### PR TITLE
Fixed optional python library build

### DIFF
--- a/projects/default/libraries/vehicle/python/Makefile
+++ b/projects/default/libraries/vehicle/python/Makefile
@@ -87,9 +87,13 @@ TARGET = $(PYOUT) $(LIBRARY)
 
 SWIG_EXISTS = $(shell which swig 2> /dev/null)
 
+ifeq (, $(shell which $(PYTHON_COMMAND)-config 2> /dev/null))
+release debug profile:
+	@echo "# \033[0;33m$(PYTHON_COMMAND)-dev not installed, skipping Python API\033[0m"
+else
 ifeq ($(SWIG_EXISTS),)
 release debug profile:
-	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
+	@echo "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
 else
 release debug profile: $(TARGET)
 
@@ -122,7 +126,7 @@ $(LIBRARY):$(WRAPPER_OBJECT)
 	$(CXX) $(LD_FLAGS) $< $(DEF) $(LIB) -o "$@"
 
 endif
-
+endif
 endif
 
 clean:

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -87,9 +87,13 @@ TARGET = $(PYOUT) $(LIBRARY)
 
 SWIG_EXISTS = $(shell which swig 2> /dev/null)
 
+ifeq (, $(shell which $(PYTHON_COMMAND)-config 2> /dev/null))
+release debug profile:
+	@echo "# \033[0;33m$(PYTHON_COMMAND)-dev not installed, skipping Python API\033[0m"
+else
 ifeq ($(SWIG_EXISTS),)
 release debug profile:
-	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
+	@echo "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
 else
 release debug profile: $(TARGET)
 
@@ -101,6 +105,7 @@ $(LIBRARY):$(WRAPPER_OBJECT)
 
 $(WRAPPER_OBJECT):$(WRAPPER)
 	$(CXX) $(C_FLAGS) $(INCLUDES) $(PYTHON_INCLUDES) $< -o $@
+endif
 endif
 
 clean:

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -123,11 +123,11 @@ TARGET          = $(PYOUT) $(LIBOUT)
 
 ifeq (, $(shell which $(PYTHON_COMMAND)-config 2> /dev/null))
 release debug profile:
-	@echo -e "# \033[0;33m$(PYTHON_COMMAND)-dev not installed, skipping Python API\033[0m"
+	@echo "# \033[0;33m$(PYTHON_COMMAND)-dev not installed, skipping Python API\033[0m"
 else
 ifeq ($(SWIG_EXISTS),)
 release debug profile:
-	@echo -e "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
+	@echo "# \033[0;33mSWIG not installed, skipping Python API\033[0m"
 else
 release debug profile: $(TARGET)
 


### PR DESCRIPTION
Following #4638, this PR fixes the optional build of python libraries depending on the python-dev packages.