### PR TITLE
Use assimp-5.2.3 on Windows

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -5,13 +5,14 @@ WEBOTS_HOME_PATH=$(strip $(subst \,/,$(WEBOTS_HOME)))
 WEBOTS_DEPENDENCY_PATH ?= $(WEBOTS_HOME_PATH)/dependencies
 DEPENDENCIES_URL = https://cyberbotics.com/files/repository/dependencies/windows/release
 
+ASSIMP_PACKAGE = assimp-5.2.3.zip
 OPEN_VR_PACKAGE = openvr-1.0.7.zip
 LUA_PACKAGE = lua-5.2.3.tar.gz
 OIS_PACKAGE = libOIS.zip
 PICO_PACKAGE = libpico.zip
 LUA_GD_PACKAGE = lua-gd-windows.zip
 
-PACKAGES = open-vr lua ois pico lua-gd
+PACKAGES = assimp open-vr lua ois pico lua-gd
 PACKAGES_CLEAN = $(addsuffix -clean, $(PACKAGES))
 null :=
 space := $(null) $(null)
@@ -55,6 +56,20 @@ $(WEBOTS_HOME_PATH)/msys64/mingw64/lib:
 
 $(TARGET_PATH):
 	@mkdir -p $(TARGET_PATH)
+
+assimp-clean:
+	@rm -f "$(WEBOTS_HOME_PATH)/msys64/mingw64/bin/libassimp-5.dll"
+	@rm -rf "$(WEBOTS_HOME_PATH)/dependencies/assimp"
+
+assimp:
+	@echo "# downloading $(ASSIMP_PACKAGE)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)"
+	@wget -qq "$(DEPENDENCIES_URL)/$(ASSIMP_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
+	@if [ "$$(md5sum $(ASSIMP_PACKAGE) | awk '{print $$1;}')" != "5942c8a16a4dc9c0ab01e50b6a1c4795" ]; then echo "MD5 checksum failed for $(ASSIMP_PACKAGE)"; exit 1; fi
+	@echo "# uncompressing $(ASSIMP_PACKAGE)"
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)"
+	@touch "$(WEBOTS_DEPENDENCY_PATH)/assimp"
 
 open-vr-clean:
 	@rm -rf "$(WEBOTS_HOME_PATH)/include/openvr" $(TARGET_PATH)/openvr_api.dll "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"

--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -58,18 +58,23 @@ $(TARGET_PATH):
 	@mkdir -p $(TARGET_PATH)
 
 assimp-clean:
-	@rm -f "$(WEBOTS_HOME_PATH)/msys64/mingw64/bin/libassimp-5.dll"
+	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)"
+	@rm -f "$(TARGET_PATH)/libassimp-5.dll"
 	@rm -rf "$(WEBOTS_HOME_PATH)/dependencies/assimp"
 
-assimp:
+assimp: $(TARGET_PATH)/libassimp-5.dll
+
+$(TARGET_PATH)/libassimp-5.dll: $(ASSIMP_PACKAGE)
+	@echo "# uncompressing $(ASSIMP_PACKAGE)"
+	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
+	@touch "$(TARGET_PATH)/libassimp-5.dll"
+
+$(ASSIMP_PACKAGE):
 	@echo "# downloading $(ASSIMP_PACKAGE)"
 	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)"
 	@wget -qq "$(DEPENDENCIES_URL)/$(ASSIMP_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
 	@if [ "$$(md5sum $(ASSIMP_PACKAGE) | awk '{print $$1;}')" != "5942c8a16a4dc9c0ab01e50b6a1c4795" ]; then echo "MD5 checksum failed for $(ASSIMP_PACKAGE)"; exit 1; fi
-	@echo "# uncompressing $(ASSIMP_PACKAGE)"
-	@unzip -q -o "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)" -d "$(WEBOTS_HOME_PATH)"
-	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(ASSIMP_PACKAGE)"
-	@touch "$(WEBOTS_DEPENDENCY_PATH)/assimp"
+	@touch $(ASSIMP_PACKAGE)
 
 open-vr-clean:
 	@rm -rf "$(WEBOTS_HOME_PATH)/include/openvr" $(TARGET_PATH)/openvr_api.dll "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"

--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -17,7 +17,6 @@ declare -a BASE_PACKAGES=(
   "mingw-w64-x86_64-qt6-websockets"   # Webots
   "mingw-w64-x86_64-libzip"           # Webots
   "mingw-w64-x86_64-woff2"            # Webots
-  "mingw-w64-x86_64-assimp"           # Webots
   "liblzma"                           # Webots
   "mingw-w64-x86_64-ffmpeg"           # Webots movies
   "mingw-w64-x86_64-dlfcn"            # dependency of ffmpeg

--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -17,6 +17,8 @@ declare -a BASE_PACKAGES=(
   "mingw-w64-x86_64-qt6-websockets"   # Webots
   "mingw-w64-x86_64-libzip"           # Webots
   "mingw-w64-x86_64-woff2"            # Webots
+  "mingw-w64-x86_64-minizip"          # Webots (assimp)
+  "mingw-w64-x86_64-zlib"             # Webots (assimp)
   "liblzma"                           # Webots
   "mingw-w64-x86_64-ffmpeg"           # Webots movies
   "mingw-w64-x86_64-dlfcn"            # dependency of ffmpeg

--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -1,5 +1,4 @@
 # needed to execute webots-bin.exe (64 bit binary)
-/mingw64/bin/libassimp-5.dll
 /mingw64/bin/libb2-1.dll
 /mingw64/bin/libbrotlicommon.dll
 /mingw64/bin/libbrotlidec.dll

--- a/scripts/packaging/webots_distro.py
+++ b/scripts/packaging/webots_distro.py
@@ -48,8 +48,11 @@ if sys.platform == 'win32':
 else:
     webots_command = os.path.join(WEBOTS_HOME, 'webots')
 
-status = os.system('bash -c "webots --update-proto-cache=projects"')
+# the following command will display the error if webots fails to start because of a missing DLL
+status = os.system(f'bash -c "{webots_command} --update-proto-cache=projects"')
 if status != 0:
+    file = os.path.join(WEBOTS_HOME, 'msys64/mingw64/bin/webots-bin.exe')
+    os.system(f'ldd {file}')
     sys.exit("Failed to start webots")
 
 print('generating asset cache')

--- a/scripts/packaging/webots_distro.py
+++ b/scripts/packaging/webots_distro.py
@@ -51,8 +51,6 @@ else:
 # the following command will display the error if webots fails to start because of a missing DLL
 status = os.system(f'bash -c "{webots_command} --update-proto-cache=projects"')
 if status != 0:
-    file = os.path.join(WEBOTS_HOME, 'msys64/mingw64/bin/webots-bin.exe')
-    os.system(f'ldd {file}')
     sys.exit("Failed to start webots")
 
 print('generating asset cache')

--- a/scripts/packaging/webots_distro.py
+++ b/scripts/packaging/webots_distro.py
@@ -47,7 +47,10 @@ if sys.platform == 'win32':
     webots_command = 'webots'
 else:
     webots_command = os.path.join(WEBOTS_HOME, 'webots')
-subprocess.run([webots_command, '--update-proto-cache=projects'])
+
+status = os.system('bash -c "webots --update-proto-cache=projects"')
+if status != 0:
+    sys.exit("Failed to start webots")
 
 print('generating asset cache')
 generate_asset_cache(current_tag)

--- a/scripts/packaging/webots_distro.py
+++ b/scripts/packaging/webots_distro.py
@@ -48,7 +48,7 @@ if sys.platform == 'win32':
 else:
     webots_command = os.path.join(WEBOTS_HOME, 'webots')
 
-# the following command will display the error if webots fails to start because of a missing DLL
+# the following command will display the error if webots fails to start
 status = os.system(f'bash -c "{webots_command} --update-proto-cache=projects"')
 if status != 0:
     sys.exit("Failed to start webots")

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -147,6 +147,7 @@ QT_OPENGL_WIDGETS_INCLUDE = -isystem $(WEBOTS_PATH)/include/qt/QtOpenGLWidgets
 QT_NETWORK_INCLUDE        = -isystem $(WEBOTS_PATH)/include/qt/QtNetwork
 QT_WEBSOCKETS_INCLUDE     = -isystem $(WEBOTS_PATH)/include/qt/QtWebSockets
 QT_XML_INCLUDE            = -isystem $(WEBOTS_PATH)/include/qt/QtXml
+ASSIMP_INCLUDE            = -I$(WEBOTS_PATH)/dependencies
 FREETYPE_INCLUDE          = -I/mingw64/include/freetype2
 TARGET_PATH               = $(WEBOTS_PATH)/msys64/mingw64/bin
 TARGET                    = $(TARGET_PATH)/webots-bin.exe
@@ -154,7 +155,7 @@ CFLAGS                    = -isystem /mingw64/lib/libzip/include
 CXXFLAGS                  = -std=c++11 -D_USE_MATH_DEFINES
 MOC                       = /mingw64/share/qt6/bin/moc
 MOC_FLAGS                += -D_WIN32
-LIBS                     += $(LIB_WREN) -L$(TARGET_PATH) -L/mingw64/bin -L/mingw64/lib -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lode -lopenal -lopengl32 -liphlpapi -ld3d9 -lgdi32 -lglu32 -lOIS -ldinput8 -ldxguid -lole32 -lsapi -loleaut32 -luuid -lpico -llua52 -lfreetype-6 -lopenvr_api -lassimp
+LIBS                     += $(LIB_WREN) -L$(TARGET_PATH) -L/mingw64/bin -L/mingw64/lib -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lode -lopenal -lopengl32 -liphlpapi -ld3d9 -lgdi32 -lglu32 -lOIS -ldinput8 -ldxguid -lole32 -lsapi -loleaut32 -luuid -lpico -llua52 -lfreetype-6 -lopenvr_api -lassimp-5
 LD_FLAGS                  = -Wl,--enable-auto-import
 EXTRA_CMD                 = cp launcher/webots-bin.exe.config $(TARGET_PATH)/
 FILES_TO_REMOVE           = $(TARGET_PATH)/webots-bin.exe.config

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -97,6 +97,8 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
     pythonCommand = "!";
   } else
     shortVersion = QString(version[0][0]) + version[0][2];
+  if (version[0][3] != '.')
+    shortVersion += version[0][3];  // handle versions 310, 311, 321, etc.
 #elif __APPLE__
   if (std::getenv("PWD"))
     shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);

--- a/src/wren/Makefile
+++ b/src/wren/Makefile
@@ -31,7 +31,7 @@ INCLUDE += -I$(WEBOTS_DEPENDENCY_PATH)/freetype2 -I$(WEBOTS_DEPENDENCY_PATH)/ass
 else ifeq ($(OSTYPE),linux)
 INCLUDE += -I/usr/include/freetype2 -I$(WEBOTS_HOME_PATH)/include/libassimp/include
 else ifeq ($(OSTYPE),windows)
-INCLUDE += -I/mingw64/include/freetype2 -I/mingw64/include
+INCLUDE += -I/mingw64/include/freetype2 -I/mingw64/include -I$(WEBOTS_DEPENDENCY_PATH)
 endif
 
 CXX_SOURCES = $(wildcard *.cpp) $(wildcard mesh/*.cpp)


### PR DESCRIPTION
Fixes #4653.

Since assimp 5.2.4 introduced a bug breaking up the skeletons / skins in Webots, this PR reverts to version 5.2.3 which works well.
On the long term, it might be a good solution to have the same version of assimp on Linux, macOS and Windows, regardless of MSYS2 updates.
