### PR TITLE
Remove timeout

### DIFF
--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -65,7 +65,6 @@ WbNetwork::~WbNetwork() {
 QNetworkAccessManager *WbNetwork::networkAccessManager() {
   if (mNetworkAccessManager == NULL) {
     mNetworkAccessManager = new QNetworkAccessManager();
-    mNetworkAccessManager->setTransferTimeout(5000);
     setProxy();
   }
   return mNetworkAccessManager;


### PR DESCRIPTION
The timeout added with the new caching system sometimes interferes with the loading (especially big worlds with slow internet connections). I added it because if the user went offline mid-download it prevented the load from getting stuck, but as it stands this approach appears to have problems of its own.
Pushing this temporary solution for now so that nightlies aren't affected by it
