### PR TITLE
fix button width for mac

### DIFF
--- a/src/webots/gui/WbShareWindow.cpp
+++ b/src/webots/gui/WbShareWindow.cpp
@@ -83,6 +83,7 @@ WbLinkWindow::WbLinkWindow(QWidget *parent) : QDialog(parent) {
   QPushButton *pushButtonOpenLink = new QPushButton(this);
   pushButtonOpenLink->setFocusPolicy(Qt::NoFocus);
   pushButtonOpenLink->setText(tr("Open in Browser"));
+  pushButtonOpenLink->setFixedWidth(pushButtonOpenLink->width() + 50);
   layout->addWidget(pushButtonOpenLink, 1, 1, 1, 1);
   connect(pushButtonOpenLink, &QPushButton::pressed, this, &WbLinkWindow::openUrl);
   connect(pushButtonOpenLink, &QPushButton::pressed, this, &WbShareWindow::close);


### PR DESCRIPTION
**Description**
When uploading a scene/animation to webots.cloud (`share`->`upload to webots.cloud`->`Export scene` or `Record and export animation`), the `Open in Browser` button is cropped on macOS. This fixes it.
