### PR TITLE
Remove R2022a windows nigthly

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -3,8 +3,8 @@ name: Test Suite Windows
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  schedule:
-    - cron:  '0 23 * * *'
+  # schedule:
+  #   - cron:  '0 23 * * *'
   push:
     tags:
       - nightly_*


### PR DESCRIPTION
As the release will happen quite soon, it is not worth investing time trying to fix the R2022a package for windows
(for more information check #4668)