### PR TITLE
Fix Qt plugin path on Windows

### DIFF
--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -94,12 +94,18 @@ static void quitApplication(int sig) {
 
 int main(int argc, char *argv[]) {
 #ifdef _WIN32
+  // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
+  // we need to use GetModuleFileName as argv[0] doesn't always provide an absolute path
+  const int BUFFER_SIZE = 4096;
+  char *modulePath = new char[BUFFER_SIZE];
+  GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
+  const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
+  delete[] modulePath;
   QProcess process;
   process.start("cygpath", QStringList{QString("-w"), QString("/")});
   process.waitForFinished(-1);
   const QString cygpath = QDir::fromNativeSeparators(process.readAllStandardOutput().trimmed());
-  const QString MSYS2_HOME =
-    cygpath.isEmpty() ? QDir::fromNativeSeparators(qEnvironmentVariable("WEBOTS_HOME")) + "/msys64" : cygpath.chopped(1);
+  const QString MSYS2_HOME = cygpath.isEmpty() ? webotsDirPath + "/msys64" : cygpath.chopped(1);
   qputenv("MSYS2_HOME", MSYS2_HOME.toUtf8());  // useful to Python >= 3.8 controllers
   QCoreApplication::setLibraryPaths(QStringList(MSYS2_HOME + "/mingw64/share/qt6/plugins"));
 #ifdef NDEBUG
@@ -117,34 +123,24 @@ int main(int argc, char *argv[]) {
   // we need to unbuffer the stderr as _IOLBF is not working in the msys console
   setvbuf(stderr, NULL, _IONBF, 0);
 #endif  // NDEBUG
-#endif  // _WIN32
-  QLocale::setDefault(QLocale::c());
-
-#ifdef __linux__
+#elif defined(__linux__)
   // on Linux, the webots binary is located in $WEBOTS_HOME/bin/webots-bin
   const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/..").canonicalPath();
 #elif defined(__APPLE__)
   // on macOS, the webots binary is located in $WEBOTS_HOME/Contents/MacOS/webots
   const QString webotsDirPath = QDir(QFileInfo(argv[0]).absolutePath() + "/../..").canonicalPath();
-#else
-  // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
-  // we need to use GetModuleFileName as argv[0] doesn't always provide an absolute path
-  const int BUFFER_SIZE = 4096;
-  char *modulePath = new char[BUFFER_SIZE];
-  GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
-  const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
-  delete[] modulePath;
 #endif
+  QLocale::setDefault(QLocale::c());
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
-    const QString platformPluginPath =
+    const QString platformPluginPath = webotsDirPath +
 #ifdef _WIN32
-      MSYS2_HOME + "\\mingw64\\share\\qt6\\plugins";
+                                       "/mingw64/share/qt6/plugins";
 #elif defined(__APPLE__)
-      webotsDirPath + "/Contents/lib/webots/qt/plugins";
+                                       "/Contents/lib/webots/qt/plugins";
 #else
-      webotsDirPath + "/lib/webots/qt/plugins";
+                                       "/lib/webots/qt/plugins";
 #endif
     qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());
   }


### PR DESCRIPTION
While testing @carikaser experienced a failure at start-up: Webots complained it could not find the Qt plugins and refused to launch. This failure is difficult to reproduce, especially on our development machines (even with a different user account), because it seems that Qt is somehow caching the path to the Qt plugins and manages to find them even though they are not correctly specified by Webots.

This PR fixes the problem (tested on a new PC on which Webots was never installed).

The previous code assumed that `WEBOTS_HOME` was properly defined, which is not the case unless the user explicitly did so.

