### PR TITLE
Fixed font warning on macOS, better default monospaced font

### DIFF
--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -93,7 +93,7 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("Editor/font", "Consolas,10");
   setDefault("General/theme", "webots_classic.qss");
 #elif defined(__APPLE__)
-  setDefault("Editor/font", "Courier,14");  // "Monospace" isn't supported under MacOS
+  setDefault("Editor/font", "Courier New,14");  // "Monospace" isn't supported under MacOS
   setDefault("General/theme", "webots_classic.qss");
 #else
   setDefault("Editor/font", "Monospace, 9");

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -15,6 +15,7 @@
 #include "WbExternProtoEditor.hpp"
 #include "WbActionManager.hpp"
 #include "WbInsertExternProtoDialog.hpp"
+#include "WbPreferences.hpp"
 #include "WbProtoManager.hpp"
 
 #include <QtCore/QEvent>
@@ -53,7 +54,7 @@ void WbExternProtoEditor::updateContents() {
   info->setAlignment(Qt::AlignCenter);
   info->setMinimumHeight(40);
   info->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-  info->setFont(QFont("Monospace", 8, QFont::Light, true));
+  info->setFont(WbPreferences::instance()->value("Editor/font").toString());
   info->setStyleSheet("background-color: transparent;");
   mLayout->addWidget(info, 0, 0, 1, 2);
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -32,10 +32,8 @@
 WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) : mRetrievalTriggered(false) {
   QVBoxLayout *const layout = new QVBoxLayout(this);
 
-  QFont font;
-  font.fromString(WbPreferences::instance()->value("Editor/font").toString());
   mSearchBar = new QLineEdit(this);
-  mSearchBar->setFont(font);
+  mSearchBar->setFont(WbPreferences::instance()->value("Editor/font").toString());
   mSearchBar->setClearButtonEnabled(true);
 
   mTree = new QTreeWidget();


### PR DESCRIPTION
This PR fixes a warning showing-up on macOS since the introduction of the EXTERNPROTO.
It also defaults to a better looking font for the text editor and console.