### PR TITLE
Remove webots_ros from sample worlds

### DIFF
--- a/src/webots/gui/WbOpenSampleWorldDialog.cpp
+++ b/src/webots/gui/WbOpenSampleWorldDialog.cpp
@@ -108,9 +108,7 @@ namespace {
     foreach (const QString &dirName, dirList) {
       QDir childDir(QString("%1/%2").arg(dir.absolutePath()).arg(dirName));
       if (directoryContainsWbtFile(childDir, wildcard)) {
-        if (dirName == "projects")  // skip the 'projects' directory in 'resources'
-          continue;
-        else if (dirName == "worlds")  // skip this directory layer
+        if (dirName == "worlds")  // skip this directory layer
           populateTreeModel(itemCounter, parent, childDir, wildcard);
         else {
           QStandardItem *item = new QStandardItem(dirName);
@@ -217,8 +215,6 @@ void WbOpenSampleWorldDialog::updateTree(const QString &reg) {
 
   int itemCounter = 0;
   populateTreeModel(itemCounter, parentItem, QDir(WbStandardPaths::projectsPath()), mFindLineEdit->text());
-  populateTreeModel(itemCounter, parentItem, QDir(WbStandardPaths::resourcesPath()),
-                    mFindLineEdit->text());  // add the worlds placed in the 'resources' directory
 
   if (itemCounter < 10)
     mTreeView->expandAll();


### PR DESCRIPTION
Worlds from the `webots_ros` submodule are located in the `resources` directory and were added to the sample worlds in #3835. This is not really useful and a bit confusing as these worlds can't work alone. Instead, they should be launched using `roslaunch` directly from the package folder.
