### PR TITLE
Remove broken dependency on Ubuntu 22.04

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -6,7 +6,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 apt update
-apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage3 libfreetype6-dev libxml2-dev libboost-dev libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 libpci-dev wget zip unzip
+apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage3 libfreetype6-dev libxml2-dev libboost-dev libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 wget zip unzip
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "20.04" ]]; then


### PR DESCRIPTION
Some dependencies were not installed because of a broken library with unmet dependencies.