### PR TITLE
Fix test world update

### DIFF
--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -69,7 +69,6 @@ jobs:
         name: build-${{ matrix.os }}
         path: |
           distribution/*.tar.bz2
-          distribution/*.zip
     - uses: actions/upload-artifact@v2
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'test suite') && !contains(github.event.pull_request.labels.*.name, 'test ros') && !contains(github.event.pull_request.labels.*.name, 'test world update') }}
       with:
@@ -77,6 +76,7 @@ jobs:
         path: |
           distribution/*.tar.bz2
           distribution/*.deb
+          distribution/*.zip
   test-suite:
     needs: build
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || github.event_name == 'schedule' }}


### PR DESCRIPTION
**Description**

The first upload job is not executed for the "scheduled" event, so the assets need to be uploaded in the second upload task, hence why the world upload worked for the manual trigger but not with a [scheduled run](https://github.com/cyberbotics/webots/runs/7033478162?check_suite_focus=true)