### PR TITLE
Fix errors import osm

### DIFF
--- a/projects/vehicles/importer_demo.sh
+++ b/projects/vehicles/importer_demo.sh
@@ -47,11 +47,11 @@ if [ -z "$WEBOTS_HOME" ]; then
 fi
 if [ -z "$SUMO_HOME" ]; then
   export SUMO_HOME=$WEBOTS_HOME/projects/default/resources/sumo
-  if [ "${os:0:5}" == "Linux" ]; then
+  if [ "${kernel:0:5}" == "Linux" ]; then
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$WEBOTS_HOME/lib
   fi
 fi
-if [ "${os:0:5}" == "Linux" ]; then
+if [ "${kernel:0:5}" == "Linux" ]; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SUMO_HOME/bin
 fi
 

--- a/projects/vehicles/importer_demo.sh
+++ b/projects/vehicles/importer_demo.sh
@@ -27,6 +27,7 @@ usage() {
 # variables
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 osm_file_path=$script_dir/resources/osm_files/$1.osm
+kernel=$(uname -s)
 
 # arguments check
 if [ $# -ne 1 ]; then
@@ -46,17 +47,13 @@ if [ -z "$WEBOTS_HOME" ]; then
 fi
 if [ -z "$SUMO_HOME" ]; then
   export SUMO_HOME=$WEBOTS_HOME/projects/default/resources/sumo
-  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  if [ "${os:0:5}" == "Linux" ]; then
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$WEBOTS_HOME/lib
   fi
 fi
-
-if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+if [ "${os:0:5}" == "Linux" ]; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SUMO_HOME/bin
 fi
-
-# dependencies
-pip install webcolors pyproj shapely >/dev/null 2>&1
 
 mkdir -p $script_dir/worlds/$1_net
 

--- a/projects/vehicles/importer_demo.sh
+++ b/projects/vehicles/importer_demo.sh
@@ -55,6 +55,9 @@ if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SUMO_HOME/bin
 fi
 
+# dependencies
+pip install webcolors pyproj shapely >/dev/null 2>&1
+
 mkdir -p $script_dir/worlds/$1_net
 
 echo


### PR DESCRIPTION
Fixes #3298.

On MacOS, `expr: syntax error` are triggered by the `import_demo.sh` script as expr substr is not supported.  See [macos-mojave-version-10-14-1-bash-3-2-expr-syntax-error](https://stackoverflow.com/questions/53701873/macos-mojave-version-10-14-1-bash-3-2-expr-syntax-error).