### PR TITLE
Removed unused variable

### DIFF
--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -280,7 +280,6 @@ int WbProjectRelocationDialog::copyProject(const QString &projectPath, bool copy
     if (proto) {
       protoProjectDir.setPath(QFileInfo(proto->fileName()).path());
       protoProjectDir.cdUp();
-      const QString &protoControllerPath = protoProjectDir.path() + "/controllers/" + controllerName + "/";
       if (mIsProtoModified && proto->fileName() == (projectPath + mRelativeFilename))
         isThisProtoModified = true;
       else


### PR DESCRIPTION
The build on macOS was failing due to a unused variable: https://github.com/cyberbotics/webots/runs/7042679339?check_suite_focus=true
This PR fixes it.
