### PR TITLE
Fix "current world" list in AddNode

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -618,6 +618,7 @@ int WbAddNodeDialog::addProtosFromProtoList(QTreeWidgetItem *parentItem, int typ
 
     // populate tree
     if (flattenHierarchy) {
+      printf("%s -> %s\n", it.key().toUtf8().constData(), info->url().toUtf8().constData());
       QTreeWidgetItem *item =
         new QTreeWidgetItem(QStringList() << QString("%1 (%2)").arg(nodeName).arg(baseType) << info->url());
       parentItem->addChild(item);


### PR DESCRIPTION
**Description**

Fixes: https://github.com/cyberbotics/webots/issues/4720

The "current world" category is supposed to list the PROTO that are referenced in the current world file (i.e. all EXTERNPROTO mentioned in the wbt). If some or all of these url are not local (as is the case for an official distribution), then its name must be inferred by a reverse lookup of the cached file (since the cached file's name is the hash). Also, being an official PROTO means we can skip the info generation step