### PR TITLE
MacOS update SUMO from 1.10.0 to 1.13.0

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -81,6 +81,7 @@ Released on XX, XXth, 2022.
     - Linux: added support for Ubuntu 22.04 LTS and **stopped support for Ubuntu 18.04** ([#4502](https://github.com/cyberbotics/webots/pull/4502)).
     - Linux: **removed support of Python 3.6** ([#4502](https://github.com/cyberbotics/webots/pull/4502)).
     - Linux: upgraded SUMO version to 1.13.0 ([#4502](https://github.com/cyberbotics/webots/pull/4502)).
+    - MacOS: upgraded SUMO version to 1.13.0 ([#4758](https://github.com/cyberbotics/webots/pull/4758)).
 
 ## Webots R2022a
 Released on December 21th, 2021.

--- a/projects/default/resources/Makefile
+++ b/projects/default/resources/Makefile
@@ -18,7 +18,6 @@ WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
 SUMO_TARGET=sumo
-SUMO_VERSION=1.10.0
 VER_UBUNTU = 20.04
 
 ifeq ($(OSTYPE),linux)
@@ -36,9 +35,10 @@ ifeq ($(OSTYPE),linux)
 endif
 
 ifeq ($(OSTYPE),darwin)
+ SUMO_VERSION=1.13.0
  OS_TAG=mac
  SUMO_PACKAGE=sumo-$(SUMO_VERSION)-mac.tar.gz
- SUMO_MD5SUM="a8900ed025fb930cb78609f08b6cd204"
+ SUMO_MD5SUM="e53ad5d12b06c48a0d81c1b0ea792b8e"
  PREVIOUS_SUMO_PACKAGE=$(filter-out $(SUMO_PACKAGE),$(wildcard sumo-*-mac.tar.gz))
  EXTRACT=tar xfz
  # remove .tar.gz
@@ -47,6 +47,7 @@ ifeq ($(OSTYPE),darwin)
 endif
 
 ifeq ($(OSTYPE),windows)
+ SUMO_VERSION=1.10.0
  OS_TAG=windows
  SUMO_PACKAGE=sumo-$(SUMO_VERSION)-windows.zip
  SUMO_MD5SUM="2fd97eeb01fb11d4e95c3e95fd2bb4a3"


### PR DESCRIPTION
SUMO 1.10.0 depends on libgdal.29.dylib which has been updated to version 31 on recent MacOS distributions. This PR updates SUMO to 1.13.0 on MacOS to fix the library dependency.

Note: the [wiki page](https://github.com/cyberbotics/webots/wiki/SUMO-compilation#mac) on how to create a SUMO package on Mac needed a refresh and is now up-to-date.