### PR TITLE
Fix import of undeclared PROTO

### DIFF
--- a/projects/default/controllers/sumo_supervisor/SumoSupervisor.py
+++ b/projects/default/controllers/sumo_supervisor/SumoSupervisor.py
@@ -100,8 +100,10 @@ class SumoSupervisor (Supervisor):
         # load the new vehicle
         vehicleString, defName = Vehicle.generate_vehicle_string(self.vehicleNumber, vehicleClass)
         self.rootChildren.importMFNodeFromString(-1, vehicleString)
-        self.vehicles[self.vehicleNumber] = Vehicle(self.getFromDef(defName))
-        self.vehicleNumber += 1
+        nodeRef = self.getFromDef(defName)
+        if nodeRef:
+            self.vehicles[self.vehicleNumber] = Vehicle(nodeRef)
+            self.vehicleNumber += 1
 
     def get_vehicle_index(self, id, generateIfneeded=True):
         """Look for the vehicle index corresponding to this id (and optionnaly create it if required)."""

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -230,7 +230,6 @@ void WbApplication::loadWorld(QString worldName, bool reloading, bool isLoadingA
     return;
   }
 
-  tokenizer.rewind();  // the backwards compatibility mechanism might have consumed tokens
   int errors = tokenizer.tokenize(worldName);
   if (errors) {
     WbLog::error(tr("'%1': Failed to load due to invalid token(s).").arg(worldName));

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -143,16 +143,6 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
 
   // check syntax
   WbParser parser(&tokenizer);
-  if (!parser.parseObject(WbWorld::instance()->fileName())) {
-    mFromSupervisor = false;
-    return FAILURE;
-  }
-
-  if (sfnode && sfnode->value() != NULL)
-    // clear selection and set mSelectedItem to NULL
-    WbSelection::instance()->selectTransformFromView3D(NULL);
-
-  tokenizer.rewind();
   const QStringList protoList = parser.protoNodeList();
   foreach (const QString &protoName, protoList) {
     // ensure the node was declared as EXTERNPROTO prior to import it
@@ -162,6 +152,15 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
       return FAILURE;
     }
   }
+
+  if (!parser.parseObject(WbWorld::instance()->fileName())) {
+    mFromSupervisor = false;
+    return FAILURE;
+  }
+
+  if (sfnode && sfnode->value() != NULL)
+    // clear selection and set mSelectedItem to NULL
+    WbSelection::instance()->selectTransformFromView3D(NULL);
 
   // read node
   WbNode::setGlobalParentNode(parentNode);

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -141,7 +141,8 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
     return FAILURE;
   }
 
-  // check syntax
+  // note: ephemeral PROTO declaration must be checked prior to checking the syntax since in order to check the latter the PROTO
+  // themselves must be locally available and readable
   WbParser parser(&tokenizer);
   const QStringList protoList = parser.protoNodeList();
   foreach (const QString &protoName, protoList) {
@@ -153,6 +154,7 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
     }
   }
 
+  // check syntax
   if (!parser.parseObject(WbWorld::instance()->fileName())) {
     mFromSupervisor = false;
     return FAILURE;

--- a/src/webots/vrml/WbParser.cpp
+++ b/src/webots/vrml/WbParser.cpp
@@ -485,22 +485,18 @@ void WbParser::skipExternProto() {
 }
 
 QStringList WbParser::protoNodeList() {
-  QStringList protoList;
+  const int position = mTokenizer->pos();
+  assert(mTokenizer->hasMoreTokens());
+  mTokenizer->nextToken();  // consume the first token so that lastWord() is defined
 
-  mTokenizer->nextToken();  // consume the first token to that lastWord() is defined
+  QStringList protoList;
   while (mTokenizer->hasMoreTokens()) {
-    // note: this function is part of the backwards compatibility mechanism and its purpose is to be able to load worlds even if
-    // they do not declare the PROTO they use (with EXTERNPROTO). The mechanism applies only to PROTO nodes that are part of the
-    // proto-list.xml (Webots PROTO) and, if they are, the names will start with an uppercase letter which allows to filter them
-    // out from other identifier tokens (ex: fields)
-    const QString &word = mTokenizer->peekWord();
-    if (mTokenizer->peekToken()->isIdentifier() && word[0].isUpper() && word != word.toUpper() &&
-        mTokenizer->lastWord() != "DEF" && mTokenizer->lastWord() != "USE" &&
-        !WbNodeModel::isBaseModelName(WbNodeModel::compatibleNodeName(word)) && !protoList.contains(word))
-      protoList << word;
+    if (mTokenizer->peekWord() == "{" && !WbNodeModel::isBaseModelName(WbNodeModel::compatibleNodeName(mTokenizer->lastWord())))
+      protoList << mTokenizer->lastWord();
 
     mTokenizer->nextToken();
   }
 
+  mTokenizer->seek(position);
   return protoList;
 }

--- a/src/webots/vrml/WbParser.hpp
+++ b/src/webots/vrml/WbParser.hpp
@@ -56,8 +56,7 @@ public:
   // prerequisite: the tokenizer must point to the "PROTO" keyword
   static void skipProtoDefinition(WbTokenizer *tokenizer);
   static double legacyGravity();
-  // returns the list of all PROTO nodes invoked by the world/string; this function is part of the backwards compatibility
-  // mechanism for worlds that do not declare the EXTERNPROTO they rely upon
+  // returns the list of all PROTO nodes invoked by a tokenized vrml string
   QStringList protoNodeList();
 
 private:

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -295,7 +295,6 @@ void WbProtoManager::loadWebotsProtoMap() {
 }
 
 void WbProtoManager::generateProtoInfoMap(int category, bool regenerate) {
-  printf("%d %d\n", category, regenerate);
   if (!regenerate)
     return;
 

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -295,6 +295,7 @@ void WbProtoManager::loadWebotsProtoMap() {
 }
 
 void WbProtoManager::generateProtoInfoMap(int category, bool regenerate) {
+  printf("%d %d\n", category, regenerate);
   if (!regenerate)
     return;
 


### PR DESCRIPTION
**Description**

Fixes: https://github.com/cyberbotics/webots/issues/4730

The existing logic to check whether a PROTO can be inserted only applied to the top level nodes. The check was bypassed in more complex vrml imports which resulted in the load execution to continue despite the missing assets.

This PR also improves the logic to identify nodes in a vrml string (used also by the backwards compatibility mechanism)