### PR TITLE
Added template.proto to distributions

### DIFF
--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -115,7 +115,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             ROS_DISTRO: noetic
-            python: 3.6
+            python: 3.8
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -130,7 +130,7 @@ jobs:
     - name: Extract Webots
       run: tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
     - name: Install Webots Dependencies
-      run: sudo scripts/install/linux_test_dependencies.sh --norecurse
+      run: sudo scripts/install/linux_test_dependencies.sh
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -115,7 +115,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             ROS_DISTRO: noetic
-            python: 3.8
+            python: 3.6
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -130,7 +130,7 @@ jobs:
     - name: Extract Webots
       run: tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
     - name: Install Webots Dependencies
-      run: sudo scripts/install/linux_test_dependencies.sh
+      run: sudo scripts/install/linux_test_dependencies.sh --norecurse
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:

--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -278,6 +278,9 @@ resources/webots_dusk.qss
 resources/webots_night.qss
 resources/sumo_exporter/
 resources/sumo_exporter/*.py
+resources/templates/
+resources/templates/protos/
+resources/templates/protos/template.proto
 resources/translations/
 resources/translations/Makefile
 resources/translations/*.ts

--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -170,6 +170,10 @@ lib/webots/qt/libexec/ [linux]
 lib/webots/qt/libexec/qt.conf [linux]
 
 resources/
+resources/fonts/
+resources/fonts/fallback_fonts.txt
+resources/fonts/SIL-Open-Font-License.txt
+resources/fonts/*.ttf
 resources/icons/
 resources/icons/core/
 resources/icons/core/*.png
@@ -185,14 +189,11 @@ resources/images/splash_images/
 resources/images/splash_images/*.jpg
 resources/images/themes/
 resources/images/themes/*.png
-resources/fonts/
-resources/fonts/fallback_fonts.txt
-resources/fonts/SIL-Open-Font-License.txt
-resources/fonts/*.ttf
-resources/templates/
-resources/templates/controllers [recurse]
-resources/templates/plugins/
-resources/templates/plugins/physics [recurse]
+resources/javascript/
+resources/javascript/jsTemplate.js
+resources/javascript/modules/
+resources/javascript/modules/webots/
+resources/javascript/modules/webots/*.js
 resources/lua/
 resources/lua/liluat/
 resources/lua/modules/
@@ -200,11 +201,6 @@ resources/lua/modules/webots/
 resources/lua/modules/webots/*.lua
 resources/lua/liluat/license.txt
 resources/lua/liluat/*.lua
-resources/javascript/
-resources/javascript/jsTemplate.js
-resources/javascript/modules/
-resources/javascript/modules/webots/
-resources/javascript/modules/webots/*.js
 resources/Makefile.include
 resources/Makefile.java.include
 resources/Makefile.os.include
@@ -270,15 +266,12 @@ resources/projects/plugins/robot_windows/generic_window/Makefile
 resources/projects/plugins/robot_windows/generic_window/*pp
 resources/projects/worlds/
 resources/projects/worlds/empty.wbt
-resources/stylesheet.linux.qss [linux]
-resources/stylesheet.macos.qss [mac]
-resources/stylesheet.windows.qss [windows]
-resources/webots_classic.qss
-resources/webots_dusk.qss
-resources/webots_night.qss
 resources/sumo_exporter/
 resources/sumo_exporter/*.py
 resources/templates/
+resources/templates/controllers [recurse]
+resources/templates/plugins/
+resources/templates/plugins/physics [recurse]
 resources/templates/protos/
 resources/templates/protos/template.proto
 resources/translations/
@@ -316,8 +309,14 @@ resources/wren/shaders/*.frag
 resources/wren/shaders/*.vert
 resources/wren/textures/
 resources/wren/textures/*.png
-resources/version.txt
 resources/qt_warning_filters.conf
+resources/stylesheet.linux.qss [linux]
+resources/stylesheet.macos.qss [mac]
+resources/stylesheet.windows.qss [windows]
+resources/version.txt
+resources/webots_classic.qss
+resources/webots_dusk.qss
+resources/webots_night.qss
 
 scripts/
 scripts/preferences_cleaner [recurse]

--- a/scripts/packaging/files_core.txt
+++ b/scripts/packaging/files_core.txt
@@ -201,9 +201,6 @@ resources/lua/modules/webots/
 resources/lua/modules/webots/*.lua
 resources/lua/liluat/license.txt
 resources/lua/liluat/*.lua
-resources/Makefile.include
-resources/Makefile.java.include
-resources/Makefile.os.include
 resources/nodes/
 resources/nodes/*.wrl
 resources/nodes/icons/
@@ -309,6 +306,10 @@ resources/wren/shaders/*.frag
 resources/wren/shaders/*.vert
 resources/wren/textures/
 resources/wren/textures/*.png
+
+resources/Makefile.include
+resources/Makefile.java.include
+resources/Makefile.os.include
 resources/qt_warning_filters.conf
 resources/stylesheet.linux.qss [linux]
 resources/stylesheet.macos.qss [mac]

--- a/scripts/packaging/generic_distro.py
+++ b/scripts/packaging/generic_distro.py
@@ -124,12 +124,6 @@ class WebotsPackage(ABC):
         if not os.access(local_dir_path, os.F_OK):
             print_error_message_and_exit(f"Missing dir: {dir_name}")
 
-    def compute_md5_of_file(self, filename):
-        with open(filename, 'rb') as file_to_check:
-            # read contents of the file and compute md5sum
-            data = file_to_check.read()
-            return hashlib.md5(data).hexdigest()
-
     @abstractmethod
     def make_dir(self, directory):
         pass

--- a/scripts/packaging/generic_distro.py
+++ b/scripts/packaging/generic_distro.py
@@ -18,7 +18,6 @@
 
 from generate_projects_files import list_projects, is_ignored_file, is_ignored_folder
 import glob
-import hashlib
 import os
 import re
 import shutil

--- a/scripts/packaging/generic_distro.py
+++ b/scripts/packaging/generic_distro.py
@@ -185,25 +185,8 @@ class WebotsPackage(ABC):
             self.package_files.append(os.path.relpath(world_project_file, self.webots_home))
 
         if file_path.endswith('.proto') and str(os.path.sep + 'protos' + os.path.sep) in file_path:
-            # compute MD5 fo PROTO file
             if not os.path.exists(absolute_path):
                 print_error_message_and_exit(f"Missing file: {absolute_path}")
-
-            md5Value = self.compute_md5_of_file(absolute_path)
-            # read cache file and check MD5 value
-            proto_cache_file = os.path.join(dirname, '.' + re.sub(r'.proto$', '.cache', basename))
-            if not os.path.exists(proto_cache_file):
-                print_error_message_and_exit(f"Missing file: {proto_cache_file}")
-
-            with open(proto_cache_file, 'r') as proto_file:
-                for line in proto_file:
-                    line.strip()
-                    if line.startswith('protoFileHash:') and md5Value != line[len("protoFileHash:"):].strip():
-                        print_error_message_and_exit(f"Out-of-date file: {proto_cache_file}")
-
-            # copy the .*.cache hidden file
-            self.set_file_attribute(proto_cache_file, 'hidden')
-            self.package_files.append(os.path.relpath(proto_cache_file, self.webots_home))
 
     def add_files_from_string(self, line):
         # add this file or folder to self.package_files and self.package_folders


### PR DESCRIPTION
Fixes #4729.

The PROTO wizard is not working in distributed packages because `template.proto ` is not distributed. The PR also removes the .cache file verification and copy when creating a distribution.
