### PR TITLE
adding the missing EXTERNPROTO definitions to the highway.wbt world

### DIFF
--- a/projects/vehicles/worlds/highway.wbt
+++ b/projects/vehicles/worlds/highway.wbt
@@ -22,6 +22,13 @@ EXTERNPROTO "webots://projects/objects/traffic/protos/HighwayPole.proto"
 EXTERNPROTO "webots://projects/objects/traffic/protos/HighwaySign.proto"
 EXTERNPROTO "webots://projects/objects/traffic/protos/DivergentIndicator.proto"
 EXTERNPROTO "webots://projects/vehicles/protos/bmw/BmwX5.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/bmw/BmwX5Simple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/citroen/CitroenCZeroSimple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/toyota/ToyotaPriusSimple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/range_rover/RangeRoverSportSVRSimple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/lincoln/LincolnMKZSimple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/tesla/TeslaModel3Simple.proto"
+EXTERNPROTO "webots://projects/vehicles/protos/mercedes_benz/MercedesBenzSprinterSimple.proto"
 EXTERNPROTO "webots://projects/objects/road/protos/Crossroad.proto"
 
 WorldInfo {


### PR DESCRIPTION
**Description**
Adding the missing EXTERNPROTO files to the `projects/vehicle/highway.wbt` world.

**Related Issues**
This pull-request fixes issue #4730.
