### PR TITLE
Fixed path to proto robot windows

### DIFF
--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -460,7 +460,11 @@ const QString WbProtoModel::projectPath() const {
 #endif
 
     QDir protoProjectDir(path);
-    while (protoProjectDir.dirName() != "protos" && protoProjectDir.cdUp()) {
+    while (protoProjectDir.dirName() != "protos") {
+      QString dir = protoProjectDir.path();
+      // cd up (we don't use QDir::cdUp() as it doesn't cd up if the upper folder doesn't exist which may happen here)
+      dir.chop(protoProjectDir.dirName().size() + 1);
+      protoProjectDir = QDir(dir);
       if (protoProjectDir.isRoot())
         return QString();
     }


### PR DESCRIPTION
In the distribution, Webots is unable to locate the robot window for a PROTO when it has to climb-up the PROTO file path, which is the case for the automobile robot window. This PR fixes the problem.

Basically, in the distribution the following folder doesn't exist: `WEBOTS_HOME/projects/vehicles/protos/` because the PROTOs are not distributed in the package any more. However, the algorithm searching for the robot window plugin will start from: `WEBOTS_HOME/projects/vehicles/protos/licoln/LincolnLKZ.proto` and climb-up to the `WEBOTS_HOME/projects/vehicles/` folder to finally find `WEBOTS_HOME/projects/vehicles/plugins/robot_windows/automobile/`. The climb-up algorithm relied on `QDir::cdUp()` which actually fails to cd up if the resulting folder doesn't exist. Thus, it was failing to cd up to `WEBOTS_HOME/projects/vehicles/protos` and was unable to find the automobile robot window.