### PR TITLE
Fix macOS contents path

### DIFF
--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
@@ -28,7 +28,12 @@ const string &RobotisOp2DirectoryManager::getDataDirectory() {
   static string path = "/robotis/Data/";
 #else
   char *WEBOTS_HOME = wbu_system_getenv("WEBOTS_HOME");
-  static string path = string(WEBOTS_HOME) + "/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
+  static string path = string(WEBOTS_HOME)
+#ifdef __APPLE__
+                       + "Contents/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
+#else
+                       + "/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
+#endif
 #endif
   return path;
 }

--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
@@ -30,10 +30,9 @@ const string &RobotisOp2DirectoryManager::getDataDirectory() {
   char *WEBOTS_HOME = wbu_system_getenv("WEBOTS_HOME");
   static string path = string(WEBOTS_HOME)
 #ifdef __APPLE__
-                       + "Contents/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
-#else
-                       + "/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
+                       + "Contents/"
 #endif
+                       + "/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
 #endif
   return path;
 }

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -87,11 +87,7 @@ const QString &WbStandardPaths::projectsPath() {
 };
 
 const QString &WbStandardPaths::resourcesPath() {
-#ifdef __APPLE__
-  static QString path(webotsHomePath() + "Contents/Resources/");
-#else
-  static QString path(webotsHomePath() + "resources/");
-#endif
+  static QString path(webotsHomePath() + cMacOsContents + "resources/");
   return path;
 };
 
@@ -273,6 +269,6 @@ const QString &WbStandardPaths::webotsTmpPath() {
 }
 
 const QString &WbStandardPaths::vehicleLibraryPath() {
-  static QString path(webotsHomePath() + "projects/default/libraries/vehicle/");
+  static QString path(webotsHomePath() + cMacOsContents + "projects/default/libraries/vehicle/");
   return path;
 }

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -87,7 +87,11 @@ const QString &WbStandardPaths::projectsPath() {
 };
 
 const QString &WbStandardPaths::resourcesPath() {
-  static QString path(webotsHomePath() + cMacOsContents + "resources/");
+#ifdef __APPLE__
+  static QString path(webotsHomePath() + "Contents/Resources/");
+#else
+  static QString path(webotsHomePath() + "resources/");
+#endif
   return path;
 };
 


### PR DESCRIPTION
**Description**
Continue fix #4761 as Contents was missing from vehicle library paths.
