### PR TITLE
Attempt to fix random robot window test failures

### DIFF
--- a/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
+++ b/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
@@ -241,7 +241,6 @@ class TestSuite (Supervisor):
 
         # 30 seconds before executing the next world, 60 seconds for the robot_window_html test
         delay = 60 if self.currentSimulationFilename.endswith('/robot_window_html.wbt') else 30
-        print(f'delay = {delay}')
         timeout = time.time() + delay
 
         running_controllers_pid = []

--- a/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
+++ b/tests/default/controllers/test_suite_supervisor/test_suite_supervisor.py
@@ -239,8 +239,10 @@ class TestSuite (Supervisor):
             receiver = self.getDevice("ts_receiver")
             receiver.enable(basicTimeStep)
 
-        # 30 seconds before executing the next world
-        timeout = time.time() + 30
+        # 30 seconds before executing the next world, 60 seconds for the robot_window_html test
+        delay = 60 if self.currentSimulationFilename.endswith('/robot_window_html.wbt') else 30
+        print(f'delay = {delay}')
+        timeout = time.time() + delay
 
         running_controllers_pid = []
         test_started = False


### PR DESCRIPTION
Fixes #4632.

The robot windows CI test requires to start a browser on the CI machine. This may be a long process as the browser start-up on these machines may be slow. Maybe it needs to install some updates from time to time.