### PR TITLE
Hotfix darwin-op motion path

### DIFF
--- a/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
+++ b/projects/robots/robotis/darwin-op/libraries/managers/src/RobotisOp2DirectoryManager.cpp
@@ -30,7 +30,7 @@ const string &RobotisOp2DirectoryManager::getDataDirectory() {
   char *WEBOTS_HOME = wbu_system_getenv("WEBOTS_HOME");
   static string path = string(WEBOTS_HOME)
 #ifdef __APPLE__
-                       + "Contents/"
+                       + "/Contents"
 #endif
                        + "/projects/robots/robotis/darwin-op/libraries/robotis-op2/robotis/Data/";
 #endif


### PR DESCRIPTION
**Description**
Backslash was in wrong position

<img width="1118" alt="Screenshot 2022-06-30 at 09 01 15" src="https://user-images.githubusercontent.com/100125668/176613695-d10c4b13-a7a2-46f4-ab91-371beb249c2e.png">

