### PR TITLE
Disable `local_proto_with_texture.wbt` in the CI

### DIFF
--- a/scripts/packaging/update_urls.py
+++ b/scripts/packaging/update_urls.py
@@ -52,11 +52,6 @@ def replace_projects_urls(tag, revert=False):
     else:
         WEBOTS_HOME = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-    skipped_files = [
-        '/tests/cache/worlds/local_proto_with_texture.wbt'
-    ]
-    skipped_files = [(Path(WEBOTS_HOME + file)).resolve() for file in skipped_files]
-
     only_replace_extern_proto = [
         '/projects/samples/howto/url/worlds/url.wbt',
         '/tests/api/worlds/camera_color.wbt'
@@ -73,8 +68,7 @@ def replace_projects_urls(tag, revert=False):
         paths.extend(list(map(lambda path: Path(WEBOTS_HOME + path), files.read().splitlines())))
 
     for path in paths:
-        if path.resolve() not in skipped_files:
-            replace_url(path, tag, True, path.resolve() in only_replace_extern_proto, revert)
+        replace_url(path, tag, True, path.resolve() in only_replace_extern_proto, revert)
 
     paths = []
     paths.extend(Path(WEBOTS_HOME + '/projects').rglob("*/plugins/robot_windows/*/*.html"))

--- a/scripts/packaging/update_urls.py
+++ b/scripts/packaging/update_urls.py
@@ -52,6 +52,11 @@ def replace_projects_urls(tag, revert=False):
     else:
         WEBOTS_HOME = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+    skipped_files = [
+        '/tests/cache/worlds/local_proto_with_texture.wbt'
+    ]
+    skipped_files = [(Path(WEBOTS_HOME + file)).resolve() for file in skipped_files]
+
     only_replace_extern_proto = [
         '/projects/samples/howto/url/worlds/url.wbt',
         '/tests/api/worlds/camera_color.wbt'
@@ -68,7 +73,8 @@ def replace_projects_urls(tag, revert=False):
         paths.extend(list(map(lambda path: Path(WEBOTS_HOME + path), files.read().splitlines())))
 
     for path in paths:
-        replace_url(path, tag, True, path.resolve() in only_replace_extern_proto, revert)
+        if path.resolve() not in skipped_files:
+            replace_url(path, tag, True, path.resolve() in only_replace_extern_proto, revert)
 
     paths = []
     paths.extend(Path(WEBOTS_HOME + '/projects').rglob("*/plugins/robot_windows/*/*.html"))

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -206,8 +206,7 @@ def generateWorldsList(groupName, worldsFilename):
             if (not filename.endswith('_temp.wbt') and
                     not ('GITHUB_ACTIONS' in os.environ and (
                         filename.endswith('speaker.wbt') or
-                        (filename.endswith('robot_window_html.wbt') and is_ubuntu_22_04) or
-                        (filename.endswith('supervisor_start_stop_movie.wbt') and is_ubuntu_22_04)
+                        filename.endswith('local_proto_with_texture.wbt')
                         ))):
                 f.write(filename + '\n')
                 worldsCount += 1


### PR DESCRIPTION
**Description**
As emerged in https://github.com/cyberbotics/webots/pull/4776, the test `local_proto_with_texture.wbt` cannot really work in the CI because a `webots://` url references locally available proto which in practice aren't distributed. It currently works because models with the same name are already in memory but shouldn't be.

In theory we can make the test "pass" by changing the urls, but what we would be testing isn't what the test is supposed to check so having it run on the CI is misleading.

The test is still rather important because it reflects the behavior we can expect in the webots development environment.