### PR TITLE
Fix clarify robot windows URLs with WEBOTS_HOME

### DIFF
--- a/resources/web/wwi/RobotWindow.js
+++ b/resources/web/wwi/RobotWindow.js
@@ -3,8 +3,8 @@ import {getGETQueryValue} from './request_methods.js';
 export default class RobotWindow {
   constructor(onready) {
     this.name = decodeURI(getGETQueryValue('name', 'undefined'));
-    if (window.location.href.includes('/~/'))
-      this.wsServer = window.location.href.substring(0, window.location.href.indexOf('/~/') + 1);
+    if (window.location.href.includes('/~WEBOTS_HOME/'))
+      this.wsServer = window.location.href.substring(0, window.location.href.indexOf('/~WEBOTS_HOME/') + 1);
     else
       this.wsServer = window.location.href.substring(0, window.location.href.indexOf('/robot_windows/') + 1);
     this.wsServer = this.wsServer.replace('https://', 'wss://').replace('http://', 'ws://');

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -37,7 +37,7 @@ void WbRobotWindow::setupPage(int port) {
   // if the file is located in Webots installation directory, the WEBOTS_HOME part is replaced by "/~/" in the absolute path
   // if the file is located at another place, only the relative path is kept
   if (windowFileName.startsWith(WbStandardPaths::webotsHomePath()))
-    windowFileName = "/~" + windowFileName.mid(WbStandardPaths::webotsHomePath().length() - 1);
+    windowFileName = "/~WEBOTS_HOME" + windowFileName.mid(WbStandardPaths::webotsHomePath().length() - 1);
   else
     windowFileName = windowFileName.mid(windowFileName.indexOf("/robot_windows"));
 

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -285,8 +285,8 @@ void WbTcpServer::sendTcpRequestReply(const QString &completeUrl, const QString 
     filePath = WbStandardPaths::resourcesProjectsPath() + "plugins/" + url;
   else if (url.startsWith("robot_windows/"))
     filePath = WbProject::current()->pluginsPath() + url;
-  else if (url.startsWith("~/"))
-    filePath = WbStandardPaths::webotsHomePath() + url.mid(2);
+  else if (url.startsWith("~WEBOTS_HOME/"))
+    filePath = WbStandardPaths::webotsHomePath() + url.mid(13);
   else if (url.endsWith(".js") || url.endsWith(".css") || url.endsWith(".html"))
     filePath = WbStandardPaths::webotsHomePath() + url;
   socket->write(filePath.isEmpty() ? WbHttpReply::forge404Reply(url) : WbHttpReply::forgeFileReply(filePath, etag, host, url));


### PR DESCRIPTION
#4803 introduced a new way to describe robot-windows files of projects located in the Webots installation directory (WEBOTS_HOME) using a tilde symbol: `/~/path/to/project`.

This PR adds WEBOTS_HOME to the tilde to clarify its signification: `/~WEBOTS_HOME/path/to/project`
