### PR TITLE
Improve field editor visibility

### DIFF
--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -264,16 +264,9 @@ void WbSceneTree::setWorld(WbWorld *world) {
 }
 
 void WbSceneTree::showExternProtoPanel() {
-  // ensure that when the button is clicked the panel is always shown
-  QList<int> currentSize = mSplitter->sizes();
-  if (currentSize[2] == 0) {
-    QList<int> sizes;
-    int quarterSize = (mSplitter->height() * 0.25);
-    sizes << currentSize[0] << (mSplitter->height() - quarterSize) << quarterSize;
-    mSplitter->setSizes(sizes);
-    mSplitter->setHandleWidth(mHandleWidth);
-  }
   clearSelection();
+  // uncollapse the field editor
+  handleFieldEditorVisibility(true);
   emit nodeSelected(NULL);
   mFieldEditor->editExternProto();
 }
@@ -1078,6 +1071,9 @@ void WbSceneTree::clearSelection() {
 
   mFieldEditor->setTitle("");
   mFieldEditor->editField(NULL, NULL);
+
+  // collapse the field editor
+  handleFieldEditorVisibility(false);
 }
 
 void WbSceneTree::updateSelection() {
@@ -1160,6 +1156,9 @@ void WbSceneTree::updateSelection() {
     mActionManager->action(WbAction::OPEN_HELP)->setEnabled(baseNode);
     emit nodeSelected(baseNode);
   }
+
+  // uncollapse the field editor
+  handleFieldEditorVisibility(true);
 }
 
 void WbSceneTree::startWatching(const QModelIndex &index) {
@@ -1569,4 +1568,20 @@ void WbSceneTree::openTemplateInstanceInTextEditor() {
     if (!templateInstancePath.isEmpty())
       emit editRequested(templateInstancePath);
   }
+}
+
+void WbSceneTree::handleFieldEditorVisibility(bool visible) {
+  const QList<int> currentSize = mSplitter->sizes();
+  QList<int> sizes;
+  int newSize;
+  if (visible && currentSize[2] == 0)
+    newSize = 1;
+  else if (!visible && currentSize[2] != 0)
+    newSize = 0;
+  else
+    return;
+  sizes << currentSize[0] << (mSplitter->height() - newSize) << newSize;
+  mSplitter->setSizes(sizes);
+  mSplitter->setHandleWidth(mHandleWidth);
+  return;
 }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1570,13 +1570,13 @@ void WbSceneTree::openTemplateInstanceInTextEditor() {
   }
 }
 
-void WbSceneTree::handleFieldEditorVisibility(bool visible) {
+void WbSceneTree::handleFieldEditorVisibility(bool isVisible) {
   const QList<int> currentSize = mSplitter->sizes();
   QList<int> sizes;
   int newSize;
-  if (visible && currentSize[2] == 0)
+  if (isVisible && currentSize[2] == 0)
     newSize = 1;
-  else if (!visible && currentSize[2] != 0)
+  else if (!isVisible && currentSize[2] != 0)
     newSize = 0;
   else
     return;

--- a/src/webots/scene_tree/WbSceneTree.hpp
+++ b/src/webots/scene_tree/WbSceneTree.hpp
@@ -102,7 +102,7 @@ private slots:
   void exportObject();
   void openProtoInTextEditor();
   void openTemplateInstanceInTextEditor();
-  void handleFieldEditorVisibility(bool visibility);
+  void handleFieldEditorVisibility(bool isVisible);
 
   void del(WbNode *nodeToDel = NULL);
 

--- a/src/webots/scene_tree/WbSceneTree.hpp
+++ b/src/webots/scene_tree/WbSceneTree.hpp
@@ -102,6 +102,7 @@ private slots:
   void exportObject();
   void openProtoInTextEditor();
   void openTemplateInstanceInTextEditor();
+  void handleFieldEditorVisibility(bool visibility);
 
   void del(WbNode *nodeToDel = NULL);
 


### PR DESCRIPTION
The field editor is currently hidden by default in many sample worlds and it is difficult for the user to find a way to unhide it to edit fields in the scene tree.

This PR ensures that when an item is selected in the scene tree, the field editor is visible. If no field is selected and the field editor shows an empty gray frame, it is automatically collapsed. The user can always collapse the editor manually to get a better visibility of the scene tree.