### PR TITLE
Fix snap warnings

### DIFF
--- a/scripts/packaging/linux_distro.py
+++ b/scripts/packaging/linux_distro.py
@@ -244,7 +244,8 @@ class LinuxWebotsPackage(WebotsPackage):
                                     "liblapack.so.3",  # netconvert (sumo)
                                     "libraw1394.so.11",
                                     "libPocoFoundation.so.62",
-                                    "libcanberra-gtk-module"]
+                                    "libcanberra-gtk-module",
+                                    "libcanberra-gtk3-module"]
 
         usr_lib_x68_64_linux_gnu += self.USR_LIB_X68_64 + self.USR_LIB_X68_64_20_04
 


### PR DESCRIPTION
Attempt to fix #4715.
Inspired from https://askubuntu.com/questions/342202/failed-to-load-module-canberra-gtk-module-but-already-installed