### PR TITLE
Fixed font in ephemeral proto warning

### DIFF
--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "WbExternProtoEditor.hpp"
 #include "WbActionManager.hpp"
+#include "WbExternProtoEditor.hpp"
 #include "WbInsertExternProtoDialog.hpp"
-#include "WbPreferences.hpp"
 #include "WbProtoManager.hpp"
 
 #include <QtCore/QEvent>
@@ -54,7 +53,6 @@ void WbExternProtoEditor::updateContents() {
   info->setAlignment(Qt::AlignCenter);
   info->setMinimumHeight(40);
   info->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-  info->setFont(WbPreferences::instance()->value("Editor/font").toString());
   info->setStyleSheet("background-color: transparent;");
   mLayout->addWidget(info, 0, 0, 1, 2);
 

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -54,6 +54,7 @@ void WbExternProtoEditor::updateContents() {
   info->setAlignment(Qt::AlignCenter);
   info->setMinimumHeight(40);
   info->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+  info->setFont(QFont(info->font().family(), 10));
   info->setStyleSheet("background-color: transparent;");
   mLayout->addWidget(info, 0, 0, 1, 2);
 

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "WbActionManager.hpp"
 #include "WbExternProtoEditor.hpp"
+
+#include "WbActionManager.hpp"
 #include "WbInsertExternProtoDialog.hpp"
 #include "WbProtoManager.hpp"
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -33,7 +33,6 @@ WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) : mRetriev
   QVBoxLayout *const layout = new QVBoxLayout(this);
 
   mSearchBar = new QLineEdit(this);
-  mSearchBar->setFont(WbPreferences::instance()->value("Editor/font").toString());
   mSearchBar->setClearButtonEnabled(true);
 
   mTree = new QTreeWidget();


### PR DESCRIPTION
Fixes #4823:

![image](https://user-images.githubusercontent.com/1264964/177153230-ef780321-49ec-4e5d-b5de-3f8050457787.png)

(Tested on Windows and Linux with various themes)