### PR TITLE
Fix inverted sound

### DIFF
--- a/src/webots/sound/WbSoundSource.cpp
+++ b/src/webots/sound/WbSoundSource.cpp
@@ -112,19 +112,19 @@ void WbSoundSource::setGain(double gain) {
 void WbSoundSource::setPosition(const WbVector3 &pos) {
   if (!WbSoundEngine::openAL())
     return;
-  alSource3f(mSource, AL_POSITION, pos.x(), pos.y(), pos.z());
+  alSource3f(mSource, AL_POSITION, -pos.x(), -pos.y(), pos.z());
 }
 
 void WbSoundSource::setVelocity(const WbVector3 &v) {
   if (!WbSoundEngine::openAL())
     return;
-  alSource3f(mSource, AL_VELOCITY, v.x(), v.y(), v.z());
+  alSource3f(mSource, AL_VELOCITY, -v.x(), -v.y(), v.z());
 }
 
 void WbSoundSource::setDirection(const WbVector3 &dir) {
   if (!WbSoundEngine::openAL())
     return;
-  alSource3f(mSource, AL_DIRECTION, dir.x(), dir.y(), dir.z());
+  alSource3f(mSource, AL_DIRECTION, -dir.x(), -dir.y(), dir.z());
 }
 
 #ifdef __APPLE__


### PR DESCRIPTION
**Description**
Fixes #4840. Does not seem like the most elegant fix, but it works.
Not sure if the problem was caused by FLU conversion: I tried switching the x, y and z values for position, sound and direction to match the conversion but it didn't work. 
Any other suggestions are appreciated!