### PR TITLE
Forgotten R2022a references

### DIFF
--- a/docs/guide/installation-procedure.md
+++ b/docs/guide/installation-procedure.md
@@ -141,7 +141,7 @@ However, the sand-boxing constraints of snaps yield the following limitations:
 ##### Download Size
 
 The download is significantly bigger as it includes all the dependencies of Webots (ffmpeg, Python, C++ and Java compilers, etc.).
-For Webots R2022a, the download size of the snap is 821MB compared to 290MB of the Debian and tarball packages.
+For Webots R2022b, the download size of the snap is 766MB compared to 201MB of the Debian package.
 
 ##### Extern Controllers
 

--- a/docs/guide/setup-a-webots-project-repository.md
+++ b/docs/guide/setup-a-webots-project-repository.md
@@ -14,7 +14,7 @@ All these dependencies could be bundled into a Docker image constructed from a r
 
 #### Running a Demo
 
-When running a demo, a single docker container will be used based on the `Dockerfile` located at the root of the project directory. If no `Dockerfile` is provided, the simulation server will use [Dockerfile.default](https://github.com/cyberbotics/webots/blob/develop/resources/web/server/config/simulation/docker/Dockerfile.default). As the default Dockerfile, you can use the following environment variables in your Dockerfile: 
+When running a demo, a single docker container will be used based on the `Dockerfile` located at the root of the project directory. If no `Dockerfile` is provided, the simulation server will use [Dockerfile.default](https://github.com/cyberbotics/webots/blob/develop/resources/web/server/config/simulation/docker/Dockerfile.default). As the default Dockerfile, you can use the following environment variables in your Dockerfile:
 - `$MAKE`: 1 if a Makefile exists in the project directory, otherwise 0.
 - `$PROJECT_PATH`: local docker project directory path
 - `$WEBOTS_DEFAULT_IMAGE`: default image of Webots according to the version of your world. This image is provided on [dockerhub](https://hub.docker.com/r/cyberbotics/webots). Only the released versions are provided.

--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -138,7 +138,7 @@ It is better to use more descriptive names, like `left arm pivot`.
 Here is a simple example of a good PROTO declaration (the implementation is not shown):
 
 ```
-#VRML_SIM R2022a utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # A color pencil


### PR DESCRIPTION
I missed some R2022a references in my previous PR.

We should also update `setup-a-webots-projects-repository.md` once we have the final docker image for R2022b