### PR TITLE
Fix controllers directory in project relocation

### DIFF
--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -220,6 +220,10 @@ void WbProjectRelocationDialog::copy() {
   dir.cdUp();  // store the upper level, probably the path where the directories are stored
   WbPreferences::instance()->setValue("Directories/projects", dir.absolutePath() + "/");
 
+  const QList<WbRobot *> &robots = WbWorld::instance()->robots();
+  foreach (WbRobot *robot, robots)
+    robot->updateControllerDir();
+
   // good news
   setStatus(tr("Project successfully relocated.") + "\n" + tr("%1 file(s) copied.").arg(copiedFilesCount));
 }
@@ -238,13 +242,14 @@ int WbProjectRelocationDialog::copyProject(const QString &projectPath) {
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();
   foreach (WbRobot *robot, robots) {
     const QString &controllerName = robot->controllerName();
+    const QString destinationPath = mTargetPath + "/controllers/" + controllerName;
     if (controllerName.isEmpty())
       continue;
     if (controllerName.front() == '<' && controllerName.back() == '>')  // <none>, <generic> or <extern>
       continue;
-    if (!copiedControllers.contains(controllerName)) {
+    if (!copiedControllers.contains(controllerName) && !QDir(destinationPath).exists()) {
       const QString &controllerPath = robot->controllerDir();
-      result += WbFileUtil::copyDir(controllerPath, mTargetPath + "/controllers/" + controllerName, true, false, true);
+      result += WbFileUtil::copyDir(controllerPath, destinationPath, true, false, true);
       copiedControllers << controllerName;
     }
   }

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -141,6 +141,7 @@ public:
 
 public slots:
   void receiveFromJavascript(const QByteArray &message);
+  void updateControllerDir();
 
 signals:
   void startControllerRequest(WbRobot *robot);
@@ -280,7 +281,6 @@ private slots:
   void updateWindow();
   void updateRemoteControl();
   void updateSimulationMode();
-  void updateControllerDir();
   void updateData();
   void updateSupervisor();
   void updateModel();


### PR DESCRIPTION
Fixes #4864.

In addition to the automatic update of controller paths, the PR adds a condition to the `controllers` folder copy to avoid multiple redundant copies causing warnings in worlds having external protos.
