### PR TITLE
Fix invalid retrieve of non-top ancestor Robot

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -69,6 +69,7 @@ Released on July, 7th, 2022.
     - Fixed some crashes loading and converting worlds created with Webots prior to R2022a ([#4633](https://github.com/cyberbotics/webots/pull/4633)).
     - Fixed animation time not starting at 0 seconds ([#4659](https://github.com/cyberbotics/webots/pull/4659)).
     - Fixed inverted left and right sound from speaker ([#4847](https://github.com/cyberbotics/webots/pull/4847)).
+    - Fixed crash using a [Speaker](speaker.md) device in a [Robot](node.md) that is not a top node ([#4878](https://github.com/cyberbotics/webots/pull/4878)).
   - Cleanup
     - Removed `wb_robot_get_type` API function as it no longer serves a purpose ([#4125](https://github.com/cyberbotics/webots/pull/4125)).
     - Removed the old i686 binary version of the libController.dll on Windows ([#4617](https://github.com/cyberbotics/webots/pull/4617)).

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2475,8 +2475,10 @@ void WbMainWindow::prepareNodeRegeneration(WbNode *node) {
       QStringList perspective = factory->windowPerspective(device);
       if (perspective.isEmpty())
         perspective = device->perspective();
-      const WbRobot *robot = dynamic_cast<const WbRobot *>(WbNodeUtilities::findTopNode(node));
-      mTemporaryProtoPerspectives.insert(robot->name() + "\n" + device->name(), perspective);
+      const WbRobot *robot = WbNodeUtilities::findRobotAncestor(device);
+      assert(robot);
+      if (robot)
+        mTemporaryProtoPerspectives.insert(robot->name() + "\n" + device->name(), perspective);
     }
   }
 }
@@ -2493,7 +2495,8 @@ void WbMainWindow::finalizeNodeRegeneration(WbNode *node) {
       WbRenderingDevice *device = dynamic_cast<WbRenderingDevice *>(n);
       if (device != NULL) {
         factory->listenToRenderingDevice(device);
-        const WbRobot *robot = dynamic_cast<const WbRobot *>(WbNodeUtilities::findTopNode(node));
+        const WbRobot *robot = WbNodeUtilities::findRobotAncestor(device);
+        assert(robot);
         const QString key = robot->name() + "\n" + device->name();
         QStringList perspective = mTemporaryProtoPerspectives.value(key);
         if (!perspective.isEmpty())

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -148,7 +148,7 @@ WbRenderingDeviceWindow::WbRenderingDeviceWindow(WbRenderingDevice *device) :
     windowHeight = textureHeight * newPixelSize;
   }
 
-  const WbRobot *const robotNode = dynamic_cast<const WbRobot *const>(WbNodeUtilities::findTopNode(mDevice));
+  const WbRobot *const robotNode = WbNodeUtilities::findRobotAncestor(mDevice);
   assert(robotNode);
   setTitle(robotNode->name() + ": " + mDevice->name());
   resize(windowWidth, windowHeight);

--- a/src/webots/nodes/WbSpeaker.cpp
+++ b/src/webots/nodes/WbSpeaker.cpp
@@ -65,7 +65,7 @@ WbSpeaker::~WbSpeaker() {
 
 void WbSpeaker::postFinalize() {
   WbSolidDevice::postFinalize();
-  WbRobot *robot = const_cast<WbRobot *>(static_cast<const WbRobot *>(WbNodeUtilities::findTopNode(this)));
+  WbRobot *robot = WbNodeUtilities::findRobotAncestor(this);
   if (robot)
     mControllerDir = robot->controllerDir();
 }


### PR DESCRIPTION
Fix retrieving ancestor Robot node.
The previous version was returning an invalid pointer when casting the top node to `WbRobot` independently from the node type.
For example it was failing in this case:
```
Group {
  children [
    Robot {
      children [
        Speaker { }
      ]
    }
  ]
}
```