### PR TITLE
Fix early WbExternProtoEditor update

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1437,6 +1437,7 @@ void WbMainWindow::saveWorld() {
     const QString thumbnailName = "." + thumbnailFilename.split("/").takeLast().replace(".wbt", ".jpg", Qt::CaseInsensitive);
     thumbnailFilename.replace(thumbnailFilename.split("/").takeLast(), thumbnailName, Qt::CaseInsensitive);
 
+    mSimulationView->sceneTree()->updateAfterWorldSave();
     savePerspective(false, true, true);
     updateWindowTitle();
     mSimulationView->takeThumbnail(thumbnailFilename);
@@ -1477,6 +1478,7 @@ void WbMainWindow::saveWorldAs(bool skipSimulationHasRunWarning) {
       const QString thumbnailName = "." + thumbnailFilename.split("/").takeLast().replace(".wbt", ".jpg", Qt::CaseInsensitive);
       thumbnailFilename.replace(thumbnailFilename.split("/").takeLast(), thumbnailName, Qt::CaseInsensitive);
 
+      mSimulationView->sceneTree()->updateAfterWorldSave();
       savePerspective(false, true, true);
       updateWindowTitle();
       mSimulationView->takeThumbnail(thumbnailFilename);

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -29,8 +29,6 @@
 
 WbExternProtoEditor::WbExternProtoEditor(QWidget *parent) : WbValueEditor(parent) {
   connect(this, &WbExternProtoEditor::changed, WbActionManager::instance()->action(WbAction::SAVE_WORLD), &QAction::setEnabled);
-  connect(WbActionManager::instance()->action(WbAction::SAVE_WORLD), &QAction::triggered,
-          [&](bool value) { updateContents(!value); });
   connect(WbApplication::instance(), &WbApplication::worldLoadCompleted, [&]() { updateContents(true); });
   updateContents();
 }

--- a/src/webots/scene_tree/WbFieldEditor.cpp
+++ b/src/webots/scene_tree/WbFieldEditor.cpp
@@ -283,6 +283,10 @@ void WbFieldEditor::applyChanges() {
   editor->applyIfNeeded();
 }
 
+void WbFieldEditor::updateContents() {
+  mExternProtoEditor->updateContents(true);
+}
+
 void WbFieldEditor::computeFieldInformation() {
   assert(mField);
 

--- a/src/webots/scene_tree/WbFieldEditor.hpp
+++ b/src/webots/scene_tree/WbFieldEditor.hpp
@@ -24,6 +24,7 @@
 
 #include "../../../include/controller/c/webots/supervisor.h"
 
+class WbExternProtoEditor;
 class WbField;
 class WbNode;
 class WbValueEditor;
@@ -53,6 +54,8 @@ public:
   // apply changes to the field value
   void applyChanges();
 
+  void updateContents();
+
   void setTitle(const QString &title);
 
   QWidget *lastEditorWidget();
@@ -72,7 +75,7 @@ protected:
 
 private:
   QMultiMap<WbFieldType, WbValueEditor *> mEditors;
-  WbValueEditor *mExternProtoEditor;
+  WbExternProtoEditor *mExternProtoEditor;
   QStackedLayout *mStackedLayout;
   QWidget *mEmptyPane;
   WbField *mField;

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -171,6 +171,10 @@ void WbSceneTree::applyChanges() {
   mFieldEditor->applyChanges();
 }
 
+void WbSceneTree::updateAfterWorldSave() const {
+  mFieldEditor->updateContents();
+}
+
 // compare old tree and new tree side by side and recursively.
 // if an index is expanded in the old tree, expand it also in the new tree
 void WbSceneTree::restoreState(WbTreeView *t1, WbTreeView *t2, const QModelIndex &i1, const QModelIndex &i2) {

--- a/src/webots/scene_tree/WbSceneTree.hpp
+++ b/src/webots/scene_tree/WbSceneTree.hpp
@@ -58,6 +58,7 @@ public:
 
   void prepareWorldLoading();
   void applyChanges();
+  void updateAfterWorldSave() const;
 
   // save/restore splitter perspective
   QByteArray saveState() const;


### PR DESCRIPTION
The WbExternProtoEditor content was previously saved as soon as the "SAVE" action was triggered but it is too early because the user could still abort the saving (from the dialog boxes that will be shown for warning about the simulation status or asking for the filename).

In this PR, instead of connecting directly to the "SAVE" action signal, the `WbExternProtoEditor::updateContents` is called just after the world is saved.