### PR TITLE
Fix missing interface informations in PROTOs

### DIFF
--- a/scripts/packaging/generate_proto_list.py
+++ b/scripts/packaging/generate_proto_list.py
@@ -78,7 +78,9 @@ class ProtoInfo:
                 self.description += clean_line.strip() + '\\n'
 
     def parse_parameters(self):
-        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+[\s\S]*?(?=\s\s+field\s|\s\s+vrmlField\s|\s\s+hiddenField\s|\s\s+hidden\s|\s\s+deprecatedField\s|\s\s+unconnectedField\s|\n\n|\]\s*\{))', self.contents):
+        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+[\s\S]*?(?=\s\s+field\s|\
+        \s\s+vrmlField\s|\s\s+hiddenField\s|\s\s+hidden\s|\s\s+deprecatedField\s|\
+        \s\s+unconnectedField\s|\n\n|\]\s*\{))', self.contents):
             self.parameters.append(match.strip())
 
     def parse_body(self):

--- a/scripts/packaging/generate_proto_list.py
+++ b/scripts/packaging/generate_proto_list.py
@@ -78,7 +78,7 @@ class ProtoInfo:
                 self.description += clean_line.strip() + '\\n'
 
     def parse_parameters(self):
-        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+[\s\S]*?(?=\s\sfield|\s\svrmlField|\s\shiddenField|\s\shidden|\s\sdeprecatedField|\s\sunconnectedField|\]\n\{))', self.contents):
+        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+[\s\S]*?(?=\s\s+field\s|\s\s+vrmlField\s|\s\s+hiddenField\s|\s\s+hidden\s|\s\s+deprecatedField\s|\s\s+unconnectedField\s|\n\n|\]\s*\{))', self.contents):
             self.parameters.append(match.strip())
 
     def parse_body(self):

--- a/scripts/packaging/generate_proto_list.py
+++ b/scripts/packaging/generate_proto_list.py
@@ -78,7 +78,7 @@ class ProtoInfo:
                 self.description += clean_line.strip() + '\\n'
 
     def parse_parameters(self):
-        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+\s+[^\n\#]+)', self.contents):
+        for match in re.findall(r'(?<=\s\s)((?:field|vrmlField)\s+(?:\w+|(?:\{.*\}))+[\s\S]*?(?=\s\sfield|\s\svrmlField|\s\shiddenField|\s\shidden|\s\sdeprecatedField|\s\sunconnectedField|\]\n\{))', self.contents):
             self.parameters.append(match.strip())
 
     def parse_body(self):

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -69,7 +69,7 @@ public:
     mIsDirty(false) {
     // extract parameter names
     foreach (const QString &parameter, mParameters) {
-      QRegularExpression re("(?:field|vrmlField)\\s+(?:\\w+|(?:\\{.*\\}))+\\s+(\\w+)\\s");
+      QRegularExpression re("(?:field|vrmlField)\\s+(?:\\w+|(?:\\{[\\s\\S]*\\}))+\\s+(\\w+)\\s");
       QRegularExpressionMatch match = re.match(parameter);
       if (match.hasMatch())
         mParameterNames << match.captured(1);


### PR DESCRIPTION
As exposed in[ #4860 (comment)](https://github.com/cyberbotics/webots/pull/4860#issuecomment-1184078213), some fields are not completely captured when generating the PROTO list. In consequence, using some PROTOs (e.g. Cabinet) in the PROTO wizard as base node will create an incomplete resulting PROTO.

