### PR TITLE
Improve robustness

### DIFF
--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -161,7 +161,7 @@ QString WbProject::computeBestPathForSaveAs(const QString &fileName) {
 }
 
 WbProject::WbProject(const QString &path) {
-  if (path.endsWith(".wbt")) {
+  if (path.endsWith(".wbt", Qt::CaseInsensitive)) {
     bool isValidProject = true;
     setPath(projectPathFromWorldFile(path, isValidProject));
   } else

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -329,7 +329,7 @@ int WbProjectRelocationDialog::copyWorldFiles() {
 
   // copy SUMO net directory if any
   QString fileName = world->fileName();
-  const QString netDir = fileName.replace(".wbt", "_net");
+  const QString netDir = fileName.replace(".wbt", "_net", Qt::CaseInsensitive);
   if (QDir().exists(netDir))
     result += WbFileUtil::copyDir(netDir, mTargetPath + "/worlds/" + QFileInfo(netDir).baseName(), true, false, true);
 

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2308,7 +2308,7 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify) {
         return;
 
       QString protoModelName(protoFileName);
-      protoModelName.replace(".proto", "");
+      protoModelName.replace(".proto", "", Qt::CaseInsensitive);
       if (!WbFileUtil::forceCopy(protoFilePath, fileToOpen)) {
         WbLog::error(tr("Error during copy of extern PROTO file '%1' to '%2'.").arg(protoModelName).arg(fileToOpen));
         return;

--- a/src/webots/gui/WbNewProjectWizard.cpp
+++ b/src/webots/gui/WbNewProjectWizard.cpp
@@ -165,7 +165,7 @@ void WbNewProjectWizard::accept() {
 
 void WbNewProjectWizard::updateUI() {
   mProject->setPath(mDirEdit->text());
-  if (!mWorldEdit->text().isEmpty() && !mWorldEdit->text().endsWith(".wbt"))
+  if (!mWorldEdit->text().isEmpty() && !mWorldEdit->text().endsWith(".wbt", Qt::CaseInsensitive))
     mWorldEdit->setText(mWorldEdit->text().append(".wbt"));
   mFilesLabel->setText(QDir::toNativeSeparators(
     mProject->newProjectFiles().join("\n").replace(WbProject::newWorldFileName(), mWorldEdit->text())));

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -136,16 +136,7 @@ QString WbCadShape::generateMaterialUrl(const QString &material, const QString &
   QString materialUrl = material;
   // manufacture material url from url of the obj file
   materialUrl.replace("\\", "/");  // use cross-platform forward slashes
-  if (materialUrl.startsWith("./"))
-    materialUrl.remove(0, 2);
-
-  QString prefixUrl = QUrl(completeUrl).adjusted(QUrl::RemoveFilename).toString();
-  while (materialUrl.startsWith("../")) {
-    prefixUrl = prefixUrl.left(prefixUrl.lastIndexOf("/"));
-    materialUrl.remove(0, 3);
-  }
-
-  return prefixUrl + materialUrl;
+  return WbUrl::combinePaths(materialUrl, completeUrl);
 }
 
 void WbCadShape::materialDownloadTracker() {

--- a/src/webots/nodes/WbCadShape.hpp
+++ b/src/webots/nodes/WbCadShape.hpp
@@ -96,7 +96,6 @@ private:
   QVector<WbDownloader *> mMaterialDownloaders;
   QStringList objMaterialList(const QString &url) const;
   bool areMaterialAssetsAvailable(const QString &url);
-  QString generateMaterialUrl(const QString &material, const QString &completeUrl);
   void retrieveMaterials();
 
   const QString vrmlPbrAppearance(const aiMaterial *material);

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -248,3 +248,63 @@ const QString &WbUrl::remoteWebotsAssetPrefix() {
     "https://raw.githubusercontent.com/cyberbotics/webots/" + (commit.isEmpty() ? version.toString() : commit) + "/";
   return url;
 }
+
+QString WbUrl::combinePaths(const QString &rawUrl, const QString &rawParentUrl) {
+  // use cross-platform forward slashes
+  QString url = rawUrl;
+  url = url.replace("\\", "/");
+  QString parentUrl = rawParentUrl;
+  parentUrl = parentUrl.replace("\\", "/");
+
+  // cases where no url manipulation is necessary
+  if (WbUrl::isWeb(url))
+    return url;
+
+  if (QDir::isAbsolutePath(url))
+    return QDir::cleanPath(url);
+
+  if (WbUrl::isLocalUrl(url)) {
+    // url fall-back mechanism: only trigger if the parent is a world file (.wbt), and the file (webots://) does not exist
+    if (parentUrl.endsWith(".wbt", Qt::CaseInsensitive) &&
+        !QFileInfo(QDir::cleanPath(WbStandardPaths::webotsHomePath() + url.mid(9))).exists()) {
+      WbLog::error(QObject::tr("URL '%1' changed by fallback mechanism. Ensure you are opening the correct world.").arg(url));
+      return url.replace("webots://", WbUrl::remoteWebotsAssetPrefix());
+    }
+
+    // infer url based on parent's url
+    const QString &prefix = WbUrl::computePrefix(parentUrl);
+    if (!prefix.isEmpty())
+      return url.replace("webots://", prefix);
+
+    if (parentUrl.isEmpty() || WbUrl::isLocalUrl(parentUrl) || QDir::isAbsolutePath(parentUrl))
+      return QDir::cleanPath(WbStandardPaths::webotsHomePath() + url.mid(9));
+
+    return QString();
+  }
+
+  if (QDir::isRelativePath(url)) {
+    // for relative urls, begin by searching relative to the world and protos folders
+    QStringList searchPaths = QStringList() << WbProject::current()->worldsPath() << WbProject::current()->protosPath();
+    foreach (const QString &path, searchPaths) {
+      QDir dir(path);
+      if (dir.exists(url))
+        return QDir::cleanPath(dir.absoluteFilePath(url));
+    }
+
+    // if it is not available in those folders, infer the url based on the parent's url
+    if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {
+      // remove filename and trailing slash from parent url
+      parentUrl = QUrl(parentUrl).adjusted(QUrl::RemoveFilename).toString();
+      if (WbUrl::isLocalUrl(parentUrl))
+        parentUrl = WbStandardPaths::webotsHomePath() + parentUrl.mid(9);
+
+      if (WbUrl::isWeb(parentUrl))
+        return QUrl(parentUrl).resolved(QUrl(url)).toString();
+      else
+        return QDir::cleanPath(QDir(parentUrl).absoluteFilePath(url));
+    }
+  }
+
+  WbLog::error(QObject::tr("Impossible to infer URL from '%1' and '%2'").arg(rawUrl).arg(rawParentUrl));
+  return QString();
+}

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -293,7 +293,7 @@ QString WbUrl::combinePaths(const QString &rawUrl, const QString &rawParentUrl) 
 
     // if it is not available in those folders, infer the url based on the parent's url
     if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {
-      // remove filename and trailing slash from parent url
+      // remove filename from parent url
       parentUrl = QUrl(parentUrl).adjusted(QUrl::RemoveFilename).toString();
       if (WbUrl::isLocalUrl(parentUrl))
         parentUrl = WbStandardPaths::webotsHomePath() + parentUrl.mid(9);

--- a/src/webots/nodes/utils/WbUrl.hpp
+++ b/src/webots/nodes/utils/WbUrl.hpp
@@ -29,6 +29,8 @@ namespace WbUrl {
   QString computePath(const WbNode *node, const QString &field, const QString &rawUrl, bool warn = true);
   QString computePath(const WbNode *node, const QString &field, const WbMFString *urlField, int index, bool warn = true);
 
+  QString combinePaths(const QString &rawUrl, const QString &rawParentUrl);
+
   QString exportResource(const WbNode *node, const QString &url, const QString &sourcePath, const QString &relativeResourcePath,
                          const WbWriter &writer, const bool isTexture = true);
   QString exportTexture(const WbNode *node, const WbMFString *urlField, int index, const WbWriter &writer);

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -626,7 +626,7 @@ int WbAddNodeDialog::addProtosFromProtoList(QTreeWidgetItem *parentItem, int typ
 
   // populate tree
   foreach (QString path, protoList) {
-    const QString protoName = QUrl(path).fileName().replace(".proto", "");
+    const QString protoName = QUrl(path).fileName().replace(".proto", "", Qt::CaseInsensitive);
     QTreeWidgetItem *parent = parentItem;
     // generate sub-items based on path (they are sorted already) only for WEBOTS_PROTO
     if (type == WbProtoManager::PROTO_WEBOTS) {
@@ -740,7 +740,8 @@ void WbAddNodeDialog::accept() {
     mSelectionPath = mSelectionPath.replace(WbStandardPaths::webotsHomePath(), "webots://");
   if (mSelectionPath.startsWith(WbProject::current()->protosPath()))
     mSelectionPath = QDir(WbProject::current()->worldsPath()).relativeFilePath(mSelectionPath);
-  WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", ""), mSelectionPath, true);
+  WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
+                                                 mSelectionPath, true);
 
   QDialog::accept();
 }

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -263,7 +263,7 @@ QMap<QString, QString> WbProtoManager::undeclaredProtoNodes(const QString &filen
     extraProto.insert(QFileInfo(path).baseName(), path);
   QMap<QString, QString> webotsProto;
   foreach (QString path, listProtoInCategory(PROTO_WEBOTS))
-    webotsProto.insert(QUrl(path).fileName().replace(".proto", ""), path);
+    webotsProto.insert(QUrl(path).fileName().replace(".proto", "", Qt::CaseInsensitive), path);
 
   QStringList knownProto;
   knownProto << localProto.keys() << extraProto.keys() << webotsProto.keys();
@@ -285,7 +285,7 @@ QMap<QString, QString> WbProtoManager::undeclaredProtoNodes(const QString &filen
       continue;
 
     url = WbUrl::computePath(url);
-    assert(url.endsWith(".proto"));
+    assert(url.endsWith(".proto", Qt::CaseInsensitive));
 
     if (WbUrl::isWeb(url)) {
       if (!protoNodeList.contains(proto))
@@ -519,7 +519,8 @@ void WbProtoManager::generateProtoInfoMap(int category, bool regenerate) {
     QString protoName;
     const bool isCachedProto = protoPath.startsWith(WbNetwork::instance()->cacheDirectory());
     if (isCachedProto)  // cached file, infer name from reverse lookup
-      protoName = QUrl(WbNetwork::instance()->getUrlFromEphemeralCache(protoPath)).fileName().replace(".proto", "");
+      protoName =
+        QUrl(WbNetwork::instance()->getUrlFromEphemeralCache(protoPath)).fileName().replace(".proto", "", Qt::CaseInsensitive);
     else
       protoName = QFileInfo(protoPath).baseName();
 
@@ -835,13 +836,13 @@ QString WbProtoManager::injectDeclarationByBackwardsCompatibility(const QString 
   // check if it's the current project
   QStringList projectProto = listProtoInCategory(PROTO_PROJECT);
   foreach (const QString &proto, projectProto) {
-    if (proto.contains(modelName + ".proto"))
+    if (proto.contains(modelName + ".proto", Qt::CaseInsensitive))
       return QFileInfo(proto).absoluteFilePath();
   }
   // check if it's in the EXTRA projects
   QStringList extraProto = listProtoInCategory(PROTO_EXTRA);
   foreach (const QString &proto, extraProto) {
-    if (proto.contains(modelName + ".proto"))
+    if (proto.contains(modelName + ".proto", Qt::CaseInsensitive))
       return QFileInfo(proto).absoluteFilePath();
   }
   // check among the  official ones

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -93,10 +93,10 @@ WbProtoModel::WbProtoModel(WbTokenizer *tokenizer, const QString &worldPath, con
   mPrefix = prefix;
   mUrl = url;
 
-  assert(mUrl.endsWith(".proto"));                           // mUrl needs to be the full reference, including file name
+  assert(mUrl.endsWith(".proto", Qt::CaseInsensitive));      // mUrl needs to be the full reference, including file name
   assert(WbUrl::isWeb(mUrl) || QDir::isAbsolutePath(mUrl));  // by this point, all urls must be resolved
 
-  if (!mUrl.endsWith(mName + ".proto")) {
+  if (!mUrl.endsWith(mName + ".proto", Qt::CaseInsensitive)) {
     tokenizer->reportFileError(tr("'%1' PROTO identifier does not match filename").arg(mName));
     throw 0;
   }

--- a/src/webots/vrml/WbProtoTreeItem.cpp
+++ b/src/webots/vrml/WbProtoTreeItem.cpp
@@ -30,7 +30,7 @@ WbProtoTreeItem::WbProtoTreeItem(const QString &url, WbProtoTreeItem *parent) :
   mParent(parent),
   mIsReady(false),
   mDownloader(NULL),
-  mName(QUrl(url).fileName().replace(".proto", "")),
+  mName(QUrl(url).fileName().replace(".proto", "", Qt::CaseInsensitive)),
   mError() {
 }
 
@@ -65,7 +65,7 @@ void WbProtoTreeItem::parseItem() {
       const QString subProto = match.captured(1);
       const QString subProtoUrl = combinePaths(subProto, mUrl);
 
-      if (!subProtoUrl.endsWith(".proto")) {
+      if (!subProtoUrl.endsWith(".proto", Qt::CaseInsensitive)) {
         mError << QString(tr("Malformed EXTERNPROTO url. The url should end with '.proto'."));
         continue;
       }
@@ -78,7 +78,7 @@ void WbProtoTreeItem::parseItem() {
       }
 
       // ensure there's no ambiguity between the declarations
-      const QString subProtoName = QUrl(subProtoUrl).fileName().replace(".proto", "");
+      const QString subProtoName = QUrl(subProtoUrl).fileName().replace(".proto", "", Qt::CaseInsensitive);
       foreach (const WbProtoTreeItem *child, mChildren) {
         if (child->name() == subProtoName && WbUrl::computePath(child->url()) != WbUrl::computePath(subProtoUrl)) {
           mError << QString(tr("PROTO '%1' is ambiguous, multiple references are provided: '%2' and '%3'. The first was used.")
@@ -188,7 +188,7 @@ void WbProtoTreeItem::recursiveErrorAccumulator(QStringList &list) {
 void WbProtoTreeItem::generateSessionProtoMap(QMap<QString, QString> &map) {
   assert(mIsReady);
   // in case of failure the tree might be incomplete, but what is inserted in the map must be known to be available
-  if (!map.contains(mName) && mUrl.endsWith(".proto"))  // only insert protos, root file may be a world file
+  if (!map.contains(mName) && mUrl.endsWith(".proto", Qt::CaseInsensitive))  // only insert protos, root file may be a world
     map.insert(mName, mUrl);
 
   foreach (WbProtoTreeItem *child, mChildren)
@@ -237,7 +237,8 @@ QString WbProtoTreeItem::combinePaths(const QString &rawUrl, const QString &rawP
 
   if (WbUrl::isLocalUrl(url)) {
     // url fall-back mechanism: only trigger if the parent is a world file (.wbt), and the file (webots://) does not exist
-    if (parentUrl.endsWith(".wbt") && !QFileInfo(QDir::cleanPath(WbStandardPaths::webotsHomePath() + url.mid(9))).exists()) {
+    if (parentUrl.endsWith(".wbt", Qt::CaseInsensitive) &&
+        !QFileInfo(QDir::cleanPath(WbStandardPaths::webotsHomePath() + url.mid(9))).exists()) {
       mError << QString(tr("URL '%1' changed by fallback mechanism. Ensure you are opening the correct world.")).arg(url);
       return url.replace("webots://", WbUrl::remoteWebotsAssetPrefix());
     }

--- a/src/webots/vrml/WbProtoTreeItem.cpp
+++ b/src/webots/vrml/WbProtoTreeItem.cpp
@@ -266,23 +266,14 @@ QString WbProtoTreeItem::combinePaths(const QString &rawUrl, const QString &rawP
     // if it is not available in those folders, infer the url based on the parent's url
     if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {
       // remove filename and trailing slash from parent url
-      parentUrl = QUrl(parentUrl).adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash).toString();
-
-      if (url.startsWith("./"))
-        url.remove(0, 2);
-
-      // consume directories in both urls accordingly
-      while (url.startsWith("../")) {
-        parentUrl = parentUrl.left(parentUrl.lastIndexOf("/"));
-        url.remove(0, 3);
-      }
-
-      const QString newUrl = parentUrl + "/" + url;
-      if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl))
-        return newUrl;
-
+      parentUrl = QUrl(parentUrl).adjusted(QUrl::RemoveFilename).toString();
       if (WbUrl::isLocalUrl(parentUrl))
-        return QDir::cleanPath(WbStandardPaths::webotsHomePath() + newUrl.mid(9));
+        parentUrl = WbStandardPaths::webotsHomePath() + parentUrl.mid(9);
+
+      if (WbUrl::isWeb(parentUrl))
+        return QUrl(parentUrl).resolved(QUrl(url)).toString();
+      else
+        return QDir::cleanPath(QDir(parentUrl).absoluteFilePath(url));
     }
   }
 

--- a/src/webots/vrml/WbProtoTreeItem.hpp
+++ b/src/webots/vrml/WbProtoTreeItem.hpp
@@ -61,8 +61,6 @@ private:
   bool isRecursiveProto(const QString &protoUrl);
   void recursiveErrorAccumulator(QStringList &list);
 
-  QString combinePaths(const QString &rawUrl, const QString &rawParentUrl);
-
   void deleteChild(const WbProtoTreeItem *child);
 
   QList<WbProtoTreeItem *> mChildren;  // list of referenced sub-proto

--- a/src/webots/vrml/WbTokenizer.cpp
+++ b/src/webots/vrml/WbTokenizer.cpp
@@ -560,13 +560,13 @@ WbTokenizer::FileType WbTokenizer::fileTypeFromFileName(const QString &fileName)
     name = WbNetwork::instance()->getUrlFromEphemeralCache(fileName);
   }
 
-  if (name.endsWith(".wbt"))
+  if (name.endsWith(".wbt", Qt::CaseInsensitive))
     return WORLD;
-  else if (name.endsWith(".proto"))
+  else if (name.endsWith(".proto", Qt::CaseInsensitive))
     return PROTO;
-  else if (name.endsWith(".wbo"))
+  else if (name.endsWith(".wbo", Qt::CaseInsensitive))
     return OBJECT;
-  else if (name.endsWith(".wrl"))
+  else if (name.endsWith(".wrl", Qt::CaseInsensitive))
     return MODEL;
   else
     return UNKNOWN;


### PR DESCRIPTION
**Description**

This PR changes:
- tests of the extension should be case-insensitive
- the way urls were combined worked well, but the robustness of the solution was limited. The important change done is at this spot: https://github.com/cyberbotics/webots/blob/be46d7978b81d84fcc3fa9cc9382bbaa8b21429e/src/webots/nodes/utils/WbUrl.cpp#L294-L305

A good way of testing the change to combinePaths is to add

```
  if (parent == NULL) {
    combinePaths("../../asd.proto",
                 "https://raw.githubusercontent.com/cyberbotics/webots/projects/devices/sick/protos/SickS300.proto");
   // etc
  }
```

to the constructor of WbProtoTreeItem (or somewhere else where are guaranteed to pass) and print the results for different combinations (webots://, absolute, remote)
