### PR TITLE
Add flag to use mingw python

### DIFF
--- a/projects/default/libraries/vehicle/python/Makefile
+++ b/projects/default/libraries/vehicle/python/Makefile
@@ -53,8 +53,14 @@ PYTHON_HOME    := $(subst \ ,$(space),$(dir $(subst $(space),\ ,$(shell which py
 C_FLAGS         = -c -O -Wall -DMS_WIN64 -D_hypot=hypot -Wno-stringop-truncation
 LD_FLAGS        = -shared -Wl,--enable-auto-import
 LIBRARY         = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).pyd
+LIB            += -L"$(WEBOTS_CONTROLLER_LIB_PATH)" -lCppController  
+ifeq ($(MINGWPYTHON),)
 PYTHON_INCLUDES = -I"$(PYTHON_HOME)include"
-LIB            += -L"$(WEBOTS_CONTROLLER_LIB_PATH)" -lCppController -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+LIB            += -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+else
+PYTHON_INCLUDES = -I"$(MSYS2_HOME)/mingw64/include/python$(PYTHON_VERSION)"
+LIB            += -lpython$(PYTHON_VERSION)
+endif
 endif
 
 ifeq ($(OSTYPE),darwin)
@@ -131,3 +137,4 @@ endif
 
 clean:
 	@rm -fr *.o *.cpp $(PYOUT) $(LIBRARY) $(MODULE_NAME).pyc _*.so
+

--- a/projects/robots/robotis/darwin-op/libraries/python/Makefile
+++ b/projects/robots/robotis/darwin-op/libraries/python/Makefile
@@ -51,8 +51,14 @@ PYTHON_HOME    := $(subst \ ,$(space),$(dir $(subst $(space),\ ,$(shell which py
 C_FLAGS         = -c -O -Wall -DMS_WIN64 -D_hypot=hypot -Wno-stringop-truncation
 LD_FLAGS        = -shared -Wl,--enable-auto-import
 LIBRARY         = $(PYTHON_LIB_FOLDER)/_$(MODULE_NAME).pyd
+LIB            += -L"$(WEBOTS_CONTROLLER_LIB_PATH)" -lController -lCppController 
+ifeq ($(MINGWPYTHON),)
 PYTHON_INCLUDES = -I"$(PYTHON_HOME)include"
-LIB            += -L"$(WEBOTS_CONTROLLER_LIB_PATH)" -lController -lCppController -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+LIB            += -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+else
+PYTHON_INCLUDES = -I"$(MSYS2_HOME)/mingw64/include/python$(PYTHON_VERSION)"
+LIB            += -lpython$(PYTHON_VERSION)
+endif
 endif
 
 ifeq ($(OSTYPE),darwin)

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -56,12 +56,18 @@ ifeq ($(PYTHON_SHORT_VERSION),310)
 C_FLAGS          += -Wno-deprecated-declarations
 endif
 LD_FLAGS        = -shared
-LIBS            = -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION) -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController -lCppController
+LIBS            = -L$(WEBOTS_CONTROLLER_LIB_PATH) -lController -lCppController
 LIBOUT          = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)/_,$(INTERFACE:.i=.pyd))
 ifneq (,$(findstring 2.,$(PYTHON_VERSION)))
 C_FLAGS        += -DMS_WIN64
 endif
+ifeq ($(MINGWPYTHON),)
 PYTHON_INCLUDES = -I"$(PYTHON_HOME)include"
+LIBS            += -L"$(PYTHON_HOME)libs" -lpython$(PYTHON_SHORT_VERSION)
+else
+PYTHON_INCLUDES = -I"$(MSYS2_HOME)/mingw64/include/python$(PYTHON_VERSION)"
+LIBS            += -lpython$(PYTHON_VERSION)
+endif
 LIBCONTROLLER   = $(WEBOTS_CONTROLLER_LIB_PATH)/Controller.dll
 LIBCPPCONTROLLER= $(WEBOTS_CONTROLLER_LIB_PATH)/CppController.dll
 endif


### PR DESCRIPTION
Basically adds a flag to windows make files so that it can compile with
mingw python as well as downloading python version externally
This is for convenience and also reduce the non interactive dependencies if you want to package it later

**Description**
So it's really hard to use the mingw's version of python with webots, in this pull request I edit the makefiles in such a way that it retains the current behaviour but given a flag it uses mingw's version of python instead of using python home




