### PR TITLE
Disable application edit actions for read-only text files

### DIFF
--- a/src/webots/editor/WbTextBuffer.cpp
+++ b/src/webots/editor/WbTextBuffer.cpp
@@ -258,6 +258,7 @@ bool WbTextBuffer::load(const QString &fn, const QString &title) {
   if (!title.isEmpty()) {
     // we only need to set a different title to the tab in case of cached assets
     setReadOnly(true);
+    setUndoRedoEnabled(false);
   }
 
   QByteArray data = file.readAll();
@@ -294,6 +295,7 @@ bool WbTextBuffer::saveAs(const QString &newName) {
   file.close();
   document()->setModified(false);
   setReadOnly(false);
+  setUndoRedoEnabled(true);
   setFileName(newName);
 
   watch();
@@ -306,6 +308,7 @@ bool WbTextBuffer::save() {
 }
 
 void WbTextBuffer::cut() {
+  assert(!isReadOnly());
   QTextCursor cursor = textCursor();
   if (cursor.hasSelection()) {
     mClipboard->setString(cursor.selection().toPlainText());
@@ -319,16 +322,14 @@ void WbTextBuffer::copy() const {
 }
 
 void WbTextBuffer::paste() {
-  if (mClipboard->isEmpty())
-    return;
-
+  assert(!isReadOnly());
   const QString text = mClipboard->stringValue();
   if (!text.isEmpty())
     textCursor().insertText(text);
 }
 
 bool WbTextBuffer::isModified() const {
-  return document()->isModified();
+  return document() && document()->isModified();
 }
 
 bool WbTextBuffer::hasSelection() const {
@@ -382,6 +383,7 @@ void WbTextBuffer::focusOutEvent(QFocusEvent *event) {
 }
 
 void WbTextBuffer::indent(IndentMode mode) {
+  assert(!isReadOnly());
   QTextCursor cur = textCursor();
   int initialAnchor = cur.anchor();
   int initialPosition = cur.position();
@@ -694,6 +696,7 @@ void WbTextBuffer::markError(int line, int column) {
 }
 
 void WbTextBuffer::addNewLine() {
+  assert(!isReadOnly());
   QTextCursor cursor = textCursor();
   cursor.beginEditBlock();
   cursor.removeSelectedText();
@@ -715,6 +718,8 @@ void WbTextBuffer::addNewLine() {
 }
 
 void WbTextBuffer::toggleLineComment() {
+  assert(!isReadOnly());
+
   // select the appropriate comment or do nothing in case of unknown an language
   QString comment = WbLanguage::findByFileName(fileName())->commentPrefix() + " ";
 

--- a/src/webots/editor/WbTextBuffer.cpp
+++ b/src/webots/editor/WbTextBuffer.cpp
@@ -325,7 +325,7 @@ void WbTextBuffer::paste() {
   assert(!isReadOnly());
   if (mClipboard->isEmpty())
     return;
-  
+
   const QString text = mClipboard->stringValue();
   if (!text.isEmpty())
     textCursor().insertText(text);

--- a/src/webots/editor/WbTextBuffer.cpp
+++ b/src/webots/editor/WbTextBuffer.cpp
@@ -323,6 +323,9 @@ void WbTextBuffer::copy() const {
 
 void WbTextBuffer::paste() {
   assert(!isReadOnly());
+  if (mClipboard->isEmpty())
+    return;
+  
   const QString text = mClipboard->stringValue();
   if (!text.isEmpty())
     textCursor().insertText(text);

--- a/src/webots/editor/WbTextEditor.cpp
+++ b/src/webots/editor/WbTextEditor.cpp
@@ -190,7 +190,7 @@ void WbTextEditor::updateEditMenu() {
 }
 
 void WbTextEditor::updateApplicationActions() {
-  QTextDocument *doc = mCurrentBuffer ? mCurrentBuffer->document() : NULL;
+  const QTextDocument *const doc = mCurrentBuffer ? mCurrentBuffer->document() : NULL;
   enableUndo(doc && doc->isUndoAvailable());
   enableRedo(doc && doc->isRedoAvailable());
   enableCopy(mCurrentBuffer && mCurrentBuffer->hasSelection());

--- a/src/webots/editor/WbTextEditor.cpp
+++ b/src/webots/editor/WbTextEditor.cpp
@@ -175,7 +175,7 @@ void WbTextEditor::updateFileNames() {
     if (windowTitle.isEmpty())
       // WbTextBuffer::fileName() is empty in case of cached asset files
       windowTitle = tr("Read-only remote file");
-    else if (selectedBuffer->document() && selectedBuffer->isModified())
+    else if (selectedBuffer->isModified())
       windowTitle += "*";
     setWindowTitle(windowTitle);
   } else

--- a/src/webots/gui/WbConsole.cpp
+++ b/src/webots/gui/WbConsole.cpp
@@ -127,7 +127,7 @@ void ConsoleEdit::focusInEvent(QFocusEvent *event) {
   // update application actions
   WbActionManager *actionManager = WbActionManager::instance();
   actionManager->setFocusObject(this);
-  actionManager->enableTextEditActions(false);
+  actionManager->enableTextEditActions(false, true);
   actionManager->setEnabled(WbAction::COPY, textCursor().hasSelection());
   actionManager->setEnabled(WbAction::SELECT_ALL, true);
   actionManager->setEnabled(WbAction::FIND, true);

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -308,7 +308,7 @@ WbView3D::~WbView3D() {
 }
 
 void WbView3D::focusInEvent(QFocusEvent *event) {
-  WbActionManager::instance()->enableTextEditActions(false);
+  WbActionManager::instance()->enableTextEditActions(false, true);
   WbActionManager::instance()->setFocusObject(this);
   emit applicationActionsUpdateRequested();
 }

--- a/src/webots/scene_tree/WbTreeView.cpp
+++ b/src/webots/scene_tree/WbTreeView.cpp
@@ -76,7 +76,7 @@ WbTreeView::~WbTreeView() {
 
 void WbTreeView::focusInEvent(QFocusEvent *event) {
   QTreeView::focusInEvent(event);
-  WbActionManager::instance()->enableTextEditActions(false);
+  WbActionManager::instance()->enableTextEditActions(false, true);
   WbActionManager::instance()->setFocusObject(this);
 
   // when this widget gets keyboard focus the higlighted color of the current

--- a/src/webots/user_commands/WbActionManager.cpp
+++ b/src/webots/user_commands/WbActionManager.cpp
@@ -1063,13 +1063,13 @@ void WbActionManager::resetApplicationActionsState() {
   mActions[REDO]->setEnabled(false);
 }
 
-void WbActionManager::enableTextEditActions(bool enabled) {
+void WbActionManager::enableTextEditActions(bool enabled, bool isReadOnly) {
   mActions[FIND]->setEnabled(enabled);
   mActions[FIND_NEXT]->setEnabled(enabled);
   mActions[FIND_PREVIOUS]->setEnabled(enabled);
-  mActions[REPLACE]->setEnabled(enabled);
+  mActions[REPLACE]->setEnabled(enabled && !isReadOnly);
   mActions[GO_TO_LINE]->setEnabled(enabled);
-  mActions[TOGGLE_LINE_COMMENT]->setEnabled(enabled);
+  mActions[TOGGLE_LINE_COMMENT]->setEnabled(enabled && !isReadOnly);
   mActions[PRINT]->setEnabled(enabled);
   mActions[PRINT_PREVIEW]->setEnabled(enabled);
 }

--- a/src/webots/user_commands/WbActionManager.hpp
+++ b/src/webots/user_commands/WbActionManager.hpp
@@ -37,7 +37,7 @@ public:
   void setEnabled(WbAction::WbActionKind kind, bool enabled);
 
   void resetApplicationActionsState();
-  void enableTextEditActions(bool enabled);
+  void enableTextEditActions(bool enabled, bool isReadOnly);
   QObject *focusObject() const { return mFocusObject; }
   void setFocusObject(QObject *object) { mFocusObject = object; }
 


### PR DESCRIPTION
Complete #4889 (addressing WbTextBuffer only) by preventing and disabling the application actions:
undo, redo, cut, paste, save and replace actions on read-only text buffer.
