### PR TITLE
Removed useless test after assert

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2477,8 +2477,7 @@ void WbMainWindow::prepareNodeRegeneration(WbNode *node) {
         perspective = device->perspective();
       const WbRobot *robot = WbNodeUtilities::findRobotAncestor(device);
       assert(robot);
-      if (robot)
-        mTemporaryProtoPerspectives.insert(robot->name() + "\n" + device->name(), perspective);
+      mTemporaryProtoPerspectives.insert(robot->name() + "\n" + device->name(), perspective);
     }
   }
 }


### PR DESCRIPTION
Since we have an assert on `robot`, we can assume that from this point `robot` will never be `NULL`. Thus, the test is superfluous.