### PR TITLE
Cleanup QString::replace usage

### DIFF
--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -91,7 +91,7 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const WbMFS
 QString WbUrl::computePath(const WbNode *node, const QString &field, const QString &rawUrl, bool warn) {
   // use cross-platform forward slashes
   QString url = rawUrl;
-  url = url.replace("\\", "/");
+  url.replace("\\", "/");
 
   // check if the first url is empty
   if (url.isEmpty()) {
@@ -142,9 +142,9 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
 QString WbUrl::generateExternProtoPath(const QString &rawUrl, const QString &rawParentUrl) {
   // use cross-platform forward slashes
   QString url = rawUrl;
-  url = url.replace("\\", "/");
+  url.replace("\\", "/");
   QString parentUrl = rawParentUrl;
-  parentUrl = parentUrl.replace("\\", "/");
+  parentUrl.replace("\\", "/");
 
   // cases where no url manipulation is necessary
   if (isWeb(url))


### PR DESCRIPTION
I believe it is slightly better to avoid using the return value of the `replace` method of `QString` if not needed.
The current usage suggest that `replace` is a `const` method that doesn't change the original `QString` object and returns a new `QString` object with the replaced string, which is not the case.
The new usage proposed in this PR makes it clear that the `QString` object is modified by the `replace` method and hence cannot be `const`.
Hence the constness of the `QString` objects can be assessed without having to check the documentation of `QString` to understand that the object is both modified and is returned as a reference.
