### PR TITLE
Fixed execution of homebrew python controllers on x86_64

### DIFF
--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -40,8 +40,8 @@ To check the versions of Python installed on your system, you can type in a term
 You can install Python 3.7, 3.8, 3.9 or 3.10 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
 To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python3 --version`, etc.
 
-Python 3.7 and Homebrew Python are not provided for M1 processors.
-If you need Homebrew Python for M1, you will have to recompile the Python wrapper by yourself, as explained below.
+Python 3.7 and Homebrew Python are not provided for Apple Silicon processors.
+If you need Homebrew Python for Apple Silicon, you will have to recompile the Python wrapper by yourself, as explained below.
 
 > **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (e.g. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
 

--- a/docs/guide/using-python.md
+++ b/docs/guide/using-python.md
@@ -40,6 +40,9 @@ To check the versions of Python installed on your system, you can type in a term
 You can install Python 3.7, 3.8, 3.9 or 3.10 from the [Python web site](https://www.python.org) or using [Homebrew](https://brew.sh).
 To check the versions of Python installed on your system, you can type in a terminal: `python --version`, `python3.8 --version`, `python3 --version`, etc.
 
+Python 3.7 and Homebrew Python are not provided for M1 processors.
+If you need Homebrew Python for M1, you will have to recompile the Python wrapper by yourself, as explained below.
+
 > **Note**: To use Python 3.x on macOS, it is recommended to set the absolute path to the python3 executable (e.g. `/Library/Frameworks/Python.framework/Versions/3.x/bin/python3`) in the [`Python command` option of the Preferences](preferences.md#general).
 
 #### Windows Installation

--- a/src/controller/python/.gitignore
+++ b/src/controller/python/.gitignore
@@ -1,4 +1,6 @@
-/controller??.o
-/controller???.o
-/controller??.cpp
-/controller???.cpp
+/controller3?.o
+/controller3??.o
+/controller3?.cpp
+/controller3??.cpp
+/controller3?_brew.cpp
+/controller3??_brew.cpp

--- a/src/controller/python/Makefile
+++ b/src/controller/python/Makefile
@@ -41,7 +41,7 @@ INTERFACE       = controller.i
 SWIG            = swig
 SWIG_OPTS       = -c++ -python -outdir $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX)/
 WEBOTS_INCLUDES = -I$(WEBOTS_HOME_PATH)/include/controller/cpp -I$(WEBOTS_HOME_PATH)/include/controller/c
-WRAPPER         = $(INTERFACE:.i=$(PYTHON_SHORT_VERSION).cpp)
+WRAPPER         = $(INTERFACE:.i=$(PYTHON_SHORT_VERSION)$(SUFFIX).cpp)
 PYOUT           = $(addprefix $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX)/,$(INTERFACE:.i=.py))
 PYTHON_PATH_SETUP := $(shell mkdir -p $(WEBOTS_CONTROLLER_LIB_PATH)/python$(PYTHON_SHORT_VERSION)$(SUFFIX))
 
@@ -79,10 +79,8 @@ PYTHON_PYMALLOC = m
 endif
 PYTHON_BIN       = $(PYTHON_PATH)/bin/
 C_FLAGS          = -c -Wall -fPIC -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-uninitialized
-ifeq ($(SUFFIX),)
 ifeq ($(PYTHON_SHORT_VERSION),38)
 C_FLAGS          += -Wno-deprecated-declarations
-endif
 endif
 ifeq ($(PYTHON_SHORT_VERSION),39)
 C_FLAGS          += -Wno-deprecated-declarations
@@ -138,6 +136,14 @@ $(PYOUT) $(WRAPPER):$(INTERFACE) $(LIBCONTROLLER) $(LIBCPPCONTROLLER)
 ifeq ($(OSTYPE),darwin)
 
 ifeq ($(PYTHON_SHORT_VERSION),37)
+  X86_64_ONLY = 1
+endif
+
+ifeq ($(SUFFIX),_brew)
+  X86_64_ONLY = 1
+endif
+
+ifeq ($(X86_64_ONLY),1)
 $(LIBOUT):$(LIBOUT_X86_64) $(LIBCONTROLLER) $(LIBCPPCONTROLLER)
 	@echo "# creating" $@
 	lipo -create -output $@ x86_64/_controller.so

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -595,7 +595,7 @@ void WbController::setProcessEnvironment() {
     process.start("which", QStringList() << mPythonCommand);
     process.waitForFinished();
     const QString output = process.readAll();
-    if (output.startsWith("/usr/local/Cellar/python@"))
+    if (output.startsWith("/usr/local/Cellar/python@") || output.startsWith("/usr/local/opt/python@"))
       addToPathEnvironmentVariable(
         env, "PYTHONPATH", WbStandardPaths::controllerLibPath() + "python" + mPythonShortVersion + "_brew", false, true);
     else


### PR DESCRIPTION
Fixes #4919.

It seems the execution of homebrew python controllers was broken after introducing the support for M1.

- The Makefile was not rebuilding the `_brew` version of the controllers.
- The `PYTHONPATH` was set to brew only if executing brew python from the `/usr/local/Cellar` folder. I also added the `/usr/local/opt` folder which is a common way to refer to the brew version of python as well.

Note: the M1 brew python is not supported because brew doesn't provide universal binaries and it would be complicated to support it (we would need to build universal binaries ourselves for brew which is not a trivial task).