### PR TITLE
Add missing window fields to protos

### DIFF
--- a/projects/robots/a4/portal/protos/Portal.proto
+++ b/projects/robots/a4/portal/protos/Portal.proto
@@ -11,6 +11,7 @@ PROTO Portal [
   field SFString   name            "Portal"     # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFString   customData      ""           # Is `Robot.customData`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
@@ -22,6 +23,7 @@ PROTO Portal [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/abb/irb/protos/Irb4600-40.proto
+++ b/projects/robots/abb/irb/protos/Irb4600-40.proto
@@ -14,6 +14,7 @@ PROTO Irb4600-40 [
   field SFString   name            "IRB 4600/40"         # Is `Solid.name`.
   field SFString   controller      "inverse_kinematics"  # Is `Robot.controller`.
   field MFString   controllerArgs  []                    # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"           # Is `Robot.window`.
   field SFString   customData      ""                    # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                 # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                  # Is `Robot.synchronization`.
@@ -403,6 +404,7 @@ PROTO Irb4600-40 [
     %< } >%
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/adept/pioneer2/protos/Pioneer2.proto
+++ b/projects/robots/adept/pioneer2/protos/Pioneer2.proto
@@ -10,6 +10,7 @@ PROTO Pioneer2 [
   field SFString   name            "Pioneer 2"   # Is `Solid.name`.
   field SFString   controller      "braitenberg" # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData      ""            # Is `Robot.customData`.
   field SFBool     supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO Pioneer2 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/adept/pioneer3/protos/Pioneer3at.proto
+++ b/projects/robots/adept/pioneer3/protos/Pioneer3at.proto
@@ -12,6 +12,7 @@ PROTO Pioneer3at [
   field SFString   name            "Pioneer 3-AT" # Is `Solid.name`.
   field SFString   controller      "<generic>"    # Is `Robot.controller`.
   field MFString   controllerArgs  []             # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"    # Is `Robot.window`.
   field SFString   customData      ""             # Is `Robot.customData`.
   field SFBool     supervisor      FALSE          # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE           # Is `Robot.synchronization`.
@@ -740,6 +741,7 @@ PROTO Pioneer3at [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/adept/pioneer3/protos/Pioneer3dx.proto
+++ b/projects/robots/adept/pioneer3/protos/Pioneer3dx.proto
@@ -12,6 +12,7 @@ PROTO Pioneer3dx [
   field SFString   name            "Pioneer 3-DX"                   # Is `Solid.name`.
   field SFString   controller      "pioneer3dx_collision_avoidance" # Is `Robot.controller`.
   field MFString   controllerArgs  []                               # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"                      # Is `Robot.window`.
   field SFString   customData      ""                               # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                            # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                             # Is `Robot.synchronization`.
@@ -1122,6 +1123,7 @@ PROTO Pioneer3dx [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto
+++ b/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto
@@ -5,15 +5,16 @@
 # The "Crazyflie" is a robot developed by "Bitcraze": https://bitcraze.io/
 
 PROTO Crazyflie [
-  field SFVec3f    translation     0 0 0.015
-  field SFRotation rotation        0 0 1 0
-  field SFString   name            "Crazyflie"
-  field SFString   controller      "crazyflie"
-  field MFString   controllerArgs  ""
-  field SFString   customData      ""
-  field SFBool     supervisor      FALSE
-  field SFBool     synchronization TRUE
-  field MFNode     extensionSlot   []
+  field SFVec3f    translation     0 0 0.015   # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Crazyflie" # Is `Solid.name`.
+  field SFString   controller      "crazyflie" # Is `Robot.controller`.
+  field MFString   controllerArgs  ""          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO Crazyflie [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/bitcraze/crazyflie/worlds/crazyflie.wbt
+++ b/projects/robots/bitcraze/crazyflie/worlds/crazyflie.wbt
@@ -6,6 +6,11 @@ EXTERNPROTO "webots://projects/objects/backgrounds/protos/TexturedBackgroundLigh
 EXTERNPROTO "webots://projects/objects/floors/protos/Floor.proto"
 
 WorldInfo {
+  info [
+    "Bitcraze's Crazyflie drone."
+    "This simulation allows you to pilot the drone with your keyboard."
+  ]
+  title "Crazyflie"
 }
 Viewpoint {
   orientation -0.10311089632172073 0.641740519713268 0.7599587149430397 0.6949228976889259

--- a/projects/robots/bluebotics/shrimp/protos/Shrimp.proto
+++ b/projects/robots/bluebotics/shrimp/protos/Shrimp.proto
@@ -6,15 +6,16 @@
 # It has 6 wheels and a passive structure that adapts to the terrain profile and climbs obstacles.
 
 PROTO Shrimp [
-  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
-  field SFString   name            "Shrimp" # Is `Solid.name`.
-  field SFString   controller      "shrimp" # Is `Robot.controller`.
-  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
-  field SFString   customData      ""       # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []       # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Shrimp"    # Is `Solid.name`.
+  field SFString   controller      "shrimp"    # Is `Robot.controller`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -22,6 +23,7 @@ PROTO Shrimp [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/boston_dynamics/atlas/protos/Atlas.proto
+++ b/projects/robots/boston_dynamics/atlas/protos/Atlas.proto
@@ -41,6 +41,7 @@ PROTO Atlas [
   field SFString   name            "Atlas"            # Is `Solid.name`.
   field SFString   controller      "hello_world_demo" # Is `Robot.controller`.
   field MFString   controllerArgs  []                 # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"        # Is `Robot.window`.
   field SFString   customData      ""                 # Is `Robot.customData`.
   field SFBool     supervisor      FALSE              # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE               # Is `Robot.synchronization`.
@@ -688,6 +689,7 @@ PROTO Atlas [
     model "Boston Dynamics Atlas"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/boston_dynamics/spot/protos/Spot.proto
+++ b/projects/robots/boston_dynamics/spot/protos/Spot.proto
@@ -19,6 +19,7 @@ PROTO Spot [
   field SFString    model            "Boston Dynamics - Spot"  # Is `Robot.model`.
   field SFString    controller       "spot_moving_demo"        # Is `Robot.controller`.
   field MFString    controllerArgs   []                        # Is `Robot.controllerArgs`.
+  field SFString    window           "<generic>"               # Is `Robot.window`.
   field SFString    customData       ""                        # Is `Robot.customData`.
   field SFBool      supervisor       FALSE                     # Is `Robot.supervisor`.
   field SFBool      synchronization  TRUE                      # Is `Robot.synchronization`.
@@ -1822,6 +1823,7 @@ PROTO Spot [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/clearpath/moose/protos/Moose.proto
+++ b/projects/robots/clearpath/moose/protos/Moose.proto
@@ -16,6 +16,7 @@ PROTO Moose [
   field SFString   name            "moose"       # Is `Solid.name`.
   field SFString   controller      "<none>"      # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
   field SFColor    color           0.8 0.5 0.1   # Set the bumper color.
   field MFNode     bodySlot        []            # Extends the robot with new nodes in the body slot.
@@ -28,6 +29,7 @@ PROTO Moose [
     model "Clearpath Moose"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     synchronization IS synchronization
     children [
       Transform {

--- a/projects/robots/clearpath/pr2/protos/Pr2.proto
+++ b/projects/robots/clearpath/pr2/protos/Pr2.proto
@@ -13,6 +13,7 @@ PROTO Pr2 [
    field SFString   name            "PR2"       # Is `Solid.name`.
    field SFString   controller      "pr2_demo"  # Is `Robot.controller`.
    field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+   field SFString   window          "<generic>" # Is `Robot.window`.
    field SFString   customData      ""          # Is `Robot.customData`.
    field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
    field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
@@ -25,6 +26,7 @@ PROTO Pr2 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/epfl/biorob/protos/GhostDog.proto
+++ b/projects/robots/epfl/biorob/protos/GhostDog.proto
@@ -5,15 +5,16 @@
 # The "GhostDog" robot is a dog-like robot developed by the EPFL BioRob laboratory.
 
 PROTO GhostDog [
-  field SFVec3f    translation     0 0 0      # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0    # Is `Transform.rotation`.
-  field SFString   name            "GhostDog" # Is `Solid.name`.
-  field SFString   controller      "ghostdog" # Is `Robot.controller`.
-  field MFString   controllerArgs  []         # Is `Robot.controllerArgs`.
-  field SFString   customData      ""         # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE      # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE       # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []         # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "GhostDog"  # Is `Solid.name`.
+  field SFString   controller      "ghostdog"  # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO GhostDog [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/epfl/biorob/protos/Salamander.proto
+++ b/projects/robots/epfl/biorob/protos/Salamander.proto
@@ -10,6 +10,7 @@ PROTO Salamander [
   field SFString   name            "Salamander" # Is `Solid.name`.
   field SFString   controller      "salamander" # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFString   customData      ""           # Is `Robot.customData`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO Salamander [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/epfl/biorob/protos/Yamor.proto
+++ b/projects/robots/epfl/biorob/protos/Yamor.proto
@@ -5,15 +5,16 @@
 # The "Yamor" robot is a modular robot developed by the EPFL BioRob laboratory.
 
 PROTO Yamor [
-  field SFVec3f    translation     0 0 0   # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0 # Is `Transform.rotation`.
-  field SFString   name            "Yamor" # Is `Solid.name`.
-  field SFString   controller      "yamor" # Is `Robot.controller`.
-  field MFString   controllerArgs  []      # Is `Robot.controllerArgs`.
-  field SFString   customData      ""      # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE   # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE    # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []      # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Yamor"     # Is `Solid.name`.
+  field SFString   controller      "yamor"     # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO Yamor [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/epfl/lis/protos/Blimp.proto
+++ b/projects/robots/epfl/lis/protos/Blimp.proto
@@ -5,15 +5,16 @@
 # The "Blimp" robot is a Zeppelin-like aerial robot developed by the EPFL LIS laboratory.
 
 PROTO Blimp [
-  field SFVec3f    translation     0 0 0   # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0 # Is `Transform.rotation`.
-  field SFString   name            "Blimp" # Is `Solid.name`.
-  field SFString   controller      "blimp" # Is `Robot.controller`.
-  field MFString   controllerArgs  []      # Is `Robot.controllerArgs`.
-  field SFString   customData      ""      # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE   # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE    # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []      # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Blimp"     # Is `Solid.name`.
+  field SFString   controller      "blimp"     # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -436,6 +437,7 @@ PROTO Blimp [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/epson/scara_t6/protos/ScaraT6.proto
+++ b/projects/robots/epson/scara_t6/protos/ScaraT6.proto
@@ -16,10 +16,10 @@ PROTO ScaraT6 [
   field SFString          name            "ScaraT6"       # Is `Solid.name`.
   field SFString          controller      "<none>"        # Is `Robot.controller`.
   field MFString          controllerArgs  []              # Is `Robot.controllerArgs`.
+  field SFString          window          "<generic>"     # Is `Robot.window`.
   field SFBool            supervisor      FALSE           # Is `Robot.supervisor`.
   field SFBool            synchronization TRUE            # Is `Robot.synchronization`.
   field SFString          customData      ""              # Is `Robot.customData`.
-  field SFString          window          "<generic>"     # Is `Robot.window`.
   field SFBool            staticBase      FALSE           # Defines if the scara base should be pinned to the static environment.
   field MFNode            handSlot        []              # Extends the shaft with new nodes in the hand slot.
 
@@ -30,7 +30,6 @@ PROTO ScaraT6 [
     rotation IS rotation
     synchronization IS synchronization
     name IS name
-    window IS window
     model "SCARA EPSON T6‑602S"
     supervisor IS supervisor
     children [
@@ -640,5 +639,6 @@ PROTO ScaraT6 [
     %< } >%
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
   }
 }

--- a/projects/robots/festo/robotino3/protos/Robotino3.proto
+++ b/projects/robots/festo/robotino3/protos/Robotino3.proto
@@ -24,6 +24,7 @@ PROTO Robotino3 [
   field  SFString    model             "Festo - Robotino 3"
   field  SFString    controller        "robotino3"
   field  MFString    controllerArgs    []
+  field  SFString    window            "<generic>"
   field  SFString    customData        ""
   field  SFBool      supervisor        FALSE
   field  SFBool      synchronization   TRUE
@@ -44,6 +45,7 @@ PROTO Robotino3 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto
+++ b/projects/robots/fp_robotics/p-rob3/protos/P-Rob3.proto
@@ -16,6 +16,7 @@ PROTO P-Rob3 [
   field SFString   name            "P-Rob3"         # Is `Solid.name`.
   field SFString   controller      "<generic>"      # Is `Robot.controller`.
   field MFString   controllerArgs  []               # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"      # Is `Robot.window`.
   field SFBool     supervisor      FALSE            # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE             # Is `Robot.synchronization`.
   field SFBool     selfCollision   TRUE             # Is `Robot.selfCollision`.
@@ -1043,6 +1044,7 @@ PROTO P-Rob3 [
     name IS name
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision

--- a/projects/robots/franka_emika/panda/protos/Panda.proto
+++ b/projects/robots/franka_emika/panda/protos/Panda.proto
@@ -13,6 +13,7 @@ PROTO Panda [
   field  SFString    name               "panda"       # Is `Solid.name`.
   field  SFString    controller         "<generic>"   # Is `Robot.controller`.
   field  MFString    controllerArgs     []            # Is `Robot.controllerArgs`.
+  field SFString     window             "<generic>"   # Is `Robot.window`.
   field  SFString    customData         ""            # Is `Robot.customData`.
   field  SFBool      supervisor         FALSE         # Is `Robot.supervisor`.
   field  SFBool      synchronization    TRUE          # Is `Robot.synchronization`.
@@ -25,6 +26,7 @@ PROTO Panda [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/fujitsu/hoap2/protos/Hoap2.proto
+++ b/projects/robots/fujitsu/hoap2/protos/Hoap2.proto
@@ -11,6 +11,7 @@ PROTO Hoap2 [
   field SFString   name                "HOAP-2"       # Is `Solid.name`.
   field SFString   controller          "hoap2"        # Is `Robot.controller`.
   field MFString   controllerArgs      []             # Is `Robot.controllerArgs`.
+  field SFString   window              "<generic>"    # Is `Robot.window`.
   field SFString   customData          ""             # Is `Robot.customData`.
   field SFBool     supervisor          FALSE          # Is `Robot.supervisor`.
   field SFBool     synchronization     TRUE           # Is `Robot.synchronization`.
@@ -2020,6 +2021,7 @@ PROTO Hoap2 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/gctronic/e-puck/protos/E-puck.proto
+++ b/projects/robots/gctronic/e-puck/protos/E-puck.proto
@@ -17,9 +17,11 @@ PROTO E-puck [
   field SFString           name                         "e-puck"                 # Is `Solid.name`.
   field SFString           controller                   "e-puck_avoid_obstacles" # Is `Robot.controller`.
   field MFString           controllerArgs               []                       # Is `Robot.controllerArgs`.
+  field SFString           window                       "e-puck"                 # Is `Robot.window`.
   field SFString           customData                   ""                       # Is `Robot.customData`.
   field SFBool             supervisor                   FALSE                    # Is `Robot.supervisor`.
   field SFBool             synchronization              TRUE                     # Is `Robot.synchronization`.
+  field MFFloat            battery                      []                       # Is `Robot.battery`.
   field SFString{"1", "2"} version                      "1"                      # Defines the e-puck version; either "1" or "2".
   field SFFloat            camera_fieldOfView           0.84                     # Is `Camera.fieldOfView`.
   field SFInt32            camera_width                 52                       # Is `Camera.width`.
@@ -31,8 +33,6 @@ PROTO E-puck [
   field SFInt32            distance_sensor_numberOfRays 1                        # Is `DistanceSensor.numberOfRays`.
   field SFInt32            emitter_channel              1                        # Is `Emitter.channel`.
   field SFInt32            receiver_channel             1                        # Is `Receiver.channel`.
-  field MFFloat            battery                      []                       # Is `Robot.battery`.
-  field SFString           window                       "e-puck"                 # Is `Robot.window`.
   field MFNode             turretSlot                   []                       # Extends the robot with new nodes in the turret slot.
   field MFNode             groundSensorsSlot            []                       # Extends the robot with new nodes in the ground slot. Typically: `E-puckGroundSensors.proto`.
   field SFBool             kinematic                    FALSE                    # Defines whether the robot motion and its sensors are computed according to a 2D kinematics algorithm.
@@ -1178,12 +1178,12 @@ Robot {
   %< } >%
   controller IS controller
   controllerArgs IS controllerArgs
+  window IS window
   customData IS customData
   supervisor IS supervisor
   synchronization IS synchronization
   battery IS battery
   cpuConsumption 1.11 # 100% to 0% in 90[s] (calibrated for the rat's life contest)
-  window IS window
   %< if (v2) { >%
     remoteControl "e-puck_wifi"
   %< } else { >%

--- a/projects/robots/gctronic/elisa/protos/Elisa3.proto
+++ b/projects/robots/gctronic/elisa/protos/Elisa3.proto
@@ -9,18 +9,19 @@
 EXTERNPROTO "webots://projects/robots/gctronic/elisa/protos/Elisa3DistanceSensor.proto"
 
 PROTO Elisa3 [
-  field SFVec3f    translation      0 0 0     # Is `Transform.translation`.
-  field SFRotation rotation         0 0 1 0   # Is `Transform.rotation`.
-  field SFString   name             "Elisa-3" # Is `Solid.name`.
-  field SFString   controller       "elisa3"  # Is `Robot.controller`.
-  field MFString   controllerArgs   []        # Is `Robot.controllerArgs`.
-  field SFString   customData       ""        # Is `Robot.customData`.
-  field SFBool     supervisor       FALSE     # Is `Robot.supervisor`.
-  field SFBool     synchronization  TRUE      # Is `Robot.synchronization`.
-  field SFInt32    emitter_channel  1         # Is `Emitter.channel`.
-  field SFInt32    receiver_channel 1         # Is `Receiver.channel`.
-  field MFFloat    battery          []        # Is `Robot.battery`.
-  field MFNode     extensionSlot    []        # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation      0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation         0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name             "Elisa-3"   # Is `Solid.name`.
+  field SFString   controller       "elisa3"    # Is `Robot.controller`.
+  field MFString   controllerArgs   []          # Is `Robot.controllerArgs`.
+  field SFString   window           "<generic>" # Is `Robot.window`.
+  field SFString   customData       ""          # Is `Robot.customData`.
+  field SFBool     supervisor       FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization  TRUE        # Is `Robot.synchronization`.
+  field SFInt32    emitter_channel  1           # Is `Emitter.channel`.
+  field SFInt32    receiver_channel 1           # Is `Receiver.channel`.
+  field MFFloat    battery          []          # Is `Robot.battery`.
+  field MFNode     extensionSlot    []          # Extends the robot with new nodes in the extension slot.
 ]
 {
 Robot {
@@ -880,6 +881,7 @@ Robot {
   }
   controller IS controller
   controllerArgs IS controllerArgs
+  window IS window
   customData IS customData
   supervisor IS supervisor
   synchronization IS synchronization

--- a/projects/robots/irobot/create/protos/Create.proto
+++ b/projects/robots/irobot/create/protos/Create.proto
@@ -10,6 +10,7 @@ PROTO Create [
   field SFString   name            "Create"                 # Is `Solid.name`.
   field SFString   controller      "create_avoid_obstacles" # Is `Robot.controller`.
   field MFString   controllerArgs  []                       # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"              # Is `Robot.window`.
   field SFString   customData      ""                       # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                    # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                     # Is `Robot.synchronization`.
@@ -593,6 +594,7 @@ Robot {
   }
   controller IS controller
   controllerArgs IS controllerArgs
+  window IS window
   customData IS customData
   supervisor IS supervisor
   synchronization IS synchronization

--- a/projects/robots/k-team/hemisson/protos/Hemisson.proto
+++ b/projects/robots/k-team/hemisson/protos/Hemisson.proto
@@ -5,15 +5,16 @@
 # The "Hemisson" is a two-wheeled robot designed for education and teaching developped by K-TEAM.
 
 PROTO Hemisson [
-  field SFVec3f    translation     0 0 0      # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0    # Is `Transform.rotation`.
-  field SFString   name            "Hemisson" # Is `Solid.name`.
-  field SFString   controller      "hemisson" # Is `Robot.controller`.
-  field MFString   controllerArgs  []         # Is `Robot.controllerArgs`.
-  field SFString   customData      ""         # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE      # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE       # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []         # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Hemisson"  # Is `Solid.name`.
+  field SFString   controller      "hemisson"  # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO Hemisson [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/k-team/khepera1/protos/Khepera1.proto
+++ b/projects/robots/k-team/khepera1/protos/Khepera1.proto
@@ -11,6 +11,7 @@ PROTO Khepera1 [
   field SFString   name            "Khepera"     # Is `Solid.name`.
   field SFString   controller      "braitenberg" # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData      ""            # Is `Robot.customData`.
   field SFBool     supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
@@ -26,6 +27,7 @@ PROTO Khepera1 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/k-team/khepera2/protos/Khepera2.proto
+++ b/projects/robots/k-team/khepera2/protos/Khepera2.proto
@@ -10,6 +10,7 @@ PROTO Khepera2 [
   field SFString   name            "Khepera II"  # Is `Solid.name`.
   field SFString   controller      "braitenberg" # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData      ""            # Is `Robot.customData`.
   field SFBool     supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO Khepera2 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/k-team/khepera3/protos/Khepera3.proto
+++ b/projects/robots/k-team/khepera3/protos/Khepera3.proto
@@ -14,6 +14,7 @@ PROTO Khepera3 [
   field SFString   name            "Khepera III" # Is `Solid.name`.
   field SFString   controller      "braitenberg" # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData      ""            # Is `Robot.customData`.
   field SFBool     supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
@@ -28,6 +29,7 @@ PROTO Khepera3 [
     name IS name
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/k-team/khepera4/protos/Khepera4.proto
+++ b/projects/robots/k-team/khepera4/protos/Khepera4.proto
@@ -12,6 +12,7 @@ PROTO Khepera4 [
   field SFString   name                "Khepera IV"            # Is `Solid.name`.
   field SFString   controller          "khepera4"              # Is `Robot.controller`.
   field MFString   controllerArgs      []                      # Is `Robot.controllerArgs`.
+  field SFString   window              "<generic>"             # Is `Robot.window`.
   field SFString   customData          ""                      # Is `Robot.customData`.
   field SFBool     supervisor          FALSE                   # Is `Robot.supervisor`.
   field SFBool     synchronization     TRUE                    # Is `Robot.synchronization`.
@@ -29,6 +30,7 @@ PROTO Khepera4 [
     name IS name
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/k-team/koala/protos/Koala.proto
+++ b/projects/robots/k-team/koala/protos/Koala.proto
@@ -5,15 +5,16 @@
 # The "Koala" robot is a six-wheeled indoor robot produced by K-Team.
 
 PROTO Koala [
-  field SFVec3f    translation     0 0 0   # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0 # Is `Transform.rotation`.
-  field SFString   name            "Koala" # Is `Solid.name`.
-  field SFString   controller      "koala" # Is `Robot.controller`.
-  field MFString   controllerArgs  []      # Is `Robot.controllerArgs`.
-  field SFString   customData      ""      # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE   # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE    # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []      # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Koala"     # Is `Solid.name`.
+  field SFString   controller      "koala"     # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO Koala [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/kinematics/tinkerbots/protos/TinkerbotsBase.proto
+++ b/projects/robots/kinematics/tinkerbots/protos/TinkerbotsBase.proto
@@ -10,6 +10,7 @@ PROTO TinkerbotsBase [
   field SFString   name            "Tinkerbots"      # Is `Solid.name`.
   field SFString   controller      "tinkerbots_demo" # Is `Robot.controller`.
   field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"       # Is `Robot.window`.
   field SFString   customData      ""                # Is `Robot.customData`.
   field SFBool     supervisor      FALSE             # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE              # Is `Robot.synchronization`.
@@ -47,6 +48,7 @@ PROTO TinkerbotsBase [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/kondo/khr-2hv/protos/Khr2hv.proto
+++ b/projects/robots/kondo/khr-2hv/protos/Khr2hv.proto
@@ -11,6 +11,7 @@ PROTO Khr2hv [
   field SFString   name            "KHR-2HV"      # Is `Solid.name`.
   field SFString   controller      "khr-2hv_demo" # Is `Robot.controller`.
   field MFString   controllerArgs  []             # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"    # Is `Robot.window`.
   field SFString   contactMaterial "default"      # Defines the `Solid.contactMaterial` for the robot parts.
   field SFString   customData      ""             # Is `Robot.customData`.
   field SFBool     supervisor      FALSE          # Is `Robot.supervisor`.
@@ -2883,6 +2884,7 @@ PROTO Khr2hv [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/kondo/khr-3hv/protos/Khr3hv.proto
+++ b/projects/robots/kondo/khr-3hv/protos/Khr3hv.proto
@@ -10,6 +10,7 @@ PROTO Khr3hv [
   field SFString   name            "KHR-3HV"    # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFString   customData      ""           # Is `Robot.customData`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
@@ -22,6 +23,7 @@ PROTO Khr3hv [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/kuka/youbot/protos/Youbot.proto
+++ b/projects/robots/kuka/youbot/protos/Youbot.proto
@@ -23,6 +23,7 @@ PROTO Youbot [
   field SFString          name            "youBot"      # Is `Solid.name`.
   field SFString          controller      "youbot"      # Is `Robot.controller`.
   field MFString          controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString          window          "<generic>"   # Is `Robot.window`.
   field SFString          customData      ""            # Is `Robot.customData`.
   field SFBool            supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool            synchronization TRUE          # Is `Robot.synchronization`.
@@ -870,5 +871,6 @@ Robot {
   }
   controller IS controller
   controllerArgs IS controllerArgs
+  window IS window
 }
 }

--- a/projects/robots/lego/mindstorms/protos/MindstormsRover.proto
+++ b/projects/robots/lego/mindstorms/protos/MindstormsRover.proto
@@ -10,6 +10,7 @@ PROTO MindstormsRover [
   field SFString   name            "MindstormsRover" # Is `Solid.name`.
   field SFString   controller      "Rover"           # Is `Robot.controller`.
   field MFString   controllerArgs  []                # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"       # Is `Robot.window`.
   field SFString   customData      ""                # Is `Robot.customData`.
   field SFBool     supervisor      FALSE             # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE              # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO MindstormsRover [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/micromagic/mantis/protos/Mantis.proto
+++ b/projects/robots/micromagic/mantis/protos/Mantis.proto
@@ -6,15 +6,16 @@
 # A human can drive this robot.
 
 PROTO Mantis [
-  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
-  field SFString   name            "Mantis" # Is `Solid.name`.
-  field SFString   controller      "mantis" # Is `Robot.controller`.
-  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
-  field SFString   customData      ""       # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []       # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "Mantis"    # Is `Solid.name`.
+  field SFString   controller      "mantis"    # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -22,6 +23,7 @@ PROTO Mantis [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/mir/mir100/protos/Mir100.proto
+++ b/projects/robots/mir/mir100/protos/Mir100.proto
@@ -16,6 +16,7 @@ PROTO Mir100 [
   field  SFString    name             "Mir100"            # Is `Robot.name`.
   field  SFString    controller       "keyboard_control"  # Is `Robot.controller`.
   field  MFString    controllerArgs   []                  # Is `Robot.controllerArgs`.
+  field SFString     window           "<generic>"         # Is `Robot.window`.
   field  SFString    customData       ""                  # Is `Robot.customData`.
   field  SFBool      supervisor       FALSE               # Is `Robot.supervisor`.
   field  SFBool      synchronization  TRUE                # Is `Robot.synchronization`.
@@ -30,6 +31,7 @@ PROTO Mir100 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/mobsya/thymio/protos/Thymio2.proto
+++ b/projects/robots/mobsya/thymio/protos/Thymio2.proto
@@ -18,10 +18,10 @@ PROTO Thymio2 [
   field SFString   name            "Thymio II"     # Is `Solid.name`.
   field SFString   controller      "thymio2_aseba" # Is `Robot.controller`.
   field MFString   controllerArgs  "port=33333"    # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"     # Is `Robot.window`.
   field SFString   customData      ""              # Is `Robot.customData`.
   field SFBool     supervisor      FALSE           # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE            # Is `Robot.synchronization`.
-  field SFString   window          "<generic>"     # Is `Robot.window`.
   field SFString   contactMaterial "thymio body"   # Defines the `Solid.contactMaterial` for the body.
   field SFBool     castLight       TRUE            # Defines whether OpenGL lights are cerated for each LEDs.
   field MFNode     bodySlot        []              # Extends the robot with new nodes in the body slot.
@@ -32,11 +32,11 @@ PROTO Thymio2 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization
     name IS name
-    window IS window
     model "Thymio II"
     children [
       Transform {

--- a/projects/robots/nasa/protos/Sojourner.proto
+++ b/projects/robots/nasa/protos/Sojourner.proto
@@ -12,6 +12,7 @@ PROTO Sojourner [
   field SFString   name            "Sojourner" # Is `Solid.name`.
   field SFString   controller      "sojourner" # Is `Robot.controller`.
   field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window         "<generic>"  # Is `Robot.window`.
   field SFString   customData      ""          # Is `Robot.customData`.
   field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
@@ -23,6 +24,7 @@ PROTO Sojourner [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/neuronics/ipr/protos/IprHd6m180.proto
+++ b/projects/robots/neuronics/ipr/protos/IprHd6m180.proto
@@ -11,6 +11,7 @@ PROTO IprHd6m180 [
   field SFString   name             "IPR"        # Is `Solid.name`.
   field SFString   controller       "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs   []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData       ""           # Is `Robot.customData`.
   field SFBool     supervisor       FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization  TRUE         # Is `Robot.synchronization`.
@@ -2137,6 +2138,7 @@ PROTO IprHd6m180 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/neuronics/ipr/protos/IprHd6m90.proto
+++ b/projects/robots/neuronics/ipr/protos/IprHd6m90.proto
@@ -11,6 +11,7 @@ PROTO IprHd6m90 [
   field SFString   name             "IPR"        # Is `Solid.name`.
   field SFString   controller       "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs   []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData       ""           # Is `Robot.customData`.
   field SFBool     supervisor       FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization  TRUE         # Is `Robot.synchronization`.
@@ -1607,6 +1608,7 @@ PROTO IprHd6m90 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/neuronics/ipr/protos/IprHd6ms180.proto
+++ b/projects/robots/neuronics/ipr/protos/IprHd6ms180.proto
@@ -11,6 +11,7 @@ PROTO IprHd6ms180 [
   field SFString   name             "IPR"        # Is `Solid.name`.
   field SFString   controller       "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs   []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData       ""           # Is `Robot.customData`.
   field SFBool     supervisor       FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization  TRUE         # Is `Robot.synchronization`.
@@ -2150,6 +2151,7 @@ PROTO IprHd6ms180 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/neuronics/ipr/protos/IprHd6ms90.proto
+++ b/projects/robots/neuronics/ipr/protos/IprHd6ms90.proto
@@ -11,6 +11,7 @@ PROTO IprHd6ms90 [
   field SFString   name             "IPR"        # Is `Solid.name`.
   field SFString   controller       "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs   []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData       ""           # Is `Robot.customData`.
   field SFBool     supervisor       FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization  TRUE         # Is `Robot.synchronization`.
@@ -1808,6 +1809,7 @@ PROTO IprHd6ms90 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/nex/protos/FireBird6.proto
+++ b/projects/robots/nex/protos/FireBird6.proto
@@ -11,6 +11,7 @@ PROTO FireBird6 [
   field SFString   name            "Fire Bird 6"                    # Is `Solid.name`.
   field SFString   controller      "fire_bird_6_obstacle_avoidance" # Is `Robot.controller`.
   field MFString   controllerArgs  []                               # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"                      # Is `Robot.window`.
   field SFString   customData      ""                               # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                            # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                             # Is `Robot.synchronization`.
@@ -581,6 +582,7 @@ Robot {
   }
   controller IS controller
   controllerArgs IS controllerArgs
+  window IS window
   customData IS customData
   supervisor IS supervisor
   synchronization IS synchronization

--- a/projects/robots/niryo/ned/protos/Ned.proto
+++ b/projects/robots/niryo/ned/protos/Ned.proto
@@ -8,15 +8,16 @@ EXTERNPROTO "webots://projects/appearances/protos/Plastic.proto"
 EXTERNPROTO "webots://projects/appearances/protos/BrushedAluminium.proto"
 
 PROTO Ned [
-  field  SFVec3f     translation     0 0 0     # Is `Transform.translation`.
-  field  SFRotation  rotation        0 0 1 0   # Is `Transform.rotation`.
-  field  SFString    name            "Ned"     # Is `Robot.name`.
-  field  SFString    controller      "ned"     # Is `Robot.controller`.
-  field  MFString    controllerArgs  []        # Is `Robot.controllerArgs`.
-  field  SFString    customData      ""        # Is `Robot.customData`.
-  field  SFBool      supervisor      FALSE     # Is `Robot.supervisor`.
-  field  SFBool      synchronization TRUE      # Is `Robot.synchronization`.
-  field  SFBool      selfCollision   FALSE     # Is `Robot.selfCollision`.
+  field SFVec3f     translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation  rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString    name            "Ned"       # Is `Robot.name`.
+  field SFString    controller      "ned"       # Is `Robot.controller`.
+  field MFString    controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString    window          "<generic>" # Is `Robot.window`.
+  field SFString    customData      ""          # Is `Robot.customData`.
+  field SFBool      supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool      synchronization TRUE        # Is `Robot.synchronization`.
+  field SFBool      selfCollision   FALSE       # Is `Robot.selfCollision`.
 ]
 {
   Robot {
@@ -24,6 +25,7 @@ PROTO Ned [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/nvidia/jetbot/protos/JetBot.proto
+++ b/projects/robots/nvidia/jetbot/protos/JetBot.proto
@@ -17,6 +17,7 @@ PROTO JetBot [
   field SFString           name                         "JetBot"                 # Is `Solid.name`.
   field SFString           controller                   "jetbot_basic_motion"    # Is `Robot.controller`.
   field MFString           controllerArgs               []                       # Is `Robot.controllerArgs`.
+  field SFString           window                       "<generic>"              # Is `Robot.window`.
   field SFString           customData                   ""                       # Is `Robot.customData`.
   field SFBool             supervisor                   FALSE                    # Is `Robot.supervisor`.
   field SFBool             synchronization              TRUE                     # Is `Robot.synchronization`.
@@ -440,6 +441,7 @@ PROTO JetBot [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto
+++ b/projects/robots/pal_robotics/tiago++/protos/Tiago++.proto
@@ -18,6 +18,7 @@ PROTO Tiago++ [
   field  SFString    name                  "TIAGo++"
   field  SFString    controller            "tiago++"
   field  MFString    controllerArgs        []
+  field  SFString    window                "<generic>"
   field  SFString    customData            ""
   field  SFBool      supervisor            FALSE
   field  SFBool      synchronization       TRUE
@@ -33,6 +34,7 @@ PROTO Tiago++ [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/pal_robotics/tiago_base/protos/TiagoBase.proto
+++ b/projects/robots/pal_robotics/tiago_base/protos/TiagoBase.proto
@@ -16,6 +16,7 @@ PROTO TiagoBase [
   field  SFString    name             "TIAGo Base"
   field  SFString    controller       "tiago_base"
   field  MFString    controllerArgs   []
+  field  SFString    window          "<generic>"
   field  SFString    customData       ""
   field  SFBool      supervisor       FALSE
   field  SFBool      synchronization  TRUE
@@ -30,6 +31,7 @@ PROTO TiagoBase [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/pal_robotics/tiago_iron/protos/TiagoIron.proto
+++ b/projects/robots/pal_robotics/tiago_iron/protos/TiagoIron.proto
@@ -15,6 +15,7 @@ PROTO TiagoIron [
   field  SFString    name             "TIAGo Iron"
   field  SFString    controller       "tiago_iron"
   field  MFString    controllerArgs   []
+  field  SFString    window           "<generic>"
   field  SFString    customData       ""
   field  SFBool      supervisor       FALSE
   field  SFBool      synchronization  TRUE
@@ -28,6 +29,7 @@ PROTO TiagoIron [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/pal_robotics/tiago_steel/protos/TiagoSteel.proto
+++ b/projects/robots/pal_robotics/tiago_steel/protos/TiagoSteel.proto
@@ -17,6 +17,7 @@ PROTO TiagoSteel [
   field  SFString    name             "TIAGo Steel"
   field  SFString    controller       "tiago_steel"
   field  MFString    controllerArgs   []
+  field  SFString    window           "<generic>"
   field  SFString    customData       ""
   field  SFBool      supervisor       FALSE
   field  SFBool      synchronization  TRUE
@@ -30,6 +31,7 @@ PROTO TiagoSteel [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/pal_robotics/tiago_titanium/protos/TiagoTitanium.proto
+++ b/projects/robots/pal_robotics/tiago_titanium/protos/TiagoTitanium.proto
@@ -17,6 +17,7 @@ PROTO TiagoTitanium [
   field  SFString    name             "TIAGo Titanium"
   field  SFString    controller       "tiago_titanium"
   field  MFString    controllerArgs   []
+  field  SFString    window           "<generic>"
   field  SFString    customData       ""
   field  SFBool      supervisor       FALSE
   field  SFBool      synchronization  TRUE
@@ -30,6 +31,7 @@ PROTO TiagoTitanium [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/parallax/boebot/protos/BoeBot.proto
+++ b/projects/robots/parallax/boebot/protos/BoeBot.proto
@@ -5,15 +5,16 @@
 # The "Boe-Bot" is a 3 wheeled robot (2 motorized wheels and a passive caster wheel) created by Parallax Inc.
 
 PROTO BoeBot [
-  field SFVec3f    translation     0 0 0    # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0  # Is `Transform.rotation`.
-  field SFString   name            "BoeBot" # Is `Solid.name`.
-  field SFString   controller      "boebot" # Is `Robot.controller`.
-  field MFString   controllerArgs  []       # Is `Robot.controllerArgs`.
-  field SFString   customData      ""       # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE    # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE     # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []       # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "BoeBot"    # Is `Solid.name`.
+  field SFString   controller      "boebot"    # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO BoeBot [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/picaxe/microbot/protos/Microbot.proto
+++ b/projects/robots/picaxe/microbot/protos/Microbot.proto
@@ -11,6 +11,7 @@ PROTO Microbot [
   field SFString   name            "BOT120"     # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFString   customData      ""           # Is `Robot.customData`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
@@ -22,6 +23,7 @@ PROTO Microbot [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/rec/fabtino/protos/Fabtino.proto
+++ b/projects/robots/rec/fabtino/protos/Fabtino.proto
@@ -5,17 +5,18 @@
 # Designed by Robotics Equipment Corporation (REC) GmbH, Fabtino is a four-wheeled (mecanum) robot.
 
 PROTO Fabtino [
-  field  SFVec3f     translation     0 0 0.0613          # Is `Transform.translation`.
-  field  SFRotation  rotation        0 0 1 0             # Is `Transform.rotation`.
-  field  SFString    name            "Fabtino"           # Is `Robot.name`.
-  field  SFString    controller      "keyboard_control"  # Is `Robot.controller`.
-  field  MFString    controllerArgs  []                  # Is `Robot.controllerArgs`.
-  field  SFString    customData      ""                  # Is `Robot.customData`.
-  field  SFBool      supervisor      FALSE               # Is `Robot.supervisor`.
-  field  SFBool      synchronization TRUE                # Is `Robot.synchronization`.
-  field  MFNode      frontLidarSlot  []                  # Extends the robot with a front lidar sensor.
-  field  MFNode      backLidarSlot   []                  # Extends the robot with a back lidar sensor.
-  field  MFNode      bodySlot        []                  # Extends the robot with new nodes (such as the Robotino3Platform for example).
+  field SFVec3f     translation     0 0 0.0613          # Is `Transform.translation`.
+  field SFRotation  rotation        0 0 1 0             # Is `Transform.rotation`.
+  field SFString    name            "Fabtino"           # Is `Robot.name`.
+  field SFString    controller      "keyboard_control"  # Is `Robot.controller`.
+  field MFString    controllerArgs  []                  # Is `Robot.controllerArgs`.
+  field SFString    window          "<generic>"         # Is `Robot.window`.
+  field SFString    customData      ""                  # Is `Robot.customData`.
+  field SFBool      supervisor      FALSE               # Is `Robot.supervisor`.
+  field SFBool      synchronization TRUE                # Is `Robot.synchronization`.
+  field MFNode      frontLidarSlot  []                  # Extends the robot with a front lidar sensor.
+  field MFNode      backLidarSlot   []                  # Extends the robot with a back lidar sensor.
+  field MFNode      bodySlot        []                  # Extends the robot with new nodes (such as the Robotino3Platform for example).
 ]
 {
   Robot {
@@ -23,6 +24,7 @@ PROTO Fabtino [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/robotis/bioloid/protos/BioloidDog.proto
+++ b/projects/robots/robotis/bioloid/protos/BioloidDog.proto
@@ -10,6 +10,7 @@ PROTO BioloidDog [
   field SFString   name            "BioloidDog"  # Is `Solid.name`.
   field SFString   controller      "bioloid_dog" # Is `Robot.controller`.
   field MFString   controllerArgs  []            # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFString   customData      ""            # Is `Robot.customData`.
   field SFBool     supervisor      FALSE         # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE          # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO BioloidDog [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS webots
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/robotis/darwin-op/protos/Darwin-op.proto
+++ b/projects/robots/robotis/darwin-op/protos/Darwin-op.proto
@@ -20,6 +20,7 @@ PROTO Darwin-op [
   field SFString   name            "DARwIn-OP"                # Is `Solid.name`.
   field SFString   controller      "motion_player"            # Is `Robot.controller`.
   field MFString   controllerArgs  []                         # Is `Robot.controllerArgs`.
+  field SFString   window          "robotis-op2_window"       # Is `Robot.window`.
   field SFString   customData      ""                         # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                      # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                       # Is `Robot.synchronization`.
@@ -1925,11 +1926,11 @@ PROTO Darwin-op [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision
-    window "robotis-op2_window"
     remoteControl "robotis-op2_tcpip"
   }
 }

--- a/projects/robots/robotis/darwin-op/protos/Darwin-opHinge2.proto
+++ b/projects/robots/robotis/darwin-op/protos/Darwin-opHinge2.proto
@@ -21,6 +21,7 @@ PROTO Darwin-opHinge2 [
   field SFString   name             "DARwIn-OP Hinge2"         # Is `Solid.name`.
   field SFString   controller       "motion_player"            # Is `Robot.controller`.
   field MFString   controllerArgs   []                         # Is `Robot.controllerArgs`.
+  field SFString   window           "robotis-op2_window"       # Is `Robot.window`.
   field SFString   customData       ""                         # Is `Robot.customData`.
   field SFBool     supervisor       FALSE                      # Is `Robot.supervisor`.
   field SFBool     synchronization  TRUE                       # Is `Robot.synchronization`.
@@ -2071,11 +2072,11 @@ PROTO Darwin-opHinge2 [
     }
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision
-    window "robotis-op2_window"
     remoteControl "robotis-op2_tcpip"
   }
 }

--- a/projects/robots/robotis/darwin-op/protos/RobotisOp2.proto
+++ b/projects/robots/robotis/darwin-op/protos/RobotisOp2.proto
@@ -19,6 +19,7 @@ PROTO RobotisOp2 [
   field SFString   name            "ROBOTIS OP2"   # Is `Solid.name`.
   field SFString   controller      "motion_player" # Is `Robot.controller`.
   field MFString   controllerArgs  []              # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"     # Is `Robot.window`.
   field SFString   customData      ""              # Is `Robot.customData`.
   field SFBool     supervisor      FALSE           # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE            # Is `Robot.synchronization`.
@@ -43,6 +44,7 @@ PROTO RobotisOp2 [
     rotation        IS rotation
     controller      IS controller
     controllerArgs  IS controllerArgs
+    window          IS window
     customData      IS customData
     supervisor      IS supervisor
     synchronization IS synchronization

--- a/projects/robots/robotis/darwin-op/protos/RobotisOp2Hinge2.proto
+++ b/projects/robots/robotis/darwin-op/protos/RobotisOp2Hinge2.proto
@@ -19,6 +19,7 @@ PROTO RobotisOp2Hinge2 [
   field SFString   name            "ROBOTIS OP2 Hinge2"   # Is `Solid.name`.
   field SFString   controller      "motion_player"        # Is `Robot.controller`.
   field MFString   controllerArgs  []                     # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"            # Is `Robot.window`.
   field SFString   customData      ""                     # Is `Robot.customData`.
   field SFBool     supervisor      FALSE                  # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE                   # Is `Robot.synchronization`.
@@ -43,6 +44,7 @@ PROTO RobotisOp2Hinge2 [
     rotation        IS rotation
     controller      IS controller
     controllerArgs  IS controllerArgs
+    window          IS window
     customData      IS customData
     supervisor      IS supervisor
     synchronization IS synchronization

--- a/projects/robots/robotis/darwin-op/protos/RobotisOp3.proto
+++ b/projects/robots/robotis/darwin-op/protos/RobotisOp3.proto
@@ -31,6 +31,7 @@ PROTO RobotisOp3 [
   field SFString   name                "ROBOTIS OP3"                  # Is `Solid.name`.
   field SFString   controller          "<generic>"                    # Is `Robot.controller`.
   field MFString   controllerArgs      []                             # Is `Robot.controllerArgs`.
+  field SFString   window              "<generic>"                    # Is `Robot.window`.
   field SFString   contactMaterial     "ROBOTIS OP3 default material" # Defines the `Solid.contactMaterial` for all the robot parts, except the feet and the hands.
   field SFString   footContactMaterial "ROBOTIS OP3 foot material"    # Defines the `Solid.contactMaterial` for the feet.
   field SFString   handContactMaterial "ROBOTIS OP3 finger material"  # Defines the `Solid.contactMaterial` for the hands.
@@ -53,6 +54,7 @@ PROTO RobotisOp3 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/robotnik/summit_xl_steel/protos/SummitXlSteel.proto
+++ b/projects/robots/robotnik/summit_xl_steel/protos/SummitXlSteel.proto
@@ -8,17 +8,18 @@
 EXTERNPROTO "webots://projects/appearances/protos/Plastic.proto"
 
 PROTO SummitXlSteel [
-  field  SFVec3f     translation     0 0 0.118           # Is `Transform.translation`.
-  field  SFRotation  rotation        0 0 1 0             # Is `Transform.rotation`.
-  field  SFString    name            "Summit-XL Steel"   # Is `Robot.name`.
-  field  SFString    controller      "keyboard_control"  # Is `Robot.controller`.
-  field  MFString    controllerArgs  []                  # Is `Robot.controllerArgs`.
-  field  SFString    customData      ""                  # Is `Robot.customData`.
-  field  SFBool      supervisor      FALSE               # Is `Robot.supervisor`.
-  field  SFBool      synchronization TRUE                # Is `Robot.synchronization`.
-  field  MFNode      frontLidarSlot  []                  # Extends the robot with a front lidar sensor.
-  field  MFNode      backLidarSlot   []                  # Extends the robot with a back lidar sensor.
-  field  MFNode      bodySlot        []                  # Extends the robot with new nodes (such as the Robotino3Platform for example).
+  field SFVec3f     translation     0 0 0.118           # Is `Transform.translation`.
+  field SFRotation  rotation        0 0 1 0             # Is `Transform.rotation`.
+  field SFString    name            "Summit-XL Steel"   # Is `Robot.name`.
+  field SFString    controller      "keyboard_control"  # Is `Robot.controller`.
+  field MFString    controllerArgs  []                  # Is `Robot.controllerArgs`.
+  field SFString    window          "<generic>"         # Is `Robot.window`.
+  field SFString    customData      ""                  # Is `Robot.customData`.
+  field SFBool      supervisor      FALSE               # Is `Robot.supervisor`.
+  field SFBool      synchronization TRUE                # Is `Robot.synchronization`.
+  field MFNode      frontLidarSlot  []                  # Extends the robot with a front lidar sensor.
+  field MFNode      backLidarSlot   []                  # Extends the robot with a back lidar sensor.
+  field MFNode      bodySlot        []                  # Extends the robot with new nodes (such as the Robotino3Platform for example).
 ]
 {
   Robot {
@@ -26,6 +27,7 @@ PROTO SummitXlSteel [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/saeon/protos/Altino.proto
+++ b/projects/robots/saeon/protos/Altino.proto
@@ -14,6 +14,7 @@ PROTO Altino [
   field SFString   name            "vehicle"               # Is `Solid.name`.
   field SFString   controller      "vehicle_driver_altino" # Is `Robot.controller`.
   field MFString   controllerArgs  []                      # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"             # Is `Robot.window`.
   field SFBool     synchronization TRUE                    # Is `Robot.synchronization`.
   field SFColor    color           0.3 0.3 0.7             # Is `Material.diffuseColor`.
 ]
@@ -25,6 +26,7 @@ PROTO Altino [
     model "Altino"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     synchronization IS synchronization
     trackFront                     0.08
     trackRear                      0.08

--- a/projects/robots/softbank/nao/protos/Nao.proto
+++ b/projects/robots/softbank/nao/protos/Nao.proto
@@ -20,11 +20,11 @@ PROTO Nao [
   field MFColor customColor          []                                          # Defines the color of the secondary plastic components.
   field SFString                     controller            "nao_demo"            # Is `Robot.controller`.
   field MFString                     controllerArgs        []                    # Is `Robot.controllerArgs`.
+  field SFString                     window                "<generic>"           # Is `Robot.window`.
   field SFString                     customData            ""                    # Is `Robot.customData`.
   field SFBool                       supervisor            FALSE                 # Is `Robot.supervisor`.
   field SFBool                       synchronization       TRUE                  # Is `Robot.synchronization`.
   field SFBool                       selfCollision         FALSE                 # Is `Robot.selfCollision`.
-  field SFString                     window                "<generic>"           # Is `Robot.window`.
   field SFFloat                      gpsAccuracy           0.0                   # Is `GPS.accuracy`.
   field SFInt32                      cameraWidth           160                   # Is `Camera.width`.
   field SFInt32                      cameraHeight          120                   # Is `Camera.height`.
@@ -105,12 +105,12 @@ PROTO Nao [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization
     contactMaterial IS contactMaterial
     selfCollision IS selfCollision
-    window IS window
     name IS name
     model %<= '"' + model + '"' >%
     children [

--- a/projects/robots/softbank/nao/protos/Nao.proto
+++ b/projects/robots/softbank/nao/protos/Nao.proto
@@ -24,6 +24,7 @@ PROTO Nao [
   field SFBool                       supervisor            FALSE                 # Is `Robot.supervisor`.
   field SFBool                       synchronization       TRUE                  # Is `Robot.synchronization`.
   field SFBool                       selfCollision         FALSE                 # Is `Robot.selfCollision`.
+  field SFString                     window                "<generic>"           # Is `Robot.window`.
   field SFFloat                      gpsAccuracy           0.0                   # Is `GPS.accuracy`.
   field SFInt32                      cameraWidth           160                   # Is `Camera.width`.
   field SFInt32                      cameraHeight          120                   # Is `Camera.height`.
@@ -109,6 +110,7 @@ PROTO Nao [
     synchronization IS synchronization
     contactMaterial IS contactMaterial
     selfCollision IS selfCollision
+    window IS window
     name IS name
     model %<= '"' + model + '"' >%
     children [

--- a/projects/robots/sony/aibo/protos/AiboErs7.proto
+++ b/projects/robots/sony/aibo/protos/AiboErs7.proto
@@ -10,9 +10,9 @@ PROTO AiboErs7 [
   field SFString   name                "ERS-7"       # Is `Solid.name`.
   field SFString   controller          "ers7"        # Is `Robot.controller`.
   field MFString   controllerArgs      []            # Is `Robot.controllerArgs`.
+  field SFString   window              "<generic>"   # Is `Robot.window`.
   field SFString   customData          ""            # Is `Robot.customData`.
   field SFBool     supervisor          FALSE         # Is `Robot.supervisor`.
-  field SFString   window              "<generic>"   # Is `Robot.window`.
   field SFBool     synchronization     TRUE          # Is `Robot.synchronization`.
   field SFFloat    camera_fieldOfView  0.993092      # Is `Camera.fieldOfView`.
   field SFInt32    camera_width        208           # Is `Camera.width`.
@@ -27,9 +27,9 @@ PROTO AiboErs7 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
-    window IS window
     synchronization IS synchronization
     name IS name
     model "Aibo ERS-7"

--- a/projects/robots/sony/aibo/protos/AiboErs7.proto
+++ b/projects/robots/sony/aibo/protos/AiboErs7.proto
@@ -12,6 +12,7 @@ PROTO AiboErs7 [
   field MFString   controllerArgs      []            # Is `Robot.controllerArgs`.
   field SFString   customData          ""            # Is `Robot.customData`.
   field SFBool     supervisor          FALSE         # Is `Robot.supervisor`.
+  field SFString   window              "<generic>"   # Is `Robot.window`.
   field SFBool     synchronization     TRUE          # Is `Robot.synchronization`.
   field SFFloat    camera_fieldOfView  0.993092      # Is `Camera.fieldOfView`.
   field SFInt32    camera_width        208           # Is `Camera.width`.
@@ -19,7 +20,6 @@ PROTO AiboErs7 [
   field SFBool     camera_antiAliasing FALSE         # Is `Camera.antiAliasing`.
   field MFNode     headSlot            []            # Extends the robot with new nodes located in the head.
   field MFNode     extensionSlot       []            # Extends the robot with new nodes located in the body center.
-  field SFString   window              "<generic>"   # Is `Robot.window`.
 ]
 {
   Robot {
@@ -29,6 +29,7 @@ PROTO AiboErs7 [
     controllerArgs IS controllerArgs
     customData IS customData
     supervisor IS supervisor
+    window IS window
     synchronization IS synchronization
     name IS name
     model "Aibo ERS-7"
@@ -3976,6 +3977,5 @@ PROTO AiboErs7 [
         0 0 -0.02
       ]
     }
-    window IS window
   }
 }

--- a/projects/robots/sony/qrio/protos/QRIO.proto
+++ b/projects/robots/sony/qrio/protos/QRIO.proto
@@ -5,15 +5,16 @@
 # QRIO ("Quest for cuRIOsity", originally named Sony Dream Robot or SDR) is a bipedal humanoid entertainment robot developed and marketed by Sony.
 
 PROTO QRIO [
-  field SFVec3f    translation     0 0 0.42  # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0   # Is `Transform.rotation`.
-  field SFString   name            "QRIO"    # Is `Solid.name`.
-  field SFString   controller      "qrio"    # Is `Robot.controller`.
-  field MFString   controllerArgs  []        # Is `Robot.controllerArgs`.
-  field SFString   customData      ""        # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE     # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE      # Is `Robot.synchronization`.
-  field MFNode     extensionSlot   []        # Extends the robot with new nodes in the extension slot.
+  field SFVec3f    translation     0 0 0.42    # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "QRIO"      # Is `Solid.name`.
+  field SFString   controller      "qrio"      # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field MFNode     extensionSlot   []          # Extends the robot with new nodes in the extension slot.
 ]
 {
   Robot {
@@ -21,6 +22,7 @@ PROTO QRIO [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/sphero/bb8/protos/BB-8.proto
+++ b/projects/robots/sphero/bb8/protos/BB-8.proto
@@ -11,24 +11,25 @@ EXTERNPROTO "webots://projects/robots/sphero/bb8/protos/BB-8BodyShape.proto"
 EXTERNPROTO "webots://projects/robots/sphero/bb8/protos/BB-8HeadShape.proto"
 
 PROTO BB-8 [
-  field SFVec3f    translation     0 0 0   # Is `Transform.translation`.
-  field SFRotation rotation        0 0 1 0 # Is `Transform.rotation`.
-  field SFString   name            "BB-8"  # Is `Solid.name`.
-  field SFString   controller      "bb-8"  # Is `Robot.controller`.
-  field MFString   controllerArgs  []      # Is `Robot.controllerArgs`.
-  field SFString   customData      ""      # Is `Robot.customData`.
-  field SFBool     supervisor      FALSE   # Is `Robot.supervisor`.
-  field SFBool     synchronization TRUE    # Is `Robot.synchronization`.
-  field SFString   contactMaterial "bb-8"  # Defines the `Solid.contactMaterial` for the robot parts.
-  field MFNode     bodySlot        []      # Extends the robot with new nodes in the body slot.
-  field SFFloat    bodyRadius      0.25    # Defines the radius of the sphere which defines the robot body.
-  field SFFloat    bodyMass        5.0     # Defines the mass of the robot body.
-  field MFNode     headSlot        []      # Extends the robot with new nodes in the head slot.
-  field SFFloat    headOffset      0.025   # Defines the distance between the body center and the head center.
-  field SFFloat    headRadius      0.15    # Defines the radius of the sphere which defines the robot head.
-  field SFFloat    headMass        1.0     # Defines the mass of the robot head.
-  field SFFloat    weightMass      20.0    # Defines the mass of the robot body.
-  field SFFloat    maxVelocity     8.72    # Defines the `RotationalMotor.maxVelocity` fields. Note: the real robot moves at 4.9 [mph].
+  field SFVec3f    translation     0 0 0       # Is `Transform.translation`.
+  field SFRotation rotation        0 0 1 0     # Is `Transform.rotation`.
+  field SFString   name            "BB-8"      # Is `Solid.name`.
+  field SFString   controller      "bb-8"      # Is `Robot.controller`.
+  field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
+  field SFString   customData      ""          # Is `Robot.customData`.
+  field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
+  field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
+  field SFString   contactMaterial "bb-8"      # Defines the `Solid.contactMaterial` for the robot parts.
+  field MFNode     bodySlot        []          # Extends the robot with new nodes in the body slot.
+  field SFFloat    bodyRadius      0.25        # Defines the radius of the sphere which defines the robot body.
+  field SFFloat    bodyMass        5.0         # Defines the mass of the robot body.
+  field MFNode     headSlot        []          # Extends the robot with new nodes in the head slot.
+  field SFFloat    headOffset      0.025       # Defines the distance between the body center and the head center.
+  field SFFloat    headRadius      0.15        # Defines the radius of the sphere which defines the robot head.
+  field SFFloat    headMass        1.0         # Defines the mass of the robot head.
+  field SFFloat    weightMass      20.0        # Defines the mass of the robot body.
+  field SFFloat    maxVelocity     8.72        # Defines the `RotationalMotor.maxVelocity` fields. Note: the real robot moves at 4.9 [mph].
 ]
 {
   %<
@@ -188,6 +189,7 @@ PROTO BB-8 [
     model "Sphero BB-8"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/surveyor/protos/SurveyorSrv1.proto
+++ b/projects/robots/surveyor/protos/SurveyorSrv1.proto
@@ -10,6 +10,7 @@ PROTO SurveyorSrv1 [
   field SFString   name            "SurveyorSrv1" # Is `Solid.name`.
   field SFString   controller      "surveyor"     # Is `Robot.controller`.
   field MFString   controllerArgs  []             # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"    # Is `Robot.window`.
   field SFString   customData      ""             # Is `Robot.customData`.
   field SFBool     supervisor      FALSE          # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE           # Is `Robot.synchronization`.
@@ -21,6 +22,7 @@ PROTO SurveyorSrv1 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/unimation/puma/protos/Puma560.proto
+++ b/projects/robots/unimation/puma/protos/Puma560.proto
@@ -10,6 +10,7 @@ PROTO Puma560 [
   field SFString   name            "PUMA 560"  # Is `Solid.name`.
   field SFString   controller      "puma560"   # Is `Robot.controller`.
   field MFString   controllerArgs  []          # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>" # Is `Robot.window`.
   field SFString   customData      ""          # Is `Robot.customData`.
   field SFBool     supervisor      FALSE       # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE        # Is `Robot.synchronization`.
@@ -22,6 +23,7 @@ PROTO Puma560 [
     rotation IS rotation
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     customData IS customData
     supervisor IS supervisor
     synchronization IS synchronization

--- a/projects/robots/universal_robots/protos/UR10e.proto
+++ b/projects/robots/universal_robots/protos/UR10e.proto
@@ -14,6 +14,7 @@ PROTO UR10e [
   field SFString   name            "UR10e"      # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
   field SFBool     selfCollision   TRUE         # Is `Robot.selfCollision`.
@@ -775,6 +776,7 @@ PROTO UR10e [
     %< } >%
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision

--- a/projects/robots/universal_robots/protos/UR3e.proto
+++ b/projects/robots/universal_robots/protos/UR3e.proto
@@ -14,6 +14,7 @@ PROTO UR3e [
   field SFString   name            "UR3e"       # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"  # Is `Robot.window`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
   field SFBool     selfCollision   TRUE         # Is `Robot.selfCollision`.
@@ -753,6 +754,7 @@ PROTO UR3e [
     model "UR3e"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision

--- a/projects/robots/universal_robots/protos/UR5e.proto
+++ b/projects/robots/universal_robots/protos/UR5e.proto
@@ -14,6 +14,7 @@ PROTO UR5e [
   field SFString   name            "UR5e"       # Is `Solid.name`.
   field SFString   controller      "<generic>"  # Is `Robot.controller`.
   field MFString   controllerArgs  []           # Is `Robot.controllerArgs`.
+  field SFString   window          "<generic>"   # Is `Robot.window`.
   field SFBool     supervisor      FALSE        # Is `Robot.supervisor`.
   field SFBool     synchronization TRUE         # Is `Robot.synchronization`.
   field SFBool     selfCollision   TRUE         # Is `Robot.selfCollision`.
@@ -740,6 +741,7 @@ PROTO UR5e [
     model "UR5e"
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     supervisor IS supervisor
     synchronization IS synchronization
     selfCollision IS selfCollision

--- a/projects/vehicles/protos/abstract/SimpleVehicle.proto
+++ b/projects/vehicles/protos/abstract/SimpleVehicle.proto
@@ -14,6 +14,7 @@ PROTO SimpleVehicle [
   field SFString   name                           "vehicle"
   field SFString   controller                     "<generic>"
   field MFString   controllerArgs                 [ ]
+  field SFString   window                         "<generic>"
   field SFBool     supervisor                     FALSE
   field SFBool     synchronization                TRUE
   field SFFloat    trackFront                     1.7
@@ -118,6 +119,7 @@ PROTO SimpleVehicle [
     name IS name
     controller IS controller
     controllerArgs IS controllerArgs
+    window IS window
     supervisor IS supervisor
     synchronization IS synchronization
     trackFront IS trackFront


### PR DESCRIPTION
**Description**
One of the goals of the specifications update for robot windows in #4501 was to be able to select `<none>` for robot windows if we did not want them to show up (in benchmarks for example). However, most robots were missing the declaration of the `window` field, so it was impossible to select or add `<none>`.

PROTOs have now been updated.