### PR TITLE
Favor relative urls when saving EXTERNPROTO declarations to file

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2326,10 +2326,7 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify) {
       }
 
       // ensure the EXTERNPROTO list points to the local copy
-      QString relativePath = fileToOpen;
-      if (relativePath.startsWith(WbProject::current()->protosPath()))
-        relativePath = QDir(WbProject::current()->worldsPath()).relativeFilePath(relativePath);
-      WbProtoManager::instance()->updateExternProto(protoModelName, relativePath);
+      WbProtoManager::instance()->updateExternProto(protoModelName, fileToOpen);
       WbWorld::instance()->setModifiedFromSceneTree();
       WbLog::info(
         tr("PROTO file '%1' copied in the local projects folder. Please save and reload the world to apply the changes.")

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -736,11 +736,6 @@ void WbAddNodeDialog::accept() {
   }
 
   // the insertion must be declared as EXTERNPROTO so that it is added to the world file when saving
-  if (mSelectionPath.startsWith(WbStandardPaths::webotsHomePath()))
-    mSelectionPath = mSelectionPath.replace(WbStandardPaths::webotsHomePath(), "webots://");
-  if (mSelectionPath.startsWith(WbProject::current()->protosPath()))
-    mSelectionPath = QDir(WbProject::current()->worldsPath()).relativeFilePath(mSelectionPath);
-
   WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
                                                  mSelectionPath, false);
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -161,10 +161,6 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // the addition must be declared as EXTERNPROTO so that it is added to the world file when saving
-  if (mPath.startsWith(WbStandardPaths::webotsHomePath()))
-    mPath = mPath.replace(WbStandardPaths::webotsHomePath(), "webots://");
-  if (mPath.startsWith(WbProject::current()->protosPath()))
-    mPath = QDir(WbProject::current()->worldsPath()).relativeFilePath(mPath);
   WbProtoManager::instance()->declareExternProto(mProto, mPath, true);
 
   QDialog::accept();

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -795,7 +795,13 @@ void WbProtoManager::declareExternProto(const QString &protoName, const QString 
     }
   }
 
-  mExternProto.push_back(new WbExternProto(protoName, protoPath, importable));
+  // favor relative paths rather than absolute
+  QString path = protoPath;
+  if (path.startsWith(WbStandardPaths::webotsHomePath()))
+    path = path.replace(WbStandardPaths::webotsHomePath(), "webots://");
+  if (path.startsWith(WbProject::current()->protosPath()))
+    path = QDir(WbProject::current()->worldsPath()).relativeFilePath(mSelectionPath);
+  mExternProto.push_back(new WbExternProto(protoName, path, importable));
   emit externProtoListChanged();
 }
 

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -796,12 +796,7 @@ void WbProtoManager::declareExternProto(const QString &protoName, const QString 
   }
 
   // favor relative paths rather than absolute
-  QString path = protoPath;
-  if (path.startsWith(WbStandardPaths::webotsHomePath()))
-    path = path.replace(WbStandardPaths::webotsHomePath(), "webots://");
-  if (path.startsWith(WbProject::current()->protosPath()))
-    path = QDir(WbProject::current()->worldsPath()).relativeFilePath(path);
-  mExternProto.push_back(new WbExternProto(protoName, path, importable));
+  mExternProto.push_back(new WbExternProto(protoName, cleanupExternProtoPath(protoPath), importable));
   emit externProtoListChanged();
 }
 
@@ -820,15 +815,23 @@ void WbProtoManager::removeImportableExternProto(const QString &protoName) {
 void WbProtoManager::updateExternProto(const QString &protoName, const QString &url) {
   for (int i = 0; i < mExternProto.size(); ++i) {
     if (mExternProto[i]->name() == protoName) {
-      mExternProto[i]->setUrl(url.startsWith(WbProject::current()->protosPath()) ?
-                                QDir(WbProject::current()->worldsPath()).relativeFilePath(url) :
-                                url);
+      mExternProto[i]->setUrl(cleanupExternProtoPath(url));
       // loaded model still refers to previous file, it will be updated on world reload
       return;  // we can stop since the list is supposed to contain unique elements, and a match was found
     }
   }
 
   assert(false);  // should not be requesting to change something that doesn't exist
+}
+
+QString WbProtoManager::cleanupExternProtoPath(const QString &url) {
+  QString path = url;
+  if (path.startsWith(WbStandardPaths::webotsHomePath()))
+    path = path.replace(WbStandardPaths::webotsHomePath(), "webots://");
+  if (path.startsWith(WbProject::current()->protosPath()))
+    path = QDir(WbProject::current()->worldsPath()).relativeFilePath(path);
+
+  return path;
 }
 
 bool WbProtoManager::isImportableExternProtoDeclared(const QString &protoName) {

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -800,7 +800,7 @@ void WbProtoManager::declareExternProto(const QString &protoName, const QString 
   if (path.startsWith(WbStandardPaths::webotsHomePath()))
     path = path.replace(WbStandardPaths::webotsHomePath(), "webots://");
   if (path.startsWith(WbProject::current()->protosPath()))
-    path = QDir(WbProject::current()->worldsPath()).relativeFilePath(mSelectionPath);
+    path = QDir(WbProject::current()->worldsPath()).relativeFilePath(path);
   mExternProto.push_back(new WbExternProto(protoName, path, importable));
   emit externProtoListChanged();
 }
@@ -820,7 +820,9 @@ void WbProtoManager::removeImportableExternProto(const QString &protoName) {
 void WbProtoManager::updateExternProto(const QString &protoName, const QString &url) {
   for (int i = 0; i < mExternProto.size(); ++i) {
     if (mExternProto[i]->name() == protoName) {
-      mExternProto[i]->setUrl(url);
+      mExternProto[i]->setUrl(url.startsWith(WbProject::current()->protosPath()) ?
+                                QDir(WbProject::current()->worldsPath()).relativeFilePath(url) :
+                                url);
       // loaded model still refers to previous file, it will be updated on world reload
       return;  // we can stop since the list is supposed to contain unique elements, and a match was found
     }

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -240,7 +240,7 @@ private:
   void displayMissingDeclarations(QString message);
 
   WbVersion checkProtoVersion(QString protoUrl, bool *foundProtoVersion);
-
+  QString cleanupExternProtoPath(const QString &url);
   void cleanup();
 };
 


### PR DESCRIPTION
**Description**

Since there's multiple places where things are declared now, it's better to cleanup the paths directly in the function rather than prior to call it.