### PR TITLE
Expose robot window of simple vehicles

### DIFF
--- a/docs/automobile/ackermannvehicle.md
+++ b/docs/automobile/ackermannvehicle.md
@@ -43,6 +43,7 @@ AckermannVehicle {
   MFNode     axisDevicesRearRight           [ ]
   MFNode     axisDevicesRearLeft            [ ]
   SFString   data                           ""
+  SFString   window                         "automobile"
 }
 ```
 

--- a/docs/automobile/car.md
+++ b/docs/automobile/car.md
@@ -22,6 +22,7 @@ Car {
   MFFloat    gearRatio                      [-12 10 7 5 2.5 1]
   SFFloat    hybridPowerSplitRatio          0.25
   SFFloat    hybridPowerSplitRPM            3000
+  SFString     window                       "automobile"
 }
 ```
 

--- a/projects/vehicles/protos/bmw/BmwX5Simple.proto
+++ b/projects/vehicles/protos/bmw/BmwX5Simple.proto
@@ -27,6 +27,7 @@ PROTO BmwX5Simple [
   field       SFString   name                "vehicle"
   field       SFString   controller          "<none>"
   field       MFString   controllerArgs      [ ]
+  field       SFString   window              "<none>"
   field       MFNode     sensorsSlotFront    [ ]
   field       MFNode     sensorsSlotRear     [ ]
   field       MFNode     sensorsSlotTop      [ ]
@@ -162,5 +163,6 @@ PROTO BmwX5Simple [
       ]
     }
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/citroen/CitroenCZeroSimple.proto
+++ b/projects/vehicles/protos/citroen/CitroenCZeroSimple.proto
@@ -24,6 +24,7 @@ PROTO CitroenCZeroSimple [
   field     SFString   name                "vehicle"
   field     SFString   controller          "<none>"
   field     MFString   controllerArgs      [ ]
+  field     SFString   window              "<none>"
   field     MFNode     sensorsSlotFront    [ ]
   field     MFNode     sensorsSlotRear     [ ]
   field     MFNode     sensorsSlotTop      [ ]
@@ -150,5 +151,6 @@ PROTO CitroenCZeroSimple [
     }
     radarCrossSection 100
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/generic/BusSimple.proto
+++ b/projects/vehicles/protos/generic/BusSimple.proto
@@ -35,7 +35,7 @@ PROTO BusSimple [
     controller IS controller
     controllerArgs IS controllerArgs
     model "bus"
-    recognitionColors IS recognitionColors # somehow duplicate with the color field, but useful to avoid lua PROTO regeneration when colors change.
+    recognitionColors IS recognitionColors # somehow duplicate with the color field, but useful to avoid javascript PROTO regeneration when colors change.
     children [
       Transform {
         children IS sensorsSlotCenter

--- a/projects/vehicles/protos/generic/BusSimple.proto
+++ b/projects/vehicles/protos/generic/BusSimple.proto
@@ -16,6 +16,7 @@ PROTO BusSimple [
   field     SFString   name                "vehicle"
   field     SFString   controller          "<none>"
   field     MFString   controllerArgs      [ ]
+  field     SFString   window              "<none>"
   field     MFNode     sensorsSlotFront    [ ]
   field     MFNode     sensorsSlotRear     [ ]
   field     MFNode     sensorsSlotTop      [ ]
@@ -27,132 +28,133 @@ PROTO BusSimple [
   hiddenField SFVec3f rearLeftWheelAngularVelocity   0 0 0
 ]
 {
-Robot {
-  translation IS translation
-  rotation IS rotation
-  name IS name
-  controller IS controller
-  controllerArgs IS controllerArgs
-  model "bus"
-  recognitionColors IS recognitionColors # somehow duplicate with the color field, but useful to avoid lua PROTO regeneration when colors change.
-  children [
-    Transform {
-      children IS sensorsSlotCenter
-    }
-    Transform {
-      translation 11.5 0 0.2
-      children IS sensorsSlotFront
-    }
-    Transform {
-      translation 2.5 0 5.3
-      children IS sensorsSlotTop
-    }
-    Transform {
-      translation -6.2 0 1
-      rotation 0 0 1 3.14159
-      children IS sensorsSlotRear
-    }
-    Transform{
-      rotation 0.57735 0.57735 0.57735 2.094395
-      children [
-        BusShape {
-          color IS color
-        } 
-      ]
-    }
-    Transform {
-      translation 6.26 -0.9 0.56
-      rotation 0 1 0 1.5708
-      children [
-        DEF FRONT_SPOT Shape {
-          appearance PBRAppearance {
-            metalness 0
-            roughness 0.3
-          }
-          geometry Cylinder {
-            height 0.056
-            radius 0.117
-            subdivision 24
-          }
-        }
-      ]
-    }
-    Transform {
-      translation 6.26 0.9 0.56
-      rotation 0 1 0 1.5708
-      children [
-        USE FRONT_SPOT
-      ]
-    }
-    DEF REAR_LEFT_WHEEL Solid {
-      angularVelocity IS rearLeftWheelAngularVelocity
-      translation 0 1.25 0
-      rotation 0 0 1 -1.5708
-      children [
-        Slot {
-          type "vehicle wheel"
-          endPoint BusWheel {
-            wheelSide TRUE
-            boundingObject IS wheelBoundingObject
-          }
-        }
-      ]
-        name "rear left wheel"
-    }
-    DEF FRONT_LEFT_WHEEL Solid {
-      angularVelocity IS frontLeftWheelAngularVelocity
-      translation 4.5 1.25 0
-      rotation 0 0 1 -1.5708
-      children [
-        Slot {
-          type "vehicle wheel"
-          endPoint BusWheel {
-            wheelSide TRUE
-            boundingObject IS wheelBoundingObject
-          }
-        }
-      ]
-        name "front left wheel"
-    }
-    DEF REAR_RIGHT_WHEEL Solid {
-      angularVelocity IS rearRightWheelAngularVelocity
-      translation 0 -1.25 0
-      rotation 0 0 1 1.5708
-      children [
-        Slot {
-          type "vehicle wheel"
-          endPoint BusWheel {
-            boundingObject IS wheelBoundingObject
-          }
-        }
-      ]
-        name "rear right wheel"
-    }
-    DEF FRONT_RIGHT_WHEEL Solid {
-      angularVelocity IS frontRightWheelAngularVelocity
-      translation 4.5 -1.25 0
-      rotation 0 0 1 1.5708
-      children [
-        Slot {
-          type "vehicle wheel"
-          endPoint BusWheel {
-            boundingObject IS wheelBoundingObject
-          }
-        }
-      ]
-        name "front right wheel"
-    }
-  ]
-  radarCrossSection 200
-  boundingObject Transform {
-    translation 1.4625 0 1.35
-    rotation 0.57735 0.57735 0.57735 2.094395
+  Robot {
+    translation IS translation
+    rotation IS rotation
+    name IS name
+    controller IS controller
+    controllerArgs IS controllerArgs
+    model "bus"
+    recognitionColors IS recognitionColors # somehow duplicate with the color field, but useful to avoid lua PROTO regeneration when colors change.
     children [
-      Box {
-        size 2.64 2.9 9.73
+      Transform {
+        children IS sensorsSlotCenter
+      }
+      Transform {
+        translation 11.5 0 0.2
+        children IS sensorsSlotFront
+      }
+      Transform {
+        translation 2.5 0 5.3
+        children IS sensorsSlotTop
+      }
+      Transform {
+        translation -6.2 0 1
+        rotation 0 0 1 3.14159
+        children IS sensorsSlotRear
+      }
+      Transform{
+        rotation 0.57735 0.57735 0.57735 2.094395
+        children [
+          BusShape {
+            color IS color
+          }
+        ]
+      }
+      Transform {
+        translation 6.26 -0.9 0.56
+        rotation 0 1 0 1.5708
+        children [
+          DEF FRONT_SPOT Shape {
+            appearance PBRAppearance {
+              metalness 0
+              roughness 0.3
+            }
+            geometry Cylinder {
+              height 0.056
+              radius 0.117
+              subdivision 24
+            }
+          }
+        ]
+      }
+      Transform {
+        translation 6.26 0.9 0.56
+        rotation 0 1 0 1.5708
+        children [
+          USE FRONT_SPOT
+        ]
+      }
+      DEF REAR_LEFT_WHEEL Solid {
+        angularVelocity IS rearLeftWheelAngularVelocity
+        translation 0 1.25 0
+        rotation 0 0 1 -1.5708
+        children [
+          Slot {
+            type "vehicle wheel"
+            endPoint BusWheel {
+              wheelSide TRUE
+              boundingObject IS wheelBoundingObject
+            }
+          }
+        ]
+          name "rear left wheel"
+      }
+      DEF FRONT_LEFT_WHEEL Solid {
+        angularVelocity IS frontLeftWheelAngularVelocity
+        translation 4.5 1.25 0
+        rotation 0 0 1 -1.5708
+        children [
+          Slot {
+            type "vehicle wheel"
+            endPoint BusWheel {
+              wheelSide TRUE
+              boundingObject IS wheelBoundingObject
+            }
+          }
+        ]
+          name "front left wheel"
+      }
+      DEF REAR_RIGHT_WHEEL Solid {
+        angularVelocity IS rearRightWheelAngularVelocity
+        translation 0 -1.25 0
+        rotation 0 0 1 1.5708
+        children [
+          Slot {
+            type "vehicle wheel"
+            endPoint BusWheel {
+              boundingObject IS wheelBoundingObject
+            }
+          }
+        ]
+          name "rear right wheel"
+      }
+      DEF FRONT_RIGHT_WHEEL Solid {
+        angularVelocity IS frontRightWheelAngularVelocity
+        translation 4.5 -1.25 0
+        rotation 0 0 1 1.5708
+        children [
+          Slot {
+            type "vehicle wheel"
+            endPoint BusWheel {
+              boundingObject IS wheelBoundingObject
+            }
+          }
+        ]
+          name "front right wheel"
       }
     ]
+    radarCrossSection 200
+    boundingObject Transform {
+      translation 1.4625 0 1.35
+      rotation 0.57735 0.57735 0.57735 2.094395
+      children [
+        Box {
+          size 2.64 2.9 9.73
+        }
+      ]
+    }
+    physics NULL
+    window IS window
   }
-  physics NULL
-}
 }

--- a/projects/vehicles/protos/generic/TruckSimple.proto
+++ b/projects/vehicles/protos/generic/TruckSimple.proto
@@ -18,6 +18,7 @@ PROTO TruckSimple [
   field     SFString   name                "vehicle"
   field     SFString   controller          "<none>"
   field     MFString   controllerArgs      [ ]
+  field     SFString   window              "<none>"
   field     MFNode     sensorsSlotFront    [ ]
   field     MFNode     sensorsSlotRear     [ ]
   field     MFNode     sensorsSlotTop      [ ]
@@ -147,5 +148,6 @@ PROTO TruckSimple [
       ]
     }
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/lincoln/LincolnMKZSimple.proto
+++ b/projects/vehicles/protos/lincoln/LincolnMKZSimple.proto
@@ -27,6 +27,7 @@ PROTO LincolnMKZSimple [
   field       SFString   name                           "vehicle"
   field       SFString   controller                     "<none>"
   field       MFString   controllerArgs                 [ ]
+  field       SFString   window                         "<none>"
   field       MFNode     sensorsSlotFront               [ ]
   field       MFNode     sensorsSlotRear                [ ]
   field       MFNode     sensorsSlotTop                 [ ]
@@ -319,5 +320,6 @@ PROTO LincolnMKZSimple [
     }
     radarCrossSection 100
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/mercedes_benz/MercedesBenzSprinterSimple.proto
+++ b/projects/vehicles/protos/mercedes_benz/MercedesBenzSprinterSimple.proto
@@ -16,6 +16,7 @@ PROTO MercedesBenzSprinterSimple [
   field       SFString   name                           "Mercedes-Benz Sprinter"
   field       SFString   controller                     "<none>"
   field       MFString   controllerArgs                 [ ]
+  field       SFString   window                         "<none>"
   field       MFNode     sensorsSlotFront               [ ]
   field       MFNode     sensorsSlotRear                [ ]
   field       MFNode     sensorsSlotTop                 [ ]
@@ -158,5 +159,6 @@ PROTO MercedesBenzSprinterSimple [
     }
     radarCrossSection 150
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/range_rover/RangeRoverSportSVRSimple.proto
+++ b/projects/vehicles/protos/range_rover/RangeRoverSportSVRSimple.proto
@@ -29,6 +29,7 @@ PROTO RangeRoverSportSVRSimple [
   field       SFString   name                           "vehicle"
   field       SFString   controller                     "<none>"
   field       MFString   controllerArgs                 [ ]
+  field       SFString   window                         "<none>"
   field       MFNode     sensorsSlotFront               [ ]
   field       MFNode     sensorsSlotRear                [ ]
   field       MFNode     sensorsSlotTop                 [ ]
@@ -410,5 +411,6 @@ PROTO RangeRoverSportSVRSimple [
     }
     radarCrossSection 100
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/tesla/TeslaModel3Simple.proto
+++ b/projects/vehicles/protos/tesla/TeslaModel3Simple.proto
@@ -18,6 +18,7 @@ PROTO TeslaModel3Simple [
   field       SFString   name                           "vehicle"
   field       SFString   controller                     "<none>"
   field       MFString   controllerArgs                 [ ]
+  field       SFString   window                         "<none>"
   field       MFNode     sensorsSlotFront               [ ]
   field       MFNode     sensorsSlotRear                [ ]
   field       MFNode     sensorsSlotTop                 [ ]
@@ -170,5 +171,6 @@ PROTO TeslaModel3Simple [
     }
     radarCrossSection 100
     physics NULL
+    window IS window
   }
 }

--- a/projects/vehicles/protos/toyota/ToyotaPriusSimple.proto
+++ b/projects/vehicles/protos/toyota/ToyotaPriusSimple.proto
@@ -22,6 +22,7 @@ PROTO ToyotaPriusSimple [
   field     SFString   name                "vehicle"
   field     SFString   controller          "<none>"
   field     MFString   controllerArgs      [ ]
+  field     SFString   window              "<none>"
   field     MFNode     sensorsSlotFront    [ ]
   field     MFNode     sensorsSlotRear     [ ]
   field     MFNode     sensorsSlotTop      [ ]
@@ -58,7 +59,7 @@ PROTO ToyotaPriusSimple [
       DEF FRONT_RIGHT_WHEEL Solid {
         angularVelocity IS frontRightWheelAngularVelocity
         translation 2.8 -0.814 0
-        rotation 0 0 1 1.5708 
+        rotation 0 0 1 1.5708
         children [
           Slot {
             type "vehicle wheel"
@@ -147,5 +148,6 @@ PROTO ToyotaPriusSimple [
     }
     radarCrossSection 100
     physics NULL
+    window IS window
   }
 }


### PR DESCRIPTION
The robot window is set to `<none>` by default as those vehicles will be used as static objects most of the time.