### PR TITLE
Fix `generate_objects_doc.py`

### DIFF
--- a/docs/guide/generate_objects_doc.py
+++ b/docs/guide/generate_objects_doc.py
@@ -201,7 +201,7 @@ for proto in prioritaryProtoList + fileList:
     for child in root:
         for item in list(child):
             if item.tag == 'name' and item.text == protoName:
-                baseType = child.find('basenode').text
+                baseType = child.find('base-type').text
     if baseType is None:
         sys.stderr.write(f'Could not find proto \"{protoName}\"\n')
 


### PR DESCRIPTION
Currently the tag name used in `generate_objects_doc.py` doesn't match the one generated in the `proto-list.xml` file and the script to generate the objects documentation is broken.