### PR TITLE
Clear old cache folder

### DIFF
--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -44,6 +44,11 @@ WbNetwork::WbNetwork() {
   mNetworkAccessManager = NULL;
   gCacheMap.clear();
 
+  // delete previous caching system folder (< R2022b)
+  QDir oldCache(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/network/");
+  if (!oldCache.exists())
+    oldCache.removeRecursively();
+
   mCacheDirectory = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/assets/";
   QDir dir(mCacheDirectory);
   if (!dir.exists())

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -46,7 +46,7 @@ WbNetwork::WbNetwork() {
 
   // delete previous caching system folder (< R2022b)
   QDir oldCache(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/network/");
-  if (!oldCache.exists())
+  if (oldCache.exists())
     oldCache.removeRecursively();
 
   mCacheDirectory = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/assets/";


### PR DESCRIPTION
**Description**

Prior to R2022b, Qt's caching system was used which means that starting from R2022b (where everything is stored in the `/assets/` folder), the previous folder is likely to persist and occupy disk space for nothing (mine had 500 MB). When an instance of R2022b is launched, we should clear the previous cache. Of course if the user then opens an old Webots version, the folder will be re-generated and the assets will be downloaded again.