### PR TITLE
Fix c3d controller

### DIFF
--- a/projects/humans/c3d/controllers/c3d_viewer/c3d.py
+++ b/projects/humans/c3d/controllers/c3d_viewer/c3d.py
@@ -326,7 +326,7 @@ class Param(object):
         assert self.dimensions, \
             '{}: cannot get value as {} array!'.format(self.name, fmt)
         elems = array.array(fmt)
-        elems.fromstring(self.bytes)
+        elems.frombytes(self.bytes)
         return np.array(elems).reshape(self.dimensions)
 
     @property


### PR DESCRIPTION
Address #4942:
`array.fromstring` function (deprecated in Python 3.2 and removed in Python 3.9) is renamed `array.frombytes`:
https://docs.python.org/3/library/array.html#array.array.frombytes
 