### PR TITLE
Fix infinite loop when searching for 'protos' parent folder

### DIFF
--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -464,7 +464,7 @@ const QString WbProtoModel::projectPath() const {
       // cd up (we don't use QDir::cdUp() as it doesn't cd up if the upper folder doesn't exist which may happen here)
       dir.chop(protoProjectDir.dirName().size() + 1);
       protoProjectDir = QDir(dir);
-      if (protoProjectDir.isRoot())
+      if (protoProjectDir.path().isEmpty())
         return QString();
     }
     protoProjectDir.cdUp();

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -463,7 +463,7 @@ const QString WbProtoModel::projectPath() const {
       QString dir = protoProjectDir.path();
       // cd up (we don't use QDir::cdUp() as it doesn't cd up if the upper folder doesn't exist which may happen here)
       dir.chop(protoProjectDir.dirName().size());
-      assert(!dir.isEmpty())
+      assert(!dir.isEmpty());
       protoProjectDir.setPath(dir);
       if (protoProjectDir.isRoot())
         return QString();

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -463,7 +463,8 @@ const QString WbProtoModel::projectPath() const {
       QString dir = protoProjectDir.path();
       // cd up (we don't use QDir::cdUp() as it doesn't cd up if the upper folder doesn't exist which may happen here)
       dir.chop(protoProjectDir.dirName().size());
-      protoProjectDir = QDir(dir);
+      assert(!dir.isEmpty())
+      protoProjectDir.setPath(dir);
       if (protoProjectDir.isRoot())
         return QString();
     }

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -462,9 +462,9 @@ const QString WbProtoModel::projectPath() const {
     while (protoProjectDir.dirName() != "protos") {
       QString dir = protoProjectDir.path();
       // cd up (we don't use QDir::cdUp() as it doesn't cd up if the upper folder doesn't exist which may happen here)
-      dir.chop(protoProjectDir.dirName().size() + 1);
+      dir.chop(protoProjectDir.dirName().size());
       protoProjectDir = QDir(dir);
-      if (protoProjectDir.path().isEmpty())
+      if (protoProjectDir.isRoot())
         return QString();
     }
     protoProjectDir.cdUp();


### PR DESCRIPTION
Fixes issue 2 in #4953:
instead of using QDir::cdUp(), the upper folder is computed using based on the path and also removing the folder separator, so when reaching the root the new dir path is empty, that translates to `./` in QDir instance and is never detected as root folder.
If we do not remove the separator it works correctly.