### PR TITLE
Fixed absolute EXTERNPROTO path

### DIFF
--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -146,7 +146,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
     } else {
       const QString url = protoDeclaration.isEmpty() ?
                             mWebotsProtoList.value(modelName)->url() :
-                            QDir(WbProject::current()->worldsPath()).relativeFilePath(protoDeclaration);
+                            QDir(QFileInfo(mCurrentWorld).absolutePath()).relativeFilePath(protoDeclaration);
       const QString errorMessage =
         (!protoDeclaration.isEmpty() || isProtoInCategory(modelName, PROTO_WEBOTS)) ?
           tr("Missing declaration for '%1', add: 'EXTERNPROTO \"%2\"' to '%3'.").arg(modelName).arg(url).arg(parentFilePath) :

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -144,14 +144,13 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
       displayMissingDeclarations(backwardsCompatibilityMessage);
       displayMissingDeclarations(outdatedProtoMessage);
     } else {
-      QString errorMessage;
-      if (!protoDeclaration.isEmpty() || isProtoInCategory(modelName, PROTO_WEBOTS))
-        errorMessage = tr("Missing declaration for '%1', add: 'EXTERNPROTO \"%2\"' to '%3'.")
-                         .arg(modelName)
-                         .arg(protoDeclaration.isEmpty() ? mWebotsProtoList.value(modelName)->url() : protoDeclaration)
-                         .arg(parentFilePath);
-      else
-        errorMessage = tr("Missing declaration for '%1', unknown node.").arg(modelName);
+      const QString url = protoDeclaration.isEmpty() ?
+                            mWebotsProtoList.value(modelName)->url() :
+                            QDir(WbProject::current()->worldsPath()).relativeFilePath(protoDeclaration);
+      const QString errorMessage =
+        (!protoDeclaration.isEmpty() || isProtoInCategory(modelName, PROTO_WEBOTS)) ?
+          tr("Missing declaration for '%1', add: 'EXTERNPROTO \"%2\"' to '%3'.").arg(modelName).arg(url).arg(parentFilePath) :
+          tr("Missing declaration for '%1', unknown node.").arg(modelName);
 
       displayMissingDeclarations(errorMessage);
     }


### PR DESCRIPTION
Fixes #4950.

We should never suggest a user to declare an EXTERNPROTO with an absolute path.