### PR TITLE
Speedup loading worlds

### DIFF
--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1261,11 +1261,12 @@ void WbNode::addExternProtoFromFile(const WbProtoModel *proto) const {
 
       // ensure there's no ambiguity between the declarations
       const QString subProtoName = QUrl(subProtoUrl).fileName().replace(".proto", "", Qt::CaseInsensitive);
-      WbProtoManager::instance()->declareExternProto(subProtoName, subProtoUrl, false, false);
+      WbProtoManager::instance()->declareExternProto(subProtoName, subProtoUrl, false, false, false);
       if (!ancestorName.isEmpty() && ancestorName == subProtoName)
         addExternProtoFromFile(WbProtoManager::instance()->findModel(proto->ancestorProtoName(), "", ""));
     }
   }
+  emit WbProtoManager::instance()->externProtoListChanged();
 }
 
 void WbNode::writeExport(WbWriter &writer) const {

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -144,14 +144,13 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
       displayMissingDeclarations(backwardsCompatibilityMessage);
       displayMissingDeclarations(outdatedProtoMessage);
     } else {
-      QString errorMessage;
-      if (!protoDeclaration.isEmpty() || isProtoInCategory(modelName, PROTO_WEBOTS))
-        errorMessage = tr("Missing declaration for '%1', add: 'EXTERNPROTO \"%2\"' to '%3'.")
-                         .arg(modelName)
-                         .arg(protoDeclaration.isEmpty() ? mWebotsProtoList.value(modelName)->url() : protoDeclaration)
-                         .arg(parentFilePath);
-      else
-        errorMessage = tr("Missing declaration for '%1', unknown node.").arg(modelName);
+      const QString url = protoDeclaration.isEmpty() ?
+                            mWebotsProtoList.value(modelName)->url() :
+                            QDir(QFileInfo(mCurrentWorld).absolutePath()).relativeFilePath(protoDeclaration);
+      const QString errorMessage =
+        (!protoDeclaration.isEmpty() || isProtoInCategory(modelName, PROTO_WEBOTS)) ?
+          tr("Missing declaration for '%1', add: 'EXTERNPROTO \"%2\"' to '%3'.").arg(modelName).arg(url).arg(parentFilePath) :
+          tr("Missing declaration for '%1', unknown node.").arg(modelName);
 
       displayMissingDeclarations(errorMessage);
     }

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -182,7 +182,8 @@ public:
   const QVector<WbExternProto *> &externProto() const { return mExternProto; };
 
   // EXTERNPROTO manipulators
-  void declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool inserted);
+  void declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool inserted,
+                          bool updateContents = true);
   void removeImportableExternProto(const QString &protoName);
 
   void purgeUnusedExternProtoDeclarations();


### PR DESCRIPTION
As reported in #4946, loading complex worlds is very slow.
The bottleneck is currently that the EXTERNPROTO Editor is updated continuously on load for each of the declared EXTERNPROTO.
This is useless and it is sufficient to update the editor only once at the end of the load.

 I also removed a duplicated replace of the webots home path.