### PR TITLE
Ameliorate load progress status

### DIFF
--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -101,8 +101,6 @@ WbSimulationWorld::WbSimulationWorld(WbTokenizer *tokenizer) :
     }
   }
 
-  emit worldLoadingStatusHasChanged(tr("Finalizing nodes"));
-
   setIsLoading(true);
   root()->finalize();
   finalize();

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -67,7 +67,7 @@ void WbGroup::preFinalize() {
   WbBaseNode::preFinalize();
 
   if (isWorldRoot()) {
-    emit worldLoadingStatusHasChanged(tr("Pre-finalize nodes"));
+    emit worldLoadingStatusHasChanged(tr("Pre-finalizing nodes"));
     mLoadProgress = 0;
   }
 

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -195,7 +195,7 @@ void WbGroup::createWrenObjects() {
   WbBaseNode::createWrenObjects();
 
   if (isWorldRoot())
-    emit worldLoadingStatusHasChanged(tr("Create WREN objects"));
+    emit worldLoadingStatusHasChanged(tr("Creating WREN objects"));
 
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -179,7 +179,7 @@ void WbGroup::createOdeObjects() {
   WbBaseNode::createOdeObjects();
 
   if (isWorldRoot())
-    emit worldLoadingStatusHasChanged(tr("Create ODE objects"));
+    emit worldLoadingStatusHasChanged(tr("Creating ODE objects"));
 
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -82,6 +82,8 @@ void WbGroup::preFinalize() {
     }
     n->preFinalize();
     emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
+    if (mFinalizationCanceled)
+      return;
   }
 }
 
@@ -124,6 +126,8 @@ void WbGroup::recomputeBoundingSphere() {
       n->postFinalize();
     mBoundingSphere->addSubBoundingSphere(n->boundingSphere());
     emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
+    if (mFinalizationCanceled)
+      return;
   }
 }
 
@@ -182,6 +186,8 @@ void WbGroup::createOdeObjects() {
     mLoadProgress++;
     static_cast<WbBaseNode *>(it.next())->createOdeObjects();
     emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
+    if (mFinalizationCanceled)
+      return;
   }
 }
 

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -66,8 +66,14 @@ void WbGroup::downloadAssets() {
 void WbGroup::preFinalize() {
   WbBaseNode::preFinalize();
 
+  if (isWorldRoot()) {
+    emit worldLoadingStatusHasChanged(tr("Pre-finalize nodes"));
+    mLoadProgress = 0;
+  }
+
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
+    mLoadProgress++;
     WbBaseNode *const n = static_cast<WbBaseNode *>(it.next());
     if (!mHasNoSolidAncestor) {
       WbGroup *group = dynamic_cast<WbGroup *>(n);
@@ -75,11 +81,15 @@ void WbGroup::preFinalize() {
         group->mHasNoSolidAncestor = false;
     }
     n->preFinalize();
+    emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
   }
 }
 
 void WbGroup::postFinalize() {
   WbBaseNode::postFinalize();
+
+  if (isWorldRoot())
+    emit worldLoadingStatusHasChanged(tr("Post-finalize nodes"));
 
   recomputeBoundingSphere();
 
@@ -102,16 +112,18 @@ void WbGroup::postFinalize() {
     connect(mChildren, &WbMFNode::changed, this, &WbGroup::topLevelListsUpdateRequested);
 }
 
-void WbGroup::recomputeBoundingSphere() const {
+void WbGroup::recomputeBoundingSphere() {
   mBoundingSphere = new WbBoundingSphere(this);
   mBoundingSphere->empty();
 
   WbMFNode::Iterator it(*mChildren);
   while (it.hasNext()) {
+    mLoadProgress++;
     WbBaseNode *const n = static_cast<WbBaseNode *>(it.next());
     if (!n->isPostFinalizedCalled())
       n->postFinalize();
     mBoundingSphere->addSubBoundingSphere(n->boundingSphere());
+    emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
   }
 }
 
@@ -162,20 +174,28 @@ int WbGroup::nodeIndex(WbNode *child) const {
 void WbGroup::createOdeObjects() {
   WbBaseNode::createOdeObjects();
 
+  if (isWorldRoot())
+    emit worldLoadingStatusHasChanged(tr("Create ODE objects"));
+
   WbMFNode::Iterator it(*mChildren);
-  while (it.hasNext())
+  while (it.hasNext()) {
+    mLoadProgress++;
     static_cast<WbBaseNode *>(it.next())->createOdeObjects();
+    emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
+  }
 }
 
 void WbGroup::createWrenObjects() {
   WbBaseNode::createWrenObjects();
 
+  if (isWorldRoot())
+    emit worldLoadingStatusHasChanged(tr("Create WREN objects"));
+
   WbMFNode::Iterator it(*mChildren);
-  int index = 0;
   while (it.hasNext()) {
-    index++;
+    mLoadProgress++;
     static_cast<WbBaseNode *>(it.next())->createWrenObjects();
-    emit childFinalizationHasProgressed(index * 100 / childCount());
+    emit childFinalizationHasProgressed(mLoadProgress * 100 / (4 * childCount()));
     if (mFinalizationCanceled)
       return;
   }

--- a/src/webots/nodes/WbGroup.cpp
+++ b/src/webots/nodes/WbGroup.cpp
@@ -91,7 +91,7 @@ void WbGroup::postFinalize() {
   WbBaseNode::postFinalize();
 
   if (isWorldRoot())
-    emit worldLoadingStatusHasChanged(tr("Post-finalize nodes"));
+    emit worldLoadingStatusHasChanged(tr("Post-finalizing nodes"));
 
   recomputeBoundingSphere();
 

--- a/src/webots/nodes/WbGroup.hpp
+++ b/src/webots/nodes/WbGroup.hpp
@@ -95,7 +95,7 @@ public:
 
   // bounding sphere
   WbBoundingSphere *boundingSphere() const override { return mBoundingSphere; }
-  void recomputeBoundingSphere() const;
+  void recomputeBoundingSphere();
   // For a group in a boundingObject
   dSpaceID odeSpace() const { return mOdeSpace; }
   void setOdeData(dSpaceID s) { mOdeSpace = s; }
@@ -115,6 +115,7 @@ signals:
   void notifyParentSlot(WbBaseNode *child);
   void notifyParentJoint(WbBaseNode *child);
   void childFinalizationHasProgressed(const int progress);  // 0: beginning, 100: end
+  void worldLoadingStatusHasChanged(QString status);
 
 protected:
   // this constructor is reserved for derived classes only
@@ -140,6 +141,7 @@ private:
 
   // user accessible fields
   WbMFNode *mChildren;
+  int mLoadProgress;
 
 public slots:
   void cancelFinalization();

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -83,7 +83,7 @@ void WbMesh::downloadUpdate() {
   updateUrl();
   WbWorld::instance()->viewpoint()->emit refreshRequired();
   const WbNode *ancestor = WbNodeUtilities::findTopNode(this);
-  const WbGroup *group = dynamic_cast<const WbGroup *>(ancestor);
+  WbGroup *group = dynamic_cast<WbGroup *>(const_cast<WbNode *>(ancestor));
   if (group)
     group->recomputeBoundingSphere();
 }

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -167,6 +167,8 @@ WbWorld::WbWorld(WbTokenizer *tokenizer) :
 
   // world loading stuff
   connect(root(), &WbGroup::childFinalizationHasProgressed, WbApplication::instance(), &WbApplication::setWorldLoadingProgress);
+  connect(root(), &WbGroup::worldLoadingStatusHasChanged, WbApplication::instance(),
+          &WbApplication::worldLoadingStatusHasChanged);
   connect(this, &WbWorld::worldLoadingStatusHasChanged, WbApplication::instance(), &WbApplication::setWorldLoadingStatus);
   connect(this, &WbWorld::worldLoadingHasProgressed, WbApplication::instance(), &WbApplication::setWorldLoadingProgress);
   connect(WbApplication::instance(), &WbApplication::worldLoadingWasCanceled, root(), &WbGroup::cancelFinalization);
@@ -174,6 +176,8 @@ WbWorld::WbWorld(WbTokenizer *tokenizer) :
 
 void WbWorld::finalize() {
   disconnect(WbApplication::instance(), &WbApplication::worldLoadingWasCanceled, root(), &WbGroup::cancelFinalization);
+  disconnect(root(), &WbGroup::worldLoadingStatusHasChanged, WbApplication::instance(),
+             &WbApplication::worldLoadingStatusHasChanged);
   disconnect(this, &WbWorld::worldLoadingStatusHasChanged, WbApplication::instance(), &WbApplication::setWorldLoadingStatus);
   disconnect(this, &WbWorld::worldLoadingHasProgressed, WbApplication::instance(), &WbApplication::setWorldLoadingProgress);
   disconnect(root(), &WbGroup::childFinalizationHasProgressed, WbApplication::instance(),


### PR DESCRIPTION
**Description**
Fixes: https://github.com/cyberbotics/webots/issues/4946

Although the finalization is comprised of multiple heavy steps, in practice the progress bar only tracked the progress of one of them which for some heavy worlds resulted in the dialog to either be black (until the steps with tracked progress were reached) or stuck at 0%.

There is still a small period of time where the progress bar is black before the "parsing nodes" phase, but it doesn't appear to be consistent nor reproducible. This might be related to the regex, but until we find an egregious example that allows to identify where it gets stuck, it's not easy to identify the source. Also, simplifying the PROTO might already do the trick.