### PR TITLE
Better Windows alias for atom

### DIFF
--- a/scripts/install/bash_profile.windows
+++ b/scripts/install/bash_profile.windows
@@ -24,7 +24,7 @@ export WEBOTS_ALLOW_MODIFY_INSTALLATION=1                 # If defined, you are 
 # These aliases are useful in combination with the Atom source code editor #
 ############################################################################
 
-alias edit="PATH=/mingw64/bin:/usr/bin:/C/WINDOWS/system32 /C/Users/$USER/AppData/Local/atom/bin/atom.cmd"
+alias atom="PATH=/mingw64/bin:/usr/bin:/C/WINDOWS/system32 /C/Users/$USER/AppData/Local/atom/bin/atom.cmd"
 alias reset_atom="edit --clear-window-state"
 
 


### PR DESCRIPTION
Typing "atom" to launch atom from the MSYS2 console is more consistent with Linux and macOS than having to type "edit".