### PR TITLE
Minor improvement to EXTERNPROTO tooltips

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -664,11 +664,12 @@ int WbAddNodeDialog::addProtosFromProtoList(QTreeWidgetItem *parentItem, int typ
     protoItem->setIcon(0, QIcon("enabledIcons:proto.png"));
     if (isDeclarationConflicting(protoName, info->url())) {
       protoItem->setDisabled(true);
-      protoItem->setToolTip(0, tr("PROTO node not available because another with the same name and different URL already "
-                                  "exists. EXTERNPROTO URL: '%1'")
-                                 .arg(WbProtoManager::instance()->formatExternProtoPath(info->url())));
+      protoItem->setToolTip(
+        0, tr("PROTO node not available because another with the same name and different URL already exists.") +
+             QString("\nEXTERNPROTO \"%1\"").arg(WbProtoManager::instance()->formatExternProtoPath(info->url())));
     } else
-      protoItem->setToolTip(0, tr("EXTERNPROTO URL: '%1'").arg(WbProtoManager::instance()->formatExternProtoPath(info->url())));
+      protoItem->setToolTip(0,
+                            QString("EXTERNPROTO \"%1\"").arg(WbProtoManager::instance()->formatExternProtoPath(info->url())));
 
     parent->addChild(protoItem);
     ++nAddedNodes;

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -81,7 +81,8 @@ void WbExternProtoEditor::updateContents() {
     QLabel *const label = new QLabel(this);
     label->setTextInteractionFlags(Qt::TextSelectableByMouse);
     label->setObjectName("externProtoEditor");
-    label->setToolTip(externProto[i]->url());
+    label->setToolTip(
+      QString("EXTERNPROTO \"%1\"").arg(WbProtoManager::instance()->formatExternProtoPath(externProto[i]->url())));
     label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     label->setText(externProto[i]->name());
 


### PR DESCRIPTION
This PR display the exact `EXTERNPROTO` declaration line in the tooltips.
Moreover, it skips the `tr` as no translation is needed for this.