### PR TITLE
Open generated template PROTO sources in read-only mode

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -40,6 +40,7 @@ Released on July, 7th, 2022.
     - Replaced ColladaShapes PROTO by the [CadShape](cadshape.md) node ([#4285](https://github.com/cyberbotics/webots/pull/4285)).
     - Reduced the loading time when texture quality is set to medium or low ([#4621](https://github.com/cyberbotics/webots/pull/4621)).
     - Changed the layout and behavior of the loading screen and progress bar for the [Web Interface](../guide/web-interface.md) ([#4593](https://github.com/cyberbotics/webots/pull/4593)).
+    - Improved display of generated PROTO sources in Text Editor that are now opened in read-only mode ([#5023](https://github.com/cyberbotics/webots/pull/5023)).
   - Bug Fixes
     - Fixed bug in `wb_supervisor_node_get_field_by_index` and `wb_supervisor_node_get_proto_field_by_index` API functions ([#4366](https://github.com/cyberbotics/webots/pull/4366)).
     - Fixed redirection of stdout/stderr to the terminal when no Webots console is open ([#4372](https://github.com/cyberbotics/webots/pull/4372)).

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -124,16 +124,12 @@ void WbNetwork::save(const QString &url, const QByteArray &content) {
 }
 
 const QString &WbNetwork::get(const QString &url) {
-  // cppcheck-suppress assertWithSideEffect
-  assert(isCached(url));  // the 'get' function should not be called unless we know that the file is cached
-
-  if (gCacheMap.contains(url))
-    return gCacheMap[url];
-
-  const QString location(WbStandardPaths::cachedAssetsPath() + urlToHash(url));
-  gCacheMap.insert(url, location);
-
-  return location;
+  if (!gCacheMap.contains(url)) {
+    const QString filePath = WbStandardPaths::cachedAssetsPath() + urlToHash(url);
+    gCacheMap.insert(url, filePath);
+    assert(QFileInfo(filePath).exists());  // the 'get' function should not be called unless we know that the file is cached
+  }
+  return gCacheMap[url];
 }
 
 bool WbNetwork::isCached(const QString &url) {

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -123,7 +123,7 @@ void WbNetwork::save(const QString &url, const QByteArray &content) {
   }
 }
 
-const QString WbNetwork::get(const QString &url) {
+const QString &WbNetwork::get(const QString &url) {
   // cppcheck-suppress assertWithSideEffect
   assert(isCached(url));  // the 'get' function should not be called unless we know that the file is cached
 

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -123,7 +123,7 @@ void WbNetwork::save(const QString &url, const QByteArray &content) {
   }
 }
 
-const QString WbNetwork::get(const QString &url) const {
+const QString WbNetwork::get(const QString &url) {
   // cppcheck-suppress assertWithSideEffect
   assert(isCached(url));  // the 'get' function should not be called unless we know that the file is cached
 
@@ -136,7 +136,7 @@ const QString WbNetwork::get(const QString &url) const {
   return location;
 }
 
-bool WbNetwork::isCached(const QString &url) const {
+bool WbNetwork::isCached(const QString &url) {
   if (gCacheMap.contains(url))  // avoid checking for file existence (and computing hash again) if asset is known to be cached
     return true;
 

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -25,13 +25,12 @@ public:
   QNetworkAccessManager *networkAccessManager();
   void setProxy();
 
-  bool isCached(const QString &url) const;
+  static bool isCached(const QString &url);
+  static const QString get(const QString &url);
   void clearCache();
   void save(const QString &url, const QByteArray &content);
-  const QString get(const QString &url) const;
 
   qint64 cacheSize() const { return mCacheSizeInBytes; };
-  const QString cacheDirectory() const { return mCacheDirectory; };
   void reduceCacheUsage();
 
   static const QString getUrlFromEphemeralCache(const QString &cachePath);
@@ -46,7 +45,6 @@ private:
 
   static const QString urlToHash(const QString &url);
 
-  QString mCacheDirectory;
   qint64 mCacheSizeInBytes;
 
   QNetworkAccessManager *mNetworkAccessManager;

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -26,7 +26,7 @@ public:
   void setProxy();
 
   static bool isCached(const QString &url);
-  static const QString get(const QString &url);
+  static const QString &get(const QString &url);
   void clearCache();
   void save(const QString &url, const QByteArray &content);
 

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -273,6 +273,11 @@ const QString &WbStandardPaths::webotsTmpPath() {
   return cWebotsTmpPath;
 }
 
+const QString &WbStandardPaths::cachedAssetsPath() {
+  static QString path(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/assets/");
+  return path;
+}
+
 const QString &WbStandardPaths::vehicleLibraryPath() {
   static QString path(webotsHomePath() + cMacOsContents + "projects/default/libraries/vehicle/");
   return path;

--- a/src/webots/core/WbStandardPaths.hpp
+++ b/src/webots/core/WbStandardPaths.hpp
@@ -59,6 +59,9 @@ namespace WbStandardPaths {
   int webotsTmpPathId();
   const QString &webotsTmpPath();
 
+  // cached assets directory
+  const QString &cachedAssetsPath();
+
   // other locations
   const QString &vehicleLibraryPath();
 

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -352,7 +352,7 @@ void WbProjectRelocationDialog::selectDirectory() {
 bool WbProjectRelocationDialog::validateLocation(QWidget *parent, QString &filename) {
   mExternalProtoProjectPath.clear();
 
-  if (WbFileUtil::isLocatedInDirectory(filename, WbNetwork::instance()->cacheDirectory())) {
+  if (WbFileUtil::isLocatedInDirectory(filename, WbStandardPaths::cachedAssetsPath())) {
     WbMessageBox::warning(tr("You are trying to modify a remote file.") + "\n\n'" + tr("This operation is not permitted."),
                           parent);
     return false;

--- a/src/webots/editor/WbTextBuffer.cpp
+++ b/src/webots/editor/WbTextBuffer.cpp
@@ -16,6 +16,7 @@
 
 #include "WbActionManager.hpp"
 #include "WbClipboard.hpp"
+#include "WbFileUtil.hpp"
 #include "WbLanguage.hpp"
 #include "WbMessageBox.hpp"
 #include "WbPreferences.hpp"
@@ -255,14 +256,15 @@ bool WbTextBuffer::load(const QString &fn, const QString &title) {
   if (!file.open(QFile::ReadOnly))
     return false;
 
-  if (!title.isEmpty()) {
-    // we only need to set a different title to the tab in case of cached assets
+  if (!title.isEmpty() || WbFileUtil::isLocatedInDirectory(fn, WbStandardPaths::webotsTmpPath()) ||
+      WbFileUtil::isLocatedInDirectory(fn, WbStandardPaths::cachedAssetsPath())) {
     setReadOnly(true);
     setUndoRedoEnabled(false);
   }
 
   QByteArray data = file.readAll();
   setPlainText(QString::fromUtf8(data));
+  // we only need to set a different title to the tab in case of cached assets
   setFileName(title.isEmpty() ? fn : title);
 
   return true;

--- a/src/webots/editor/WbTextEditor.cpp
+++ b/src/webots/editor/WbTextEditor.cpp
@@ -175,6 +175,8 @@ void WbTextEditor::updateFileNames() {
     if (windowTitle.isEmpty())
       // WbTextBuffer::fileName() is empty in case of cached asset files
       windowTitle = tr("Read-only remote file");
+    else if (selectedBuffer->isReadOnly())
+      windowTitle += tr(" (read-only)");
     else if (selectedBuffer->isModified())
       windowTitle += "*";
     setWindowTitle(windowTitle);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2276,8 +2276,8 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify) {
 
   QString fileToOpen(fileName);
   QString title;
-  if (WbUrl::isWeb(fileName) && WbNetwork::instance()->isCached(fileName)) {
-    const QString &protoFilePath = WbNetwork::instance()->get(fileName);
+  if (WbUrl::isWeb(fileName) && WbNetwork::isCached(fileName)) {
+    const QString &protoFilePath = WbNetwork::get(fileName);
     const QString protoFileName(QFileInfo(fileName).fileName());
     if (modify && protoFileName.endsWith(".proto", Qt::CaseInsensitive)) {
       if (WbMessageBox::question(

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -205,9 +205,9 @@ void WbBackground::downloadAsset(const QString &url, int index, bool postpone) {
 
 void WbBackground::downloadAssets() {
   for (int i = 0; i < 6; ++i) {
-    if (mUrlFields[i]->size() && !WbNetwork::instance()->isCached(mUrlFields[i]->item(0)))
+    if (mUrlFields[i]->size() && !WbNetwork::isCached(mUrlFields[i]->item(0)))
       downloadAsset(mUrlFields[i]->item(0), i, false);
-    if (mIrradianceUrlFields[i]->size() && !WbNetwork::instance()->isCached(mIrradianceUrlFields[i]->item(0)))
+    if (mIrradianceUrlFields[i]->size() && !WbNetwork::isCached(mIrradianceUrlFields[i]->item(0)))
       downloadAsset(mIrradianceUrlFields[i]->item(0), i + 6, false);
   }
 }
@@ -337,7 +337,7 @@ void WbBackground::updateCubemap() {
       for (int i = 0; i < 6; i++) {
         if (hasCompleteBackground) {
           const QString &completeUrl = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl) && mDownloader[i] == NULL) {
             downloadAsset(completeUrl, i, true);
             postpone = true;
           } else {
@@ -347,7 +347,7 @@ void WbBackground::updateCubemap() {
         }
         if (mIrradianceUrlFields[i]->size() > 0) {
           const QString &completeUrl = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i + 6] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl) && mDownloader[i + 6] == NULL) {
             downloadAsset(completeUrl, i + 6, true);
             postpone = true;
           } else {
@@ -432,8 +432,8 @@ bool WbBackground::loadTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::instance()->isCached(url))
-      url = WbNetwork::instance()->get(url);  // get reference to the corresponding file in the cache
+    if (WbNetwork::isCached(url))
+      url = WbNetwork::get(url);  // get reference to the corresponding file in the cache
     else {
       if (mDownloader[i] && !mDownloader[i]->error().isEmpty())
         warn(mDownloader[i]->error());
@@ -520,8 +520,8 @@ bool WbBackground::loadIrradianceTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::instance()->isCached(url))
-      url = WbNetwork::instance()->get(url);
+    if (WbNetwork::isCached(url))
+      url = WbNetwork::get(url);
     else {
       if (mDownloader[i + 6] && !mDownloader[i + 6]->error().isEmpty())
         warn(mDownloader[i + 6]->error());

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -88,7 +88,7 @@ void WbCadShape::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || (WbNetwork::instance()->isCached(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
+  if (!WbUrl::isWeb(completeUrl) || (WbNetwork::isCached(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -210,7 +210,7 @@ void WbCadShape::updateUrl() {
       return;
     }
 
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::isCached(completeUrl)) {
       if (mDownloader && mDownloader->hasFinished()) {
         delete mDownloader;
         mDownloader = NULL;
@@ -230,7 +230,7 @@ void WbCadShape::updateUrl() {
       QStringList rawMaterials = objMaterialList(completeUrl);
       foreach (QString material, rawMaterials) {
         QString adjustedUrl = WbUrl::combinePaths(material, completeUrl);
-        assert(WbNetwork::instance()->isCached(adjustedUrl));
+        assert(WbNetwork::isCached(adjustedUrl));
         if (!mObjMaterials.contains(material))
           mObjMaterials.insert(material, adjustedUrl);
       }
@@ -246,7 +246,7 @@ void WbCadShape::updateUrl() {
 bool WbCadShape::areMaterialAssetsAvailable(const QString &url) {
   QStringList rawMaterials = objMaterialList(url);  // note: 'dae' files will generate an empty list
   foreach (QString material, rawMaterials) {
-    if (!WbNetwork::instance()->isCached(WbUrl::combinePaths(material, url)))
+    if (!WbNetwork::isCached(WbUrl::combinePaths(material, url)))
       return false;
   }
   return true;
@@ -259,8 +259,8 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
 
   QStringList materials;
   QFile objFile;
-  if (WbNetwork::instance()->isCached(url))
-    objFile.setFileName(WbNetwork::instance()->get(url));
+  if (WbNetwork::isCached(url))
+    objFile.setFileName(WbNetwork::get(url));
   else  // local file
     objFile.setFileName(url);
   if (objFile.open(QIODevice::ReadOnly)) {
@@ -336,13 +336,13 @@ void WbCadShape::createWrenObjects() {
   }
 
   if (WbUrl::isWeb(completeUrl)) {
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::isCached(completeUrl)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;
     }
 
-    QFile file(WbNetwork::instance()->get(completeUrl));
+    QFile file(WbNetwork::get(completeUrl));
     if (!file.open(QIODevice::ReadOnly)) {
       warn(tr("File could not be read: '%1'").arg(completeUrl));
       return;
@@ -354,7 +354,7 @@ void WbCadShape::createWrenObjects() {
       QMapIterator<QString, QString> it(mObjMaterials);
       while (it.hasNext()) {
         it.next();
-        data.replace(it.key().toUtf8(), WbNetwork::instance()->get(it.value()).toUtf8());
+        data.replace(it.key().toUtf8(), WbNetwork::get(it.value()).toUtf8());
       }
     }
 

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -162,7 +162,7 @@ void WbCamera::downloadAssets() {
   const QString &noiseMaskUrl = mNoiseMaskUrl->value();
   if (!noiseMaskUrl.isEmpty()) {  // noise mask not mandatory, URL can be empty
     const QString completeUrl = WbUrl::computePath(this, "noiseMaskUrl", noiseMaskUrl);
-    if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+    if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
       return;
 
     if (mDownloader != NULL)
@@ -1146,12 +1146,12 @@ void WbCamera::updateNoiseMaskUrl() {
       return;
     }
 
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::isCached(completeUrl)) {
       downloadAssets();  // URL was changed from the scene tree or supervisor
       return;
     }
 
-    noiseMaskPath = WbNetwork::instance()->get(completeUrl);
+    noiseMaskPath = WbNetwork::get(completeUrl);
   } else
     noiseMaskPath = completeUrl;
 

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -65,7 +65,7 @@ void WbContactProperties::downloadAsset(const QString &url, int index) {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, gUrlNames[index], url);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
     return;
 
   if (mDownloader[index] != NULL)
@@ -230,7 +230,7 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
       mDownloader[index] = NULL;
       return;
     }
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::isCached(completeUrl)) {
       downloadAsset(completeUrl, index);  // changed by supervisor
       return;
     }
@@ -241,8 +241,8 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
   const QString extension = sound.mid(sound.lastIndexOf('.') + 1).toLower();
 
   if (WbUrl::isWeb(completeUrl)) {
-    assert(WbNetwork::instance()->isCached(completeUrl));  // by this point, the asset should be cached
-    *clip = WbSoundEngine::sound(WbNetwork::instance()->get(completeUrl), extension);
+    assert(WbNetwork::isCached(completeUrl));  // by this point, the asset should be cached
+    *clip = WbSoundEngine::sound(WbNetwork::get(completeUrl), extension);
   } else
     *clip = WbSoundEngine::sound(WbUrl::computePath(this, name, completeUrl), extension);
 }

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -120,7 +120,7 @@ void WbImageTexture::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
     return;
 
   if (mDownloader && mDownloader->hasFinished())
@@ -163,10 +163,10 @@ void WbImageTexture::postFinalize() {
 bool WbImageTexture::loadTexture() {
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
   const bool isWebAsset = WbUrl::isWeb(completeUrl);
-  if (isWebAsset && !WbNetwork::instance()->isCached(completeUrl))
+  if (isWebAsset && !WbNetwork::isCached(completeUrl))
     return false;
 
-  const QString filePath = isWebAsset ? WbNetwork::instance()->get(completeUrl) : path();
+  const QString filePath = isWebAsset ? WbNetwork::get(completeUrl) : path();
   QFile file(filePath);
   if (!file.open(QIODevice::ReadOnly)) {
     warn(tr("Texture file could not be read: '%1'").arg(filePath));
@@ -347,7 +347,7 @@ void WbImageTexture::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::instance()->isCached(completeUrl) && mDownloader == NULL) {
+      if (!WbNetwork::isCached(completeUrl) && mDownloader == NULL) {
         downloadAssets();  // URL was changed from the scene tree or supervisor
         return;
       }

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -66,7 +66,7 @@ void WbMesh::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -143,13 +143,13 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                        aiProcess_FlipUVs;
 
   if (WbUrl::isWeb(filePath)) {
-    if (!WbNetwork::instance()->isCached(filePath)) {
+    if (!WbNetwork::isCached(filePath)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;
     }
 
-    QFile file(WbNetwork::instance()->get(filePath));
+    QFile file(WbNetwork::get(filePath));
     if (!file.open(QIODevice::ReadOnly)) {
       warn(tr("Mesh file could not be read: '%1'").arg(filePath));
       return;
@@ -329,7 +329,7 @@ void WbMesh::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::instance()->isCached(completeUrl)) {
+      if (!WbNetwork::isCached(completeUrl)) {
         if (mDownloader && mDownloader->hasFinished()) {
           delete mDownloader;
           mDownloader = NULL;

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -104,7 +104,7 @@ void WbMotor::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "sound", soundString);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
     return;
 
   if (mDownloader != NULL)
@@ -302,7 +302,7 @@ void WbMotor::updateSound() {
         mDownloader = NULL;
         return;
       }
-      if (!WbNetwork::instance()->isCached(completeUrl)) {
+      if (!WbNetwork::isCached(completeUrl)) {
         downloadAssets();
         return;
       }
@@ -312,7 +312,7 @@ void WbMotor::updateSound() {
     // determine extension from URL since for remotely defined assets the cached version does not retain this information
     const QString extension = completeUrl.mid(completeUrl.lastIndexOf('.') + 1).toLower();
     if (WbUrl::isWeb(completeUrl))
-      mSoundClip = WbSoundEngine::sound(WbNetwork::instance()->get(completeUrl), extension);
+      mSoundClip = WbSoundEngine::sound(WbNetwork::get(completeUrl), extension);
     else
       mSoundClip = WbSoundEngine::sound(completeUrl, extension);
   }

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -259,7 +259,7 @@ void WbSkin::updateModelUrl() {
     }
 
     const QString &completeUrl = WbUrl::computePath(this, "modelUrl", mModelUrl->value());
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl)) {
       // URL was changed from the scene tree or supervisor
       downloadAssets();
       mIsModelUrlValid = true;
@@ -497,8 +497,8 @@ void WbSkin::createWrenSkeleton() {
   int count;
   const char *error;
   if (WbUrl::isWeb(meshFilePath)) {
-    if (WbNetwork::instance()->isCached(meshFilePath)) {
-      QFile file(WbNetwork::instance()->get(meshFilePath));
+    if (WbNetwork::isCached(meshFilePath)) {
+      QFile file(WbNetwork::get(meshFilePath));
       if (!file.open(QIODevice::ReadOnly))
         return;
       const QByteArray &data = file.readAll();

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -207,7 +207,7 @@ const QString WbUrl::computeLocalAssetUrl(const WbNode *node, const QString &fie
 }
 
 const QString WbUrl::computePrefix(const QString &rawUrl) {
-  const QString url = rawUrl.startsWith(WbNetwork::instance()->cacheDirectory()) ?
+  const QString url = WbFileUtil::isLocatedInDirectory(rawUrl, WbStandardPaths::cachedAssetsPath()) ?
                         WbNetwork::instance()->getUrlFromEphemeralCache(rawUrl) :
                         rawUrl;
 

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -215,7 +215,7 @@ void WbAddNodeDialog::iconUpdate() {
   }
 
   // set the image
-  const QString &pixmapPath = WbNetwork::instance()->get(source->url().toString());
+  const QString &pixmapPath = WbNetwork::get(source->url().toString());
   QPixmap pixmap(pixmapPath);
   if (!pixmap.isNull()) {
     if (pixmap.size() != QSize(128, 128)) {
@@ -428,8 +428,8 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
   mPixmapLabel->hide();
   if (!pixmapPath.isEmpty()) {
     if (WbUrl::isWeb(pixmapPath)) {
-      if (WbNetwork::instance()->isCached(pixmapPath))
-        pixmapPath = WbNetwork::instance()->get(pixmapPath);
+      if (WbNetwork::isCached(pixmapPath))
+        pixmapPath = WbNetwork::get(pixmapPath);
       else {
         downloadIcon(pixmapPath);
         return;
@@ -524,7 +524,7 @@ void WbAddNodeDialog::buildTree() {
       if (!WbNodeModel::isBaseModelName(currentModelName)) {
         nodeFilePath = WbProtoManager::instance()->externProtoDeclaration(currentModelName);
         if (WbUrl::isWeb(nodeFilePath))
-          nodeFilePath = WbNetwork::instance()->get(nodeFilePath);
+          nodeFilePath = WbNetwork::get(nodeFilePath);
       }
       QStringList strl(QStringList() << currentFullDefName << nodeFilePath);
 
@@ -748,7 +748,7 @@ void WbAddNodeDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::instance()->isCached(mSelectionPath)) {
+  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::isCached(mSelectionPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.")
                    .arg(QUrl(mSelectionPath).fileName()));
     QDialog::reject();
@@ -793,7 +793,7 @@ void WbAddNodeDialog::exportProto() {
     return;
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::instance()->isCached(mSelectionPath)) {
+  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::isCached(mSelectionPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.")
                    .arg(QUrl(mSelectionPath).fileName()));
     QDialog::reject();

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -20,6 +20,7 @@
 #include "WbDictionary.hpp"
 #include "WbDownloader.hpp"
 #include "WbField.hpp"
+#include "WbFileUtil.hpp"
 #include "WbLog.hpp"
 #include "WbMFNode.hpp"
 #include "WbMessageBox.hpp"
@@ -348,7 +349,7 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
   QString pixmapPath;
 
   QString path = nodeFileName;
-  if (path.startsWith(WbNetwork::instance()->cacheDirectory()))
+  if (WbFileUtil::isLocatedInDirectory(path, WbStandardPaths::cachedAssetsPath()))
     path = WbNetwork::instance()->getUrlFromEphemeralCache(nodeFileName);
 
   const QFileInfo fileInfo(path);

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -174,7 +174,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mPath) && !WbNetwork::instance()->isCached(mPath)) {
+  if (WbUrl::isWeb(mPath) && !WbNetwork::isCached(mPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.").arg(mProto));
     QDialog::reject();
   }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1591,7 +1591,7 @@ void WbSceneTree::openTemplateInstanceInTextEditor() {
   const QString generatedProtos("generated_protos");
   tmpDir.mkdir(generatedProtos);
   QFile file(
-    QString("%1/%2/%3.generated_proto").arg(WbStandardPaths::webotsTmpPath()).arg(generatedProtos).arg(node->proto()->name()));
+    QString("%1%2/%3.generated_proto").arg(WbStandardPaths::webotsTmpPath()).arg(generatedProtos).arg(node->proto()->name()));
   file.open(QIODevice::WriteOnly | QIODevice::Text);
   file.write(node->protoInstanceTemplateContent());
   file.close();

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1143,7 +1143,7 @@ void WbSceneTree::updateSelection() {
   if (mSelectedItem->node() && mSelectedItem->node()->isProtoInstance()) {
     WbContextMenuGenerator::enableProtoActions(true);
     const QString &url = mSelectedItem->node()->proto()->url();
-    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::instance()->isCached(url));
+    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::isCached(url));
   } else {
     WbContextMenuGenerator::enableProtoActions(false);
     WbContextMenuGenerator::enableExternProtoActions(false);

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1218,9 +1218,8 @@ void WbNode::exportExternalSubProto() const {
 }
 
 void WbNode::addExternProtoFromFile(const WbProtoModel *proto) const {
-  const QString path = (WbUrl::isWeb(proto->url()) && WbNetwork::instance()->isCached(proto->url())) ?
-                         WbNetwork::instance()->get(proto->url()) :
-                         proto->url();
+  const QString path =
+    (WbUrl::isWeb(proto->url()) && WbNetwork::isCached(proto->url())) ? WbNetwork::get(proto->url()) : proto->url();
 
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly)) {

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -69,7 +69,7 @@ WbProtoManager::~WbProtoManager() {
 WbProtoModel *WbProtoManager::readModel(const QString &url, const QString &worldPath, const QString &prefix,
                                         const QStringList &baseTypeList) const {
   WbTokenizer tokenizer;
-  const QString path = WbUrl::isWeb(url) ? WbNetwork::instance()->get(url) : url;
+  const QString path = WbUrl::isWeb(url) ? WbNetwork::get(url) : url;
   int errors = tokenizer.tokenize(path, prefix);
   if (errors > 0)
     return NULL;
@@ -172,7 +172,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
 
   // a PROTO declaration is provided, enforce it
   QString modelPath;  // how the PROTO is referenced
-  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::instance()->isCached(modelPath))
+  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::isCached(modelPath))
     modelPath = protoDeclaration;
   else if (WbUrl::isLocalUrl(protoDeclaration) || QDir::isRelativePath(protoDeclaration)) {
     // two possibitilies arise if the declaration is local (webots://)
@@ -198,7 +198,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
         else  // if it's a relative url, then manufacture a remote url based on the relative path and the parent's path
           modelPath = WbUrl::combinePaths(protoDeclaration, parentFile);
         // if the PROTO tree was built correctly, by definition the child must be cached already too
-        assert(WbNetwork::instance()->isCached(modelPath));
+        assert(WbNetwork::isCached(modelPath));
       } else {
         WbLog::error(tr("The cascaded URL inferring mechanism is supported only for official Webots assets."));
         return NULL;
@@ -211,7 +211,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
     modelPath = WbUrl::combinePaths(protoDeclaration, parentFilePath);
   }
   // determine prefix and disk location from modelPath
-  const QString modelDiskPath = WbUrl::isWeb(modelPath) ? WbNetwork::instance()->get(modelPath) : modelPath;
+  const QString modelDiskPath = WbUrl::isWeb(modelPath) ? WbNetwork::get(modelPath) : modelPath;
   const QString prefix = WbUrl::computePrefix(modelPath);  // used to retrieve remote assets (replaces webots:// in the body)
 
   if (!modelPath.isEmpty() && QFileInfo(modelDiskPath).exists()) {
@@ -230,7 +230,7 @@ QString WbProtoManager::findExternProtoDeclarationInFile(const QString &url, con
   if (url.isEmpty())
     return QString();
 
-  QFile file(WbUrl::isWeb(url) ? WbNetwork::instance()->get(url) : url);
+  QFile file(WbUrl::isWeb(url) ? WbNetwork::get(url) : url);
   if (!file.open(QIODevice::ReadOnly)) {
     WbLog::error(tr("Could not search for EXTERNPROTO declarations in '%1' because the file is not readable.").arg(url));
     return QString();
@@ -586,8 +586,8 @@ QStringList WbProtoManager::listProtoInCategory(int category) const {
       for (int i = 0; i < mExternProto.size(); ++i) {
         QString protoPath = WbUrl::resolveUrl(mExternProto[i]->url());
         // mExternProto contains raw paths, retrieve corresponding disk file
-        if (WbUrl::isWeb(protoPath) && WbNetwork::instance()->isCached(protoPath))
-          protoPath = WbNetwork::instance()->get(protoPath);
+        if (WbUrl::isWeb(protoPath) && WbNetwork::isCached(protoPath))
+          protoPath = WbNetwork::get(protoPath);
 
         protos << protoPath;
       }
@@ -757,8 +757,8 @@ WbProtoInfo *WbProtoManager::generateInfoFromProtoFile(const QString &protoFileN
 void WbProtoManager::exportProto(const QString &path, int category, const QString &destination) {
   QString url = WbUrl::resolveUrl(path);
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::instance()->isCached(url))
-      url = WbNetwork::instance()->get(url);
+    if (WbNetwork::isCached(url))
+      url = WbNetwork::get(url);
     else {
       WbLog::error(tr("Cannot export '%1', file not locally available.").arg(url));
       return;
@@ -926,7 +926,7 @@ QString WbProtoManager::injectDeclarationByBackwardsCompatibility(const QString 
   if (isProtoInCategory(modelName, PROTO_WEBOTS)) {
     QString url = mWebotsProtoList.value(modelName)->url();
     if (WbUrl::isWeb(url)) {
-      if (WbNetwork::instance()->isCached(url))
+      if (WbNetwork::isCached(url))
         return url;
     }
 

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -211,7 +211,8 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
     modelPath = WbUrl::combinePaths(protoDeclaration, parentFilePath);
   }
   // determine prefix and disk location from modelPath
-  const QString modelDiskPath = WbUrl::isWeb(modelPath) ? WbNetwork::get(modelPath) : modelPath;
+  const QString modelDiskPath =
+    WbUrl::isWeb(modelPath) && WbNetwork::isCached(modelPath) ? WbNetwork::get(modelPath) : modelPath;
   const QString prefix = WbUrl::computePrefix(modelPath);  // used to retrieve remote assets (replaces webots:// in the body)
 
   if (!modelPath.isEmpty() && QFileInfo(modelDiskPath).exists()) {

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -607,7 +607,7 @@ bool WbProtoModel::checkIfDocumentationPageExist(const QString &page) const {
 
 const QString WbProtoModel::diskPath() const {
   if (WbUrl::isWeb(mUrl))
-    return WbNetwork::instance()->get(mUrl);
+    return WbNetwork::get(mUrl);
 
   return mUrl;
 }

--- a/src/webots/vrml/WbProtoTreeItem.cpp
+++ b/src/webots/vrml/WbProtoTreeItem.cpp
@@ -39,8 +39,8 @@ WbProtoTreeItem::~WbProtoTreeItem() {
 
 void WbProtoTreeItem::parseItem() {
   QString path = mUrl;
-  if (WbUrl::isWeb(path) && WbNetwork::instance()->isCached(path))
-    path = WbNetwork::instance()->get(path);
+  if (WbUrl::isWeb(path) && WbNetwork::isCached(path))
+    path = WbNetwork::get(path);
 
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly)) {
@@ -135,7 +135,7 @@ void WbProtoTreeItem::download() {
   }
 
   if (WbUrl::isWeb(mUrl)) {
-    if (!WbNetwork::instance()->isCached(mUrl)) {
+    if (!WbNetwork::isCached(mUrl)) {
       mDownloader = new WbDownloader(this);
       connect(mDownloader, &WbDownloader::complete, this, &WbProtoTreeItem::downloadUpdate);
       mDownloader->download(QUrl(mUrl));
@@ -156,7 +156,7 @@ void WbProtoTreeItem::downloadUpdate() {
     return;
   }
 
-  assert(WbNetwork::instance()->isCached(mUrl));
+  assert(WbNetwork::isCached(mUrl));
   parseItem();
 }
 

--- a/src/webots/vrml/WbTokenizer.cpp
+++ b/src/webots/vrml/WbTokenizer.cpp
@@ -15,9 +15,11 @@
 #include "WbTokenizer.hpp"
 
 #include "WbApplicationInfo.hpp"
+#include "WbFileUtil.hpp"
 #include "WbLog.hpp"
 #include "WbNetwork.hpp"
 #include "WbProtoTemplateEngine.hpp"
+#include "WbStandardPaths.hpp"
 #include "WbToken.hpp"
 
 #include <QtCore/QFile>
@@ -555,7 +557,7 @@ void WbTokenizer::reportFileError(const QString &message) const {
 
 WbTokenizer::FileType WbTokenizer::fileTypeFromFileName(const QString &fileName) {
   QString name = fileName;
-  if (fileName.startsWith(WbNetwork::instance()->cacheDirectory())) {
+  if (WbFileUtil::isLocatedInDirectory(fileName, WbStandardPaths::cachedAssetsPath())) {
     // attempting to tokenize a cached file, determine its original format from the ephemeral cache representation
     name = WbNetwork::instance()->getUrlFromEphemeralCache(fileName);
   }

--- a/src/webots/vrml/WbTokenizer.cpp
+++ b/src/webots/vrml/WbTokenizer.cpp
@@ -95,14 +95,14 @@ void WbTokenizer::markTokenStart() {
   mTokenColumn = mColumn;
 }
 
-void WbTokenizer::displayHeaderHelp(QString fileName, QString headerTag) {
+void WbTokenizer::displayHeaderHelp(const QString &fileName, const QString &headerTag) {
   const WbVersion &v = WbApplicationInfo::version();
   WbLog::info(
     QObject::tr("Please modify the first line of '%1' to \"#%2 %3 utf8\".").arg(fileName).arg(headerTag).arg(v.toString(false)),
     false, WbLog::PARSING);
 }
 
-bool WbTokenizer::readFileInfo(bool headerRequired, bool displayWarning, QString headerTag, bool isProto) {
+bool WbTokenizer::readFileInfo(bool headerRequired, bool displayWarning, const QString &headerTag, bool isProto) {
   // reset version
   const WbVersion &webotsVersion = WbApplicationInfo::version();
   mFileVersion = webotsVersion;

--- a/src/webots/vrml/WbTokenizer.hpp
+++ b/src/webots/vrml/WbTokenizer.hpp
@@ -140,8 +140,8 @@ private:
   QString readWord();
   void skipWhiteSpace();
   bool checkFileHeader();
-  bool readFileInfo(bool headerRequired, bool displayWarning, QString headerTag, bool isProto = false);
-  static void displayHeaderHelp(QString fileName, QString headerTag);
+  bool readFileInfo(bool headerRequired, bool displayWarning, const QString &headerTag, bool isProto = false);
+  static void displayHeaderHelp(const QString &fileName, const QString &headerTag);
   void markTokenStart();
   static FileType fileTypeFromFileName(const QString &fileName);
   void reportError(const QString &message, int line, int column) const;


### PR DESCRIPTION
Addresses #4955:
I think that opening the generated PROTO sources as read-only is cleaner for the user that can easier understand that any changes to this file won't be taken into account by Webots.
If they want to modify the file, they can use the "Save as" option.
Note that the action is also named "Show" and not "Edit", so it seems more coherent to not allow to modify this file.

Other improvements:
* I moved the definition of the assets cached path to the `WbStandardPaths` namespaces with all the other path declarations
* fixed generated PROTO sources path containing double path separator
* fixed cppcheck errors:
  * `WbTokenizer` class: arguments passed by copy instead of reference
  * `WbNetwork` class:
    * some functions that can be defined as static and return reference to string
    * fix assert causing different behavior in debug and release mode