### PR TITLE
Remove PROTO nodes copy in test suite

### DIFF
--- a/scripts/packaging/generic_distro.py
+++ b/scripts/packaging/generic_distro.py
@@ -161,7 +161,6 @@ class WebotsPackage(ABC):
     def add_file(self, file_path):
         # add this file and self.package_files
         # if WBT file, then also add associated WBPROJ
-        # if PROTO file, then check md5sum and also add associated cache file
 
         absolute_path = os.path.abspath(file_path)
         if not os.path.exists(absolute_path):
@@ -179,10 +178,6 @@ class WebotsPackage(ABC):
             world_project_file = os.path.join(dirname, '.' + re.sub(r'.wbt$', '.wbproj', basename))
             self.set_file_attribute(world_project_file, 'hidden')
             self.package_files.append(os.path.relpath(world_project_file, self.webots_home))
-
-        if file_path.endswith('.proto') and str(os.path.sep + 'protos' + os.path.sep) in file_path:
-            if not os.path.exists(absolute_path):
-                print_error_message_and_exit(f"Missing file: {absolute_path}")
 
     def add_files_from_string(self, line):
         # add this file or folder to self.package_files and self.package_folders

--- a/tests/api/protos/.gitignore
+++ b/tests/api/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/cache/protos/.gitignore
+++ b/tests/cache/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/other_api/protos/.gitignore
+++ b/tests/other_api/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/parser/protos/.gitignore
+++ b/tests/parser/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/physics/protos/.gitignore
+++ b/tests/physics/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/protos/protos/.gitignore
+++ b/tests/protos/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/rendering/protos/.gitignore
+++ b/tests/rendering/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -331,14 +331,6 @@ for groupName in testGroups:
         os.path.join(defaultProjectPath, 'controllers', supervisorControllerName, supervisorControllerName + '.py'),
         os.path.join(supervisorTargetDirectory, supervisorControllerName + '.py')
     )
-    # parser tests uses a slightly different Supervisor PROTO
-    protosTargetDirectory = os.path.join(testsFolderPath, groupName, 'protos')
-    protosSourceDirectory = os.path.join(defaultProjectPath, 'protos')
-    if not os.path.exists(protosTargetDirectory):
-        os.makedirs(protosTargetDirectory)
-    for protoFileName in protoFileNames:
-        shutil.copyfile(os.path.join(protosSourceDirectory, protoFileName),
-                        os.path.join(protosTargetDirectory, protoFileName))
 
     worldsFilename = os.path.join(testsFolderPath, groupName, 'worlds.txt')
     worldsCount = 0

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -59,7 +59,6 @@ testsFolderPath = os.path.dirname(os.path.abspath(__file__))
 outputFilename = os.path.join(testsFolderPath, 'output.txt')
 defaultProjectPath = os.path.join(testsFolderPath, 'default')
 supervisorControllerName = 'test_suite_supervisor'
-protoFileNames = ['TestSuiteSupervisor.proto', 'TestSuiteEmitter.proto']
 tempWorldCounterFilename = os.path.join(testsFolderPath, 'world_counter.txt')
 webotsStdOutFilename = os.path.join(testsFolderPath, 'webots_stdout.txt')
 webotsStdErrFilename = os.path.join(testsFolderPath, 'webots_stderr.txt')

--- a/tests/with_rendering/protos/.gitignore
+++ b/tests/with_rendering/protos/.gitignore
@@ -1,3 +1,0 @@
-/*.cache
-/TestSuiteSupervisor.proto
-/TestSuiteEmitter.proto


### PR DESCRIPTION
It is no longer needed to copy the PROTO nodes from the `test/default` folder.