### PR TITLE
Fixed Qt plugins path on Windows

### DIFF
--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -127,13 +127,13 @@ int main(int argc, char *argv[]) {
   QLocale::setDefault(QLocale::c());
 
 #ifdef _WIN32
-  const char *MSYS2_HOME = getenv("MSYS2_HOME");
+  const QString MSYS2_HOME(getenv("MSYS2_HOME"));
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
 #ifdef _WIN32
-    if (MSYS2_HOME && MSYS2_HOME[0])  // Webots was started from a MSYS2 console (development environment)
+    if (!MSYS2_HOME.isEmpty())  // Webots was started from a MSYS2 console (development environment)
       QCoreApplication::addLibraryPath(QStringList(MSYS2_HOME + "/mingw64/share/qt6/plugins"));
     else
       QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/mingw64/share/qt6/plugins"));
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
 #endif
   }
 
-  if (MSYS2_HOME == NULL || MSYS2_HOME[0] == '\0')                       // Webots was not started from a MSYS2 console
+  if (MSYS2_HOME.isEmpty())                                              // Webots was not started from a MSYS2 console
     qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
 
   // load qt warning filters from file

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -101,13 +101,7 @@ int main(int argc, char *argv[]) {
   GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
   const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
   delete[] modulePath;
-  QProcess process;
-  process.start("cygpath", QStringList{QString("-w"), QString("/")});
-  process.waitForFinished(-1);
-  const QString cygpath = QDir::fromNativeSeparators(process.readAllStandardOutput().trimmed());
-  const QString MSYS2_HOME = cygpath.isEmpty() ? webotsDirPath + "/msys64" : cygpath.chopped(1);
-  qputenv("MSYS2_HOME", MSYS2_HOME.toUtf8());  // useful to Python >= 3.8 controllers
-  QCoreApplication::setLibraryPaths(QStringList(MSYS2_HOME + "/mingw64/share/qt6/plugins"));
+
 #ifdef NDEBUG
   const char *MSYSCON = getenv("MSYSCON");
   if (MSYSCON && strncmp("mintty.exe", MSYSCON, 10) == 0)
@@ -132,18 +126,26 @@ int main(int argc, char *argv[]) {
 #endif
   QLocale::setDefault(QLocale::c());
 
+#ifdef _WIN32
+  const char *MSYS2_HOME = getenv("MSYS2_HOME");
+#endif
+
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
-    const QString platformPluginPath = webotsDirPath +
 #ifdef _WIN32
-                                       "/mingw64/share/qt6/plugins";
+    if (MSYS2_HOME && MSYS2_HOME[0])  // Webots was started from a MSYS2 console (development environment)
+      QCoreApplication::addLibraryPath(QStringList(MSYS2_HOME + "/mingw64/share/qt6/plugins"));
+    else
+      QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/mingw64/share/qt6/plugins"));
 #elif defined(__APPLE__)
-                                       "/Contents/lib/webots/qt/plugins";
+    QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/Contents/lib/webots/qt/plugins"));
 #else
-                                       "/lib/webots/qt/plugins";
+    QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/lib/webots/qt/plugins"));
 #endif
-    qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", platformPluginPath.toUtf8());
   }
+
+  if (MSYS2_HOME == NULL || MSYS2_HOME[0] == '\0')                       // Webots was not started from a MSYS2 console
+    qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
 
   // load qt warning filters from file
   QString qtFiltersFilePath = QDir::fromNativeSeparators(webotsDirPath + "/resources/qt_warning_filters.conf");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -134,13 +134,13 @@ int main(int argc, char *argv[]) {
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
 #ifdef _WIN32
     if (!MSYS2_HOME.isEmpty())  // Webots was started from a MSYS2 console (development environment)
-      QCoreApplication::addLibraryPath(QStringList(MSYS2_HOME + "/mingw64/share/qt6/plugins"));
+      QCoreApplication::addLibraryPath(MSYS2_HOME + "/mingw64/share/qt6/plugins");
     else
-      QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/mingw64/share/qt6/plugins"));
+      QCoreApplication::addLibraryPath(webotsDirPath + "/mingw64/share/qt6/plugins");
 #elif defined(__APPLE__)
-    QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/Contents/lib/webots/qt/plugins"));
+    QCoreApplication::addLibraryPath(webotsDirPath + "/Contents/lib/webots/qt/plugins");
 #else
-    QCoreApplication::addLibraryPath(QStringList(webotsDirPath + "/lib/webots/qt/plugins"));
+    QCoreApplication::addLibraryPath(webotsDirPath + "/lib/webots/qt/plugins");
 #endif
   }
 

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -127,25 +127,22 @@ int main(int argc, char *argv[]) {
   QLocale::setDefault(QLocale::c());
 
 #ifdef _WIN32
-  const QString MSYS2_HOME(getenv("MSYS2_HOME"));
+  const QString MSYS2_HOME = QDir::fromNativeSeparators(getenv("MSYS2_HOME"));
+  if (MSYS2_HOME.isEmpty())                                              // Webots was not started from a MSYS2 console
+    qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
 #ifdef _WIN32
-    if (!MSYS2_HOME.isEmpty())  // Webots was started from a MSYS2 console (development environment)
-      QCoreApplication::addLibraryPath(MSYS2_HOME + "/mingw64/share/qt6/plugins");
-    else
-      QCoreApplication::addLibraryPath(webotsDirPath + "/mingw64/share/qt6/plugins");
+    QCoreApplication::addLibraryPath((MSYS2_HOME.isEmpty() ? webotsDirPath + "/msys64" : MSYS2_HOME) +
+                                     "/mingw64/share/qt6/plugins");
 #elif defined(__APPLE__)
     QCoreApplication::addLibraryPath(webotsDirPath + "/Contents/lib/webots/qt/plugins");
 #else
     QCoreApplication::addLibraryPath(webotsDirPath + "/lib/webots/qt/plugins");
 #endif
   }
-
-  if (MSYS2_HOME.isEmpty())                                              // Webots was not started from a MSYS2 console
-    qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
 
   // load qt warning filters from file
   QString qtFiltersFilePath = QDir::fromNativeSeparators(webotsDirPath + "/resources/qt_warning_filters.conf");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -127,22 +127,24 @@ int main(int argc, char *argv[]) {
   QLocale::setDefault(QLocale::c());
 
 #ifdef _WIN32
-  const QString MSYS2_HOME = QDir::fromNativeSeparators(getenv("MSYS2_HOME"));
-  if (MSYS2_HOME.isEmpty())                                              // Webots was not started from a MSYS2 console
-    qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
+  QString MSYS2_HOME = QDir::fromNativeSeparators(getenv("MSYS2_HOME"));
+  if (MSYS2_HOME.isEmpty()) {  // Webots was not started from a MSYS2 console
+    MSYS2_HOME = webotsDirPath + "/msys64";
+    qputenv("MSYS2_HOME", MSYS2_HOME.toUtf8());  // useful to Python >= 3.8 controllers
+  }
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
-  if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty()) {
+  if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty())
+    QCoreApplication::addLibraryPath(
 #ifdef _WIN32
-    QCoreApplication::addLibraryPath((MSYS2_HOME.isEmpty() ? webotsDirPath + "/msys64" : MSYS2_HOME) +
-                                     "/mingw64/share/qt6/plugins");
+      MSYS2_HOME + "/mingw64/share/qt6/plugins"
 #elif defined(__APPLE__)
-    QCoreApplication::addLibraryPath(webotsDirPath + "/Contents/lib/webots/qt/plugins");
+      webotsDirPath + "/Contents/lib/webots/qt/plugins"
 #else
-    QCoreApplication::addLibraryPath(webotsDirPath + "/lib/webots/qt/plugins");
+      webotsDirPath + "/lib/webots/qt/plugins"
 #endif
-  }
+    );
 
   // load qt warning filters from file
   QString qtFiltersFilePath = QDir::fromNativeSeparators(webotsDirPath + "/resources/qt_warning_filters.conf");

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -127,18 +127,19 @@ int main(int argc, char *argv[]) {
   QLocale::setDefault(QLocale::c());
 
 #ifdef _WIN32
-  QString MSYS2_HOME = QDir::fromNativeSeparators(getenv("MSYS2_HOME"));
-  if (MSYS2_HOME.isEmpty()) {  // Webots was not started from a MSYS2 console
-    MSYS2_HOME = webotsDirPath + "/msys64";
-    qputenv("MSYS2_HOME", MSYS2_HOME.toUtf8());  // useful to Python >= 3.8 controllers
-  }
+  const QString MSYS2_HOME = QDir::fromNativeSeparators(getenv("MSYS2_HOME"));
+  if (MSYS2_HOME.isEmpty())                                              // Webots was not started from a MSYS2 console
+    qputenv("MSYS2_HOME", QString(webotsDirPath + "/msys64").toUtf8());  // useful to Python >= 3.8 controllers
+  const QString relativeQtPluginsPath("/mingw64/share/qt6/plugins");
+  const QString webotsQtPluginsPath(webotsDirPath + "/msys64" + relativeQtPluginsPath);
+  const QString qtPluginsPath = QDir(webotsQtPluginsPath).exists() ? webotsQtPluginsPath : MSYS2_HOME + relativeQtPluginsPath;
 #endif
 
   const QString QT_QPA_PLATFORM_PLUGIN_PATH = qEnvironmentVariable("QT_QPA_PLATFORM_PLUGIN_PATH");
   if (QT_QPA_PLATFORM_PLUGIN_PATH.isEmpty())
     QCoreApplication::addLibraryPath(
 #ifdef _WIN32
-      MSYS2_HOME + "/mingw64/share/qt6/plugins"
+      qtPluginsPath
 #elif defined(__APPLE__)
       webotsDirPath + "/Contents/lib/webots/qt/plugins"
 #else


### PR DESCRIPTION
The previous code was relying on `cygpath` to determine if MSYS2 was installed. This failed on @ygoumaz's machine because he had Git installed in `C:\Program Files\Git` which comes with its own `cygpath` and provides a wrong path for MSYS2. This PR removes the dependency on `cygpath` and simply tests for the existence of the Qt plugins folder in the Webots installation folder. If not found, it assumes we are in the development environment and reverts to the Qt plugins folder of MSYS2.

Also, I removed the override of `QT_QPA_PLATFORM_PLUGIN_PATH` which doesn't work. This variable is taken into account only when set before starting Webots, and not if set from within Webots.