### PR TITLE
Fix high DPI scaling bug on i3 window manager (Linux)

### DIFF
--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -71,13 +71,16 @@ export WEBOTS_TMPDIR=$WEBOTS_TMPDIR
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
 export LD_LIBRARY_PATH="$webots_home/lib/webots":$LD_LIBRARY_PATH
 
-#Fix for i3 not working with qt6
+# Fix for i3 window manager not working with Qt6
 if [ "$XDG_CURRENT_DESKTOP" == "i3" ]; then
-export QT_ENABLE_HIGHDPI_SCALING=0
-export QT_SCALE_FACTOR=2
-export QT_FONT_DPI=80
+  DPI=`xrdb -query -all | grep Xft.dpi | awk '{print $2}'`
+  if [[ "$DPI" > 96 ]]; then
+    export QT_ENABLE_HIGHDPI_SCALING=0
+    export QT_SCALE_FACTOR=2
+    export QT_FONT_DPI=80
+  fi
 else
-export QT_ENABLE_HIGHDPI_SCALING=1
+  export QT_ENABLE_HIGHDPI_SCALING=1
 fi
 
 # Fixes warning on Ubuntu 22.04

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -71,7 +71,14 @@ export WEBOTS_TMPDIR=$WEBOTS_TMPDIR
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
 export LD_LIBRARY_PATH="$webots_home/lib/webots":$LD_LIBRARY_PATH
 
+#Fix for i3 not working with qt6
+if [ "$XDG_CURRENT_DESKTOP" == "i3" ]; then
+export QT_ENABLE_HIGHDPI_SCALING=0
+export QT_SCALE_FACTOR=2
+export QT_FONT_DPI=80
+else
 export QT_ENABLE_HIGHDPI_SCALING=1
+fi
 
 # Fixes warning on Ubuntu 22.04
 unset XDG_SESSION_TYPE


### PR DESCRIPTION
This adjusts the Linux launch script to deal with a scaling bug in the i3 window manager and Qt6 on high DPI monitors.
The high DPI handling of Qt6 is disabled and the UI is manually scaled.

Scaling issue in simulation UI R2022b https://github.com/cyberbotics/webots/issues/5024

- [x] A check with non 4k monitor or non high dpi monitor would be interesting