### PR TITLE
Add globals to eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,9 +11,15 @@
   },
 
   "globals": {
+    "canvas": false,
+    "Enum": false,
     "document": false,
+    "glm": false,
+    "Module": false,
     "navigator": false,
-    "window": false
+    "Quaternion": false,
+    "window": false,
+    "_free": false
   },
 
   "rules": {


### PR DESCRIPTION
I added all the global variables/functions that we use in WebotsJS in the eslintrc to avoid warning.

However I did not add the wrenjs functions (functions that begin with `_wr` or _wrjs) because I would need to add them all and there is a lot of them...

I tried to see if some pattern matching was possible (something like `_wr*`) but I couldn't find anything.

Another solution would be to use the complete syntax and to replace all `_wr` functions by `Module.wr` but I do not think it is worth to make the code more heavy to read.