### PR TITLE
Improve new IMPORTABLE EXTERNPROTO dialog

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -65,7 +65,6 @@ WbAddNodeDialog::WbAddNodeDialog(WbNode *currentNode, WbField *field, int index,
   mNewNodeType(UNKNOWN),
   mDefNodeIndex(-1),
   mActionType(CREATE),
-  mIsFolderItemSelected(true),
   mRetrievalTriggered(false) {
   assert(mCurrentNode && mField);
 
@@ -261,7 +260,6 @@ void WbAddNodeDialog::updateItemInfo() {
   mDocumentationLabel->hide();
   if (selectedItem->childCount() > 0 || topLevel == selectedItem) {
     // a folder is selected
-    mIsFolderItemSelected = true;
     mPixmapLabel->hide();
 
     switch (topLevel->type()) {
@@ -299,8 +297,6 @@ void WbAddNodeDialog::updateItemInfo() {
     }
   } else {
     // a node is selected
-    mIsFolderItemSelected = false;
-
     // check if USE node
     switch (topLevel->type()) {
       case Category::USE: {
@@ -693,7 +689,7 @@ bool WbAddNodeDialog::isDeclarationConflicting(const QString &protoName, const Q
 }
 
 void WbAddNodeDialog::checkAndAddSelectedItem() {
-  if (mIsFolderItemSelected)
+  if (!mAddButton->isEnabled())
     return;
 
   accept();

--- a/src/webots/scene_tree/WbAddNodeDialog.hpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.hpp
@@ -83,7 +83,6 @@ private:
   bool mHasRobotTopNode;
   ActionType mActionType;
   QString mImportFileName;
-  bool mIsFolderItemSelected;
 
   QString mSelectionPath;
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -32,9 +32,7 @@
 #include <QtWidgets/QTreeWidgetItem>
 #include <QtWidgets/QVBoxLayout>
 
-WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) :
-  mRetrievalTriggered(false),
-  mIsFolderItemSelected(false) {
+WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) : mRetrievalTriggered(false) {
   QVBoxLayout *const layout = new QVBoxLayout(this);
 
   mSearchBar = new QLineEdit(this);
@@ -155,7 +153,7 @@ void WbInsertExternProtoDialog::updateProtoTree() {
 }
 
 void WbInsertExternProtoDialog::accept() {
-  if (mTree->selectedItems().size() == 0 || mIsFolderItemSelected)
+  if (mTree->selectedItems().size() == 0 || !mInsertButton->isEnabled())
     return;
 
   const WbExternProto *cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
@@ -216,11 +214,9 @@ void WbInsertExternProtoDialog::updateSelection() {
     topLevel = topLevel->parent();
 
   if (selectedItem->childCount() > 0 || topLevel == selectedItem) {
-    mIsFolderItemSelected = true;
     mInsertButton->setEnabled(false);  // selected a category or folder
     return;
   }
 
-  mIsFolderItemSelected = false;
   mInsertButton->setEnabled(true);
 }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -32,7 +32,9 @@
 #include <QtWidgets/QTreeWidgetItem>
 #include <QtWidgets/QVBoxLayout>
 
-WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) : mRetrievalTriggered(false) {
+WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) :
+  mRetrievalTriggered(false),
+  mIsFolderItemSelected(false) {
   QVBoxLayout *const layout = new QVBoxLayout(this);
 
   mSearchBar = new QLineEdit(this);
@@ -40,12 +42,14 @@ WbInsertExternProtoDialog::WbInsertExternProtoDialog(QWidget *parent) : mRetriev
 
   mTree = new QTreeWidget();
   mTree->setHeaderHidden(true);
+  connect(mTree, &QTreeWidget::doubleClicked, this, &WbInsertExternProtoDialog::accept);
 
   // define buttons
   mCancelButton = new QPushButton(tr("Cancel"), this);
   mCancelButton->setFocusPolicy(Qt::ClickFocus);
   mInsertButton = new QPushButton(tr("Insert"), this);
   mInsertButton->setFocusPolicy(Qt::ClickFocus);
+  mInsertButton->setEnabled(false);
   connect(mCancelButton, &QPushButton::pressed, this, &WbInsertExternProtoDialog::reject);
   connect(mInsertButton, &QPushButton::pressed, this, &WbInsertExternProtoDialog::accept);
 
@@ -151,7 +155,7 @@ void WbInsertExternProtoDialog::updateProtoTree() {
 }
 
 void WbInsertExternProtoDialog::accept() {
-  if (mTree->selectedItems().size() == 0)
+  if (mTree->selectedItems().size() == 0 || mIsFolderItemSelected)
     return;
 
   const WbExternProto *cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
@@ -212,9 +216,11 @@ void WbInsertExternProtoDialog::updateSelection() {
     topLevel = topLevel->parent();
 
   if (selectedItem->childCount() > 0 || topLevel == selectedItem) {
+    mIsFolderItemSelected = true;
     mInsertButton->setEnabled(false);  // selected a category or folder
     return;
   }
 
+  mIsFolderItemSelected = false;
   mInsertButton->setEnabled(true);
 }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.hpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.hpp
@@ -43,6 +43,8 @@ private:
   QTreeWidget *mTree;
   QLineEdit *mSearchBar;
 
+  bool mIsFolderItemSelected;
+
   QPushButton *mInsertButton;
   QPushButton *mCancelButton;
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.hpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.hpp
@@ -43,8 +43,6 @@ private:
   QTreeWidget *mTree;
   QLineEdit *mSearchBar;
 
-  bool mIsFolderItemSelected;
-
   QPushButton *mInsertButton;
   QPushButton *mCancelButton;
 


### PR DESCRIPTION
Fixes #4771.

An IMPORTABLE EXTERNPROTO can now be added to the list by double-clicking. Also the Insert button is greyed out by default.
