### PR TITLE
Fix assertion crash when importing some PROTOs with supervisor

### DIFF
--- a/docs/guide/webots-cloud.md
+++ b/docs/guide/webots-cloud.md
@@ -75,6 +75,11 @@ To include an IDE in a webots.cloud project, a line of the following type should
 A typical example of a simulation repository can be found in the [webots.cloud simulation template](https://github.com/cyberbotics/webots-cloud-simulation-template).
 This template can be used as a base to create your own simulations on webots.cloud, and includes a functional `Dockerfile` and `webots.yml` file.
 
+#### Examples
+
+Several examples of simulation repositories can be found in the [webots.cloud simulation examples](https://github.com/cyberbotics/webots-cloud-simulation-examples) repository.
+These examples illustrate how to create a basic simulation repository but also showcase more advanced use cases like adding additional dependencies to the `Dockerfile`, compiling controllers and running an online IDE.
+
 ### Server Information
 
 The server tab on webots.cloud contains information on the [Simulation Servers](simulation-server.md). To setup your own server, follow the guide on how to setup a [Web Server](web-server.md).

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -418,7 +418,7 @@ void WbNodeOperations::notifyNodeDeleted(WbNode *node) {
   emit nodeDeleted(node);
 }
 
-void WbNodeOperations::setFromSupervisor(const bool value) {
+void WbNodeOperations::setFromSupervisor(bool value) {
   mFromSupervisor = value;
   WbProtoManager::instance()->setImportedFromSupervisor(value);
 }

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -83,8 +83,6 @@ void WbNodeOperations::cleanup() {
 }
 
 WbNodeOperations::WbNodeOperations() : mNodesAreAboutToBeInserted(false), mSkipUpdates(false), mFromSupervisor(false) {
-  connect(this, &WbNodeOperations::changedFromSupervisor, WbProtoManager::instance(),
-          &WbProtoManager::setImportedFromSupervisor);
 }
 
 void WbNodeOperations::enableSolidNameClashCheckOnNodeRegeneration(bool enabled) const {
@@ -117,8 +115,7 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(int nodeId, int f
 WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNode, WbField *field, int itemIndex,
                                                                const QString &filename, ImportType origin,
                                                                const QString &nodeString, bool avoidIntersections) {
-  mFromSupervisor = origin == FROM_SUPERVISOR;
-  emit changedFromSupervisor(mFromSupervisor);
+  setFromSupervisor(origin == FROM_SUPERVISOR);
 
   WbSFNode *sfnode = dynamic_cast<WbSFNode *>(field->value());
 #ifndef NDEBUG
@@ -137,14 +134,12 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
     tokenizer.setReferralFile(WbWorld::instance() ? WbWorld::instance()->fileName() : "");
     errors = tokenizer.tokenizeString(nodeString);
   } else {
-    mFromSupervisor = false;
-    emit changedFromSupervisor(mFromSupervisor);
+    setFromSupervisor(false);
     return FAILURE;
   }
 
   if (errors) {
-    mFromSupervisor = false;
-    emit changedFromSupervisor(mFromSupervisor);
+    setFromSupervisor(false);
     return FAILURE;
   }
 
@@ -157,16 +152,14 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
     if (mFromSupervisor && !WbProtoManager::instance()->isImportableExternProtoDeclared(protoName)) {
       WbLog::error(
         tr("In order to import the PROTO '%1', first it must be declared in the IMPORTABLE EXTERNPROTO list.").arg(protoName));
-      mFromSupervisor = false;
-      emit changedFromSupervisor(mFromSupervisor);
+      setFromSupervisor(false);
       return FAILURE;
     }
   }
 
   // check syntax
   if (!parser.parseObject(WbWorld::instance()->fileName())) {
-    mFromSupervisor = false;
-    emit changedFromSupervisor(mFromSupervisor);
+    setFromSupervisor(false);
     return FAILURE;
   }
 
@@ -225,8 +218,7 @@ WbNodeOperations::OperationResult WbNodeOperations::importNode(WbNode *parentNod
       break;
   }
 
-  mFromSupervisor = false;
-  emit changedFromSupervisor(mFromSupervisor);
+  setFromSupervisor(false);
   return isNodeRegenerated ? REGENERATION_REQUIRED : SUCCESS;
 }
 
@@ -365,8 +357,7 @@ bool WbNodeOperations::deleteNode(WbNode *node, bool fromSupervisor) {
   if (node == NULL)
     return false;
 
-  mFromSupervisor = fromSupervisor;
-  emit changedFromSupervisor(mFromSupervisor);
+  setFromSupervisor(fromSupervisor);
 
   if (dynamic_cast<WbSolid *>(node))
     WbWorld::instance()->awake();
@@ -393,8 +384,7 @@ bool WbNodeOperations::deleteNode(WbNode *node, bool fromSupervisor) {
   if (success && dictionaryNeedsUpdate)
     updateDictionary(false, NULL);
 
-  mFromSupervisor = false;
-  emit changedFromSupervisor(mFromSupervisor);
+  setFromSupervisor(false);
 
   WbProtoManager::instance()->purgeUnusedExternProtoDeclarations();
 
@@ -426,4 +416,9 @@ void WbNodeOperations::notifyNodeAdded(WbNode *node) {
 
 void WbNodeOperations::notifyNodeDeleted(WbNode *node) {
   emit nodeDeleted(node);
+}
+
+void WbNodeOperations::setFromSupervisor(const bool value) {
+  mFromSupervisor = value;
+  WbProtoManager::instance()->setImportedFromSupervisor(value);
 }

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -62,8 +62,6 @@ public:
   bool isSkipUpdates() { return mSkipUpdates; }
   bool isFromSupervisor() { return mFromSupervisor; }
 
-  void setFromSupervisor(const bool value);
-
   static QString exportNodeToString(WbNode *node);
 
   void enableSolidNameClashCheckOnNodeRegeneration(bool enabled) const;
@@ -84,6 +82,8 @@ private:
   bool mNodesAreAboutToBeInserted;
   bool mSkipUpdates;
   bool mFromSupervisor;
+
+  void setFromSupervisor(bool value);
 
 private slots:
   void resolveSolidNameClashIfNeeded(WbNode *node) const;

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -62,6 +62,8 @@ public:
   bool isSkipUpdates() { return mSkipUpdates; }
   bool isFromSupervisor() { return mFromSupervisor; }
 
+  void setFromSupervisor(const bool value);
+
   static QString exportNodeToString(WbNode *node);
 
   void enableSolidNameClashCheckOnNodeRegeneration(bool enabled) const;
@@ -73,7 +75,6 @@ public slots:
 signals:
   void nodeAdded(WbNode *node);
   void nodeDeleted(WbNode *node);
-  void changedFromSupervisor(const bool value);
 
 private:
   static WbNodeOperations *cInstance;

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -137,6 +137,8 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
       if (proto->name() == modelName && (proto->isImportable() || proto->isFromRootNodeConversion()))
         protoDeclaration = proto->url();
     }
+
+    mImportedFromSupervisor = false;
     // for supervisor imported nodes, there should always be a corresponding PROTO in the IMPORTABLE list
     assert(!mImportedFromSupervisor || !protoDeclaration.isEmpty());
   }

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -138,10 +138,10 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
         protoDeclaration = proto->url();
     }
 
-    mImportedFromSupervisor = false;
     // for supervisor imported nodes, there should always be a corresponding PROTO in the IMPORTABLE list
     assert(!mImportedFromSupervisor || !protoDeclaration.isEmpty());
   }
+  mImportedFromSupervisor = false;
 
   // based on the declaration found in the file or in the mExternProto list, check if it's a known model
   if (!protoDeclaration.isEmpty()) {

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -137,11 +137,10 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
       if (proto->name() == modelName && (proto->isImportable() || proto->isFromRootNodeConversion()))
         protoDeclaration = proto->url();
     }
-
     // for supervisor imported nodes, there should always be a corresponding PROTO in the IMPORTABLE list
     assert(!mImportedFromSupervisor || !protoDeclaration.isEmpty());
+    mImportedFromSupervisor = false;
   }
-  mImportedFromSupervisor = false;
 
   // based on the declaration found in the file or in the mExternProto list, check if it's a known model
   if (!protoDeclaration.isEmpty()) {

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -128,7 +128,7 @@ public:
   // WbInsertExternProtoDialog) to categorize their respective PROTO
   enum { BASE_NODE = 10001, PROTO_WORLD = 10002, PROTO_PROJECT = 10003, PROTO_EXTRA = 10004, PROTO_WEBOTS = 10005 };
 
-  void setImportedFromSupervisor(const bool value) { mImportedFromSupervisor = value; };
+  void setImportedFromSupervisor(bool value) { mImportedFromSupervisor = value; };
 
   // given a category and a PROTO name, it returns the URL from the corresponding list
   QString protoUrl(const QString &protoName, int category) const;

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -128,6 +128,8 @@ public:
   // WbInsertExternProtoDialog) to categorize their respective PROTO
   enum { BASE_NODE = 10001, PROTO_WORLD = 10002, PROTO_PROJECT = 10003, PROTO_EXTRA = 10004, PROTO_WEBOTS = 10005 };
 
+  void setImportedFromSupervisor(const bool value) { mImportedFromSupervisor = value; };
+
   // given a category and a PROTO name, it returns the URL from the corresponding list
   QString protoUrl(const QString &protoName, int category) const;
   // tests if the PROTO of the provided name exists in the specified category
@@ -197,9 +199,6 @@ public:
   QString formatExternProtoPath(const QString &url) const;
 
   void updateCurrentWorld(const QString &world) { mCurrentWorld = world; }
-
-public slots:
-  void setImportedFromSupervisor(const bool value) { mImportedFromSupervisor = value; };
 
 signals:
   void retrievalCompleted();


### PR DESCRIPTION
#5049 introduced a bug when importing PROTOs that contain other nested PROTOs with a supervisor (e.g. RectangleArena), causing an assertion to trigger. The variable `mImportedFromSupervisor` should only be true for level 1 of the PROTO.

The PR also removes the signal/slot mechanism which is not the lightest solution to synchronize the `mImportedFromSupervisor` variable between `WbNodeOperations` and `WbProtoManager`.