### PR TITLE
Fix lidar FLU conversion + update WREN rotations

### DIFF
--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -1055,15 +1055,15 @@ void WbCamera::updateLensFlare() {
 void WbCamera::updateCameraOrientation() {
   if (hasBeenSetup()) {
     // FLU axis orientation
-    mWrenCamera->rotatePitch(M_PI_2);
-    mWrenCamera->rotateRoll(-M_PI_2);
+    mWrenCamera->rotateRoll(M_PI_2);
+    mWrenCamera->rotateYaw(-M_PI_2);
   }
 }
 
 void WbCamera::updateSegmentationCameraOrientation() {
   // FLU axis orientation
-  mSegmentationCamera->rotatePitch(M_PI_2);
-  mSegmentationCamera->rotateRoll(-M_PI_2);
+  mSegmentationCamera->rotateRoll(M_PI_2);
+  mSegmentationCamera->rotateYaw(-M_PI_2);
 }
 
 void WbCamera::updateNear() {

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -206,7 +206,7 @@ void WbLidar::prePhysicsStep(double ms) {
     if (s)
       s->rotate(WbVector3(0.0, 0.0, angle));
     if (hasBeenSetup()) {
-      mWrenCamera->rotateRoll(angle);
+      mWrenCamera->rotateYaw(angle);
       mPreviousRotatingAngle = mCurrentRotatingAngle;
       mCurrentRotatingAngle += angle;
     }
@@ -467,8 +467,8 @@ void WbLidar::createWrenCamera() {
 void WbLidar::updateOrientation() {
   if (hasBeenSetup()) {
     // FLU axis orientation
-    mWrenCamera->rotatePitch(M_PI_2);
-    mWrenCamera->rotateRoll(-M_PI_2);
+    mWrenCamera->rotateRoll(M_PI_2);
+    mWrenCamera->rotateYaw(-M_PI_2);
   }
 }
 

--- a/src/webots/nodes/WbRangeFinder.cpp
+++ b/src/webots/nodes/WbRangeFinder.cpp
@@ -71,8 +71,8 @@ void WbRangeFinder::postFinalize() {
 void WbRangeFinder::updateOrientation() {
   if (hasBeenSetup()) {
     // FLU axis orientation
-    mWrenCamera->rotatePitch(M_PI_2);
-    mWrenCamera->rotateRoll(-M_PI_2);
+    mWrenCamera->rotateRoll(M_PI_2);
+    mWrenCamera->rotateYaw(-M_PI_2);
   }
 }
 

--- a/src/wren/Camera.hpp
+++ b/src/wren/Camera.hpp
@@ -87,9 +87,9 @@ namespace wren {
     }
 
     void setDirection(const glm::vec3 &direction);
-    void applyYaw(float angle) { applyRotation(angle, gVec3UnitY); }
-    void applyPitch(float angle) { applyRotation(angle, gVec3UnitX); }
-    void applyRoll(float angle) { applyRotation(angle, gVec3UnitZ); }
+    void applyYaw(float angle) { applyRotation(angle, gVec3UnitZ); }
+    void applyPitch(float angle) { applyRotation(angle, gVec3UnitY); }
+    void applyRoll(float angle) { applyRotation(angle, gVec3UnitX); }
 
     WrCameraProjectionMode projectionMode() const { return mProjectionMode; }
     float aspectRatio() const { return mAspectRatio; }


### PR DESCRIPTION
Fixes #4786.

The conversion to FLU was not completely achieved in `WbLidar.cpp`. This PR also changes the location of the conversion. It is now done at the wren level instead of the devices.