### PR TITLE
Fix new project wizard wrong world location

### DIFF
--- a/src/webots/gui/WbNewProjectWizard.cpp
+++ b/src/webots/gui/WbNewProjectWizard.cpp
@@ -70,6 +70,7 @@ void WbNewProjectWizard::accept() {
     QDialog::accept();
     return;
   }
+  WbProject::setCurrent(mProject);
   createWorldFile();
   // store the accepted project directory in the preferences
   QDir dir(mProject->path());


### PR DESCRIPTION
Fixes #5089.

The new project was never set as current WbProject.