### PR TITLE
Fix nested proto visibility

### DIFF
--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -235,7 +235,7 @@ WbNode::WbNode(const WbNode &other) :
     // copy fields
     foreach (WbField *parameterNodeField, other.mFields) {
       WbField *field = NULL;
-      if (gNestedProtoFlag) {
+      if (gNestedProtoFlag && (!parameterNodeField->alias().isEmpty() || !parameterNodeField->isParameter())) {
         // create an instance of a nested PROTO parameter node
         // don't redirect PROTO instance fields to PROTO node fields
         // PROTO instance fields will be redirected to PROTO node parameters in function cloneAndReferenceProtoInstance()


### PR DESCRIPTION
**Description**
Fix #5028 

The problem of urls path (`protos/` instead of `worlds/`) and the fact the `TruckTrailerSimple` was never updated if we tried to change its color/texture was due to the fact that the exposed field was not correctly redirected in the case of nested Proto.

The best solution I found is to modify this line: https://github.com/cyberbotics/webots/blob/2307b3f68c99df6faf18fe6ec210e76eb875a94c/src/webots/vrml/WbNode.cpp#L238)

In:
```
      if (gNestedProtoFlag && (!parameterNodeField->alias().isEmpty() || !parameterNodeField->isParameter())) {
```

It fixes the issue, pass the test suite and I detected no side effect.

However, if I just do: 
```
      if (gNestedProtoFlag && !parameterNodeField->alias().isEmpty()) {
```
I get exactly the same result, even if I find it less conceptually correct (put useless redirection on internal nodes)

So I am a bit hesitating on the way to follow.
@stefaniapedrazzi, maybe you have an idea?

Other points that worry me a bit is that issue: https://github.com/cyberbotics/webots/issues/3979 or the fact that the `tiago++` -> `endEffectorRightSlot` -> `TiagoGripper` -> `translation` field does not work until we changed the name.

Both problem are not new (already present in R2022a and even before I think) but they seem really close to the one fixed by this PR so I am a bit afraid that this PR fixes only part of the problem
