### PR TITLE
Fix executing color edit dialog when running in fast mode

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -71,6 +71,7 @@ Released on July, 7th, 2022.
     - Fixed animation time not starting at 0 seconds ([#4659](https://github.com/cyberbotics/webots/pull/4659)).
     - Fixed inverted left and right sound from speaker ([#4847](https://github.com/cyberbotics/webots/pull/4847)).
     - Fixed various crashes with devices whose top node is not a [Robot](robot.md) node ([#4878](https://github.com/cyberbotics/webots/pull/4878)).
+    - Fixed freezing Color Picker dialog if opened while a simulation is running in fast mode ([#5097](https://github.com/cyberbotics/webots/pull/5097)).
   - Cleanup
     - Moved the Wizard menu inside the File / New menu ([#5075](https://github.com/cyberbotics/webots/pull/5075)).
     - Removed WBO file import from Webots and from the Controller API ([#5061](https://github.com/cyberbotics/webots/pull/5061)).

--- a/src/webots/scene_tree/WbColorEditor.cpp
+++ b/src/webots/scene_tree/WbColorEditor.cpp
@@ -54,7 +54,8 @@ WbColorEditor::WbColorEditor(QWidget *parent) : WbValueEditor(parent), mColorBut
   mLayout->setColumnStretch(3, 1);
 }
 
-WbColorEditor::~WbColorEditor() {}
+WbColorEditor::~WbColorEditor() {
+}
 
 void WbColorEditor::recursiveBlockSignals(bool block) {
   blockSignals(block);

--- a/src/webots/scene_tree/WbColorEditor.cpp
+++ b/src/webots/scene_tree/WbColorEditor.cpp
@@ -134,8 +134,10 @@ void WbColorEditor::openColorChooser() {
   QColor color(r, g, b);
   QColorDialog dialog(color, this);
   const int result = dialog.exec();
-  if (result == QDialog::Rejected)
+  if (result == QDialog::Rejected) {
+    WbSimulationState::instance()->resumeSimulation();
     return;
+  }
 
   color = dialog.currentColor();
   mRgb.setValue(color.redF(), color.greenF(), color.blueF());

--- a/src/webots/scene_tree/WbColorEditor.cpp
+++ b/src/webots/scene_tree/WbColorEditor.cpp
@@ -18,6 +18,7 @@
 #include "WbFieldDoubleSpinBox.hpp"
 #include "WbMFColor.hpp"
 #include "WbSFColor.hpp"
+#include "WbSimulationState.hpp"
 
 #include <QtWidgets/QColorDialog>
 #include <QtWidgets/QComboBox>
@@ -53,8 +54,7 @@ WbColorEditor::WbColorEditor(QWidget *parent) : WbValueEditor(parent), mColorBut
   mLayout->setColumnStretch(3, 1);
 }
 
-WbColorEditor::~WbColorEditor() {
-}
+WbColorEditor::~WbColorEditor() {}
 
 void WbColorEditor::recursiveBlockSignals(bool block) {
   blockSignals(block);
@@ -125,6 +125,7 @@ void WbColorEditor::takeKeyboardFocus() {
 }
 
 void WbColorEditor::openColorChooser() {
+  WbSimulationState::instance()->pauseSimulation();
   const int r = mRgb.redByte();
   const int g = mRgb.greenByte();
   const int b = mRgb.blueByte();
@@ -140,6 +141,7 @@ void WbColorEditor::openColorChooser() {
 
   updateSpinBoxes();
   apply();
+  WbSimulationState::instance()->resumeSimulation();
 }
 
 void WbColorEditor::applyIfNeeded() {


### PR DESCRIPTION
Fix #5090: pause the simulation while a dialog is open to avoid UI refresh issues.

I can reproduce the same issue in R2021b as well.