### PR TITLE
Silence false GCC 12.2.0 warning

### DIFF
--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -373,7 +373,7 @@ void WbConnector::snapOrigins(WbConnector *other) {
       h[i] /= 2.0;
   }
 
-  // gcc version 12.1.0 and 12.2.0 is raising a false positive warning here about dangling pointers
+// gcc version 12.1.0 and 12.2.0 is raising a false positive warning here about dangling pointers
 #pragma GCC diagnostic push
 #if __GNUC__ == 12 && __GNUC_MINOR__ >= 1 && __GNUC_MINOR__ <= 2 && __GNUC_PATCHLEVEL__ == 0
 #pragma GCC diagnostic ignored "-Wdangling-pointer"

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -365,7 +365,6 @@ void WbConnector::snapOrigins(WbConnector *other) {
   // retrieve current body positions
   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();
   const dReal *d2 = b2 ? dBodyGetPosition(b2) : other->matrix().translation().ptr();
-
   // each body must be shifted towards the other by half the distance
   dReal h[3] = {p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]};
   if (b1 && b2) {
@@ -373,9 +372,9 @@ void WbConnector::snapOrigins(WbConnector *other) {
       h[i] /= 2.0;
   }
 
-// gcc 12.1.0 is raising a false positive warning here about dangling pointers
+  // gcc version 12.1.0 and 12.2.0 is raising a false positive warning here about dangling pointers
 #pragma GCC diagnostic push
-#if __GNUC__ == 12 && __GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ == 0
+#if __GNUC__ == 12 && __GNUC_MINOR__ >= 1 && __GNUC_MINOR__ <= 2 && __GNUC_PATCHLEVEL__ == 0
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
   // shift bodies

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -365,6 +365,7 @@ void WbConnector::snapOrigins(WbConnector *other) {
   // retrieve current body positions
   const dReal *d1 = b1 ? dBodyGetPosition(b1) : matrix().translation().ptr();
   const dReal *d2 = b2 ? dBodyGetPosition(b2) : other->matrix().translation().ptr();
+
   // each body must be shifted towards the other by half the distance
   dReal h[3] = {p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]};
   if (b1 && b2) {


### PR DESCRIPTION
GCC 12.1.0 and 12.2.0 seem to display false warnings about dangling pointers (tested on Windows). This PR extends the silencing of the warning to GCC 12.2.0 which came as a MSYS2 update today.