### PR TITLE
Fixed running Webots in UTF-8 path

### DIFF
--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -159,7 +159,7 @@ $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
 	@echo "# downloading $(PICO_PACKAGE)"
 	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
 	@wget -qq "$(DEPENDENCIES_URL)/$(PICO_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
-	@if [ "$$(md5sum $(PICO_PACKAGE) | awk '{print $$1;}')" != "9b0dce0cbabc887eca320b7d20b42f0f" ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
+	@if [ "$$(md5sum $(PICO_PACKAGE) | awk '{print $$1;}')" != "78a74b1190eb3a75bc0ae5360c699517" ]; then echo "MD5 checksum failed for $(PICO_PACKAGE)"; exit 1; fi
 	@touch "$(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)"
 
 lua-gd-clean:

--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -9,7 +9,7 @@ ASSIMP_PACKAGE = assimp-5.2.3.zip
 OPEN_VR_PACKAGE = openvr-1.0.7.zip
 LUA_PACKAGE = lua-5.2.3.tar.gz
 OIS_PACKAGE = libOIS.zip
-PICO_PACKAGE = libpico.zip
+PICO_PACKAGE = libpico-1.0.zip
 LUA_GD_PACKAGE = lua-gd-windows.zip
 
 PACKAGES = assimp open-vr lua ois pico lua-gd

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -42,6 +42,7 @@ Released on July, 7th, 2022.
     - Changed the layout and behavior of the loading screen and progress bar for the [Web Interface](../guide/web-interface.md) ([#4593](https://github.com/cyberbotics/webots/pull/4593)).
     - Improved display of generated PROTO sources in Text Editor that are now opened in read-only mode ([#5023](https://github.com/cyberbotics/webots/pull/5023)).
   - Bug Fixes
+    - Fixed execution of Webots on Windows in a UTF-8 path with non-ASCII characters ([#5103](https://github.com/cyberbotics/webots/pull/5103)).
     - Fixed bug in `wb_supervisor_node_get_field_by_index` and `wb_supervisor_node_get_proto_field_by_index` API functions ([#4366](https://github.com/cyberbotics/webots/pull/4366)).
     - Fixed redirection of stdout/stderr to the terminal when no Webots console is open ([#4372](https://github.com/cyberbotics/webots/pull/4372)).
     - Fixed a situation where the joystick's release button status could not be obtained when using ros, and the POV data could not be read using the Int8Stamped type ([#4405](https://github.com/cyberbotics/webots/pull/4405)).

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -97,11 +97,11 @@ int main(int argc, char *argv[]) {
   // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
   // we need to use GetModuleFileName as argv[0] doesn't always provide an absolute path
   const int BUFFER_SIZE = 4096;
-  char *modulePath = new char[BUFFER_SIZE];
-  GetModuleFileName(NULL, modulePath, BUFFER_SIZE);
+  wchar_t *tmp = new wchar_t[4096];
+  GetModuleFileNameW(NULL, tmp, BUFFER_SIZE);
+  const QString modulePath = QString::fromWCharArray(tmp);
+  delete[] tmp;
   const QString webotsDirPath = QDir(QFileInfo(modulePath).absolutePath() + "/../../..").canonicalPath();
-  delete[] modulePath;
-
 #ifdef NDEBUG
   const char *MSYSCON = getenv("MSYSCON");
   if (MSYSCON && strncmp("mintty.exe", MSYSCON, 10) == 0)
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
     RedirectIOToConsole();  // the release version is built with the -mwindows flag
                             // which drops stdout/stderr, so we need to redirect
                             // them to the parent console in case Webots was started
-                            // from a DOS
+                            // from a DOS console
 #else
   // we need to unbuffer the stderr as _IOLBF is not working in the msys console
   setvbuf(stderr, NULL, _IONBF, 0);

--- a/src/webots/gui/main.cpp
+++ b/src/webots/gui/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
   // on Windows, the webots binary is located in $WEBOTS_HOME/msys64/mingw64/bin/webots
   // we need to use GetModuleFileName as argv[0] doesn't always provide an absolute path
   const int BUFFER_SIZE = 4096;
-  wchar_t *tmp = new wchar_t[4096];
+  wchar_t *tmp = new wchar_t[BUFFER_SIZE];
   GetModuleFileNameW(NULL, tmp, BUFFER_SIZE);
   const QString modulePath = QString::fromWCharArray(tmp);
   delete[] tmp;

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -373,9 +373,9 @@ void WbConnector::snapOrigins(WbConnector *other) {
       h[i] /= 2.0;
   }
 
-// gcc 12.1.0 is raising a false positive warning here about dangling pointers
+// gcc version 12.1.0 and 12.2.0 is raising a false positive warning here about dangling pointers
 #pragma GCC diagnostic push
-#if __GNUC__ == 12 && __GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ == 0
+#if __GNUC__ == 12 && __GNUC_MINOR__ >= 1 && __GNUC_MINOR__ <= 2 && __GNUC_PATCHLEVEL__ == 0
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
   // shift bodies

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -158,8 +158,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
     const char *hint = filePath.mid(filePath.lastIndexOf('.') + 1).toUtf8().constData();
     scene = importer.ReadFileFromMemory(data.constData(), data.size(), flags, hint);
   } else
-    scene = importer.ReadFile(filePath.toStdString().c_str(), flags);
-
+    scene = importer.ReadFile(filePath.toUtf8().constData(), flags);
   if (!scene) {
     warn(tr("Invalid data, please verify mesh file (bone weights, normals, ...): %1").arg(importer.GetErrorString()));
     return;

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -159,6 +159,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
     scene = importer.ReadFileFromMemory(data.constData(), data.size(), flags, hint);
   } else
     scene = importer.ReadFile(filePath.toUtf8().constData(), flags);
+
   if (!scene) {
     warn(tr("Invalid data, please verify mesh file (bone weights, normals, ...): %1").arg(importer.GetErrorString()));
     return;

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -302,7 +302,9 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
 uint64_t WbMesh::computeHash() const {
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0);
   const QString meshPathNameIndex = completeUrl + (mIsCollada ? mName->value() + QString::number(mMaterialIndex->value()) : "");
-  return WbTriangleMeshCache::sipHash13x(meshPathNameIndex.toUtf8().constData(), meshPathNameIndex.size());
+  const QByteArray key = meshPathNameIndex.toUtf8();
+  const uint64_t hash = WbTriangleMeshCache::sipHash13x(key.constData(), key.size());
+  return hash;
 }
 
 void WbMesh::updateUrl() {

--- a/src/webots/nodes/utils/WbDisplayFont.cpp
+++ b/src/webots/nodes/utils/WbDisplayFont.cpp
@@ -77,7 +77,6 @@ unsigned char *WbDisplayFont::generateCharBuffer(unsigned long character, bool a
   FT_Int32 aliasingFlags = antiAliasing ? FT_LOAD_RENDER | FT_LOAD_TARGET_NORMAL : FT_LOAD_RENDER | FT_LOAD_TARGET_MONO;
 
   mFallbackFaces.prepend(mFace);
-
   foreach (const FT_Face face, mFallbackFaces) {
     unsigned int index = FT_Get_Char_Index(face, character);
     FT_Error error = FT_Load_Glyph(face, index, aliasingFlags);
@@ -113,7 +112,27 @@ void WbDisplayFont::setFont(const QString &filename, unsigned int size) {
 void WbDisplayFont::loadFace(FT_Face *face, const QString &filename, unsigned int size) {
   mError = "";
   mFontSize = size;
+
+#ifdef _WIN32
+  // on Windows, we cannot call FT_New_Face directly as it doesn't support multi byte characters
+  // thus, we have to load its contents into the memory before calling FT_Open_Face
+  QFile file(filename);
+  if (!file.open(QIODevice::ReadOnly)) {
+    fprintf(stderr, "Cannot open file\n");
+    fflush(stderr);
+    mError = "The font file could not be opened.";
+    return;
+  }
+  mFileBuffers.append(file.readAll());
+  FT_Open_Args args;
+  args.flags = FT_OPEN_MEMORY;
+  args.memory_base = reinterpret_cast<const unsigned char *>(mFileBuffers.last().constData());
+  // reinterpret_cast<const unsigned char *>(mFileBuffer.constData());
+  args.memory_size = mFileBuffers.last().size();
+  FT_Error error = FT_Open_Face(mLibrary, &args, 0, face);
+#else
   FT_Error error = FT_New_Face(mLibrary, filename.toUtf8().constData(), 0, face);
+#endif
   if (error == FT_Err_Unknown_File_Format)
     mError = "The font file could be opened and read, but its font format is unsupported.";
   else if (error)

--- a/src/webots/nodes/utils/WbDisplayFont.hpp
+++ b/src/webots/nodes/utils/WbDisplayFont.hpp
@@ -50,6 +50,9 @@ private:
   bool mFaceIsInitialized;
   QString mError;
   unsigned int mFontSize;
+#ifdef _WIN32
+  QByteArrayList mFileBuffers;
+#endif
 };
 
 #endif  // WB_DISPLAY_FONT_HPP

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1742,13 +1742,8 @@ WbNode *WbNode::createProtoInstanceFromParameters(WbProtoModel *proto, const QVe
         WbField *aliasParam = aliasIt.next();
         if (aliasParam->name() == param->alias() && aliasParam->type() == param->type()) {
           aliasNotFound = false;
-          bool aliasTemplate = aliasParam->isTemplateRegenerator();
-          if (!aliasTemplate) {
-            bool paramTemplate = param->isTemplateRegenerator();
-            aliasParam->setTemplateRegenerator(paramTemplate);
-            if (paramTemplate)
-              instance->mProto->setIsTemplate(true);
-          }
+          if (!aliasParam->isTemplateRegenerator())
+            aliasParam->setTemplateRegenerator(param->isTemplateRegenerator());
 
           WbNode *tmpParent = gParent;
           foreach (WbField *internalField, param->internalFields()) {

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -360,7 +360,7 @@ WbNode *WbProtoModel::generateRoot(const QVector<WbField *> &parameters, const Q
     }
     if (key.isEmpty()) {
       // FIXME: this should never happen, however it does happen when opening
-      // webots/projects/samples/geometries/worlds/textured_boxes.wbt
+      // webots/projects/samples/geometries/worlds/textured_proto_shapes.wbt
     } else if (!mIsDeterministic ||
                (!mDeterministicContentMap.contains(key) || mDeterministicContentMap.value(key).isEmpty())) {
       WbProtoTemplateEngine te(mContent);

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -346,8 +346,8 @@ WbNode *WbProtoModel::generateRoot(const QVector<WbField *> &parameters, const Q
 
   int rootUniqueId = -1;
   QString content = mContent;
-  QString key;
   if (mTemplate) {
+    QString key;
     if (mIsDeterministic) {
       foreach (WbField *parameter, parameters) {
         if (parameter->isTemplateRegenerator()) {
@@ -358,8 +358,11 @@ WbNode *WbProtoModel::generateRoot(const QVector<WbField *> &parameters, const Q
         }
       }
     }
-
-    if (!mIsDeterministic || (!mDeterministicContentMap.contains(key) || mDeterministicContentMap.value(key).isEmpty())) {
+    if (key.isEmpty()) {
+      // FIXME: this should never happen, however it does happen when opening
+      // webots/projects/samples/geometries/worlds/textured_boxes.wbt
+    } else if (!mIsDeterministic ||
+               (!mDeterministicContentMap.contains(key) || mDeterministicContentMap.value(key).isEmpty())) {
       WbProtoTemplateEngine te(mContent);
       rootUniqueId = uniqueId >= 0 ? uniqueId : WbNode::getFreeUniqueId();
       if (!te.generate(name() + ".proto", parameters, mUrl, worldPath, rootUniqueId, mTemplateLanguage)) {

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -480,13 +480,6 @@ QStringList WbProtoModel::parameterNames() const {
   return names;
 }
 
-void WbProtoModel::setIsTemplate(bool value) {
-  mTemplate = value;
-  if (mTemplate && mIsDeterministic) {  // if ancestor is nonDeterministic this proto can't be either
-    mIsDeterministic = mAncestorProtoModel->isDeterministic();
-  }
-}
-
 void WbProtoModel::setupNodeAliasing(WbNode *node, WbFieldModel *param, WbTokenizer *tokenizer, bool searchInParameters,
                                      bool &ok) {
   QVector<WbField *> fields;

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -358,11 +358,7 @@ WbNode *WbProtoModel::generateRoot(const QVector<WbField *> &parameters, const Q
         }
       }
     }
-    if (key.isEmpty()) {
-      // FIXME: this should never happen, however it does happen when opening
-      // webots/projects/samples/geometries/worlds/textured_proto_shapes.wbt
-    } else if (!mIsDeterministic ||
-               (!mDeterministicContentMap.contains(key) || mDeterministicContentMap.value(key).isEmpty())) {
+    if (!mIsDeterministic || (!mDeterministicContentMap.contains(key) || mDeterministicContentMap.value(key).isEmpty())) {
       WbProtoTemplateEngine te(mContent);
       rootUniqueId = uniqueId >= 0 ? uniqueId : WbNode::getFreeUniqueId();
       if (!te.generate(name() + ".proto", parameters, mUrl, worldPath, rootUniqueId, mTemplateLanguage)) {

--- a/src/webots/vrml/WbProtoModel.hpp
+++ b/src/webots/vrml/WbProtoModel.hpp
@@ -100,9 +100,6 @@ public:
   QStringList parameterNames() const;
   QMap<QString, QString> parameterAliases() const { return mParameterAliases; }
 
-  // set nested proto property based on base proto
-  void setIsTemplate(bool value);
-
   // add/remove a reference to this proto model from a proto instance
   // when the reference count reaches zero (in unref()) the proto model gets deleted
   // the optional argument defines if it is called from the creation of a proto instance

--- a/src/wren/FileImport.cpp
+++ b/src/wren/FileImport.cpp
@@ -65,15 +65,14 @@ namespace wren {
         return true;
       }
 
+#ifdef _WIN32  // handle UTF-8 paths on Windows
       wchar_t *wFileName = new wchar_t[len + 1];
-#ifdef _WIN32  // mbstowcs doesn't work properly on Windows
       MultiByteToWideChar(CP_UTF8, 0, fileName, -1, wFileName, len + 1);
-#else
-      // cppcheck-suppress uninitdata
-      mbstowcs(wFileName, fileName, len + 1);
-#endif
       std::ifstream infile(wFileName, std::ios::in | std::ios::binary);
       delete[] wFileName;
+#else
+      std::ifstream infile(fileName, std::ios::in | std::ios::binary);
+#endif
 
       std::string line;
       glm::vec3 zero(0.0f, 0.0f, 0.0f);

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -79,7 +79,7 @@ namespace wren {
     // and load its contents into the memory before calling FT_Open_Face
     const int l = strlen(filename) + 1;  // include the final '\0'
     wchar_t *wfilename = new wchar_t[l];
-    MultiByteToWideChar(CP_UTF8, 0, filename, l, wfilename, l);
+    MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, l);
     FILE *fp = _wfopen(wfilename, L"rb");
     fseek(fp, 0, SEEK_END);
     const long size = ftell(fp);

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -25,11 +25,18 @@ namespace wren {
     FT_Error fontError = FT_Init_FreeType(&mLibrary);
     if (fontError)
       mError = WR_FONT_ERROR_FREETYPE_LOADING;
+#ifdef _WIN32
+    mFileBuffer = NULL;
+#endif
   }
 
   Font::~Font() {
-    if (mFaceIsInitialized)
+    if (mFaceIsInitialized) {
       FT_Done_Face(mFace);
+#ifdef _WIN32
+      delete[] mFileBuffer;
+#endif
+    }
     FT_Done_FreeType(mLibrary);
   }
 
@@ -66,7 +73,31 @@ namespace wren {
     if (mFaceIsInitialized)
       FT_Done_Face(mFace);
 
+#ifdef _WIN32
+    // on Windows, we cannot call FT_New_Face directly as it doesn't support multi byte characters
+    // thus, we have to convert the multi byte file name into a wchar_t array to open it
+    // and load its contents into the memory before calling FT_Open_Face
+    const int l = strlen(filename) + 1;  // include the final '\0'
+    wchar_t *wfilename = new wchar_t[l];
+    MultiByteToWideChar(CP_UTF8, 0, filename, l, wfilename, l);
+    FILE *fp = _wfopen(wfilename, L"rb");
+    fseek(fp, 0, SEEK_END);
+    const long size = ftell(fp);
+    rewind(fp);
+    delete[] mFileBuffer;
+    mFileBuffer = new unsigned char[size + 1];
+    fread(mFileBuffer, 1, size, fp);
+    mFileBuffer[size] = '\0';
+    fclose(fp);
+    FT_Open_Args args;
+    args.flags = FT_OPEN_MEMORY;
+    args.memory_base = mFileBuffer;
+    args.memory_size = size;
+    FT_Error fontError = FT_Open_Face(mLibrary, &args, 0, &mFace);
+#else
     FT_Error fontError = FT_New_Face(mLibrary, filename, 0, &mFace);
+#endif
+
     if (fontError == FT_Err_Unknown_File_Format)
       mError = WR_FONT_ERROR_UNKNOWN_FILE_FORMAT;
     else if (fontError)
@@ -84,7 +115,9 @@ namespace wren {
       mError = WR_FONT_ERROR_FONT_SIZE;
   }
 
-  unsigned int Font::verticalSpace() const { return mFace->size->metrics.height >> 6; }
+  unsigned int Font::verticalSpace() const {
+    return mFace->size->metrics.height >> 6;
+  }
 
   void Font::getBoundingBox(const char *text, int *width, int *height) {
     *height = 0;

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -120,9 +120,7 @@ namespace wren {
       mError = WR_FONT_ERROR_FONT_SIZE;
   }
 
-  unsigned int Font::verticalSpace() const {
-    return mFace->size->metrics.height >> 6;
-  }
+  unsigned int Font::verticalSpace() const { return mFace->size->metrics.height >> 6; }
 
   void Font::getBoundingBox(const char *text, int *width, int *height) {
     *height = 0;

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -81,6 +81,11 @@ namespace wren {
     wchar_t *wfilename = new wchar_t[l];
     MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, l);
     FILE *fp = _wfopen(wfilename, L"rb");
+    delete[] wfilename;
+    if (fp == NULL) {
+      mError = WR_FONT_ERROR_FONT_LOADING;
+      return;
+    }
     fseek(fp, 0, SEEK_END);
     const long size = ftell(fp);
     rewind(fp);
@@ -102,8 +107,8 @@ namespace wren {
       mError = WR_FONT_ERROR_UNKNOWN_FILE_FORMAT;
     else if (fontError)
       mError = WR_FONT_ERROR_FONT_LOADING;
-
-    mFaceIsInitialized = true;
+    else
+      mFaceIsInitialized = true;
   }
 
   void Font::setFontSize(unsigned int size) {
@@ -115,7 +120,9 @@ namespace wren {
       mError = WR_FONT_ERROR_FONT_SIZE;
   }
 
-  unsigned int Font::verticalSpace() const { return mFace->size->metrics.height >> 6; }
+  unsigned int Font::verticalSpace() const {
+    return mFace->size->metrics.height >> 6;
+  }
 
   void Font::getBoundingBox(const char *text, int *width, int *height) {
     *height = 0;

--- a/src/wren/Font.cpp
+++ b/src/wren/Font.cpp
@@ -115,9 +115,7 @@ namespace wren {
       mError = WR_FONT_ERROR_FONT_SIZE;
   }
 
-  unsigned int Font::verticalSpace() const {
-    return mFace->size->metrics.height >> 6;
-  }
+  unsigned int Font::verticalSpace() const { return mFace->size->metrics.height >> 6; }
 
   void Font::getBoundingBox(const char *text, int *width, int *height) {
     *height = 0;

--- a/src/wren/Font.hpp
+++ b/src/wren/Font.hpp
@@ -50,6 +50,9 @@ namespace wren {
     bool mFaceIsInitialized;
     WrFontError mError;
     unsigned int mFontSize;
+#ifdef _WIN32
+    unsigned char *mFileBuffer;
+#endif
   };
 
 }  // namespace wren

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -76,9 +76,9 @@ namespace wren {
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
 #ifdef _WIN32                         // mbstowcs doesn't work properly on Windows
-    const int l = path.length() + 1;  // final '\0'
-    wchar_t *filename = new wchar_t[l];
-    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, l);
+    const int len = path.length() + 1;  // final '\0'
+    wchar_t *filename = new wchar_t[len];
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, len);
     std::ifstream in(filename, std::ios::in | std::ios::binary);
     delete[] filename;
 #else

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -75,16 +75,15 @@ namespace wren {
   void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
+#ifdef _WIN32                         // mbstowcs doesn't work properly on Windows
     const int l = path.length() + 1;  // final '\0'
     wchar_t *filename = new wchar_t[l];
-#ifdef _WIN32  // mbstowcs doesn't work properly on Windows
     MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, l);
-#else
-    // cppcheck-suppress uninitdata
-    mbstowcs(filename, path.c_str(), l);
-#endif
     std::ifstream in(filename, std::ios::in | std::ios::binary);
     delete[] filename;
+#else
+    std::ifstream in(path, std::ios::in | std::ios::binary);
+#endif
     if (in) {
       in.seekg(0, std::ios::end);
       contents.resize(in.tellg());

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -72,20 +72,29 @@ namespace wren {
       uniform.second->uploadValue();
   }
 
-  void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
+  void ShaderProgram::release() const {
+    glstate::releaseProgram(mGlName);
+  }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
-    std::ifstream in(path, std::ios::in | std::ios::binary);
+    int l = path.length();
+    wchar_t *filename = new wchar_t[l + 1];
+#ifdef _WIN32  // mbstowcs doesn't work properly on Windows
+    l = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, l + 1) - 1;
+#else
+    // cppcheck-suppress uninitdata
+    l = mbstowcs(filename, path.c_str(), l + 1);
+#endif
+    std::ifstream in(filename, std::ios::in | std::ios::binary);
+    delete[] filename;
     if (in) {
       in.seekg(0, std::ios::end);
       contents.resize(in.tellg());
       in.seekg(0, std::ios::beg);
       in.read(&contents[0], contents.size());
       in.close();
-
       return true;
     }
-
     return false;
   }
 

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -72,9 +72,7 @@ namespace wren {
       uniform.second->uploadValue();
   }
 
-  void ShaderProgram::release() const {
-    glstate::releaseProgram(mGlName);
-  }
+  void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
     int l = path.length();

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -72,16 +72,18 @@ namespace wren {
       uniform.second->uploadValue();
   }
 
-  void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
+  void ShaderProgram::release() const {
+    glstate::releaseProgram(mGlName);
+  }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
-    int l = path.length();
-    wchar_t *filename = new wchar_t[l + 1];
+    const int l = path.length() + 1;  // final '\0'
+    wchar_t *filename = new wchar_t[l];
 #ifdef _WIN32  // mbstowcs doesn't work properly on Windows
-    l = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, l + 1) - 1;
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, l);
 #else
     // cppcheck-suppress uninitdata
-    l = mbstowcs(filename, path.c_str(), l + 1);
+    mbstowcs(filename, path.c_str(), l);
 #endif
     std::ifstream in(filename, std::ios::in | std::ios::binary);
     delete[] filename;

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -72,9 +72,7 @@ namespace wren {
       uniform.second->uploadValue();
   }
 
-  void ShaderProgram::release() const {
-    glstate::releaseProgram(mGlName);
-  }
+  void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
     const int l = path.length() + 1;  // final '\0'

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -75,7 +75,7 @@ namespace wren {
   void ShaderProgram::release() const { glstate::releaseProgram(mGlName); }
 
   bool ShaderProgram::readFile(const std::string &path, std::string &contents) {
-#ifdef _WIN32                         // mbstowcs doesn't work properly on Windows
+#ifdef _WIN32                           // mbstowcs doesn't work properly on Windows
     const int len = path.length() + 1;  // final '\0'
     wchar_t *filename = new wchar_t[len];
     MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, filename, len);


### PR DESCRIPTION
Fix #4757.
I had to fix [libpico.dll](https://github.com/naggety/picotts/commit/049f942c833048a1dbabca3a8a52841618ba69f9) which was having problems with UTF-8 paths on Windows. Therefore, you will have to re-install pico to test this PR on Windows.
I can now run the guided tour without any error with Webots installed in a path with UTF-8 characters (e.g., Chinese characters).
I also tested a few other world files and they all run flawlessly in that path.

In addition to fixing UTF-8 paths, this PR also:
- Fixes a bug with the `mTemplate` field of `WbProtoModel` which was wrongly set: the `textured_proto_shape.wbt` example was causing the initialization of the Lua engine which was completely useless.
- The computation of the hash for the meshes was wrong, causing different UTF-8 URLs to have the same hash.
