### PR TITLE
Cleanup `WbNetwork` to a singleton class

### DIFF
--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -118,7 +118,7 @@ void WbNetwork::save(const QString &url, const QByteArray &content) {
   }
 }
 
-const QString WbNetwork::get(const QString &url) {
+const QString &WbNetwork::get(const QString &url) {
   if (!mCacheMap.contains(url)) {
     const QString filePath = WbStandardPaths::cachedAssetsPath() + urlToHash(url);
     mCacheMap.insert(url, filePath);

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -40,7 +40,6 @@ WbNetwork *WbNetwork::instance() {
 
 WbNetwork::WbNetwork() {
   mNetworkAccessManager = NULL;
-  mCacheMap.clear();
 
   // delete previous caching system folder (< R2022b)
   QDir oldCache(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/network/");

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -104,7 +104,7 @@ void WbNetwork::setProxy() {
 }
 
 void WbNetwork::save(const QString &url, const QByteArray &content) {
-  if (!isCached(url)) {
+  if (!isCachedWithMapUpdate(url)) {
     // save to file
     const QString path(WbStandardPaths::cachedAssetsPath() + urlToHash(url));
     QFile file(path);
@@ -127,7 +127,7 @@ const QString &WbNetwork::get(const QString &url) {
   return mCacheMap[url];
 }
 
-bool WbNetwork::isCached(const QString &url) {
+bool WbNetwork::isCachedWithMapUpdate(const QString &url) {
   if (mCacheMap.contains(url))  // avoid checking for file existence (and computing hash again) if asset is known to be cached
     return true;
 
@@ -137,6 +137,18 @@ bool WbNetwork::isCached(const QString &url) {
     mCacheMap.insert(url, filePath);  // knowing it exists, keep track of it in case it gets asked again
     return true;
   }
+
+  return false;
+}
+
+bool WbNetwork::isCachedNoMapUpdate(const QString &url) const {
+  if (mCacheMap.contains(url))  // avoid checking for file existence (and computing hash again) if asset is known to be cached
+    return true;
+
+  // if URL is not in the internal representation, check for file existence on disk
+  const QString filePath = WbStandardPaths::cachedAssetsPath() + urlToHash(url);
+  if (QFileInfo(filePath).exists())
+    return true;
 
   return false;
 }

--- a/src/webots/core/WbNetwork.cpp
+++ b/src/webots/core/WbNetwork.cpp
@@ -28,10 +28,6 @@
 
 static WbNetwork *gInstance = NULL;
 
-// gCacheMap is an ephemeral (internal) representation of what is known about the cache at every session, as such it isn't
-// persistent nor is it ever complete. Its purpose is to speed up checking and retrieving previously referenced assets.
-static QMap<QString, QString> gCacheMap;
-
 void WbNetwork::cleanup() {
   delete gInstance;
 }
@@ -44,7 +40,7 @@ WbNetwork *WbNetwork::instance() {
 
 WbNetwork::WbNetwork() {
   mNetworkAccessManager = NULL;
-  gCacheMap.clear();
+  mCacheMap.clear();
 
   // delete previous caching system folder (< R2022b)
   QDir oldCache(QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/network/");
@@ -118,28 +114,28 @@ void WbNetwork::save(const QString &url, const QByteArray &content) {
       mCacheSizeInBytes += file.size();
       file.close();
       // save reference in internal representation
-      gCacheMap.insert(url, path);
+      mCacheMap.insert(url, path);
     }
   }
 }
 
-const QString &WbNetwork::get(const QString &url) {
-  if (!gCacheMap.contains(url)) {
+const QString WbNetwork::get(const QString &url) {
+  if (!mCacheMap.contains(url)) {
     const QString filePath = WbStandardPaths::cachedAssetsPath() + urlToHash(url);
-    gCacheMap.insert(url, filePath);
+    mCacheMap.insert(url, filePath);
     assert(QFileInfo(filePath).exists());  // the 'get' function should not be called unless we know that the file is cached
   }
-  return gCacheMap[url];
+  return mCacheMap[url];
 }
 
 bool WbNetwork::isCached(const QString &url) {
-  if (gCacheMap.contains(url))  // avoid checking for file existence (and computing hash again) if asset is known to be cached
+  if (mCacheMap.contains(url))  // avoid checking for file existence (and computing hash again) if asset is known to be cached
     return true;
 
   // if URL is not in the internal representation, check for file existence on disk
   const QString filePath = WbStandardPaths::cachedAssetsPath() + urlToHash(url);
   if (QFileInfo(filePath).exists()) {
-    gCacheMap.insert(url, filePath);  // knowing it exists, keep track of it in case it gets asked again
+    mCacheMap.insert(url, filePath);  // knowing it exists, keep track of it in case it gets asked again
     return true;
   }
 
@@ -173,8 +169,8 @@ void WbNetwork::reduceCacheUsage() {
     QDir().remove(fi.absoluteFilePath());  // remove the file from disk
 
     // find key (url) corresponding to path, and remove it from the internal representation
-    const QString key = gCacheMap.key(fi.absoluteFilePath());
-    gCacheMap.remove(key);
+    const QString key = mCacheMap.key(fi.absoluteFilePath());
+    mCacheMap.remove(key);
 
     mCacheSizeInBytes -= fi.size();
   }
@@ -193,7 +189,7 @@ void WbNetwork::clearCache() {
   }
 
   mCacheSizeInBytes = 0;
-  gCacheMap.clear();
+  mCacheMap.clear();
 }
 
 void WbNetwork::recomputeCacheSize() {
@@ -206,7 +202,7 @@ void WbNetwork::recomputeCacheSize() {
   }
 }
 
-const QString WbNetwork::getUrlFromEphemeralCache(const QString &cachePath) {
-  assert(gCacheMap.values().contains(cachePath));  // should not attempt to get the URL from the hash unless it's available
-  return gCacheMap.key(cachePath);
+const QString WbNetwork::getUrlFromEphemeralCache(const QString &cachePath) const {
+  assert(mCacheMap.values().contains(cachePath));  // should not attempt to get the URL from the hash unless it's available
+  return mCacheMap.key(cachePath);
 }

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -25,15 +25,15 @@ public:
   QNetworkAccessManager *networkAccessManager();
   void setProxy();
 
-  static bool isCached(const QString &url);
-  static const QString &get(const QString &url);
+  bool isCached(const QString &url);
+  const QString get(const QString &url);
   void clearCache();
   void save(const QString &url, const QByteArray &content);
 
   qint64 cacheSize() const { return mCacheSizeInBytes; };
   void reduceCacheUsage();
 
-  static const QString getUrlFromEphemeralCache(const QString &cachePath);
+  const QString getUrlFromEphemeralCache(const QString &cachePath) const;
 
 private:
   static void cleanup();
@@ -43,7 +43,11 @@ private:
   void recomputeCacheSize();
   static bool lastReadLessThan(QFileInfo &f1, QFileInfo &f2);
 
-  static const QString urlToHash(const QString &url);
+  const QString urlToHash(const QString &url);
+
+  // mCacheMap is an ephemeral (internal) representation of what is known about the cache at every session, as such it isn't
+  // persistent nor is it ever complete. Its purpose is to speed up checking and retrieving previously referenced assets.
+  QMap<QString, QString> mCacheMap;
 
   qint64 mCacheSizeInBytes;
 

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -43,7 +43,7 @@ private:
   void recomputeCacheSize();
   static bool lastReadLessThan(QFileInfo &f1, QFileInfo &f2);
 
-  const QString urlToHash(const QString &url);
+  static const QString urlToHash(const QString &url);
 
   // mCacheMap is an ephemeral (internal) representation of what is known about the cache at every session, as such it isn't
   // persistent nor is it ever complete. Its purpose is to speed up checking and retrieving previously referenced assets.

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -25,9 +25,11 @@ public:
   QNetworkAccessManager *networkAccessManager();
   void setProxy();
 
+  // check the file in the cache and add it to the internal representation. Outside of the assets, this function should be used
+  // above isCachedNoMapUpdate().
   bool isCachedWithMapUpdate(const QString &url);
-  // check the file in the cache without adding it to the internal representation. This is useful for assertions that
-  // should not have side effects.
+  // check the file in the cache without adding it to the internal representation. This one should only be used in assertions
+  // because they cannot have side effects.
   bool isCachedNoMapUpdate(const QString &url) const;
   const QString &get(const QString &url);
   void clearCache();

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -26,7 +26,7 @@ public:
   void setProxy();
 
   bool isCached(const QString &url);
-  const QString get(const QString &url);
+  const QString &get(const QString &url);
   void clearCache();
   void save(const QString &url, const QByteArray &content);
 

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -25,7 +25,10 @@ public:
   QNetworkAccessManager *networkAccessManager();
   void setProxy();
 
-  bool isCached(const QString &url);
+  bool isCachedWithMapUpdate(const QString &url);
+  // check the file in the cache without adding it to the internal representation. This is useful for assertions that
+  // should not have side effects.
+  bool isCachedNoMapUpdate(const QString &url) const;
   const QString &get(const QString &url);
   void clearCache();
   void save(const QString &url, const QByteArray &content);

--- a/src/webots/core/WbNetwork.hpp
+++ b/src/webots/core/WbNetwork.hpp
@@ -25,11 +25,9 @@ public:
   QNetworkAccessManager *networkAccessManager();
   void setProxy();
 
-  // check the file in the cache and add it to the internal representation. Outside of the assets, this function should be used
-  // above isCachedNoMapUpdate().
+  // check the file in the cache and add it to the internal representation (don't use it in asserts, but everywhere else).
   bool isCachedWithMapUpdate(const QString &url);
-  // check the file in the cache without adding it to the internal representation. This one should only be used in assertions
-  // because they cannot have side effects.
+  // check the file in the cache without adding it to the internal representation (for use in asserts, no side effect).
   bool isCachedNoMapUpdate(const QString &url) const;
   const QString &get(const QString &url);
   void clearCache();

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2277,7 +2277,7 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
 
   QString fileToOpen(fileName);
   QString title;
-  if (WbUrl::isWeb(fileName) && WbNetwork::instance()->isCached(fileName)) {
+  if (WbUrl::isWeb(fileName) && WbNetwork::instance()->isCachedWithMapUpdate(fileName)) {
     const QString &protoFilePath = WbNetwork::instance()->get(fileName);
     const QString protoFileName(QFileInfo(fileName).fileName());
     if (modify && protoFileName.endsWith(".proto", Qt::CaseInsensitive)) {

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2277,8 +2277,8 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
 
   QString fileToOpen(fileName);
   QString title;
-  if (WbUrl::isWeb(fileName) && WbNetwork::isCached(fileName)) {
-    const QString &protoFilePath = WbNetwork::get(fileName);
+  if (WbUrl::isWeb(fileName) && WbNetwork::instance()->isCached(fileName)) {
+    const QString &protoFilePath = WbNetwork::instance()->get(fileName);
     const QString protoFileName(QFileInfo(fileName).fileName());
     if (modify && protoFileName.endsWith(".proto", Qt::CaseInsensitive)) {
       if (WbMessageBox::question(

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -205,9 +205,9 @@ void WbBackground::downloadAsset(const QString &url, int index, bool postpone) {
 
 void WbBackground::downloadAssets() {
   for (int i = 0; i < 6; ++i) {
-    if (mUrlFields[i]->size() && !WbNetwork::instance()->isCached(mUrlFields[i]->item(0)))
+    if (mUrlFields[i]->size() && !WbNetwork::instance()->isCachedWithMapUpdate(mUrlFields[i]->item(0)))
       downloadAsset(mUrlFields[i]->item(0), i, false);
-    if (mIrradianceUrlFields[i]->size() && !WbNetwork::instance()->isCached(mIrradianceUrlFields[i]->item(0)))
+    if (mIrradianceUrlFields[i]->size() && !WbNetwork::instance()->isCachedWithMapUpdate(mIrradianceUrlFields[i]->item(0)))
       downloadAsset(mIrradianceUrlFields[i]->item(0), i + 6, false);
   }
 }
@@ -337,7 +337,7 @@ void WbBackground::updateCubemap() {
       for (int i = 0; i < 6; i++) {
         if (hasCompleteBackground) {
           const QString &completeUrl = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && mDownloader[i] == NULL) {
             downloadAsset(completeUrl, i, true);
             postpone = true;
           } else {
@@ -347,7 +347,7 @@ void WbBackground::updateCubemap() {
         }
         if (mIrradianceUrlFields[i]->size() > 0) {
           const QString &completeUrl = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i + 6] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && mDownloader[i + 6] == NULL) {
             downloadAsset(completeUrl, i + 6, true);
             postpone = true;
           } else {
@@ -432,7 +432,7 @@ bool WbBackground::loadTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::instance()->isCached(url))
+    if (WbNetwork::instance()->isCachedWithMapUpdate(url))
       url = WbNetwork::instance()->get(url);  // get reference to the corresponding file in the cache
     else {
       if (mDownloader[i] && !mDownloader[i]->error().isEmpty())
@@ -520,7 +520,7 @@ bool WbBackground::loadIrradianceTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::instance()->isCached(url))
+    if (WbNetwork::instance()->isCachedWithMapUpdate(url))
       url = WbNetwork::instance()->get(url);
     else {
       if (mDownloader[i + 6] && !mDownloader[i + 6]->error().isEmpty())

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -205,9 +205,9 @@ void WbBackground::downloadAsset(const QString &url, int index, bool postpone) {
 
 void WbBackground::downloadAssets() {
   for (int i = 0; i < 6; ++i) {
-    if (mUrlFields[i]->size() && !WbNetwork::isCached(mUrlFields[i]->item(0)))
+    if (mUrlFields[i]->size() && !WbNetwork::instance()->isCached(mUrlFields[i]->item(0)))
       downloadAsset(mUrlFields[i]->item(0), i, false);
-    if (mIrradianceUrlFields[i]->size() && !WbNetwork::isCached(mIrradianceUrlFields[i]->item(0)))
+    if (mIrradianceUrlFields[i]->size() && !WbNetwork::instance()->isCached(mIrradianceUrlFields[i]->item(0)))
       downloadAsset(mIrradianceUrlFields[i]->item(0), i + 6, false);
   }
 }
@@ -337,7 +337,7 @@ void WbBackground::updateCubemap() {
       for (int i = 0; i < 6; i++) {
         if (hasCompleteBackground) {
           const QString &completeUrl = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl) && mDownloader[i] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i] == NULL) {
             downloadAsset(completeUrl, i, true);
             postpone = true;
           } else {
@@ -347,7 +347,7 @@ void WbBackground::updateCubemap() {
         }
         if (mIrradianceUrlFields[i]->size() > 0) {
           const QString &completeUrl = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl) && mDownloader[i + 6] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl) && mDownloader[i + 6] == NULL) {
             downloadAsset(completeUrl, i + 6, true);
             postpone = true;
           } else {
@@ -432,8 +432,8 @@ bool WbBackground::loadTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::isCached(url))
-      url = WbNetwork::get(url);  // get reference to the corresponding file in the cache
+    if (WbNetwork::instance()->isCached(url))
+      url = WbNetwork::instance()->get(url);  // get reference to the corresponding file in the cache
     else {
       if (mDownloader[i] && !mDownloader[i]->error().isEmpty())
         warn(mDownloader[i]->error());
@@ -520,8 +520,8 @@ bool WbBackground::loadIrradianceTexture(int i) {
   }
 
   if (WbUrl::isWeb(url)) {
-    if (WbNetwork::isCached(url))
-      url = WbNetwork::get(url);
+    if (WbNetwork::instance()->isCached(url))
+      url = WbNetwork::instance()->get(url);
     else {
       if (mDownloader[i + 6] && !mDownloader[i + 6]->error().isEmpty())
         warn(mDownloader[i + 6]->error());

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -337,7 +337,8 @@ void WbBackground::updateCubemap() {
       for (int i = 0; i < 6; i++) {
         if (hasCompleteBackground) {
           const QString &completeUrl = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && mDownloader[i] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) &&
+              mDownloader[i] == NULL) {
             downloadAsset(completeUrl, i, true);
             postpone = true;
           } else {
@@ -347,7 +348,8 @@ void WbBackground::updateCubemap() {
         }
         if (mIrradianceUrlFields[i]->size() > 0) {
           const QString &completeUrl = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
-          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && mDownloader[i + 6] == NULL) {
+          if (WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) &&
+              mDownloader[i + 6] == NULL) {
             downloadAsset(completeUrl, i + 6, true);
             postpone = true;
           } else {

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -88,7 +88,8 @@ void WbCadShape::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || (WbNetwork::instance()->isCached(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
+  if (!WbUrl::isWeb(completeUrl) ||
+      (WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -210,7 +211,7 @@ void WbCadShape::updateUrl() {
       return;
     }
 
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       if (mDownloader && mDownloader->hasFinished()) {
         delete mDownloader;
         mDownloader = NULL;
@@ -230,7 +231,7 @@ void WbCadShape::updateUrl() {
       QStringList rawMaterials = objMaterialList(completeUrl);
       foreach (QString material, rawMaterials) {
         QString adjustedUrl = WbUrl::combinePaths(material, completeUrl);
-        assert(WbNetwork::instance()->isCached(adjustedUrl));
+        assert(WbNetwork::instance()->isCachedNoMapUpdate(adjustedUrl));
         if (!mObjMaterials.contains(material))
           mObjMaterials.insert(material, adjustedUrl);
       }
@@ -246,7 +247,7 @@ void WbCadShape::updateUrl() {
 bool WbCadShape::areMaterialAssetsAvailable(const QString &url) {
   QStringList rawMaterials = objMaterialList(url);  // note: 'dae' files will generate an empty list
   foreach (QString material, rawMaterials) {
-    if (!WbNetwork::instance()->isCached(WbUrl::combinePaths(material, url)))
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(WbUrl::combinePaths(material, url)))
       return false;
   }
   return true;
@@ -259,7 +260,7 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
 
   QStringList materials;
   QFile objFile;
-  if (WbNetwork::instance()->isCached(url))
+  if (WbNetwork::instance()->isCachedWithMapUpdate(url))
     objFile.setFileName(WbNetwork::instance()->get(url));
   else  // local file
     objFile.setFileName(url);
@@ -336,7 +337,7 @@ void WbCadShape::createWrenObjects() {
   }
 
   if (WbUrl::isWeb(completeUrl)) {
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -88,7 +88,7 @@ void WbCadShape::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || (WbNetwork::isCached(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
+  if (!WbUrl::isWeb(completeUrl) || (WbNetwork::instance()->isCached(completeUrl) && areMaterialAssetsAvailable(completeUrl)))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -210,7 +210,7 @@ void WbCadShape::updateUrl() {
       return;
     }
 
-    if (!WbNetwork::isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCached(completeUrl)) {
       if (mDownloader && mDownloader->hasFinished()) {
         delete mDownloader;
         mDownloader = NULL;
@@ -230,7 +230,7 @@ void WbCadShape::updateUrl() {
       QStringList rawMaterials = objMaterialList(completeUrl);
       foreach (QString material, rawMaterials) {
         QString adjustedUrl = WbUrl::combinePaths(material, completeUrl);
-        assert(WbNetwork::isCached(adjustedUrl));
+        assert(WbNetwork::instance()->isCached(adjustedUrl));
         if (!mObjMaterials.contains(material))
           mObjMaterials.insert(material, adjustedUrl);
       }
@@ -246,7 +246,7 @@ void WbCadShape::updateUrl() {
 bool WbCadShape::areMaterialAssetsAvailable(const QString &url) {
   QStringList rawMaterials = objMaterialList(url);  // note: 'dae' files will generate an empty list
   foreach (QString material, rawMaterials) {
-    if (!WbNetwork::isCached(WbUrl::combinePaths(material, url)))
+    if (!WbNetwork::instance()->isCached(WbUrl::combinePaths(material, url)))
       return false;
   }
   return true;
@@ -259,8 +259,8 @@ QStringList WbCadShape::objMaterialList(const QString &url) const {
 
   QStringList materials;
   QFile objFile;
-  if (WbNetwork::isCached(url))
-    objFile.setFileName(WbNetwork::get(url));
+  if (WbNetwork::instance()->isCached(url))
+    objFile.setFileName(WbNetwork::instance()->get(url));
   else  // local file
     objFile.setFileName(url);
   if (objFile.open(QIODevice::ReadOnly)) {
@@ -336,13 +336,13 @@ void WbCadShape::createWrenObjects() {
   }
 
   if (WbUrl::isWeb(completeUrl)) {
-    if (!WbNetwork::isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCached(completeUrl)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;
     }
 
-    QFile file(WbNetwork::get(completeUrl));
+    QFile file(WbNetwork::instance()->get(completeUrl));
     if (!file.open(QIODevice::ReadOnly)) {
       warn(tr("File could not be read: '%1'").arg(completeUrl));
       return;
@@ -354,7 +354,7 @@ void WbCadShape::createWrenObjects() {
       QMapIterator<QString, QString> it(mObjMaterials);
       while (it.hasNext()) {
         it.next();
-        data.replace(it.key().toUtf8(), WbNetwork::get(it.value()).toUtf8());
+        data.replace(it.key().toUtf8(), WbNetwork::instance()->get(it.value()).toUtf8());
       }
     }
 

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -162,7 +162,7 @@ void WbCamera::downloadAssets() {
   const QString &noiseMaskUrl = mNoiseMaskUrl->value();
   if (!noiseMaskUrl.isEmpty()) {  // noise mask not mandatory, URL can be empty
     const QString completeUrl = WbUrl::computePath(this, "noiseMaskUrl", noiseMaskUrl);
-    if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+    if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
       return;
 
     if (mDownloader != NULL)
@@ -1146,7 +1146,7 @@ void WbCamera::updateNoiseMaskUrl() {
       return;
     }
 
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       downloadAssets();  // URL was changed from the scene tree or supervisor
       return;
     }

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -162,7 +162,7 @@ void WbCamera::downloadAssets() {
   const QString &noiseMaskUrl = mNoiseMaskUrl->value();
   if (!noiseMaskUrl.isEmpty()) {  // noise mask not mandatory, URL can be empty
     const QString completeUrl = WbUrl::computePath(this, "noiseMaskUrl", noiseMaskUrl);
-    if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
+    if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
       return;
 
     if (mDownloader != NULL)
@@ -1146,12 +1146,12 @@ void WbCamera::updateNoiseMaskUrl() {
       return;
     }
 
-    if (!WbNetwork::isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCached(completeUrl)) {
       downloadAssets();  // URL was changed from the scene tree or supervisor
       return;
     }
 
-    noiseMaskPath = WbNetwork::get(completeUrl);
+    noiseMaskPath = WbNetwork::instance()->get(completeUrl);
   } else
     noiseMaskPath = completeUrl;
 

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -65,7 +65,7 @@ void WbContactProperties::downloadAsset(const QString &url, int index) {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, gUrlNames[index], url);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 
   if (mDownloader[index] != NULL)
@@ -230,7 +230,7 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
       mDownloader[index] = NULL;
       return;
     }
-    if (!WbNetwork::isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCached(completeUrl)) {
       downloadAsset(completeUrl, index);  // changed by supervisor
       return;
     }
@@ -241,8 +241,8 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
   const QString extension = sound.mid(sound.lastIndexOf('.') + 1).toLower();
 
   if (WbUrl::isWeb(completeUrl)) {
-    assert(WbNetwork::isCached(completeUrl));  // by this point, the asset should be cached
-    *clip = WbSoundEngine::sound(WbNetwork::get(completeUrl), extension);
+    assert(WbNetwork::instance()->isCached(completeUrl));  // by this point, the asset should be cached
+    *clip = WbSoundEngine::sound(WbNetwork::instance()->get(completeUrl), extension);
   } else
     *clip = WbSoundEngine::sound(WbUrl::computePath(this, name, completeUrl), extension);
 }

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -65,7 +65,7 @@ void WbContactProperties::downloadAsset(const QString &url, int index) {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, gUrlNames[index], url);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
     return;
 
   if (mDownloader[index] != NULL)
@@ -230,7 +230,7 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
       mDownloader[index] = NULL;
       return;
     }
-    if (!WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       downloadAsset(completeUrl, index);  // changed by supervisor
       return;
     }
@@ -241,7 +241,7 @@ void WbContactProperties::loadSound(int index, const QString &sound, const QStri
   const QString extension = sound.mid(sound.lastIndexOf('.') + 1).toLower();
 
   if (WbUrl::isWeb(completeUrl)) {
-    assert(WbNetwork::instance()->isCached(completeUrl));  // by this point, the asset should be cached
+    assert(WbNetwork::instance()->isCachedNoMapUpdate(completeUrl));  // by this point, the asset should be cached
     *clip = WbSoundEngine::sound(WbNetwork::instance()->get(completeUrl), extension);
   } else
     *clip = WbSoundEngine::sound(WbUrl::computePath(this, name, completeUrl), extension);

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -118,7 +118,7 @@ void WbImageTexture::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 
   if (mDownloader && mDownloader->hasFinished())
@@ -161,10 +161,10 @@ void WbImageTexture::postFinalize() {
 bool WbImageTexture::loadTexture() {
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
   const bool isWebAsset = WbUrl::isWeb(completeUrl);
-  if (isWebAsset && !WbNetwork::isCached(completeUrl))
+  if (isWebAsset && !WbNetwork::instance()->isCached(completeUrl))
     return false;
 
-  const QString filePath = isWebAsset ? WbNetwork::get(completeUrl) : path();
+  const QString filePath = isWebAsset ? WbNetwork::instance()->get(completeUrl) : path();
   QFile file(filePath);
   if (!file.open(QIODevice::ReadOnly)) {
     warn(tr("Texture file could not be read: '%1'").arg(filePath));
@@ -345,7 +345,7 @@ void WbImageTexture::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::isCached(completeUrl) && mDownloader == NULL) {
+      if (!WbNetwork::instance()->isCached(completeUrl) && mDownloader == NULL) {
         downloadAssets();  // URL was changed from the scene tree or supervisor
         return;
       }

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -118,7 +118,7 @@ void WbImageTexture::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
     return;
 
   if (mDownloader && mDownloader->hasFinished())
@@ -161,7 +161,7 @@ void WbImageTexture::postFinalize() {
 bool WbImageTexture::loadTexture() {
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl->item(0));
   const bool isWebAsset = WbUrl::isWeb(completeUrl);
-  if (isWebAsset && !WbNetwork::instance()->isCached(completeUrl))
+  if (isWebAsset && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
     return false;
 
   const QString filePath = isWebAsset ? WbNetwork::instance()->get(completeUrl) : path();
@@ -345,7 +345,7 @@ void WbImageTexture::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::instance()->isCached(completeUrl) && mDownloader == NULL) {
+      if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl) && mDownloader == NULL) {
         downloadAssets();  // URL was changed from the scene tree or supervisor
         return;
       }

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -66,7 +66,7 @@ void WbMesh::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -143,7 +143,7 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                        aiProcess_FlipUVs;
 
   if (WbUrl::isWeb(filePath)) {
-    if (!WbNetwork::instance()->isCached(filePath)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(filePath)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;
@@ -329,7 +329,7 @@ void WbMesh::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::instance()->isCached(completeUrl)) {
+      if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
         if (mDownloader && mDownloader->hasFinished()) {
           delete mDownloader;
           mDownloader = NULL;

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -66,7 +66,7 @@ void WbMesh::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 
   if (mDownloader != NULL && mDownloader->hasFinished())
@@ -143,13 +143,13 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
                        aiProcess_FlipUVs;
 
   if (WbUrl::isWeb(filePath)) {
-    if (!WbNetwork::isCached(filePath)) {
+    if (!WbNetwork::instance()->isCached(filePath)) {
       if (mDownloader == NULL)  // never attempted to download it, try now
         downloadAssets();
       return;
     }
 
-    QFile file(WbNetwork::get(filePath));
+    QFile file(WbNetwork::instance()->get(filePath));
     if (!file.open(QIODevice::ReadOnly)) {
       warn(tr("Mesh file could not be read: '%1'").arg(filePath));
       return;
@@ -329,7 +329,7 @@ void WbMesh::updateUrl() {
         return;
       }
 
-      if (!WbNetwork::isCached(completeUrl)) {
+      if (!WbNetwork::instance()->isCached(completeUrl)) {
         if (mDownloader && mDownloader->hasFinished()) {
           delete mDownloader;
           mDownloader = NULL;

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -104,7 +104,7 @@ void WbMotor::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "sound", soundString);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCachedWithMapUpdate(completeUrl))
     return;
 
   if (mDownloader != NULL)
@@ -302,7 +302,7 @@ void WbMotor::updateSound() {
         mDownloader = NULL;
         return;
       }
-      if (!WbNetwork::instance()->isCached(completeUrl)) {
+      if (!WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
         downloadAssets();
         return;
       }

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -104,7 +104,7 @@ void WbMotor::downloadAssets() {
     return;
 
   const QString &completeUrl = WbUrl::computePath(this, "sound", soundString);
-  if (!WbUrl::isWeb(completeUrl) || WbNetwork::isCached(completeUrl))
+  if (!WbUrl::isWeb(completeUrl) || WbNetwork::instance()->isCached(completeUrl))
     return;
 
   if (mDownloader != NULL)
@@ -302,7 +302,7 @@ void WbMotor::updateSound() {
         mDownloader = NULL;
         return;
       }
-      if (!WbNetwork::isCached(completeUrl)) {
+      if (!WbNetwork::instance()->isCached(completeUrl)) {
         downloadAssets();
         return;
       }
@@ -312,7 +312,7 @@ void WbMotor::updateSound() {
     // determine extension from URL since for remotely defined assets the cached version does not retain this information
     const QString extension = completeUrl.mid(completeUrl.lastIndexOf('.') + 1).toLower();
     if (WbUrl::isWeb(completeUrl))
-      mSoundClip = WbSoundEngine::sound(WbNetwork::get(completeUrl), extension);
+      mSoundClip = WbSoundEngine::sound(WbNetwork::instance()->get(completeUrl), extension);
     else
       mSoundClip = WbSoundEngine::sound(completeUrl, extension);
   }

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -259,7 +259,7 @@ void WbSkin::updateModelUrl() {
     }
 
     const QString &completeUrl = WbUrl::computePath(this, "modelUrl", mModelUrl->value());
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::isCached(completeUrl)) {
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl)) {
       // URL was changed from the scene tree or supervisor
       downloadAssets();
       mIsModelUrlValid = true;
@@ -497,8 +497,8 @@ void WbSkin::createWrenSkeleton() {
   int count;
   const char *error;
   if (WbUrl::isWeb(meshFilePath)) {
-    if (WbNetwork::isCached(meshFilePath)) {
-      QFile file(WbNetwork::get(meshFilePath));
+    if (WbNetwork::instance()->isCached(meshFilePath)) {
+      QFile file(WbNetwork::instance()->get(meshFilePath));
       if (!file.open(QIODevice::ReadOnly))
         return;
       const QByteArray &data = file.readAll();

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -259,7 +259,8 @@ void WbSkin::updateModelUrl() {
     }
 
     const QString &completeUrl = WbUrl::computePath(this, "modelUrl", mModelUrl->value());
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) &&
+        !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       // URL was changed from the scene tree or supervisor
       downloadAssets();
       mIsModelUrlValid = true;

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -259,7 +259,7 @@ void WbSkin::updateModelUrl() {
     }
 
     const QString &completeUrl = WbUrl::computePath(this, "modelUrl", mModelUrl->value());
-    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCached(completeUrl)) {
+    if (!WbWorld::instance()->isLoading() && WbUrl::isWeb(completeUrl) && !WbNetwork::instance()->isCachedWithMapUpdate(completeUrl)) {
       // URL was changed from the scene tree or supervisor
       downloadAssets();
       mIsModelUrlValid = true;
@@ -497,7 +497,7 @@ void WbSkin::createWrenSkeleton() {
   int count;
   const char *error;
   if (WbUrl::isWeb(meshFilePath)) {
-    if (WbNetwork::instance()->isCached(meshFilePath)) {
+    if (WbNetwork::instance()->isCachedWithMapUpdate(meshFilePath)) {
       QFile file(WbNetwork::instance()->get(meshFilePath));
       if (!file.open(QIODevice::ReadOnly))
         return;

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -406,7 +406,7 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
   mPixmapLabel->hide();
   if (!pixmapPath.isEmpty()) {
     if (WbUrl::isWeb(pixmapPath)) {
-      if (WbNetwork::instance()->isCached(pixmapPath))
+      if (WbNetwork::instance()->isCachedWithMapUpdate(pixmapPath))
         pixmapPath = WbNetwork::instance()->get(pixmapPath);
       else {
         downloadIcon(pixmapPath);
@@ -713,7 +713,7 @@ void WbAddNodeDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::instance()->isCached(mSelectionPath)) {
+  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::instance()->isCachedWithMapUpdate(mSelectionPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.")
                    .arg(QUrl(mSelectionPath).fileName()));
     QDialog::reject();

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -198,7 +198,7 @@ void WbAddNodeDialog::iconUpdate() {
     // failure downloading or file does not exist (404)
     pixmapPath = WbUrl::missingProtoIcon();
   } else {
-    pixmapPath = WbNetwork::get(source->url().toString());
+    pixmapPath = WbNetwork::instance()->get(source->url().toString());
   }
 
   QPixmap pixmap(pixmapPath);
@@ -406,8 +406,8 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
   mPixmapLabel->hide();
   if (!pixmapPath.isEmpty()) {
     if (WbUrl::isWeb(pixmapPath)) {
-      if (WbNetwork::isCached(pixmapPath))
-        pixmapPath = WbNetwork::get(pixmapPath);
+      if (WbNetwork::instance()->isCached(pixmapPath))
+        pixmapPath = WbNetwork::instance()->get(pixmapPath);
       else {
         downloadIcon(pixmapPath);
         return;
@@ -502,7 +502,7 @@ void WbAddNodeDialog::buildTree() {
       if (!WbNodeModel::isBaseModelName(currentModelName)) {
         nodeFilePath = WbProtoManager::instance()->externProtoUrl(defNode);
         if (WbUrl::isWeb(nodeFilePath))
-          nodeFilePath = WbNetwork::get(nodeFilePath);
+          nodeFilePath = WbNetwork::instance()->get(nodeFilePath);
       }
       QStringList strl(QStringList() << currentFullDefName << nodeFilePath);
 
@@ -713,7 +713,7 @@ void WbAddNodeDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::isCached(mSelectionPath)) {
+  if (WbUrl::isWeb(mSelectionPath) && !WbNetwork::instance()->isCached(mSelectionPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.")
                    .arg(QUrl(mSelectionPath).fileName()));
     QDialog::reject();

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -193,7 +193,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mPath) && !WbNetwork::isCached(mPath)) {
+  if (WbUrl::isWeb(mPath) && !WbNetwork::instance()->isCached(mPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.").arg(mProto));
     QDialog::reject();
   }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -193,7 +193,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // this point should only be reached after the retrieval and therefore from this point the PROTO must be available locally
-  if (WbUrl::isWeb(mPath) && !WbNetwork::instance()->isCached(mPath)) {
+  if (WbUrl::isWeb(mPath) && !WbNetwork::instance()->isCachedWithMapUpdate(mPath)) {
     WbLog::error(tr("Retrieval of PROTO '%1' was unsuccessful, the asset should be cached but it is not.").arg(mProto));
     QDialog::reject();
   }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1136,7 +1136,7 @@ void WbSceneTree::updateSelection() {
   if (mSelectedItem->node() && mSelectedItem->node()->isProtoInstance()) {
     WbContextMenuGenerator::enableProtoActions(true);
     const QString &url = mSelectedItem->node()->proto()->url();
-    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::instance()->isCached(url));
+    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::instance()->isCachedWithMapUpdate(url));
   } else {
     WbContextMenuGenerator::enableProtoActions(false);
     WbContextMenuGenerator::enableExternProtoActions(false);

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1136,7 +1136,7 @@ void WbSceneTree::updateSelection() {
   if (mSelectedItem->node() && mSelectedItem->node()->isProtoInstance()) {
     WbContextMenuGenerator::enableProtoActions(true);
     const QString &url = mSelectedItem->node()->proto()->url();
-    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::isCached(url));
+    WbContextMenuGenerator::enableExternProtoActions(WbUrl::isWeb(url) && WbNetwork::instance()->isCached(url));
   } else {
     WbContextMenuGenerator::enableProtoActions(false);
     WbContextMenuGenerator::enableExternProtoActions(false);

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1220,8 +1220,9 @@ void WbNode::exportExternalSubProto(WbWriter &writer) const {
 }
 
 void WbNode::addExternProtoFromFile(const WbProtoModel *proto, WbWriter &writer) const {
-  const QString path =
-    (WbUrl::isWeb(proto->url()) && WbNetwork::isCached(proto->url())) ? WbNetwork::get(proto->url()) : proto->url();
+  const QString path = (WbUrl::isWeb(proto->url()) && WbNetwork::instance()->isCached(proto->url())) ?
+                         WbNetwork::instance()->get(proto->url()) :
+                         proto->url();
 
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly)) {

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1220,7 +1220,7 @@ void WbNode::exportExternalSubProto(WbWriter &writer) const {
 }
 
 void WbNode::addExternProtoFromFile(const WbProtoModel *proto, WbWriter &writer) const {
-  const QString path = (WbUrl::isWeb(proto->url()) && WbNetwork::instance()->isCached(proto->url())) ?
+  const QString path = (WbUrl::isWeb(proto->url()) && WbNetwork::instance()->isCachedWithMapUpdate(proto->url())) ?
                          WbNetwork::instance()->get(proto->url()) :
                          proto->url();
 

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -73,7 +73,7 @@ WbProtoManager::~WbProtoManager() {
 WbProtoModel *WbProtoManager::readModel(const QString &url, const QString &worldPath, const QString &prefix,
                                         const QStringList &baseTypeList) const {
   WbTokenizer tokenizer;
-  const QString path = WbUrl::isWeb(url) ? WbNetwork::get(url) : url;
+  const QString path = WbUrl::isWeb(url) ? WbNetwork::instance()->get(url) : url;
   int errors = tokenizer.tokenize(path, prefix);
   if (errors > 0)
     return NULL;
@@ -182,7 +182,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
 
   // a PROTO declaration is provided, enforce it
   QString modelPath;  // how the PROTO is referenced
-  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::isCached(modelPath))
+  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::instance()->isCached(modelPath))
     modelPath = protoDeclaration;
   else if (WbUrl::isLocalUrl(protoDeclaration) || QDir::isRelativePath(protoDeclaration)) {
     // two possibitilies arise if the declaration is local (webots://)
@@ -208,7 +208,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
         else  // if it's a relative url, then manufacture a remote url based on the relative path and the parent's path
           modelPath = WbUrl::combinePaths(protoDeclaration, parentFile);
         // if the PROTO tree was built correctly, by definition the child must be cached already too
-        assert(WbNetwork::isCached(modelPath));
+        assert(WbNetwork::instance()->isCached(modelPath));
       } else {
         WbLog::error(tr("The cascaded URL inferring mechanism is supported only for official Webots assets."));
         return NULL;
@@ -222,7 +222,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
   }
   // determine prefix and disk location from modelPath
   const QString modelDiskPath =
-    WbUrl::isWeb(modelPath) && WbNetwork::isCached(modelPath) ? WbNetwork::get(modelPath) : modelPath;
+    WbUrl::isWeb(modelPath) && WbNetwork::instance()->isCached(modelPath) ? WbNetwork::instance()->get(modelPath) : modelPath;
   const QString prefix = WbUrl::computePrefix(modelPath);  // used to retrieve remote assets (replaces webots:// in the body)
 
   if (!modelPath.isEmpty() && QFileInfo(modelDiskPath).exists()) {
@@ -241,7 +241,7 @@ QString WbProtoManager::findExternProtoDeclarationInFile(const QString &url, con
   if (url.isEmpty())
     return QString();
 
-  QFile file(WbUrl::isWeb(url) ? WbNetwork::get(url) : url);
+  QFile file(WbUrl::isWeb(url) ? WbNetwork::instance()->get(url) : url);
   if (!file.open(QIODevice::ReadOnly)) {
     WbLog::error(tr("Could not search for EXTERNPROTO declarations in '%1' because the file is not readable.").arg(url));
     return QString();
@@ -602,8 +602,8 @@ QStringList WbProtoManager::listProtoInCategory(int category) const {
       for (int i = 0; i < mExternProto.size(); ++i) {
         QString protoPath(mExternProto[i]->url());
         // mExternProto contains raw paths, retrieve corresponding disk file
-        if (WbUrl::isWeb(protoPath) && WbNetwork::isCached(protoPath))
-          protoPath = WbNetwork::get(protoPath);
+        if (WbUrl::isWeb(protoPath) && WbNetwork::instance()->isCached(protoPath))
+          protoPath = WbNetwork::instance()->get(protoPath);
 
         protos << protoPath;
       }
@@ -927,7 +927,7 @@ QString WbProtoManager::injectDeclarationByBackwardsCompatibility(const QString 
   if (isProtoInCategory(modelName, PROTO_WEBOTS)) {
     QString url = mWebotsProtoList.value(modelName)->url();
     if (WbUrl::isWeb(url)) {
-      if (WbNetwork::isCached(url))
+      if (WbNetwork::instance()->isCached(url))
         return url;
     }
 

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -182,7 +182,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
 
   // a PROTO declaration is provided, enforce it
   QString modelPath;  // how the PROTO is referenced
-  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::instance()->isCached(modelPath))
+  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::instance()->isCachedWithMapUpdate(modelPath))
     modelPath = protoDeclaration;
   else if (WbUrl::isLocalUrl(protoDeclaration) || QDir::isRelativePath(protoDeclaration)) {
     // two possibitilies arise if the declaration is local (webots://)
@@ -208,7 +208,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
         else  // if it's a relative url, then manufacture a remote url based on the relative path and the parent's path
           modelPath = WbUrl::combinePaths(protoDeclaration, parentFile);
         // if the PROTO tree was built correctly, by definition the child must be cached already too
-        assert(WbNetwork::instance()->isCached(modelPath));
+        assert(WbNetwork::instance()->isCachedNoMapUpdate(modelPath));
       } else {
         WbLog::error(tr("The cascaded URL inferring mechanism is supported only for official Webots assets."));
         return NULL;
@@ -221,8 +221,9 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
     modelPath = WbUrl::combinePaths(protoDeclaration, parentFilePath);
   }
   // determine prefix and disk location from modelPath
-  const QString modelDiskPath =
-    WbUrl::isWeb(modelPath) && WbNetwork::instance()->isCached(modelPath) ? WbNetwork::instance()->get(modelPath) : modelPath;
+  const QString modelDiskPath = WbUrl::isWeb(modelPath) && WbNetwork::instance()->isCachedWithMapUpdate(modelPath) ?
+                                  WbNetwork::instance()->get(modelPath) :
+                                  modelPath;
   const QString prefix = WbUrl::computePrefix(modelPath);  // used to retrieve remote assets (replaces webots:// in the body)
 
   if (!modelPath.isEmpty() && QFileInfo(modelDiskPath).exists()) {
@@ -544,8 +545,8 @@ void WbProtoManager::generateProtoInfoMap(int category, bool regenerate) {
 
     QString protoInferredPath;
     QString protoName;
-    const bool isCachedProto = WbFileUtil::isLocatedInDirectory(protoPath, WbStandardPaths::cachedAssetsPath());
-    if (isCachedProto) {  // cached file, infer name from reverse lookup
+    const bool isCachedWithMapUpdateProto = WbFileUtil::isLocatedInDirectory(protoPath, WbStandardPaths::cachedAssetsPath());
+    if (isCachedWithMapUpdateProto) {  // cached file, infer name from reverse lookup
       protoInferredPath = WbNetwork::instance()->getUrlFromEphemeralCache(protoPath);
       protoName = QUrl(protoInferredPath).fileName().replace(".proto", "", Qt::CaseInsensitive);
     } else {
@@ -565,7 +566,7 @@ void WbProtoManager::generateProtoInfoMap(int category, bool regenerate) {
                                  (WbUrl::resolveUrl(protoUrl(protoName, PROTO_WEBOTS)) == WbUrl::resolveUrl(protoInferredPath));
       // for distributions, the official PROTO can be used only if it is in the cache, which is not the case in the development
       // environment
-      if (isWebotsProto && (isCachedProto || WbUrl::isLocalUrl(protoPath)))
+      if (isWebotsProto && (isCachedWithMapUpdateProto || WbUrl::isLocalUrl(protoPath)))
         // the proto is an official one, both in name and url, so copy the info from the one provided in proto-list.xml
         // note: a copy is necessary because other categories can be deleted, but the webots one can't and shouldn't
         info = new WbProtoInfo(*protoInfo(protoName, PROTO_WEBOTS));
@@ -602,7 +603,7 @@ QStringList WbProtoManager::listProtoInCategory(int category) const {
       for (int i = 0; i < mExternProto.size(); ++i) {
         QString protoPath(mExternProto[i]->url());
         // mExternProto contains raw paths, retrieve corresponding disk file
-        if (WbUrl::isWeb(protoPath) && WbNetwork::instance()->isCached(protoPath))
+        if (WbUrl::isWeb(protoPath) && WbNetwork::instance()->isCachedWithMapUpdate(protoPath))
           protoPath = WbNetwork::instance()->get(protoPath);
 
         protos << protoPath;
@@ -927,7 +928,7 @@ QString WbProtoManager::injectDeclarationByBackwardsCompatibility(const QString 
   if (isProtoInCategory(modelName, PROTO_WEBOTS)) {
     QString url = mWebotsProtoList.value(modelName)->url();
     if (WbUrl::isWeb(url)) {
-      if (WbNetwork::instance()->isCached(url))
+      if (WbNetwork::instance()->isCachedWithMapUpdate(url))
         return url;
     }
 

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -608,7 +608,7 @@ bool WbProtoModel::checkIfDocumentationPageExist(const QString &page) const {
 
 const QString WbProtoModel::diskPath() const {
   if (WbUrl::isWeb(mUrl))
-    return WbNetwork::get(mUrl);
+    return WbNetwork::instance()->get(mUrl);
 
   return mUrl;
 }

--- a/src/webots/vrml/WbProtoTreeItem.cpp
+++ b/src/webots/vrml/WbProtoTreeItem.cpp
@@ -39,7 +39,7 @@ WbProtoTreeItem::~WbProtoTreeItem() {
 
 void WbProtoTreeItem::parseItem() {
   QString path = mUrl;
-  if (WbUrl::isWeb(path) && WbNetwork::instance()->isCached(path))
+  if (WbUrl::isWeb(path) && WbNetwork::instance()->isCachedWithMapUpdate(path))
     path = WbNetwork::instance()->get(path);
 
   QFile file(path);
@@ -135,7 +135,7 @@ void WbProtoTreeItem::download() {
   }
 
   if (WbUrl::isWeb(mUrl)) {
-    if (!WbNetwork::instance()->isCached(mUrl)) {
+    if (!WbNetwork::instance()->isCachedWithMapUpdate(mUrl)) {
       mDownloader = new WbDownloader(this);
       connect(mDownloader, &WbDownloader::complete, this, &WbProtoTreeItem::downloadUpdate);
       mDownloader->download(QUrl(mUrl));
@@ -156,7 +156,7 @@ void WbProtoTreeItem::downloadUpdate() {
     return;
   }
 
-  assert(WbNetwork::instance()->isCached(mUrl));
+  assert(WbNetwork::instance()->isCachedNoMapUpdate(mUrl));
   parseItem();
 }
 

--- a/src/webots/vrml/WbProtoTreeItem.cpp
+++ b/src/webots/vrml/WbProtoTreeItem.cpp
@@ -39,8 +39,8 @@ WbProtoTreeItem::~WbProtoTreeItem() {
 
 void WbProtoTreeItem::parseItem() {
   QString path = mUrl;
-  if (WbUrl::isWeb(path) && WbNetwork::isCached(path))
-    path = WbNetwork::get(path);
+  if (WbUrl::isWeb(path) && WbNetwork::instance()->isCached(path))
+    path = WbNetwork::instance()->get(path);
 
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly)) {
@@ -135,7 +135,7 @@ void WbProtoTreeItem::download() {
   }
 
   if (WbUrl::isWeb(mUrl)) {
-    if (!WbNetwork::isCached(mUrl)) {
+    if (!WbNetwork::instance()->isCached(mUrl)) {
       mDownloader = new WbDownloader(this);
       connect(mDownloader, &WbDownloader::complete, this, &WbProtoTreeItem::downloadUpdate);
       mDownloader->download(QUrl(mUrl));
@@ -156,7 +156,7 @@ void WbProtoTreeItem::downloadUpdate() {
     return;
   }
 
-  assert(WbNetwork::isCached(mUrl));
+  assert(WbNetwork::instance()->isCached(mUrl));
   parseItem();
 }
 


### PR DESCRIPTION
The way `WbNetwork` is used is not consistent. Sometimes it is called as a singleton, sometimes not. This PR cleans up the class to get consistent use as a singleton class. 

The side effect of this inconsistency is that the value of `gCacheMap` was not the same in all calls to the `get`, `isCached` and `getUrlFromEphemeralCache` methods. This is leading to errors when loading worlds that have some PROTOs already present in the assets cache, e.g. the worlds loaded in the `world update` test of the CI (see #5087).
