### PR TITLE
Fix the switching of worlds in webotsJS

### DIFF
--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -613,10 +613,11 @@ void WbTcpServer::sendWorldToClient(QWebSocket *client) {
 
   QString worlds;
   foreach (const QFileInfo item, worldFiles)
-    worlds += QDir(WbProject::current()->dir()).relativeFilePath(item.absoluteFilePath()) + ";";
+    worlds += QDir(WbProject::current()->dir()).relativeFilePath(item.absoluteFilePath()).split('/')[1] + ";";
   worlds.chop(1);  // remove last separator
 
-  const QString &currentWorld = QDir(WbProject::current()->dir()).relativeFilePath(WbWorld::instance()->fileName());
+  const QString &currentWorld =
+    QDir(WbProject::current()->dir()).relativeFilePath(WbWorld::instance()->fileName()).split('/')[1];
   client->sendTextMessage("world:" + currentWorld + ':' + worlds);
 
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -415,7 +415,7 @@ void WbTcpServer::processTextMessage(QString message) {
       WbApplication::instance()->worldReload();
     else if (message.startsWith("load:")) {
       const QString &worldsPath = WbProject::current()->worldsPath();
-      const QString &fullPath = worldsPath + '/' + message.mid(5);
+      const QString &fullPath = worldsPath + '/' + message.mid(5).split('/').takeLast();
       if (!QFile::exists(fullPath))
         WbLog::error(tr("Streaming server: world %1 doesn't exist.").arg(fullPath));
       else if (QDir(worldsPath) != QFileInfo(fullPath).absoluteDir())
@@ -613,11 +613,10 @@ void WbTcpServer::sendWorldToClient(QWebSocket *client) {
 
   QString worlds;
   foreach (const QFileInfo item, worldFiles)
-    worlds += QDir(WbProject::current()->dir()).relativeFilePath(item.absoluteFilePath()).split('/')[1] + ";";
+    worlds += QDir(WbProject::current()->dir()).relativeFilePath(item.absoluteFilePath()) + ";";
   worlds.chop(1);  // remove last separator
 
-  const QString &currentWorld =
-    QDir(WbProject::current()->dir()).relativeFilePath(WbWorld::instance()->fileName()).split('/')[1];
+  const QString &currentWorld = QDir(WbProject::current()->dir()).relativeFilePath(WbWorld::instance()->fileName());
   client->sendTextMessage("world:" + currentWorld + ':' + worlds);
 
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();


### PR DESCRIPTION
**Description**
Due to past changes, the list of the world was not sent anymore to webotsJS as `nao_demo.wbt` for example but as `worlds/nao_demo.wbt`.

This causes a bug because when WebotsJS was sending back the name to request to switch the worlds, Webots adds the name from WebotsJS to the path of the current world which would give something like:
```
/home/benjamin/webots/projects/robots/adept/pioneer3/worlds//worlds/pioneer3dx_gripper.wbt
```
