### PR TITLE
Fix URL format when converting to base node

### DIFF
--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -692,7 +692,7 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
     WbField urlFieldCopy(*findField(gUrlNames(i), true));
     const QString &imagePath = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
     if (WbUrl::isLocalUrl(imagePath))
-      backgroundFileNames[i] = WbUrl::computeLocalAssetUrl(imagePath);
+      backgroundFileNames[i] = WbUrl::computeLocalAssetUrl(imagePath, writer.isX3d());
     else if (WbUrl::isWeb(imagePath))
       backgroundFileNames[i] = imagePath;
     else {
@@ -712,7 +712,7 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
 
     const QString &irradiancePath = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
     if (WbUrl::isLocalUrl(irradiancePath))
-      irradianceFileNames[i] = WbUrl::computeLocalAssetUrl(irradiancePath);
+      irradianceFileNames[i] = WbUrl::computeLocalAssetUrl(irradiancePath, writer.isX3d());
     else if (WbUrl::isWeb(irradiancePath))
       irradianceFileNames[i] = irradiancePath;
     else {

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -591,7 +591,7 @@ void WbCadShape::exportNodeFields(WbWriter &writer) const {
     const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, i);
     WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
     if (WbUrl::isLocalUrl(completeUrl))
-      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl));
+      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl, writer.isX3d()));
     else if (WbUrl::isWeb(completeUrl))
       urlFieldValue->setItem(i, completeUrl);
     else {
@@ -607,7 +607,7 @@ void WbCadShape::exportNodeFields(WbWriter &writer) const {
       QString materialUrl = WbUrl::combinePaths(material, parentUrl);
       WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
       if (WbUrl::isLocalUrl(materialUrl))
-        urlFieldValue->addItem(WbUrl::computeLocalAssetUrl(materialUrl));
+        urlFieldValue->addItem(WbUrl::computeLocalAssetUrl(materialUrl, writer.isX3d()));
       else if (WbUrl::isWeb(materialUrl))
         urlFieldValue->addItem(materialUrl);
       else {

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -549,7 +549,7 @@ void WbImageTexture::exportNodeFields(WbWriter &writer) const {
     QString completeUrl = WbUrl::computePath(this, "url", mUrl, i);
     WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
     if (WbUrl::isLocalUrl(completeUrl))
-      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl));
+      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl, writer.isX3d()));
     else if (WbUrl::isWeb(completeUrl))
       urlFieldValue->setItem(i, completeUrl);
     else {

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -398,7 +398,7 @@ void WbMesh::exportNodeFields(WbWriter &writer) const {
     const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, i);
     WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
     if (WbUrl::isLocalUrl(completeUrl))
-      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl));
+      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl, writer.isX3d()));
     else if (WbUrl::isWeb(completeUrl))
       urlFieldValue->setItem(i, completeUrl);
     else {

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -225,7 +225,10 @@ bool WbUrl::isLocalUrl(const QString &url) {
   return url.startsWith("webots://") || url.startsWith(WbStandardPaths::webotsHomePath());
 }
 
-const QString WbUrl::computeLocalAssetUrl(QString url) {
+const QString WbUrl::computeLocalAssetUrl(QString url, bool isX3d) {
+  if (!isX3d)
+    return url.replace(WbStandardPaths::webotsHomePath(), "webots://");
+
   if (!WbApplicationInfo::repo().isEmpty() && !WbApplicationInfo::branch().isEmpty()) {
     // when streaming locally, build the URL from branch.txt in order to serve 'webots://' assets
     const QString prefix =

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -307,7 +307,7 @@ QString WbUrl::combinePaths(const QString &rawUrl, const QString &rawParentUrl) 
     // if it is not available in those folders, infer the URL based on the parent's url
     if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {
       // remove filename from parent url
-      parentUrl = QUrl(parentUrl).adjusted(QUrl::RemoveFilename).toString();
+      parentUrl = parentUrl.sliced(0, parentUrl.lastIndexOf("/") + 1);
       if (WbUrl::isLocalUrl(parentUrl))
         parentUrl.replace("webots://", WbStandardPaths::webotsHomePath());
 

--- a/src/webots/nodes/utils/WbUrl.hpp
+++ b/src/webots/nodes/utils/WbUrl.hpp
@@ -38,7 +38,7 @@ namespace WbUrl {
   const QString &missingProtoIcon();
   bool isWeb(const QString &url);
   bool isLocalUrl(const QString &url);
-  const QString computeLocalAssetUrl(QString url);
+  const QString computeLocalAssetUrl(QString url, bool isX3d);
   const QString computePrefix(const QString &rawUrl);
 
   const QString remoteWebotsAssetRegex(bool capturing);


### PR DESCRIPTION
Currently, when converting a PROTO to base node from the scene tree, the URLs of `ImageTextures`, `CadShapes`, `Backgrounds` and `Meshes` are automatically converted to web format (`raw.githubusercontent.com/`). This should not be the case if we are not in a distribution and not streaming in x3d mode.