### PR TITLE
Load meshes only once

### DIFF
--- a/src/webots/nodes/WbTriangleMeshGeometry.cpp
+++ b/src/webots/nodes/WbTriangleMeshGeometry.cpp
@@ -97,9 +97,6 @@ void WbTriangleMeshGeometry::clearTrimeshResources() {
 }
 
 void WbTriangleMeshGeometry::createWrenObjects() {
-  if (WbNodeUtilities::findContainingProto(this))
-    updateTriangleMesh(false);
-
   foreach (QString warning, mTriangleMesh->warnings())
     parsingWarn(warning);
 


### PR DESCRIPTION
Fix #5111 

The meshes were loaded twice when in a Proto:
- once in `WbTriangleMeshGeometry::createTriangleMesh()`
- once in `WbTriangleMeshGeometry::createWrenObjects()`

By removing the call in `createWrenObjects` the mesh are now loaded only once.

However, I could not find/understand why there was this additional call in `createWrenObjects`. All that I know is that it is very old (prior to R2019).

I tested all the functionnalities I thought of and everything seems fine (regeneration, convert to base node, test suite, load mesh in proto,...).

I anybody know more about why we called `updateTriangleMesh` in `WbTriangleMeshGeometry::createWrenObjects`, let me know!