### PR TITLE
Print postponed log messages when load is cancelled

### DIFF
--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -160,11 +160,11 @@ void WbApplication::cancelWorldLoading(bool loadEmpty, bool deleteWorld) {
     mWorld = NULL;
   }
 
-  if (loadEmpty) {
-    WbLog::setConsoleLogsPostponed(false);
-    WbLog::showPendingConsoleMessages();
+  WbLog::setConsoleLogsPostponed(false);
+  WbLog::showPendingConsoleMessages();
+
+  if (loadEmpty)
     loadWorld(WbProject::newWorldPath(), false);
-  }
 }
 
 bool WbApplication::isValidWorldFileName(const QString &worldName) {


### PR DESCRIPTION
Fix #5127:
always unset the postponed logs flag and print queued messages when canceling a world load.