### PR TITLE
Fix conversion to `<generic>` and warn user

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2352,7 +2352,7 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
           const int commentIndex = line.indexOf("#");
           const int start = binaryMatch.capturedStart(2);
           const int length = binaryMatch.capturedEnd(2) - start;
-          QString replacement = "<generic>";
+          const QString replacement = "<generic>";
           line.replace(start, length, replacement);
           // adjust comment indentation
           const int offset = commentIndex - line.indexOf("#");

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2315,24 +2315,25 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
         return;
       }
 
-      // in webots development environment use 'webots://', in a distribution use the version
-      if (WbApplicationInfo::branch().isEmpty()) {
-        // adjust all the urls referenced by the PROTO
-        // note: this won't work well if a URL is forged with Javascript code
-        QFile localFile(fileToOpen);
-        localFile.open(QIODevice::ReadWrite);
-        const QString repo = fileName.mid(0, fileName.lastIndexOf('/') + 1);
-        // the webots repository URL looks like: https://raw.githubusercontent.com/cyberbotics/webots/branch-tag-or-hash/
-        const int index =  // find the index of the '/' immediately following the branch-tag-or-hash component
-          fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', 8) + 1) + 1) + 1) + 1;
-        const QString webotsRepo = fileName.mid(0, index);
-        const QString contents = QString(localFile.readAll());
-        const QRegularExpression resources("\"([^\"]*)\\.(jpe?g|png|hdr|obj|stl|dae|wav|mp3|proto)\"",
-                                           QRegularExpression::CaseInsensitiveOption);
-        const QRegularExpression binary("\\s*field\\s+SFString\\s+(controller|window)\\s+\"(.+)\"");
-        // "$\\s*field\\s+SFString\\s+(controller|window)\\s+\"(.+)\""
-        QStringList lines = contents.split('\n');
-        for (QString &line : lines) {
+      QFile localFile(fileToOpen);
+      localFile.open(QIODevice::ReadWrite);
+      const QString contents = QString(localFile.readAll());
+
+      QStringList lines = contents.split('\n');
+      for (QString &line : lines) {
+        // in webots development environment use 'webots://', in a distribution use the version
+        if (WbApplicationInfo::branch().isEmpty()) {
+          // adjust all the urls referenced by the PROTO
+          // note: this won't work well if a URL is forged with Javascript code
+          const QString repo = fileName.mid(0, fileName.lastIndexOf('/') + 1);
+          // the webots repository URL looks like: https://raw.githubusercontent.com/cyberbotics/webots/branch-tag-or-hash/
+          const int index =  // find the index of the '/' immediately following the branch-tag-or-hash component
+            fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', 8) + 1) + 1) + 1) + 1;
+          const QString webotsRepo = fileName.mid(0, index);
+
+          const QRegularExpression resources("\"([^\"]*)\\.(jpe?g|png|hdr|obj|stl|dae|wav|mp3|proto)\"",
+                                             QRegularExpression::CaseInsensitiveOption);
+
           // replace the "webots://" URLs with "https://" URLs
           line.replace("webots://", webotsRepo);
           // replace the local URLs with "https://" URLs
@@ -2346,30 +2347,36 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
             line.replace(start, match.capturedEnd(0) - start, url);
             continue;
           }
-          // replace the controller and window parameter with generic ones
-          const QRegularExpressionMatch binaryMatch = binary.match(line);
-          if (binaryMatch.hasMatch()) {
-            const int commentIndex = line.indexOf("#");
-            const int start = binaryMatch.capturedStart(2);
-            const int length = binaryMatch.capturedEnd(2) - start;
-            QString replacement = "<generic>";
-            line.replace(start, length, replacement);
-            // adjust comment indentation
-            const int offset = commentIndex - line.indexOf("#");
-            const int end = start + replacement.size() + 1;
-            if (offset > 0)  // add some extra spaces
-              line.replace(end, 0, QString(offset, ' '));
-            else if (offset < 0) {  // remove some spaces if possible
-              const int n = (end < commentIndex) ? -offset : commentIndex - offset - end - 1;
-              if (n > 0)
-                line.replace(end, n, "");
-            }
-          }
         }
-        localFile.seek(0);
-        localFile.write(lines.join("\n").toUtf8());
-        localFile.close();
+        // replace the controller and window parameter with generic ones
+        const QRegularExpression binary("\\s*field\\s+SFString\\s+(controller|window)\\s+\"(.+)\"");
+        // "$\\s*field\\s+SFString\\s+(controller|window)\\s+\"(.+)\""
+        const QRegularExpressionMatch binaryMatch = binary.match(line);
+        if (binaryMatch.hasMatch()) {
+          const int commentIndex = line.indexOf("#");
+          const int start = binaryMatch.capturedStart(2);
+          const int length = binaryMatch.capturedEnd(2) - start;
+          QString replacement = "<generic>";
+          line.replace(start, length, replacement);
+          // adjust comment indentation
+          const int offset = commentIndex - line.indexOf("#");
+          const int end = start + replacement.size() + 1;
+          if (offset > 0)  // add some extra spaces
+            line.replace(end, 0, QString(offset, ' '));
+          else if (offset < 0) {  // remove some spaces if possible
+            const int n = (end < commentIndex) ? -offset : commentIndex - offset - end - 1;
+            if (n > 0)
+              line.replace(end, n, "");
+          }
+          const int fieldNameStart = binaryMatch.capturedStart(1);
+          const int fieldNameLength = binaryMatch.capturedEnd(1) - fieldNameStart;
+          WbLog::info(tr("The '%1' field of the robot has been changed to \"<generic>\".")
+                        .arg(line.sliced(fieldNameStart, fieldNameLength)));
+        }
       }
+      localFile.seek(0);
+      localFile.write(lines.join("\n").toUtf8());
+      localFile.close();
 
       // ensure the EXTERNPROTO list points to the local copy
       WbProtoManager::instance()->updateExternProto(protoModelName, fileToOpen);

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2315,11 +2315,6 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
         return;
       }
 
-      QFile localFile(fileToOpen);
-      localFile.open(QIODevice::ReadWrite);
-      const QString contents = QString(localFile.readAll());
-
-      QStringList lines = contents.split('\n');
       // adjust all the urls referenced by the PROTO
       // note: this won't work well if a URL is forged with Javascript code
       const QString repo = fileName.mid(0, fileName.lastIndexOf('/') + 1);
@@ -2327,9 +2322,12 @@ void WbMainWindow::openFileInTextEditor(const QString &fileName, bool modify, bo
       const int index =  // find the index of the '/' immediately following the branch-tag-or-hash component
         fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', fileName.indexOf('/', 8) + 1) + 1) + 1) + 1;
       const QString webotsRepo = fileName.mid(0, index);
-
       const QRegularExpression resources("\"([^\"]*)\\.(jpe?g|png|hdr|obj|stl|dae|wav|mp3|proto)\"",
                                          QRegularExpression::CaseInsensitiveOption);
+      QFile localFile(fileToOpen);
+      localFile.open(QIODevice::ReadWrite);
+      const QString contents = QString(localFile.readAll());
+      QStringList lines = contents.split('\n');
       for (QString &line : lines) {
         // replace the "webots://" URLs with "https://" URLs
         line.replace("webots://", webotsRepo);

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1493,14 +1493,17 @@ void WbRobot::exportNodeFields(WbWriter &writer) const {
 }
 
 void WbRobot::fixMissingResources() const {
-  if (controllerName() != "<generic>" && mControllerDir != (WbProject::current()->controllersPath() + controllerName() + "/"))
+  if (controllerName() != "<generic>" && mControllerDir != (WbProject::current()->controllersPath() + controllerName() + "/")) {
     mController->setValue("<generic>");
+    WbLog::info(tr("The 'controller' field of the robot has been changed to \"<generic>\"."));
+  }
 
   if (window() != "<generic>" &&
       windowFile() != (WbProject::current()->robotWindowPluginsPath() + window() + "/" + window() + ".html")) {
     mWindow->blockSignals(true);
     mWindow->setValue("<generic>");
     mWindow->blockSignals(false);
+    WbLog::info(tr("The 'window' field of the robot has been changed to \"<generic>\"."));
   }
 }
 


### PR DESCRIPTION
The conversion to `<generic>` controllers and robot-windows when opening a remote Robot PROTO in the text editor is only working in distributions, but not in the development environment. Moreover, relative and `webots://` URLs in remote PROTOs were not correctly converted when editing them locally from the development environment.

This PR fixes these issues, and adds `INFO` logs in the console to warn the user that `controller` and `window` fields have been updated.