### PR TITLE
Fix urls that are send to webotsJS with a space

### DIFF
--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -66,7 +66,7 @@ void WbX3dStreamingServer::create(int port) {
 void WbX3dStreamingServer::sendTcpRequestReply(const QString &url, const QString &etag, const QString &host,
                                                QTcpSocket *socket) {
   QString urlWithSpaces(url);
-  urlWithSpaces = urlWithSpaces.replace("%20", " ");
+  urlWithSpaces.replace("%20", " ");
   QFileInfo file(WbProject::current()->dir().absolutePath() + "/" + urlWithSpaces);
   if (file.exists())
     socket->write(WbHttpReply::forgeFileReply(file.absoluteFilePath(), etag, host, urlWithSpaces));

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -65,11 +65,10 @@ void WbX3dStreamingServer::create(int port) {
 
 void WbX3dStreamingServer::sendTcpRequestReply(const QString &url, const QString &etag, const QString &host,
                                                QTcpSocket *socket) {
-  QString urlWithSpaces(url);
-  urlWithSpaces.replace("%20", " ");
-  QFileInfo file(WbProject::current()->dir().absolutePath() + "/" + urlWithSpaces);
+  const QString decodedUrl = QUrl::fromPercentEncoding(url.toUtf8());
+  QFileInfo file(WbProject::current()->dir().absolutePath() + "/" + decodedUrl);
   if (file.exists())
-    socket->write(WbHttpReply::forgeFileReply(file.absoluteFilePath(), etag, host, urlWithSpaces));
+    socket->write(WbHttpReply::forgeFileReply(file.absoluteFilePath(), etag, host, decodedUrl));
   else
     WbTcpServer::sendTcpRequestReply(url, etag, host, socket);
 }

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -65,9 +65,11 @@ void WbX3dStreamingServer::create(int port) {
 
 void WbX3dStreamingServer::sendTcpRequestReply(const QString &url, const QString &etag, const QString &host,
                                                QTcpSocket *socket) {
-  QFileInfo file(WbProject::current()->dir().absolutePath() + "/" + url);
+  QString urlWithSpaces(url);
+  urlWithSpaces = urlWithSpaces.replace("%20", " ");
+  QFileInfo file(WbProject::current()->dir().absolutePath() + "/" + urlWithSpaces);
   if (file.exists())
-    socket->write(WbHttpReply::forgeFileReply(file.absoluteFilePath(), etag, host, url));
+    socket->write(WbHttpReply::forgeFileReply(file.absoluteFilePath(), etag, host, urlWithSpaces));
   else
     WbTcpServer::sendTcpRequestReply(url, etag, host, socket);
 }


### PR DESCRIPTION
When streaming assets that have spaces in their path (either in some folder name or directly in their filename), the urls are automatically converted by `fetch` such that all spaces are replaced by `%20`.

However, in Webots we need to convert the `%20` back to normal spaces otherwise Webots will not found the files.