### PR TITLE
Fix copy of relative texture URLs during project relcoation

### DIFF
--- a/src/webots/core/WbFileUtil.cpp
+++ b/src/webots/core/WbFileUtil.cpp
@@ -148,11 +148,13 @@ bool WbFileUtil::areIdenticalFiles(const QString &fileAPath, const QString &file
 }
 
 bool WbFileUtil::isLocatedInDirectory(const QString &file, const QString &directory) {
+  return QFileInfo(file).absoluteFilePath().startsWith(QFileInfo(directory).absoluteFilePath(),
 #ifdef _WIN32
-  return file.startsWith(directory, Qt::CaseInsensitive);
+                                                       Qt::CaseInsensitive);
 #else
-  return file.startsWith(directory, Qt::CaseSensitive);
+                                                       Qt::CaseSensitive
 #endif
+  );
 }
 
 bool WbFileUtil::isLocatedInInstallationDirectory(const QString &file) {

--- a/src/webots/editor/WbProjectRelocationDialog.hpp
+++ b/src/webots/editor/WbProjectRelocationDialog.hpp
@@ -21,6 +21,7 @@
 
 #include <QtWidgets/QDialog>
 
+class WbMFString;
 class WbLineEdit;
 class WbProject;
 
@@ -60,6 +61,9 @@ private:
   QDialogButtonBox *mButtonBox;
   bool mIsCompleteRelocation;
 
+  // List of relative textures that needs to be converted to absolute after relocation
+  QList<WbMFString *> mRelativeTextureFields;
+
   // path to the projects folder of the modified PROTO resource located outside the current project path
   static QString mExternalProtoProjectPath;
 
@@ -75,6 +79,7 @@ private:
   const QString &targetPath() const { return mTargetPath; }
   int copyProject(const QString &projectPath);
   int copyWorldFiles();
+  QString targetFilePath(const QString &path, bool &valid) const;
 
   void setStatus(const QString &text, bool ok = true);
 };

--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -571,9 +571,8 @@ QList<WbSolid *> WbWorld::findSolids(bool visibleNodes) const {
   return allSolids;
 }
 
-QStringList WbWorld::listTextureFiles() const {
-  QStringList list = mRoot->listTextureFiles();
-  list.removeDuplicates();
+QList<QPair<QString, WbMFString *>> WbWorld::listTextureFiles() const {
+  QList<QPair<QString, WbMFString *>> list = mRoot->listTextureFiles();
   return list;
 }
 

--- a/src/webots/nodes/utils/WbWorld.hpp
+++ b/src/webots/nodes/utils/WbWorld.hpp
@@ -128,7 +128,7 @@ public:
   void addRobotIfNotAlreadyPresent(WbRobot *robot);
 
   // return the list of texture files used in this world (no duplicates)
-  QStringList listTextureFiles() const;
+  QList<QPair<QString, WbMFString *>> listTextureFiles() const;
 
   // shortcut
   double basicTimeStep() const { return mWorldInfo->basicTimeStep(); }

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1083,8 +1083,8 @@ void WbNode::write(WbWriter &writer) const {
 // This function lists only the texture files which are explicitly referred to in
 // this world file and not the one implicitly referred to by included PROTO files.
 // This list may contain duplicate texture files.
-QStringList WbNode::listTextureFiles() const {
-  QStringList list;
+QList<QPair<QString, WbMFString *>> WbNode::listTextureFiles() const {
+  QList<QPair<QString, WbMFString *>> list;
   bool imageTexture = model()->name() == "ImageTexture";
   const QString currentTexturePath = WbProject::current()->worldsPath();
   foreach (WbField *field, fields())
@@ -1110,7 +1110,7 @@ QStringList WbNode::listTextureFiles() const {
         if (proto && QFile::exists(protoPath + textureFile))  // PROTO texture
           continue;                                           // skip it
         if (QFile::exists(currentTexturePath + textureFile))
-          list << textureFile;
+          list << QPair<QString, WbMFString *>(textureFile, mfstring);
       }
     }
   return list;

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -193,8 +193,8 @@ public:
   // return the node contained in a PROTO parameter that represents the current instance in the scene tree
   WbNode *protoParameterNode() const { return mProtoParameterNode; }
 
-  // list all the texture files used (may include duplicates)
-  QStringList listTextureFiles() const;
+  // list all the texture files used and the corresponding field
+  QList<QPair<QString, WbMFString *>> listTextureFiles() const;
 
   // write node and fields as text
   virtual void write(WbWriter &writer) const;


### PR DESCRIPTION
Fix #5131: do not copy textures outside the new project folder chosen by the user.
If a world uses relative URLs:
* if they are located inside the new project path: keep the relative URL and copy the texture if needed
* otherwise if the relative path is no longer valid: convert the relative path to the corresponding absolute path