### PR TITLE
Fix crash transparency

### DIFF
--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -768,7 +768,7 @@ void WbNode::notifyFieldChanged() {
   WbField *const field = static_cast<WbField *>(sender());
 
   WbField *const parentField = this->parentField();
-  if (parentField && isProtoParameterNode())
+  if (parentField && parentField->parameter() && isProtoParameterNode())
     emit parentField->parentNode()->parameterChanged(parentField);
 
   if (mIsBeingDeleted || cUpdatingDictionary) {


### PR DESCRIPTION
This PR want to fix #5135 

It comes from [here](https://github.com/cyberbotics/webots/blob/7a09896b9e0080ba4360efae828f93d0a5925fb6/src/webots/vrml/WbNode.cpp#L772).

This was introduced in #5092 to fix https://github.com/cyberbotics/webots/issues/5092#issuecomment-1222366931

Adding an additional condition seems to fix it. However I am not 100% convinced is it correct and it is not just some "luck"