### PR TITLE
Fix alias not propagating in derived proto and empty add-node

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -82,6 +82,7 @@ Released on July, 7th, 2022.
     - Fixed the background reflection on objects when the `skyColor` is updated ([#5133](https://github.com/cyberbotics/webots/pull/5133)).
     - Fixed multiple crashes when using invalid URLs in the fields of [Skin](skin.md), [Motor](motor.md), [Camera](camera.md) and [ContactProperties](contactproperties.md) ([#5132](https://github.com/cyberbotics/webots/pull/5132)).
     - Fixed the sanitization of `WbPbrAppearance` to also trigger at the creation of the node ([#5139](https://github.com/cyberbotics/webots/pull/5139)).
+    - Fixed field change not propagating in nested derived PROTO ([#5157](https://github.com/cyberbotics/webots/pull/5157)).
   - Cleanup
     - Moved the Wizard menu inside the File / New menu ([#5075](https://github.com/cyberbotics/webots/pull/5075)).
     - Removed WBO file import from Webots and from the Controller API ([#5061](https://github.com/cyberbotics/webots/pull/5061)).

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -247,7 +247,7 @@ WbNode::WbNode(const WbNode &other) :
         field->redirectTo(parameterNodeField);
         field->setScope(parameterNodeField->scope());
 
-        if (!other.mProto && gDerivedProtoAncestorFlag && !gTopParameterFlag)
+        if (!other.mProto && gDerivedProtoAncestorFlag)
           field->setAlias(parameterNodeField->alias());
       }
 


### PR DESCRIPTION
**Description**

Fixes: https://github.com/cyberbotics/webots/issues/5148 (both issues)

Due to the lack of a link between field and parameter in a derived PROTO context (without derivation everything works), changes to the parameter didn't propagate (first issue) and it wasn't possible to insert the second Lincoln in a slot of a Truck (second issue, add-node showed up empty whereas it was possible to insert it in a TruckSimple).

Intuitively it seems wrong to me that the alias connection is made only if the parameter belongs to the base PROTO. In the Lincoln case for example, the parameter `plate` is indeed a parameter exclusive to the derived PROTO (Lincoln), not the base ones (Car, Ackermann).

So far I haven't encountered side effects but I'll keep investigating