### PR TITLE
Add space to empty.wbt

### DIFF
--- a/resources/projects/worlds/empty.wbt
+++ b/resources/projects/worlds/empty.wbt
@@ -1,4 +1,5 @@
 #VRML_SIM R2022b utf8
+
 WorldInfo {
 }
 Viewpoint {


### PR DESCRIPTION
**Description**

With the introduction of EXTERNPROTO declarations, a minimum of one space is enforced during a save (before and after the declarations). Even if no declarations are present, at least one line of space is generated between the header and the first node.
`empty.wbt` currently doesn't follow this rule and therefore generates a diff when running test_worlds.