### PR TITLE
Restore lost declaration after cut-paste

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -683,12 +683,21 @@ void WbAddNodeDialog::accept() {
     return;
   }
 
-  const WbExternProto *cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
+  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
   const QString protoName =
     QUrl(mTree->selectedItems().at(0)->text(FILE_NAME)).fileName().replace(".proto", "", Qt::CaseInsensitive);
-  if (cutBuffer && cutBuffer->name() == protoName && !mRetrievalTriggered) {
+
+  bool conflict = false;
+  foreach (const WbExternProto *proto, cutBuffer) {
+    if (proto && proto->name() == protoName && !mRetrievalTriggered) {
+      conflict = true;
+      break;
+    }
+  }
+
+  if (conflict) {
     const QMessageBox::StandardButton cutBufferWarningDialog = WbMessageBox::warning(
-      "A PROTO node with the same name as the one you are about to insert is contained in the clipboard. Do "
+      "One or more PROTO nodes with the same name as the one you are about to insert is contained in the clipboard. Do "
       "you want to continue? This operation will clear the clipboard.",
       this, "Warning", QMessageBox::Cancel, QMessageBox::Ok | QMessageBox::Cancel);
 

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -156,10 +156,18 @@ void WbInsertExternProtoDialog::accept() {
   if (mTree->selectedItems().size() == 0 || !mInsertButton->isEnabled())
     return;
 
-  const WbExternProto *cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
-  if (cutBuffer && cutBuffer->name() == mTree->selectedItems().at(0)->text(0) && !mRetrievalTriggered) {
+  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
+  bool conflict = false;
+  foreach (const WbExternProto *proto, cutBuffer) {
+    if (proto && proto->name() == mTree->selectedItems().at(0)->text(0) && !mRetrievalTriggered) {
+      conflict = true;
+      break;
+    }
+  }
+
+  if (conflict) {
     const QMessageBox::StandardButton cutBufferWarningDialog = WbMessageBox::warning(
-      "A PROTO node with the same name as the one you are about to insert is contained in the clipboard. Do "
+      "One or more PROTO nodes with the same name as the one you are about to insert is contained in the clipboard. Do "
       "you want to continue? This operation will clear the clipboard.",
       this, "Warning", QMessageBox::Cancel, QMessageBox::Ok | QMessageBox::Cancel);
 

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -299,7 +299,7 @@ void WbSceneTree::handleUserCommand(WbAction::WbActionKind actionKind) {
 
 void WbSceneTree::cut() {
   if (mSelectedItem->isNode()) {
-    QList<const WbNode *> cutNodes = WbNodeUtilities::protoNodesInWorldFile(mSelectedItem->node());
+    const QList<const WbNode *> cutNodes = WbNodeUtilities::protoNodesInWorldFile(mSelectedItem->node());
     if (!WbProtoManager::instance()->externProtoCutBuffer().isEmpty())
       WbProtoManager::instance()->clearExternProtoCutBuffer();
     WbProtoManager::instance()->saveToExternProtoCutBuffer(cutNodes);

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -299,9 +299,10 @@ void WbSceneTree::handleUserCommand(WbAction::WbActionKind actionKind) {
 
 void WbSceneTree::cut() {
   if (mSelectedItem->isNode()) {
-    if (WbProtoManager::instance()->externProtoCutBuffer())
+    QList<const WbNode *> cutNodes = WbNodeUtilities::protoNodesInWorldFile(mSelectedItem->node());
+    if (!WbProtoManager::instance()->externProtoCutBuffer().isEmpty())
       WbProtoManager::instance()->clearExternProtoCutBuffer();
-    WbProtoManager::instance()->saveToExternProtoCutBuffer(mSelectedItem->node()->modelName());
+    WbProtoManager::instance()->saveToExternProtoCutBuffer(cutNodes);
   }
   copy();
   del();
@@ -341,9 +342,9 @@ void WbSceneTree::paste() {
   if (!mSelectedItem)
     return;
 
-  const WbExternProto *cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
-  if (cutBuffer)
-    WbProtoManager::instance()->declareExternProto(cutBuffer->name(), cutBuffer->url(), cutBuffer->isImportable(), true);
+  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
+  foreach (const WbExternProto *item, cutBuffer)
+    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable(), true);
 
   if (mSelectedItem->isField() && mSelectedItem->field()->isSingle())
     pasteInSFValue();

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -821,7 +821,7 @@ QString WbProtoManager::externProtoUrl(const WbNode *node, bool formatted) const
   return QString();
 }
 
-void WbProtoManager::saveToExternProtoCutBuffer(QList<const WbNode *> &nodes) {
+void WbProtoManager::saveToExternProtoCutBuffer(const QList<const WbNode *> &nodes) {
   foreach (const WbNode *node, nodes) {
     if (!node->proto())
       continue;

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -109,11 +109,12 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
   // nodes imported from a supervisor should only check the IMPORTABLE list
   if (!mImportedFromSupervisor) {
     // check the cut buffer
-    if (protoDeclaration.isEmpty() && !mExternProtoCutBuffer.isEmpty())
+    if (protoDeclaration.isEmpty() && !mExternProtoCutBuffer.isEmpty()) {
       foreach (const WbExternProto *item, mExternProtoCutBuffer) {
         if (item->name() == modelName)
           protoDeclaration = item->url();
       }
+    }
 
     // determine the location of the PROTO based on the EXTERNPROTO declaration in the parent file
     if (protoDeclaration.isEmpty())
@@ -835,8 +836,6 @@ void WbProtoManager::saveToExternProtoCutBuffer(QList<const WbNode *> &nodes) {
 }
 
 void WbProtoManager::clearExternProtoCutBuffer() {
-  // delete mExternProtoCutBuffer;
-  // mExternProtoCutBuffer = NULL;
   qDeleteAll(mExternProtoCutBuffer);
   mExternProtoCutBuffer.clear();
 }

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -185,7 +185,7 @@ public:
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;
-  void saveToExternProtoCutBuffer(QList<const WbNode *> &nodes);
+  void saveToExternProtoCutBuffer(const QList<const WbNode *> &nodes);
 
   QString findExternProtoDeclarationInFile(const QString &url, const QString &modelName);
   void removeImportableExternProto(const QString &protoName);

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -176,7 +176,7 @@ public:
   const QVector<WbExternProto *> &externProto() const { return mExternProto; };
 
   // EXTERNPROTO stored after cutting an inserted node
-  const WbExternProto *externProtoCutBuffer() const { return mExternProtoCutBuffer; };
+  QList<WbExternProto *> externProtoCutBuffer() const { return mExternProtoCutBuffer; };
 
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared
@@ -185,7 +185,7 @@ public:
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;
-  void saveToExternProtoCutBuffer(const QString &protoName);
+  void saveToExternProtoCutBuffer(QList<const WbNode *> &nodes);
 
   QString findExternProtoDeclarationInFile(const QString &url, const QString &modelName);
   void removeImportableExternProto(const QString &protoName);
@@ -236,7 +236,7 @@ private:
   QVector<WbExternProto *> mExternProto;
 
   // mExternProtoCutBuffer: contains the externProto reference of the last cut instance
-  WbExternProto *mExternProtoCutBuffer;
+  QList<WbExternProto *> mExternProtoCutBuffer;
 
   // stores PROTO metadata
   QMap<QString, WbProtoInfo *> mWebotsProtoList;     // loaded from proto-list.xml

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -176,7 +176,7 @@ public:
   const QVector<WbExternProto *> &externProto() const { return mExternProto; };
 
   // EXTERNPROTO stored after cutting an inserted node
-  QList<WbExternProto *> externProtoCutBuffer() const { return mExternProtoCutBuffer; };
+  const QList<WbExternProto *> externProtoCutBuffer() const { return mExternProtoCutBuffer; };
 
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared


### PR DESCRIPTION
**Description**

Fixes https://github.com/cyberbotics/webots/issues/5156

When cutting a PROTO node that contains additional (slotted) PROTO nodes, all of them need to be re-declared on a paste.

