### PR TITLE
Added scale update in animations

### DIFF
--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -224,6 +224,13 @@ export default class X3dScene {
           if (WbWorld.instance.readyForUpdates)
             object.applyRotationToWren();
         }
+      } else if (key === 'scale') {
+        const scale = convertStringToVec3(pose[key]);
+        if (object instanceof WbTransform) {
+          object.scale = scale;
+          if (WbWorld.instance.readyForUpdates)
+            object.applyScaleToWren();
+        }
       } else if (object instanceof WbPbrAppearance || object instanceof WbMaterial) {
         if (key === 'baseColor')
           object.baseColor = convertStringToVec3(pose[key]);

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -225,9 +225,8 @@ export default class X3dScene {
             object.applyRotationToWren();
         }
       } else if (key === 'scale') {
-        const scale = convertStringToVec3(pose[key]);
         if (object instanceof WbTransform) {
-          object.scale = scale;
+          object.scale = convertStringToVec3(pose[key]);
           if (WbWorld.instance.readyForUpdates)
             object.applyScaleToWren();
         }


### PR DESCRIPTION
This minor feature is needed for the SimGait project as I need to scale non-uniformly the shape of the muscles.

Although the scale of a Transform should never change while a simulation is running (except if a supervisor changes it explicitly), I needed this feature in my [conversion script](https://github.com/cyberbotics/scone-playback/blob/main/convert.py) that produces Webots animations from OpenSim model and motion files.