### PR TITLE
Fix convert root to basenode and other conversion issues

### DIFF
--- a/src/webots/control/WbControlledWorld.hpp
+++ b/src/webots/control/WbControlledWorld.hpp
@@ -28,7 +28,7 @@ public:
   static WbControlledWorld *instance();
 
   // constructors and destructor
-  WbControlledWorld(WbTokenizer *tokenizer = NULL);
+  explicit WbControlledWorld(WbTokenizer *tokenizer = NULL);
   virtual ~WbControlledWorld();
 
   void startController(WbRobot *robot);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -966,7 +966,7 @@ void WbController::copyBinaryAndDependencies(const QString &filename) {
 
 #ifdef __APPLE__
   // silently change RPATH before launching controller, if the controller is not in the installation path.
-  if (filename.startsWith(WbStandardPaths::webotsHomePath()) || !QFileInfo(filename).isWritable())
+  if (WbFileUtil::isLocatedInDirectory(filename, WbStandardPaths::webotsHomePath()) || !QFileInfo(filename).isWritable())
     return;
 
   QProcess process;

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -966,7 +966,7 @@ void WbController::copyBinaryAndDependencies(const QString &filename) {
 
 #ifdef __APPLE__
   // silently change RPATH before launching controller, if the controller is not in the installation path.
-  if (WbFileUtil::isLocatedInDirectory(filename, WbStandardPaths::webotsHomePath()) || !QFileInfo(filename).isWritable())
+  if (WbFileUtil::isLocatedInInstallationDirectory(filename, true) || !QFileInfo(filename).isWritable())
     return;
 
   QProcess process;

--- a/src/webots/core/WbFileUtil.cpp
+++ b/src/webots/core/WbFileUtil.cpp
@@ -155,9 +155,9 @@ bool WbFileUtil::isLocatedInDirectory(const QString &file, const QString &direct
 #endif
 }
 
-bool WbFileUtil::isLocatedInInstallationDirectory(const QString &file) {
+bool WbFileUtil::isLocatedInInstallationDirectory(const QString &file, bool ignoreAllowModify) {
   const bool inWebots = WbFileUtil::isLocatedInDirectory(file, WbStandardPaths::webotsHomePath());
-  return inWebots && !WbPreferences::booleanEnvironmentVariable("WEBOTS_ALLOW_MODIFY_INSTALLATION");
+  return inWebots && (ignoreAllowModify || !WbPreferences::booleanEnvironmentVariable("WEBOTS_ALLOW_MODIFY_INSTALLATION"));
 }
 
 void WbFileUtil::searchDirectoryNameRecursively(QStringList &results, const QString &directoryName, const QString &root) {

--- a/src/webots/core/WbFileUtil.hpp
+++ b/src/webots/core/WbFileUtil.hpp
@@ -41,7 +41,7 @@ namespace WbFileUtil {
 
   // check if a file is located in the specified directory tree; both paths are absolute
   bool isLocatedInDirectory(const QString &file, const QString &directory);
-  bool isLocatedInInstallationDirectory(const QString &file);
+  bool isLocatedInInstallationDirectory(const QString &file, bool ignoreAllowModify = false);
 
   // search all the directories named directoryName in the root directory
   void searchDirectoryNameRecursively(QStringList &results, const QString &directoryName, const QString &root);

--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -250,12 +250,7 @@ bool WbProject::createNewProjectFolders() {
 }
 
 bool WbProject::isReadOnly() const {
-#ifdef _WIN32
-  Qt::CaseSensitivity caseSensitivity = Qt::CaseInsensitive;
-#else
-  Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive;
-#endif
-  return mPath.startsWith(WbStandardPaths::webotsHomePath(), caseSensitivity);
+  return WbFileUtil::isLocatedInDirectory(mPath, WbStandardPaths::webotsHomePath());
 }
 
 QString WbProject::controllerPathFromDir(const QString &dirPath) {

--- a/src/webots/core/WbProject.cpp
+++ b/src/webots/core/WbProject.cpp
@@ -250,7 +250,7 @@ bool WbProject::createNewProjectFolders() {
 }
 
 bool WbProject::isReadOnly() const {
-  return WbFileUtil::isLocatedInDirectory(mPath, WbStandardPaths::webotsHomePath());
+  return WbFileUtil::isLocatedInInstallationDirectory(mPath, true);
 }
 
 QString WbProject::controllerPathFromDir(const QString &dirPath) {

--- a/src/webots/core/WbVersion.hpp
+++ b/src/webots/core/WbVersion.hpp
@@ -24,7 +24,7 @@
 
 class WbVersion {
 public:
-  WbVersion(int major = 0, int minor = 0, int revision = 0, bool webots = false);
+  explicit WbVersion(int major = 0, int minor = 0, int revision = 0, bool webots = false);
   WbVersion(const WbVersion &other);
   virtual ~WbVersion() {}
 

--- a/src/webots/editor/WbFindReplaceDialog.cpp
+++ b/src/webots/editor/WbFindReplaceDialog.cpp
@@ -117,11 +117,11 @@ void WbFindReplaceDialog::setFindString(const QString &findWhat) {
 WbTextFind::FindFlags WbFindReplaceDialog::findFlags() {
   WbTextFind::FindFlags flags = WbTextFind::FIND_NONE;
   if (mRegExpCheckBox->isChecked())
-    flags = (WbTextFind::FindFlags)(flags | WbTextFind::FIND_REGULAR_EXPRESSION);
+    flags |= WbTextFind::FIND_REGULAR_EXPRESSION;
   if (mCaseSensitiveCheckBox->isChecked())
-    flags = (WbTextFind::FindFlags)(flags | WbTextFind::FIND_CASE_SENSITIVE);
+    flags |= WbTextFind::FIND_CASE_SENSITIVE;
   if (mWholeWordsCheckBox->isChecked())
-    flags = (WbTextFind::FindFlags)(flags | WbTextFind::FIND_WHOLE_WORDS);
+    flags |= WbTextFind::FIND_WHOLE_WORDS;
   return flags;
 }
 

--- a/src/webots/engine/WbSimulationWorld.hpp
+++ b/src/webots/engine/WbSimulationWorld.hpp
@@ -38,7 +38,7 @@ public:
   static WbSimulationWorld *instance();
 
   // constructors and destructor
-  WbSimulationWorld(WbTokenizer *tokenizer = NULL);
+  explicit WbSimulationWorld(WbTokenizer *tokenizer = NULL);
   virtual ~WbSimulationWorld();
 
   // returns the physics plugin used in this world or NULL if none

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -36,7 +36,7 @@ void WbRobotWindow::setupPage(int port) {
 
   // if the file is located in Webots installation directory, the WEBOTS_HOME part is replaced by "/~/" in the absolute path
   // if the file is located at another place, only the relative path is kept
-  if (windowFileName.startsWith(WbStandardPaths::webotsHomePath()))
+  if (WbFileUtil::isLocatedInDirectory(windowFileName, WbStandardPaths::webotsHomePath()))
     windowFileName = "/~WEBOTS_HOME" + windowFileName.mid(WbStandardPaths::webotsHomePath().length() - 1);
   else
     windowFileName = windowFileName.mid(windowFileName.indexOf("/robot_windows"));

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -37,7 +37,7 @@ void WbRobotWindow::setupPage(int port) {
 
   // if the file is located in Webots installation directory, the WEBOTS_HOME part is replaced by "/~/" in the absolute path
   // if the file is located at another place, only the relative path is kept
-  if (WbFileUtil::isLocatedInDirectory(windowFileName, WbStandardPaths::webotsHomePath()))
+  if (WbFileUtil::isLocatedInInstallationDirectory(windowFileName, true))
     windowFileName = "/~WEBOTS_HOME" + windowFileName.mid(WbStandardPaths::webotsHomePath().length() - 1);
   else
     windowFileName = windowFileName.mid(windowFileName.indexOf("/robot_windows"));

--- a/src/webots/gui/WbRobotWindow.cpp
+++ b/src/webots/gui/WbRobotWindow.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include "WbDesktopServices.hpp"
+#include "WbFileUtil.hpp"
 #include "WbLog.hpp"
 #include "WbPreferences.hpp"
 #include "WbStandardPaths.hpp"

--- a/src/webots/nodes/WbHingeJointParameters.hpp
+++ b/src/webots/nodes/WbHingeJointParameters.hpp
@@ -23,7 +23,7 @@ class WbHingeJointParameters : public WbJointParameters {
 
 public:
   explicit WbHingeJointParameters(const QString &modelName, WbTokenizer *tokenizer = NULL);
-  WbHingeJointParameters(WbTokenizer *tokenizer = NULL, bool fromDeprecatedHinge2JointParameters = false);
+  explicit WbHingeJointParameters(WbTokenizer *tokenizer = NULL, bool fromDeprecatedHinge2JointParameters = false);
   WbHingeJointParameters(const WbHingeJointParameters &other);
   explicit WbHingeJointParameters(const WbNode &other, bool fromDeprecatedHinge2JointParameters = false);
   virtual ~WbHingeJointParameters();

--- a/src/webots/nodes/utils/WbJoystickInterface.cpp
+++ b/src/webots/nodes/utils/WbJoystickInterface.cpp
@@ -128,7 +128,7 @@ WbJoystickInterface::~WbJoystickInterface() {
   try {
     if (gInputManager && mJoystick)
       gInputManager->destroyInputObject(mJoystick);
-  } catch (OIS::Exception &e) {
+  } catch (const OIS::Exception &e) {
   }
   if (gInputManager && gCurrentNumberOfInterface == 0) {
     OIS::InputManager::destroyInputSystem(gInputManager);
@@ -170,7 +170,7 @@ void WbJoystickInterface::setForceFeedback() {
       mForceFeedback->modify(mEffect);
     else
       mForceFeedback->upload(mEffect);
-  } catch (OIS::Exception &e) {
+  } catch (const OIS::Exception &e) {
     mHasForceFeedback = false;
   }
 

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -286,6 +286,8 @@ QString WbUrl::combinePaths(const QString &rawUrl, const QString &rawParentUrl) 
   }
 
   if (QDir::isRelativePath(url)) {
+    if (parentUrl.startsWith(WbStandardPaths::cachedAssetsPath()))
+      parentUrl = WbNetwork::instance()->getUrlFromEphemeralCache(parentUrl);
     // if it is not available in those folders, infer the URL based on the parent's url
     if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {
       // remove filename from parent url

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -88,7 +88,7 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
       // note: derived PROTO are a special case because instances of the intermediary ancestors from which it is defined don't
       // persist after the build process, hence why we keep track of the scope while building the node itself
       if (protoNode->proto()->isDerived()) {
-        if (f->scope().startsWith(WbStandardPaths::cachedAssetsPath()))
+        if (WbFileUtil::isLocatedInDirectory(f->scope(), WbStandardPaths::cachedAssetsPath()))
           parentUrl = WbNetwork::instance()->getUrlFromEphemeralCache(f->scope());
         else
           parentUrl = f->scope();
@@ -198,7 +198,7 @@ bool WbUrl::isWeb(const QString &url) {
 }
 
 bool WbUrl::isLocalUrl(const QString &url) {
-  return url.startsWith("webots://") || url.startsWith(WbStandardPaths::webotsHomePath());
+  return url.startsWith("webots://") || WbFileUtil::isLocatedInDirectory(url, WbStandardPaths::webotsHomePath());
 }
 
 const QString WbUrl::computeLocalAssetUrl(QString url, bool isX3d) {
@@ -286,7 +286,7 @@ QString WbUrl::combinePaths(const QString &rawUrl, const QString &rawParentUrl) 
   }
 
   if (QDir::isRelativePath(url)) {
-    if (parentUrl.startsWith(WbStandardPaths::cachedAssetsPath()))
+    if (WbFileUtil::isLocatedInDirectory(parentUrl, WbStandardPaths::cachedAssetsPath()))
       parentUrl = WbNetwork::instance()->getUrlFromEphemeralCache(parentUrl);
     // if it is not available in those folders, infer the URL based on the parent's url
     if (WbUrl::isWeb(parentUrl) || QDir::isAbsolutePath(parentUrl) || WbUrl::isLocalUrl(parentUrl)) {

--- a/src/webots/nodes/utils/WbUrl.cpp
+++ b/src/webots/nodes/utils/WbUrl.cpp
@@ -198,7 +198,7 @@ bool WbUrl::isWeb(const QString &url) {
 }
 
 bool WbUrl::isLocalUrl(const QString &url) {
-  return url.startsWith("webots://") || WbFileUtil::isLocatedInDirectory(url, WbStandardPaths::webotsHomePath());
+  return url.startsWith("webots://") || WbFileUtil::isLocatedInInstallationDirectory(url, true);
 }
 
 const QString WbUrl::computeLocalAssetUrl(QString url, bool isX3d) {

--- a/src/webots/nodes/utils/WbWorld.hpp
+++ b/src/webots/nodes/utils/WbWorld.hpp
@@ -46,7 +46,7 @@ public:
   // constructor
   // the world is read using 'tokenizer': the file syntax must have been checked with WbParser
   // if 'tokenizer' is not specified, the world is created with default WorldInfo and Viewpoint nodes
-  WbWorld(WbTokenizer *tokenizer = NULL);
+  explicit WbWorld(WbTokenizer *tokenizer = NULL);
 
   // destructor
   virtual ~WbWorld();

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -746,6 +746,20 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
       writer.setRootNode(NULL);
     currentNode->write(writer);
 
+    // relative urls that get exposed by the conversion need to be changed to remote ones
+    QRegularExpressionMatchIterator it = WbUrl::vrmlResourceRegex().globalMatch(nodeString);
+    while (it.hasNext()) {
+      const QRegularExpressionMatch match = it.next();
+      if (match.hasMatch()) {
+        QString asset = match.captured(0);
+        asset.replace("\"", "");
+        if (!WbUrl::isWeb(asset) && QDir::isRelativePath(asset)) {
+          QString newUrl = QString("\"%1\"").arg(WbUrl::combinePaths(asset, currentNode->proto()->url()));
+          nodeString.replace(QString("\"%1\"").arg(asset), newUrl.replace(WbStandardPaths::webotsHomePath(), "webots://"));
+        }
+      }
+    }
+
     const bool skipTemplateRegeneration =
       WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, parentNode);
     if (skipTemplateRegeneration)

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1246,6 +1246,16 @@ void WbNode::exportExternalSubProto(WbWriter &writer) const {
   if (!isProtoInstance())
     return;
 
+  // find all proto that were already exposed prior to converting the root (typically, slots with world visibility)
+  const QList<const WbNode *> protos = WbNodeUtilities::protoNodesInWorldFile(this);
+  foreach (const WbNode *p, protos)
+    // the node itself doesn't need to be re-declared since it won't exist after conversion
+    if (p != this) {
+      const QString protoDeclaration = WbProtoManager::instance()->externProtoUrl(p, false);
+      assert(!protoDeclaration.isEmpty());  // since the proto has world-visibility, a declaration for it must exist
+      writer.trackDeclaration(p->modelName(), protoDeclaration);
+    }
+
   addExternProtoFromFile(mProto, writer);
 }
 

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1248,13 +1248,14 @@ void WbNode::exportExternalSubProto(WbWriter &writer) const {
 
   // find all proto that were already exposed prior to converting the root (typically, slots with world visibility)
   const QList<const WbNode *> protos = WbNodeUtilities::protoNodesInWorldFile(this);
-  foreach (const WbNode *p, protos)
+  foreach (const WbNode *p, protos) {
     // the node itself doesn't need to be re-declared since it won't exist after conversion
     if (p != this) {
       const QString protoDeclaration = WbProtoManager::instance()->externProtoUrl(p, false);
       assert(!protoDeclaration.isEmpty());  // since the proto has world-visibility, a declaration for it must exist
       writer.trackDeclaration(p->modelName(), protoDeclaration);
     }
+  }
 
   addExternProtoFromFile(mProto, writer);
 }

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -870,7 +870,7 @@ void WbProtoManager::updateExternProto(const QString &protoName, const QString &
 
 QString WbProtoManager::formatExternProtoPath(const QString &url) const {
   QString path = url;
-  if (path.startsWith(WbStandardPaths::webotsHomePath()))
+  if (WbFileUtil::isLocatedInDirectory(path, WbStandardPaths::webotsHomePath()))
     path.replace(WbStandardPaths::webotsHomePath(), "webots://");
   if (path.startsWith(WbProject::current()->protosPath()))
     path = QDir(QFileInfo(mCurrentWorld).absolutePath()).relativeFilePath(path);

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -870,7 +870,7 @@ void WbProtoManager::updateExternProto(const QString &protoName, const QString &
 
 QString WbProtoManager::formatExternProtoPath(const QString &url) const {
   QString path = url;
-  if (WbFileUtil::isLocatedInDirectory(path, WbStandardPaths::webotsHomePath()))
+  if (WbFileUtil::isLocatedInInstallationDirectory(path, true))
     path.replace(WbStandardPaths::webotsHomePath(), "webots://");
   if (path.startsWith(WbProject::current()->protosPath()))
     path = QDir(QFileInfo(mCurrentWorld).absolutePath()).relativeFilePath(path);

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -454,7 +454,7 @@ const QString WbProtoModel::projectPath() const {
     if (WbUrl::isWeb(protoPath))
       protoPath.replace(QRegularExpression(WbUrl::remoteWebotsAssetRegex(false)), WbStandardPaths::webotsHomePath());
 #ifdef __APPLE__
-    if (WbFileUtil::isLocatedInDirectory(protoPath, WbStandardPaths::webotsHomePath()))
+    if (WbFileUtil::isLocatedInInstallationDirectory(protoPath, true))
       protoPath.insert(WbStandardPaths::webotsHomePath().length(), "Contents/");
 #endif
 

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -453,7 +453,7 @@ const QString WbProtoModel::projectPath() const {
     if (WbUrl::isWeb(protoPath))
       protoPath.replace(QRegularExpression(WbUrl::remoteWebotsAssetRegex(false)), WbStandardPaths::webotsHomePath());
 #ifdef __APPLE__
-    if (protoPath.startsWith(WbStandardPaths::webotsHomePath()))
+    if (WbFileUtil::isLocatedInDirectory(protoPath, WbStandardPaths::webotsHomePath()))
       protoPath.insert(WbStandardPaths::webotsHomePath().length(), "Contents/");
 #endif
 

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -16,6 +16,7 @@
 
 #include "WbField.hpp"
 #include "WbFieldModel.hpp"
+#include "WbFileUtil.hpp"
 #include "WbLog.hpp"
 #include "WbNetwork.hpp"
 #include "WbNode.hpp"

--- a/src/wren/Debug.hpp
+++ b/src/wren/Debug.hpp
@@ -46,28 +46,28 @@ namespace wren {
 #else
   inline void PhongMaterial::printCacheContents() {
     std::cerr << "PhongMaterial cache, number of entries: " << PhongMaterial::cCache.size() << std::endl;
-    for (auto &data : PhongMaterial::cCache) {
+    for (const auto &data : PhongMaterial::cCache) {
       std::cerr << "Hash: " << data.first.mHash << ", users: " << data.second.mNumUsers << std::endl;
     }
   }
 
   inline void PbrMaterial::printCacheContents() {
     std::cerr << "PbrMaterial cache, number of entries: " << PbrMaterial::cCache.size() << std::endl;
-    for (auto &data : PbrMaterial::cCache) {
+    for (const auto &data : PbrMaterial::cCache) {
       std::cerr << "Hash: " << data.first.mHash << ", users: " << data.second.mNumUsers << std::endl;
     }
   }
 
   inline void StaticMesh::printCacheContents() {
     std::cerr << "Mesh cache, number of entries: " << StaticMesh::cCache.size() << std::endl;
-    for (auto &data : StaticMesh::cCache) {
+    for (const auto &data : StaticMesh::cCache) {
       std::cerr << "Hash: " << data.first.mHash << ", users: " << data.second.mNumUsers << std::endl;
     }
   }
 
   inline void Texture2d::printCacheContents() {
     std::cerr << "Texture2d cache, number of entries: " << Texture2d::cCache.size() << std::endl;
-    for (auto &data : Texture2d::cCache) {
+    for (const auto &data : Texture2d::cCache) {
       std::cerr << "Hash: " << data.first.mHash << ", users: " << data.second.mNumUsers << std::endl;
     }
   }

--- a/src/wren/Material.cpp
+++ b/src/wren/Material.cpp
@@ -149,7 +149,7 @@ namespace wren {
     }
   }
 
-  int Material::countTextureInstances(const Texture *texture) {
+  int Material::countTextureInstances(const Texture *texture) const {
     int instances = 0;
     for (const auto &textureInstance : mTextures) {
       if (textureInstance.first == texture)

--- a/src/wren/Material.cpp
+++ b/src/wren/Material.cpp
@@ -151,7 +151,7 @@ namespace wren {
 
   int Material::countTextureInstances(const Texture *texture) {
     int instances = 0;
-    for (auto &textureInstance : mTextures) {
+    for (const auto &textureInstance : mTextures) {
       if (textureInstance.first == texture)
         ++instances;
     }

--- a/src/wren/Material.hpp
+++ b/src/wren/Material.hpp
@@ -161,7 +161,7 @@ namespace wren {
     void useProgram() const;
     void bindTextures() const;
     virtual void updateUniforms() const;
-    int countTextureInstances(const Texture *texture);
+    int countTextureInstances(const Texture *texture) const;
 
     bool mHasPremultipliedAlpha;
     bool mIsTranslucent;

--- a/src/wren/PostProcessingEffect.cpp
+++ b/src/wren/PostProcessingEffect.cpp
@@ -89,7 +89,7 @@ namespace wren {
 
     glstate::setBlend(mUseAlphaBlending);
 
-    for (auto &element : mProgramParameters)
+    for (const auto &element : mProgramParameters)
       mProgram->setCustomUniformValue(element.first, *element.second);
 
     mProgram->bind();
@@ -187,7 +187,7 @@ namespace wren {
 #endif
         mInputTextures[inputOutput.mInputTextureIndex] = inputOutput.mTextureEven;
 
-        for (Connection &connection : mConnections) {
+        for (const Connection &connection : mConnections) {
           if (connection.mOutputIndex == inputOutput.mOutputTextureIndexEven && connection.mFrom == this)
             connection.mTo->mInputTextures[connection.mInputIndex] = inputOutput.mTextureOdd;
         }
@@ -201,7 +201,7 @@ namespace wren {
 #endif
         mInputTextures[inputOutput.mInputTextureIndex] = inputOutput.mTextureOdd;
 
-        for (Connection &connection : mConnections) {
+        for (const Connection &connection : mConnections) {
           if (connection.mOutputIndex == inputOutput.mOutputTextureIndexEven && connection.mFrom == this)
             connection.mTo->mInputTextures[connection.mInputIndex] = inputOutput.mTextureEven;
         }

--- a/src/wren/Primitive.hpp
+++ b/src/wren/Primitive.hpp
@@ -36,7 +36,7 @@ namespace wren {
     };
 
     struct Sphere : public Primitive {
-      Sphere(const glm::vec3 &center = gVec3Zeros, float radius = 0.0f);
+      explicit Sphere(const glm::vec3 &center = gVec3Zeros, float radius = 0.0f);
 
       Sphere computeBoundingSphere() const override { return *this; }
 
@@ -45,7 +45,7 @@ namespace wren {
     };
 
     struct Plane : public Primitive {
-      Plane(const glm::vec3 &normal = gVec3UnitY, float negativeDistance = 0.0f);
+      explicit Plane(const glm::vec3 &normal = gVec3UnitY, float negativeDistance = 0.0f);
 
       void normalize() {
         const float divisor = 1.0f / glm::length(mNormal);
@@ -60,7 +60,7 @@ namespace wren {
     };
 
     struct Aabb : public Primitive {
-      Aabb(const glm::vec3 &min = gVec3Zeros, const glm::vec3 &max = gVec3Zeros);
+      explicit Aabb(const glm::vec3 &min = gVec3Zeros, const glm::vec3 &max = gVec3Zeros);
       explicit Aabb(const std::vector<glm::vec3> &vertices);
       explicit Aabb(const std::vector<Aabb> &aabbs);
 
@@ -85,7 +85,7 @@ namespace wren {
     };
 
     struct Ray : public Primitive {
-      Ray(const glm::vec3 &origin = gVec3Zeros, const glm::vec3 &direction = -gVec3UnitZ);
+      explicit Ray(const glm::vec3 &origin = gVec3Zeros, const glm::vec3 &direction = -gVec3UnitZ);
 
       Sphere computeBoundingSphere() const override { return gSphereInf; }
 
@@ -94,7 +94,7 @@ namespace wren {
     };
 
     struct Box : public Primitive {
-      Box(const glm::vec3 &center = gVec3Zeros, const glm::vec3 &extents = glm::vec3(0.5f));
+      explicit Box(const glm::vec3 &center = gVec3Zeros, const glm::vec3 &extents = glm::vec3(0.5f));
 
       Sphere computeBoundingSphere() const override { return Sphere(mCenter, glm::length(mExtents)); }
 
@@ -103,7 +103,7 @@ namespace wren {
     };
 
     struct Rectangle : public Primitive {
-      Rectangle(const glm::vec3 &center = gVec3Zeros, const glm::vec2 &extents = glm::vec2(0.5f, 0.5f));
+      explicit Rectangle(const glm::vec3 &center = gVec3Zeros, const glm::vec2 &extents = glm::vec2(0.5f, 0.5f));
 
       Sphere computeBoundingSphere() const override {
         return Sphere(mCenter, glm::length(glm::vec3(mExtents.x, 0.0f, mExtents.y)));
@@ -114,8 +114,8 @@ namespace wren {
     };
 
     struct Capsule : public Primitive {
-      Capsule(const glm::vec3 &center = gVec3Zeros, float radius = 0.5f, float height = 1.0f, bool hasSide = true,
-              bool hasTop = true, bool hasBottom = true);
+      explicit Capsule(const glm::vec3 &center = gVec3Zeros, float radius = 0.5f, float height = 1.0f, bool hasSide = true,
+                       bool hasTop = true, bool hasBottom = true);
 
       Sphere computeBoundingSphere() const override;
 
@@ -128,8 +128,8 @@ namespace wren {
     };
 
     struct Cone : public Primitive {
-      Cone(const glm::vec3 &center = gVec3Zeros, float radius = 1.0f, float height = 1.0f, bool hasSide = true,
-           bool hasBottom = true);
+      explicit Cone(const glm::vec3 &center = gVec3Zeros, float radius = 1.0f, float height = 1.0f, bool hasSide = true,
+                    bool hasBottom = true);
 
       Sphere computeBoundingSphere() const override;
 
@@ -141,8 +141,8 @@ namespace wren {
     };
 
     struct Cylinder : public Primitive {
-      Cylinder(const glm::vec3 &center = gVec3Zeros, float radius = 1.0f, float height = 1.0f, bool hasSide = true,
-               bool hasTop = true, bool hasBottom = true);
+      explicit Cylinder(const glm::vec3 &center = gVec3Zeros, float radius = 1.0f, float height = 1.0f, bool hasSide = true,
+                        bool hasTop = true, bool hasBottom = true);
 
       Sphere computeBoundingSphere() const override;
 

--- a/src/wren/ShaderProgram.cpp
+++ b/src/wren/ShaderProgram.cpp
@@ -145,7 +145,7 @@ namespace wren {
   }
 
   ShaderProgram::~ShaderProgram() {
-    for (auto &uniform : mCustomUniforms)
+    for (const auto &uniform : mCustomUniforms)
       delete uniform.second;
   }
 


### PR DESCRIPTION
**Description**

Fixes: https://github.com/cyberbotics/webots/issues/5173

Also fixes 2 issues with the conversion:

- If slots with PROTO nodes were present prior to the conversion, when deleting the node (prior to spawning the converted version) the declaration of these slots would be removed and they weren't re-added afterwards
- In the process of recursively exposing the declarations needed when converting derived PROTO to base-node, it could happen that the parent file was a cached file, and its disk location (rather than the original URL) was used when determining the full URL of a relatively-defined PROTO.

Concerning the relative URL appearing after conversion:

It turns out that solution 2 is not really an option, or at least not without rethinking the writer logic from the ground up. The reason is that when converting root to base node, as the name implies, the writer does not progress through nodes which are themselves PROTO (nested PROTO). Since it doesn't progress through it, the corresponding ImageTextures will be skipped. After the conversion however, the visibility will go up one layer and all of a sudden they are world-visible and therefore their URL needs to be converted nonetheless, so solution 1 albeit less optimal, seems to be the only approach.

In the case of the Lincoln for example, `textures/lincoln_mkz_details_base_color.jpg` is initially internal to the Lincoln, but child to `VehicleLights`. After root conversion, the Lincoln disappears but `VehicleLights` remains as a PROTO and therefore doesn't go through the writer. After conversion however, `VehicleLights` went up one layer in visibility, from internal it becomes world-visible, and its URLs therefore cannot remain relative and must be changed regardless.