### PR TITLE
Fix copy of binary controllers

### DIFF
--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -51,6 +51,8 @@ If for example the answer is `Python 3.8.10`, `python3X` should be `python38`.
 
 &nbsp;
 
+**MATLAB**: Here is an example of what you should enter in the MATLAB console:
+
 ```matlab
 >> setenv('WEBOTS_PROJECT', 'C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -51,22 +51,6 @@ If for example the answer is `Python 3.8.10`, `python3X` should be `python38`.
 
 &nbsp;
 
-For convenience, it is possible to set environment variables programmatically in your controller program as the very first statements before initializing the Webots controller API.
-
-&nbsp;
-
-**C/C++**: You can set environment variables using `putenv("VARIABLE=VALUE")`.
-It is not recommended to use `setenv()` as this function is not available on Windows.
-
-&nbsp;
-
-**Python**: You can set environment variables using `os.environ["VARIABLE"] = "VALUE"`.
-
-&nbsp;
-
-**MATLAB**: You can set environment variables using `setenv('VARIABLE', 'VALUE')`
-Here is an example of what you should enter in the MATLAB console:
-
 ```matlab
 >> setenv('WEBOTS_PROJECT', 'C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -52,10 +52,24 @@ If for example the answer is `Python 3.8.10`, `python3X` should be `python38`.
 
 &nbsp;
 
-**MATLAB**: Here is an example of what you should enter in the MATLAB console:
+For convenience, it is possible to set environment variables programmatically in your controller program as the very first statements before initializing the Webots controller API.
+
+&nbsp;
+
+**C/C++**: You can set environment variables using `putenv("VARIABLE=VALUE")`.
+It is not recommended to use `setenv()` as this function is not available on Windows.
+
+&nbsp;
+
+**Python**: You can set environment variables using `os.environ["VARIABLE"] = "VALUE"`.
+
+&nbsp;
+
+**MATLAB**: You can set environment variables using `setenv('VARIABLE', 'VALUE')`
+Here is an example of what you should enter in the MATLAB console:
 
 ```matlab
->> setenv('WEBOTS_PROJECT','C:\Users\MyUsername\my_folder\my_webots_project')
+>> setenv('WEBOTS_PROJECT', 'C:\Users\MyUsername\my_folder\my_webots_project')
 >> setenv('WEBOTS_CONTROLLER_NAME', 'my_robot_controller')
 >> setenv('WEBOTS_VERSION', '{{ webots.version.full }}')
 >> cd(getenv('WEBOTS_HOME'))
@@ -65,7 +79,7 @@ If for example the answer is `Python 3.8.10`, `python3X` should be `python38`.
 
 &nbsp;
 
-**Java**: Add the following options to the `java` command line launching the Java controller:
+**Java**: You should add the following options to the `java` command line for launching the Java controller:
 - `-classpath $WEBOTS_HOME\lib\controller\java\Controller.jar:$WEBOTS_HOME\my_project\controllers\MyController\`
 - `-Djava.library.path=$WEBOTS_HOME\lib\controller\java`
 

--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -515,10 +515,10 @@ endif
 else
 
 $(MAIN_TARGET): $(BUILD_GOAL_DIR)/$(MAIN_TARGET)
-	@# In Webots context (WEBOTS_DISABLE_BINARY_COPY set), copy only if the target
-	@# does not exist yet, thus there cannot be error due to replacement.
-	@# Otherwise, Webots does the copy systematically before running the simulation.
-	@# Outside Webots context, always copy the target.
+	@# Even when compiled from Webots with possibly the previous version of the binary
+	@# being executed, it is safe to delete it and copy the new version as a replacement.
+	@# This new version will be executed only when the process restarts.
+	@# Note: this binary may be an executable (e.g., a controller) or shared library (e.g., a physics plug-in).
 	@rm -f $(MAIN_TARGET) > /dev/null 2>&1 && echo "# copying to" $(MAIN_TARGET_COPY) && cp $(BUILD_GOAL_DIR)/$(MAIN_TARGET) $(MAIN_TARGET_COPY) > /dev/null 2>&1
 ifdef VS_DEF_NAME
 	@# Generate the .lib libraries to facilitate the integration with Visual Studio

--- a/resources/Makefile.include
+++ b/resources/Makefile.include
@@ -519,11 +519,7 @@ $(MAIN_TARGET): $(BUILD_GOAL_DIR)/$(MAIN_TARGET)
 	@# does not exist yet, thus there cannot be error due to replacement.
 	@# Otherwise, Webots does the copy systematically before running the simulation.
 	@# Outside Webots context, always copy the target.
-	@if [ -z "${WEBOTS_DISABLE_BINARY_COPY}" ] || [ ! -e "$(MAIN_TARGET)" ]; then \
-		echo "# copying to" $(MAIN_TARGET_COPY); \
-		rm -f $(MAIN_TARGET) > /dev/null 2>&1 ; \
-		cp $(BUILD_GOAL_DIR)/$(MAIN_TARGET) $(MAIN_TARGET_COPY) > /dev/null 2>&1 ; \
-	fi || :
+	@rm -f $(MAIN_TARGET) > /dev/null 2>&1 && echo "# copying to" $(MAIN_TARGET_COPY) && cp $(BUILD_GOAL_DIR)/$(MAIN_TARGET) $(MAIN_TARGET_COPY) > /dev/null 2>&1
 ifdef VS_DEF_NAME
 	@# Generate the .lib libraries to facilitate the integration with Visual Studio
 	@# if the .def file is existing.

--- a/src/webots/app/WbApplication.cpp
+++ b/src/webots/app/WbApplication.cpp
@@ -92,8 +92,6 @@ WbApplication::WbApplication() {
     qputenv("Path", QByteArray(newPath.toUtf8()));
   }
 #endif
-
-  qputenv("WEBOTS_DISABLE_BINARY_COPY", "True");
 }
 
 WbApplication::~WbApplication() {

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -239,6 +239,9 @@ void WbBuildEditor::processFinished(int exitCode, QProcess::ExitStatus exitStatu
       // should not happen, but just in case
       WbLog::appendStderr("external make process crashed!\n", WbLog::COMPILATION);
       break;
+    default:
+      WbLog::appendStderr("Make finished with unknown exit status.\n", WbLog::COMPILATION);
+      break;
   }
 
   cleanupProcess();
@@ -301,9 +304,8 @@ void WbBuildEditor::make(const QString &target) {
   bool isJavaProgram = (currentBuffer()->language()->code() == WbLanguage::JAVA);
 
   // find out compilation directory
-  // WbTextBuffer *currentBuffer = currentBuffer();
   QString compilePath = compileDir().absolutePath();
-// On Windows, make won't work if the Makefile file is located in a path with UTF-8 characters (e.g., Chinese)
+  // On Windows, make won't work if the Makefile file is located in a path with UTF-8 characters (e.g., Chinese)
 #ifdef _WIN32
   if (!isJavaProgram && QString(compilePath.toUtf8()) != QString::fromLocal8Bit(compilePath.toLocal8Bit())) {
     WbMessageBox::warning(tr("\'%1\'\n\nThe path to this Webots project contains non 8-bit characters. "
@@ -410,10 +412,9 @@ void WbBuildEditor::make(const QString &target) {
   // launch external make and wait at most 5 sec
   mProcess->setWorkingDirectory(compilePath);
   mProcess->start(command, arguments);
-  bool started = mProcess->waitForStarted(5000);
 
   // check that program is available
-  if (!started) {
+  if (!mProcess->waitForStarted(5000)) {
 #ifdef _WIN32
     WbLog::appendStderr(tr("Installation problem: could not start '%1'.\n").arg(command), WbLog::COMPILATION);
 #else

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -237,10 +237,10 @@ void WbBuildEditor::processFinished(int exitCode, QProcess::ExitStatus exitStatu
     }
     case QProcess::CrashExit:
       // should not happen, but just in case
-      WbLog::appendStderr("external make process crashed!\n", WbLog::COMPILATION);
+      WbLog::appendStderr("Make process crashed!\n", WbLog::COMPILATION);
       break;
     default:
-      WbLog::appendStderr("Make finished with unknown exit status.\n", WbLog::COMPILATION);
+      WbLog::appendStderr("Make process finished with unknown exit status.\n", WbLog::COMPILATION);
       break;
   }
 

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -83,14 +83,13 @@ void WbProjectRelocationDialog::initCompleteRelocation() {
   QLabel *title = new QLabel(tr("<b>Copy necessary files from source to target directory?</b>"), this);
 
   const QString &sourcePath = QDir::toNativeSeparators(mProject->path());
-  mTargetPath =
-    QDir::toNativeSeparators(WbPreferences::instance()->value("Directories/projects").toString() + mProject->dirName());
+  mTargetPath = WbPreferences::instance()->value("Directories/projects").toString() + mProject->dirName();
 
   mSourceEdit = new WbLineEdit(sourcePath, this);
   mSourceEdit->setReadOnly(true);
   mSourceEdit->setMinimumWidth(sourcePath.length() * 8);
 
-  mTargetEdit = new WbLineEdit(mTargetPath, this);
+  mTargetEdit = new WbLineEdit(QDir::toNativeSeparators(mTargetPath), this);
 #ifdef __APPLE__
   mTargetEdit->setMinimumWidth(mTargetPath.length() * 8);
 #endif
@@ -285,7 +284,7 @@ int WbProjectRelocationDialog::copyWorldFiles() {
   // copy the .wbt file, the .wbproj file
   QDir targetPathDir(mTargetPath + "/worlds");
   targetPathDir.mkpath(".");
-  const QString mTargetWorld(mTargetPath + "/worlds/" + worldFileBaseName);
+  mTargetWorld = mTargetPath + "/worlds/" + worldFileBaseName;
   if (QFile::copy(mProject->worldsPath() + worldFileBaseName + ".wbt", mTargetWorld + ".wbt")) {
     QFile::setPermissions(mTargetWorld + ".wbt",
                           QFile::permissions(mTargetWorld + ".wbt") | QFile::WriteOwner | QFile::WriteUser);
@@ -378,8 +377,8 @@ void WbProjectRelocationDialog::selectDirectory() {
   if (path.isEmpty())
     return;
 
-  mTargetPath = path;
-  mTargetEdit->setText(QDir::toNativeSeparators(mTargetPath));
+  mTargetEdit->setText(path);
+  mTargetPath = QDir::fromNativeSeparators(path);
   setStatus(tr("Push the [Copy] button to copy the necessary project files."));
 }
 
@@ -473,7 +472,7 @@ void WbProjectRelocationDialog::accept() {
   mFieldsToUpdate.clear();
 
   WbProtoManager::instance()->updateCurrentWorld(mTargetWorld);
-  WbProject::current()->setPath(mTargetWorld);
+  WbProject::current()->setPath(mTargetPath);
 
   QDialog::accept();
 }

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -325,8 +325,7 @@ int WbProjectRelocationDialog::copyWorldFiles() {
       }
 
       // copy textures to the new location
-      const QString relativePath =
-        QDir(QFileInfo(mTargetWorld + ".wbt").absolutePath()).relativeFilePath(fi.absoluteFilePath());
+      const QString relativePath = QDir(QFileInfo(mTargetWorld).absolutePath()).relativeFilePath(fi.absoluteFilePath());
       if (!fi.exists() && QFile::copy(sourceTexturePath, fi.absoluteFilePath()))
         result++;
 

--- a/src/webots/editor/WbProjectRelocationDialog.cpp
+++ b/src/webots/editor/WbProjectRelocationDialog.cpp
@@ -284,10 +284,9 @@ int WbProjectRelocationDialog::copyWorldFiles() {
   // copy the .wbt file, the .wbproj file
   QDir targetPathDir(mTargetPath + "/worlds");
   targetPathDir.mkpath(".");
-  mTargetWorld = mTargetPath + "/worlds/" + worldFileBaseName;
-  if (QFile::copy(mProject->worldsPath() + worldFileBaseName + ".wbt", mTargetWorld + ".wbt")) {
-    QFile::setPermissions(mTargetWorld + ".wbt",
-                          QFile::permissions(mTargetWorld + ".wbt") | QFile::WriteOwner | QFile::WriteUser);
+  mTargetWorld = mTargetPath + "/worlds/" + worldFileBaseName + ".wbt";
+  if (QFile::copy(mProject->worldsPath() + worldFileBaseName + ".wbt", mTargetWorld)) {
+    QFile::setPermissions(mTargetWorld, QFile::permissions(mTargetWorld) | QFile::WriteOwner | QFile::WriteUser);
     result++;
   }
   const QString &targetProjectFile(mTargetPath + "/worlds/." + worldFileBaseName + ".wbproj");


### PR DESCRIPTION
Fixes #5186.

In addition to fixing the above mentioned issue, this PR also enforce the copy of a controller compiled from the Webots build editor. This is actually needed when compiling extern controllers because Webots won't make the copy of the controller before starting an extern controller. It does it only for non-extern controllers. So, it is annoying when developing an extern controller to have to make the copy manually after re-compiling.