### PR TITLE
Fix field editor size update

### DIFF
--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -396,7 +396,7 @@ void WbNodeOperations::updateExternProtoDeclarations(WbField *field) {
   QList<const WbNode *> protoList(WbNodeUtilities::protoNodesInWorldFile(topProto));
   foreach (const WbNode *proto, protoList) {
     const QString previousUrl(
-      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, false, false));
+      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, false));
     if (!previousUrl.isEmpty())
       WbLog::warning(tr("Conflicting declarations for '%1' are provided: \"%2\" and \"%3\", the first one will be used after "
                         "saving and reverting the world. "

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -731,7 +731,7 @@ void WbAddNodeDialog::accept() {
 
   // the insertion must be declared as EXTERNPROTO so that it is added to the world file when saving
   WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
-                                                 mSelectionPath, false, true);
+                                                 mSelectionPath, true);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbExternProtoEditor.cpp
+++ b/src/webots/scene_tree/WbExternProtoEditor.cpp
@@ -29,7 +29,6 @@
 
 WbExternProtoEditor::WbExternProtoEditor(QWidget *parent) : WbValueEditor(parent) {
   connect(this, &WbExternProtoEditor::changed, WbActionManager::instance()->action(WbAction::SAVE_WORLD), &QAction::setEnabled);
-  connect(WbProtoManager::instance(), &WbProtoManager::externProtoListChanged, this, &WbExternProtoEditor::updateContents);
 }
 
 WbExternProtoEditor::~WbExternProtoEditor() {

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -207,7 +207,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // the addition must be declared as EXTERNPROTO so that it is added to the world file when saving
-  WbProtoManager::instance()->declareExternProto(mProto, mPath, true, true);
+  WbProtoManager::instance()->declareExternProto(mProto, mPath, true);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -344,7 +344,7 @@ void WbSceneTree::paste() {
 
   const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
   foreach (const WbExternProto *item, cutBuffer)
-    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable(), true);
+    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable());
 
   if (mSelectedItem->isField() && mSelectedItem->field()->isSingle())
     pasteInSFValue();
@@ -773,7 +773,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     // declare PROTO nodes that have become visible at the world level
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {
-      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false, false));
+      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false));
       if (!previousUrl.isEmpty())
         WbLog::warning(tr("Conflicting declarations for '%1' are provided: %2 and %3, the first one will be used. "
                           "To use the other instead you will need to change it manually in the world file.")

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -411,7 +411,7 @@ void WbProtoManager::loadWorld() {
 
   // declare all root PROTO defined at the world level, and inferred by backwards compatibility, to the list of EXTERNPROTO
   foreach (const WbProtoTreeItem *const child, mTreeRoot->children())
-    declareExternProto(child->name(), child->url(), child->isImportable(), false);
+    declareExternProto(child->name(), child->url(), child->isImportable());
 
   // cleanup and load world at last
   mTreeRoot->deleteLater();
@@ -765,7 +765,7 @@ WbProtoInfo *WbProtoManager::generateInfoFromProtoFile(const QString &protoFileN
 }
 
 QString WbProtoManager::declareExternProto(const QString &protoName, const QString &protoPath, bool importable,
-                                           bool updateContents, bool forceUpdate) {
+                                           bool forceUpdate) {
   QString previousUrl;
   const QString expandedProtoPath(WbUrl::resolveUrl(protoPath));
   for (int i = 0; i < mExternProto.size(); ++i) {
@@ -776,15 +776,11 @@ QString WbProtoManager::declareExternProto(const QString &protoName, const QStri
         if (forceUpdate)
           mExternProto[i]->setUrl(expandedProtoPath);
       }
-      if (updateContents)
-        emit externProtoListChanged();
       return previousUrl;
     }
   }
 
   mExternProto.push_back(new WbExternProto(protoName, expandedProtoPath, importable, !forceUpdate));
-  if (updateContents)
-    emit externProtoListChanged();
   return previousUrl;
 }
 
@@ -850,7 +846,6 @@ void WbProtoManager::removeImportableExternProto(const QString &protoName) {
         delete mExternProto[i];
         mExternProto.remove(i);
       }
-      emit externProtoListChanged();
       return;  // we can stop since the list is supposed to contain unique elements, and a match was found
     }
   }

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -180,8 +180,7 @@ public:
 
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared
-  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool updateContents,
-                             bool forceUpdate = true);
+  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool forceUpdate = true);
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;
@@ -201,7 +200,6 @@ public:
 signals:
   void retrievalCompleted();
   void dependenciesAvailable();
-  void externProtoListChanged();
 
 private slots:
   void loadWorld();


### PR DESCRIPTION
Fix #5189:
the `WbExternProtoEditor` content was updated when modifying a new PROTO to the externproto list, even if the editor was not visible, and this was increasing the size of all the field editors.
Given the latest changes in the IMPORTABLE vs other EXTERNPROTO declarations, the importable list can currently only be changed by `WbExternProtoEditor` itself and it is not modified by other user actions.
Thus, we can simplify the code and completely remove the notification when the list of EXTERNPROTO changes.