### PR TITLE
Fix UNDO crash

### DIFF
--- a/src/webots/user_commands/WbUndoStack.cpp
+++ b/src/webots/user_commands/WbUndoStack.cpp
@@ -51,6 +51,9 @@ void WbUndoStack::push(QUndoCommand *cmd) {
 
   QUndoStack::push(cmd);
 
+  if (mClearRequest)
+    clear();
+
   updateActions();
   // notify the scene tree that some fields changed in order to update the
   // field editor if needed

--- a/src/webots/user_commands/WbUndoStack.cpp
+++ b/src/webots/user_commands/WbUndoStack.cpp
@@ -49,7 +49,7 @@ void WbUndoStack::push(QUndoCommand *cmd) {
 
   mClearRequest = false;
 
-  QUndoStack::push(cmd);
+  QUndoStack::push(cmd);  // may change the value of mClearRequest via the clearRequest slot
 
   // cppcheck-suppress knownConditionTrueFalse
   if (mClearRequest)

--- a/src/webots/user_commands/WbUndoStack.cpp
+++ b/src/webots/user_commands/WbUndoStack.cpp
@@ -51,6 +51,7 @@ void WbUndoStack::push(QUndoCommand *cmd) {
 
   QUndoStack::push(cmd);
 
+  // cppcheck-suppress knownConditionTrueFalse
   if (mClearRequest)
     clear();
 


### PR DESCRIPTION
**Description**

Essentially the logic seems to be that actions that result in a template regeneration are not even pushed to the undo stack although the action itself takes place otherwise the scene tree wouldn't be updated. 

The function itself seems rather odd since we set `mClearRequest` to false 2 lines above, but I suspect that the execution of `QUndoStack::push(cmd)` calls `setClearRequest` which changes the flag back to positive, ensuring that we enter the `clear()` function. In short we push it, do the action, and remove it from the stack and since it's no longer there neither the menu option nor CTRL+Z have anything to revert to (i.e., the button remains disabled) .

These two lines appear in the source code of R2022a but no longer do in our repo. I've tried to figure out at which point they were removed but I can't find any indication they ever were, the last change in this function (both on master/develop) dates from 4  years ago, long before R2022a. How can the history have changed without leaving any trace is beyond me.