### PR TITLE
Fix incorrect insertion in IMPORTABLE EXTERNPROTO list

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -731,7 +731,7 @@ void WbAddNodeDialog::accept() {
 
   // the insertion must be declared as EXTERNPROTO so that it is added to the world file when saving
   WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
-                                                 mSelectionPath, true);
+                                                 mSelectionPath, false);
 
   QDialog::accept();
 }


### PR DESCRIPTION
The clean-up of #5193 removed the wrong boolean in the call to `declareExternProto` in `WbAddNodeDialog`, causing the Add Node button to also add the PROTO to the IMPORTABLE list.