### PR TITLE
Fix upload of resources that have a space in their name

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1611,7 +1611,8 @@ void WbMainWindow::upload() {
     }
 
     mainPart.setHeader(QNetworkRequest::ContentDispositionHeader,
-                       QVariant("form-data; name=" + map["name"] + "; filename=" + fileName));
+                       QVariant("form-data; name=" + map["name"] + "; filename=\"" + fileName + "\""));
+
 
     // read file content
     if (fileName != "") {

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1613,7 +1613,6 @@ void WbMainWindow::upload() {
     mainPart.setHeader(QNetworkRequest::ContentDispositionHeader,
                        QVariant("form-data; name=" + map["name"] + "; filename=\"" + fileName + "\""));
 
-
     // read file content
     if (fileName != "") {
       QFile *file = new QFile(map["foldername"] + fileName);


### PR DESCRIPTION
If a resource had a name like `Cat 3D Model`, the name was cut in the POST request in just `Cat`