### PR TITLE
Fix lidar rotating head export to x3d

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -230,7 +230,7 @@ void WbLidar::write(WbWriter &writer) const {
 
 void WbLidar::exportNodeSubNodes(WbWriter &writer) const {
   WbAbstractCamera::exportNodeSubNodes(writer);
-  if (writer.isWebots() || writer.isUrdf())
+  if (writer.isWebots())
     return;
 
   WbSolid *s = solidEndPoint();

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -222,14 +222,20 @@ void WbLidar::postPhysicsStep() {
 }
 
 void WbLidar::write(WbWriter &writer) const {
+  if (writer.isWebots()) {
+    WbBaseNode::write(writer);
+  } else
+    writeExport(writer);
+}
+
+void WbLidar::exportNodeSubNodes(WbWriter &writer) const {
+  WbAbstractCamera::exportNodeSubNodes(writer);
   if (writer.isWebots())
-    WbBaseNode::write(writer);
-  else {
-    WbBaseNode::write(writer);
-    WbSolid *s = solidEndPoint();
-    if (s)
-      s->write(writer);
-  }
+    return;
+
+  WbSolid *s = solidEndPoint();
+  if (s)
+    s->write(writer);
 }
 
 void WbLidar::addConfigureToStream(WbDataStream &stream, bool reconfigure) {

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -222,7 +222,7 @@ void WbLidar::postPhysicsStep() {
 }
 
 void WbLidar::write(WbWriter &writer) const {
-  if (writer.isWebots()) {
+  if (writer.isWebots() || writer.isUrdf()) {
     WbBaseNode::write(writer);
   } else
     writeExport(writer);
@@ -230,7 +230,7 @@ void WbLidar::write(WbWriter &writer) const {
 
 void WbLidar::exportNodeSubNodes(WbWriter &writer) const {
   WbAbstractCamera::exportNodeSubNodes(writer);
-  if (writer.isWebots())
+  if (writer.isWebots() || writer.isUrdf())
     return;
 
   WbSolid *s = solidEndPoint();

--- a/src/webots/nodes/WbLidar.hpp
+++ b/src/webots/nodes/WbLidar.hpp
@@ -53,6 +53,7 @@ public:
   void prePhysicsStep(double ms) override;
   void postPhysicsStep() override;
   void write(WbWriter &writer) const override;
+  void exportNodeSubNodes(WbWriter &writer) const override;
   WbRgb enabledCameraFrustrumColor() const override { return WbRgb(0.0f, 1.0f, 1.0f); }
 
   double maxRange() const override { return mMaxRange->value(); }


### PR DESCRIPTION
Before the rotating head was export side-by-side with the lidar and not _in_ the lidar.

The consequence was that if the lidar has a translation/rotation, it was not applied to the rotating head once exported in x3d.