### PR TITLE
fix WbLightSensor: collect behavior of recieving light of SpotLight

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -3,6 +3,7 @@
 ## Webots R2022b Revision 1
  - Bug Fixes
    - Fixes the export of lidar's rotating head to X3D. ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
+   - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
 
 
 ## Webots R2022b

--- a/src/webots/nodes/WbLightSensor.cpp
+++ b/src/webots/nodes/WbLightSensor.cpp
@@ -315,7 +315,7 @@ void WbLightSensor::computeLightMeasurement(const WbLight *light,
 
     // compute spot's beam effect
     const WbVector3 &dir = spotLight->direction();
-    const WbTransform* ut = spotLight->upperTransform();
+    const WbTransform *ut = spotLight->upperTransform();
     WbVector3 R = -(ut->rotation().toMatrix3() * dir);
     R.normalize();
     double alpha = WbMathsUtilities::clampedAcos(lightDirection.dot(R));  // both lightDirection and R are normalized

--- a/src/webots/nodes/WbLightSensor.cpp
+++ b/src/webots/nodes/WbLightSensor.cpp
@@ -315,7 +315,8 @@ void WbLightSensor::computeLightMeasurement(const WbLight *light,
 
     // compute spot's beam effect
     const WbVector3 &dir = spotLight->direction();
-    WbVector3 R = -dir;
+    const WbTransform* ut = spotLight->upperTransform();
+    WbVector3 R = -(ut->rotation().toMatrix3() * dir);
     R.normalize();
     double alpha = WbMathsUtilities::clampedAcos(lightDirection.dot(R));  // both lightDirection and R are normalized
     assert(!std::isnan(alpha));


### PR DESCRIPTION
In `WbLightSensor::computeLightMeasurement`, `R` is directly used from `spotLight->direction()`.
So `WbLightSensor` class does not work correctly when spot light object is moved.

I think `R` should be calculate using `spotLight->upperTransform()->rotation()`.

Thank you for making nice application, and maintenance!