### PR TITLE
Fix labels reset

### DIFF
--- a/resources/web/wwi/Animation.js
+++ b/resources/web/wwi/Animation.js
@@ -40,6 +40,27 @@ export default class Animation {
     this._labelsIds = typeof this.data.labelsIds === 'undefined' ? [] : this.data.labelsIds.split(';')
       .filter(Boolean).map(s => parseInt(s));
 
+    const firstFrame = this.data.frames[0];
+    if (firstFrame && this._labelsIds.length > 0) {
+      const labelsIdsAtStart = new Set();
+      if (firstFrame.labels) {
+        firstFrame.labels.forEach((label) => {
+          labelsIdsAtStart.add(label.id);
+        });
+      } else
+        firstFrame.labels = [];
+
+      this._labelsIds.forEach((labelId) => {
+        if (!labelsIdsAtStart.has(labelId)) {
+          const newlabel = {
+            id: labelId,
+            rgba: '0, 0, 0, 0'
+          };
+          firstFrame.labels.push(newlabel);
+        }
+      });
+    }
+
     // generate keyFrames to speed up the navigation.
     this._keyFrames = new Map();
     this.keyFrameStepSize = 1000; // Generate a keyFrame each 1000 timesteps. It is an empirical value.

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -261,10 +261,13 @@ webots.View = class View {
       this._x3dDiv.appendChild(labelElement);
     }
 
-    let font = properties.font.split('/');
-    font = font[font.length - 1].replace('.ttf', '');
+    if (properties.font) {
+      let font = properties.font.split('/');
+      font = font[font.length - 1].replace('.ttf', '');
 
-    labelElement.style.fontFamily = font;
+      labelElement.style.fontFamily = font;
+    }
+
     labelElement.style.color = 'rgba(' + properties.color + ')';
     // 2.25 is an empirical value to match with Webots appearance
     labelElement.style.fontSize = this._getHeight(this._x3dDiv) * properties.size / 2.25 + 'px';
@@ -274,7 +277,7 @@ webots.View = class View {
     labelElement.y = properties.y;
     labelElement.size = properties.size;
 
-    if (properties.text.includes('█')) {
+    if (properties.text && properties.text.includes('█')) {
       properties.text = properties.text.replaceAll('█', '<span style="background:' + labelElement.style.color + '"> </span>');
       labelElement.style.zIndex = '1';
     }


### PR DESCRIPTION
At setup we check if all labels are present in the first frame to have a reference point when jumping backward and forward in the animation.

If it is not the case, create a label instruction in the first frame which set the label to transparent (and empty)

Fix #5227 