### PR TITLE
Fix webotsJS follow viewpoint

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -4,6 +4,7 @@
  - Bug Fixes
    - Fixes the export of lidar's rotating head to X3D. ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
+   - Fixed the reset of the viewpoint in animation when the follow is actived ([5237](https://github.com/cyberbotics/webots/pull/5237)).
 
 
 ## Webots R2022b

--- a/resources/web/wwi/nodes/WbViewpoint.js
+++ b/resources/web/wwi/nodes/WbViewpoint.js
@@ -164,9 +164,8 @@ export default class WbViewpoint extends WbBaseNode {
     // reset the viewpoint position and the variables when the animation restarts
     if (time === 0) {
       this._viewpointLastUpdate = time;
-      this.position = this._initialPosition;
+      this.position = this.position.sub(this._defaultPosition.sub(this._initialPosition));
       this._defaultPosition = this._initialPosition;
-      this.orientation = this._initialOrientation;
       this._followedObjectDeltaPosition = new WbVector3();
       this._viewpointForce = new WbVector3();
       this._viewpointVelocity = new WbVector3();


### PR DESCRIPTION
Fix #5228 

I tried several things but finally went for a very simple solution:

- If the viewpoint follow is not enabled, we never touch the viewpoint position (except if the user reset it manually).
- If the viewpoint follow is enable, we reset it **but** we preserve the transformations (translation and rotation) done by the user.
  We are force to kind of reset the position otherwise we have some problems with the follow (it does not like big jump). 