### PR TITLE
GPS: Remove wrong const attribute

### DIFF
--- a/docs/reference/gps.md
+++ b/docs/reference/gps.md
@@ -64,7 +64,7 @@ void wb_gps_enable(WbDeviceTag tag, int sampling_period);
 void wb_gps_disable(WbDeviceTag tag);
 int wb_gps_get_sampling_period(WbDeviceTag tag);
 const double *wb_gps_get_values(WbDeviceTag tag);
-const double wb_gps_get_speed(WbDeviceTag tag);
+double wb_gps_get_speed(WbDeviceTag tag);
 const double *wb_gps_get_speed_vector(WbDeviceTag tag);
 ```
 
@@ -81,7 +81,7 @@ namespace webots {
     virtual void disable();
     int getSamplingPeriod() const;
     const double *getValues() const;
-    const double getSpeed() const;
+    double getSpeed() const;
     const double *getSpeedVector() const;
     // ...
   }

--- a/include/controller/c/webots/gps.h
+++ b/include/controller/c/webots/gps.h
@@ -32,7 +32,7 @@ void wb_gps_enable(WbDeviceTag tag, int sampling_period);
 void wb_gps_disable(WbDeviceTag tag);
 int wb_gps_get_sampling_period(WbDeviceTag tag);
 
-const double wb_gps_get_speed(WbDeviceTag tag);
+double wb_gps_get_speed(WbDeviceTag tag);
 const double *wb_gps_get_speed_vector(WbDeviceTag tag);
 const double *wb_gps_get_values(WbDeviceTag tag);
 

--- a/include/controller/cpp/webots/GPS.hpp
+++ b/include/controller/cpp/webots/GPS.hpp
@@ -30,7 +30,7 @@ namespace webots {
     int getSamplingPeriod() const;
 
     const double *getValues() const;
-    const double getSpeed() const;
+    double getSpeed() const;
     const double *getSpeedVector() const;
 
     const CoordinateSystem getCoordinateSystem() const;

--- a/src/controller/c/gps.c
+++ b/src/controller/c/gps.c
@@ -181,7 +181,7 @@ const double *wb_gps_get_values(WbDeviceTag tag) {
   return result;
 }
 
-const double wb_gps_get_speed(WbDeviceTag tag) {
+double wb_gps_get_speed(WbDeviceTag tag) {
   double result = NAN;
   robot_mutex_lock();
   GPS *gps = gps_get_struct(tag);

--- a/src/controller/cpp/GPS.cpp
+++ b/src/controller/cpp/GPS.cpp
@@ -37,7 +37,7 @@ const double *GPS::getValues() const {
   return wb_gps_get_values(getTag());
 }
 
-const double GPS::getSpeed() const {
+double GPS::getSpeed() const {
   return wb_gps_get_speed(getTag());
 }
 


### PR DESCRIPTION
wb_gps_get_speed() was labeled as const, and should not.

**Related Issues**
This pull-request fixes issue #5235