### PR TITLE
added shader that creates a more promissing spherical image

### DIFF
--- a/resources/wren/shaders/merge_spherical.frag
+++ b/resources/wren/shaders/merge_spherical.frag
@@ -33,18 +33,36 @@ uniform float fovYCorrectionCoefficient;
 
 uniform sampler2D inputTextures[6];
 
+
 void main() {
-  // update the z 3D-coordinate
-  float yCurrentAngle = (texUv.y - 0.5) * fovY / fovYCorrectionCoefficient + pi_2;
-  vec3 coord3d = vec3(0.0, 0.0, cos(yCurrentAngle));
+  //https://www.shadertoy.com/view/lssGD4
+  vec3 coord3d;
 
-  // update the x spherical coordinate
-  float xCurrentAngle = (0.5 - texUv.x) * fovX;
+  //workaround for lidars, as this breaks them due to the lack of equirectangular images
+  if (rangeCamera > 0) {
+    // update the z 3D-coordinate
+    float yCurrentAngle = (texUv.y - 0.5) * fovY / fovYCorrectionCoefficient + pi_2;
+    coord3d = vec3(0.0, 0.0, cos(yCurrentAngle));
 
-  // update the x-y 3d coordinate
-  float sinY = sin(yCurrentAngle);
-  coord3d.x = sinY * cos(xCurrentAngle);
-  coord3d.y = sinY * sin(xCurrentAngle);
+    // update the x spherical coordinate
+    float xCurrentAngle = (0.5 - texUv.x) * fovX;
+
+    // update the x-y 3d coordinate
+    float sinY = sin(yCurrentAngle);
+    coord3d.x = sinY * cos(xCurrentAngle);
+    coord3d.y = sinY * sin(xCurrentAngle);
+
+  }
+  else {
+    vec2 d = texUv-0.5;//vec2(x, y);
+    float yaw = sqrt(d.x*d.x +d.y*d.y) * fovX;
+
+    float roll = -atan(d.y, d.x);
+    float sy = -sin(yaw) * cos(roll);
+    float sz = sin(yaw) * sin(roll);
+    float sx = cos(yaw);
+    coord3d = vec3(sx, sy, sz);
+  }
 
   // normalize the 3d coordinate
   vec3 coord3dAbs = abs(coord3d);
@@ -113,6 +131,7 @@ void main() {
 
   vec2 faceCoord = vec2(0.5 * (1.0 - coord.x), 0.5 * (1.0 - coord.y));
   ivec2 imageIndex = ivec2(round(faceCoord.x * (subCamerasResolutionX - 1)), round(faceCoord.y * (subCamerasResolutionY - 1)));
+
 
   fragColor = vec4(0.0, 0.0, 0.0, 1.0);
   if (face == FRONT)


### PR DESCRIPTION
Updates  #2295

This PR provides a fisheye shader adapted from https://www.shadertoy.com/view/lssGD4 to create a spherical image which distorts in both directions instead of only one. 

It currently only works for rgb cameras as the merge_spherical.frag shader is also a basis for the LIDAR class and changing these projection for range images therefore destroys lidar range images and point clouds.

In general a test, if this shader projects the image correct, should be done.

Maybe the two shaders should be split into an equirectangular and a fisheye shader class which can be properly assigned.