### PR TITLE
added section to correct corners that are separated by commas instead…

### DIFF
--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -187,8 +187,6 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
     rotation_next_object = []
     miss_rotation = False
     last_type = ''
-
-
     for line in fileinput.input(filename, inplace=True):
 
         type = [x for x in re.compile('\n|,| ').split(line) if (any(x_char.isalpha() for x_char in x))]

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -218,7 +218,7 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
                 if "," in line:
                     vectors = [x for x in re.compile('[,]').split(line)]
                     for vector in vectors:
-                        print(add_space(line)+vector.strip())
+                        print(add_space(line) + vector.strip())
                 else:
                     print(line, end='')
         else:

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -187,6 +187,8 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
     rotation_next_object = []
     miss_rotation = False
     last_type = ''
+
+
     for line in fileinput.input(filename, inplace=True):
 
         type = [x for x in re.compile('\n|,| ').split(line) if (any(x_char.isalpha() for x_char in x))]
@@ -217,7 +219,7 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
                 if "," in line:
                     vectors = [x for x in re.compile('[,]').split(line)]
                     for vector in vectors:
-                        print(vector)
+                        print(add_space(line)+vector.strip())
                 else:
                     print(line, end='')
         else:

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -213,7 +213,7 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
                 next_line_is_corners = -1
                 print(line, end ='')
             else:  # else we convert the line
-                # fix for issue where corners are comma separated
+                # split coordinates separated by commas on new lines
                 if "," in line:
                     vectors = [x for x in re.compile('[,]').split(line)]
                     for vector in vectors:

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -211,7 +211,7 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
         elif next_line_is_corners == 1:
             if ']' in line:  # we stop when we reach the end of the node 'point' of 'coord'
                 next_line_is_corners = -1
-                print(line, end ='')
+                print(line, end='')
             else:  # else we convert the line
                 # split coordinates separated by commas on new lines
                 if "," in line:

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -208,7 +208,7 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
                         type in ['shape'] and 'Crossroad' in last_type):
             if '[]' not in line:  # if type not empty
                 next_line_is_corners = 1
-            print(line,end='')
+            print(line, end='')
         elif next_line_is_corners == 1:
             if ']' in line:  # we stop when we reach the end of the node 'point' of 'coord'
                 next_line_is_corners = -1

--- a/scripts/converter/convert_nue_to_enu_rub_to_flu.py
+++ b/scripts/converter/convert_nue_to_enu_rub_to_flu.py
@@ -188,7 +188,6 @@ def convert_nue_to_enu_world(filename, mode='all', objects_pi=[], objects_pi_2=[
     miss_rotation = False
     last_type = ''
 
-
     for line in fileinput.input(filename, inplace=True):
 
         type = [x for x in re.compile('\n|,| ').split(line) if (any(x_char.isalpha() for x_char in x))]


### PR DESCRIPTION
… of newlines

**Description**
Encountered an issue in which when upgrading some SimpleBuildings were converted correctly but others appeared flipped. upon investigation it was found that those SimpleBuildings were using comma separated vectors for its corners instead of newline separated like the script expects. This PR goes through and changes any comma-separated lists of corners into newline separated before the file is parsed by the main script

**Additional context**
Persuant to a conversation had in the webots discord on 19th september 2022
