### PR TITLE
Make conversion script more robust

### DIFF
--- a/scripts/converter/declare_externproto.py
+++ b/scripts/converter/declare_externproto.py
@@ -81,7 +81,7 @@ for file, path in local_files.items():
     header = []
     index = None
     for n, line in enumerate(contents):
-        if line.replace(' ', '') == '\n':
+        if line.replace(' ', '').replace('\t', '') == '\n':
             continue
         clean_line = line.strip()
         if clean_line.startswith('#'):

--- a/scripts/converter/declare_externproto.py
+++ b/scripts/converter/declare_externproto.py
@@ -78,19 +78,27 @@ for file, path in local_files.items():
 
     contents = contents.splitlines(keepends=True)
 
-    version = re.search(r'^#\s*VRML_SIM\s+([a-zA-Z0-9\-]+)\s+utf8', contents[0])
-    if not version:
+    header = []
+    index = None
+    for n, line in enumerate(contents):
+        if line.replace(' ', '') == '\n':
+            continue
+        clean_line = line.strip()
+        if clean_line.startswith('#'):
+            header.append(clean_line + '\n')
+        else:
+            index = n
+            break
+
+    if not header:
         raise RuntimeError(f'File {path.name} is invalid because it has no header')
+    version = re.search(r'^#\s*VRML_SIM\s+([a-zA-Z0-9\-]+)\s+utf8', header[0])
+    if not version:
+        raise RuntimeError(f'The header of {path.name} is not recognized')
     elif (version.group(1) >= 'R2022b'):
         print(f'Skipping "{path.name}" because header is already R2022b or higher')
         continue
 
-    # find first non-commented line
-    index = None
-    for n, line in enumerate(contents):
-        if not line.startswith('#'):
-            index = n
-            break
     if index:
         # consume all the empty lines following the index or previous attempts at declaring EXTERNPROTO
         while contents[index] == '\n' or contents[index].startswith('EXTERNPROTO'):
@@ -128,7 +136,9 @@ for file, path in local_files.items():
         contents.insert(index, '\n')
 
     # update proto header
-    contents[0] = '#VRML_SIM R2022b utf8\n'
+    contents = contents[n:]  # remove old header
+    header[0] = '#VRML_SIM R2022b utf8\n'
+    contents = header + contents
 
     # write to file
     with open(path, "w") as f:


### PR DESCRIPTION
**Description**

As reported by a user, PROTO files can be rather messy (useless spaces, newlines, tabs, ..) which made the script fail. For example:

```

    
 

  #VRML_SIM R2022a utf8
# 123
		# 567
		   
PROTO MineGearsRover [
    field SFVec3f    translation  0 0 0
    field SFRotation rotation     0 0 1 0
    field SFString   name            "MineGearsRover" # Is `Solid.name`.
    field SFString   controller      "mine_gears_rover"
  ]
  {
    Robot {
    }
```

This PR improves robustness