### PR TITLE
Allow progress text to be on two lines

### DIFF
--- a/resources/web/wwi/css/progress.css
+++ b/resources/web/wwi/css/progress.css
@@ -151,13 +151,14 @@ webots-view #progress-bar-info {
   text-align: center;
   width: 100%;
   right: 0;
-  bottom: 0;
+  top: 54;
   font-size: 11px;
   font-family: 'Arial';
   color: gray;
   text-overflow: ellipsis;
-  white-space: nowrap;
   overflow: hidden;
+  line-height: 1.5em;
+  height: 3em;
 }
 
 /* Animation */

--- a/resources/web/wwi/css/progress.css
+++ b/resources/web/wwi/css/progress.css
@@ -151,7 +151,7 @@ webots-view #progress-bar-info {
   text-align: center;
   width: 100%;
   right: 0;
-  top: 54;
+  top: 54px;
   font-size: 11px;
   font-family: 'Arial';
   color: gray;


### PR DESCRIPTION
Some errors/warning does not hold on one line.

Can be seen here: https://testing.webots.cloud/run?version=R2022b&url=https://github.com/BenjaminDeleze/sandbox/blob/master/simulation_testing/worlds/testing.wbt