### PR TITLE
Fix terminal/ide/... with mjpeg

### DIFF
--- a/resources/web/wwi/Toolbar.js
+++ b/resources/web/wwi/Toolbar.js
@@ -87,9 +87,11 @@ export default class Toolbar {
     }
 
     // Right part
-    this._createTerminalButton();
-    this._createIdeButton();
-    this._createRobotWindowButton();
+    if (this._view.mode !== 'mjpeg') {
+      this._createTerminalButton();
+      this._createIdeButton();
+      this._createRobotWindowButton();
+    }
     this._createInfoButton();
     if (this._view.mode !== 'mjpeg')
       this._createSettings();


### PR DESCRIPTION
The windowing system we are using for robot windows, ide, terminal,... does not work with `mjpeg`. So we should not create the corresponding buttons when in `mjpeg` streaming mode.

Note: I made this PR on develop because for robot windows, another test further in the code prevent the robot window to be created, so this is more an optimization for robot window. But the terminal make the toolbar throw an exception so it should be patched