### PR TITLE
Enhance robot window in webots.js for mjpeg mode

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -6,6 +6,7 @@ Released on December, 12th, 2022.
     - Added a non-interactive terminal for web streaming ([#5119](https://github.com/cyberbotics/webots/pull/5119)).
     - Added a customizable window for animations to display graphs or other user defined content ([5265](https://github.com/cyberbotics/webots/pull/5265)).
   - Enhancements
+    - Add the support of robot windows for mjpeg streaming ([#5272](https://github.com/cyberbotics/webots/pull/5272)).
   - New Robots
   - New Objects
     - Added some static animals (cow, horse, deer, sheep, dog, fox, cat and rabbit) and a barn ([#4539](https://github.com/cyberbotics/webots/pull/4539)).

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -36,7 +36,7 @@
     <div class="webots-view-container">
       <webots-view></webots-view>
     </div>
-    <script type="module" src="../wwi/WebotsView.js"></script>
+    <script type="module" src="https://cyberbotics.com/wwi/R2023a/WebotsView.js"></script>
     <script src="setup_viewer.js"></script>
   </body>
 </html>

--- a/resources/web/streaming_viewer/index.html
+++ b/resources/web/streaming_viewer/index.html
@@ -36,7 +36,7 @@
     <div class="webots-view-container">
       <webots-view></webots-view>
     </div>
-    <script type="module" src="https://cyberbotics.com/wwi/R2023a/WebotsView.js"></script>
+    <script type="module" src="../wwi/WebotsView.js"></script>
     <script src="setup_viewer.js"></script>
   </body>
 </html>

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -283,7 +283,6 @@ export default class Parser {
     WbWorld.instance.basicTimeStep = parseInt(getNodeAttribute(node, 'basicTimeStep', 32));
     WbWorld.instance.title = getNodeAttribute(node, 'title', 'No title');
     WbWorld.instance.description = getNodeAttribute(node, 'info', 'No description was provided for this world.');
-    WbWorld.instance.window = getNodeAttribute(node, 'window', '<none>');
 
     // Update information panel when switching between worlds
     let webotsView = document.getElementsByTagName('webots-view')[0];

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -126,9 +126,6 @@ export default class Parser {
       if (typeof callback === 'function')
         callback();
 
-      if (document.getElementById('robot-window-button') !== null)
-        document.getElementsByTagName('webots-view')[0].toolbar.loadRobotWindows();
-
       console.timeEnd('Loaded in: ');
     });
   }
@@ -476,16 +473,9 @@ export default class Parser {
       newNode = new WbTrackWheel(id, translation, scale, rotation, radius, inner);
 
       parentNode.wheelsList.push(newNode);
-    } else if (type === 'solid' || type === 'robot') {
+    } else if (type === 'solid' || type === 'robot')
       newNode = new WbSolid(id, translation, scale, rotation);
-      if (type === 'robot') {
-        const window = (node.hasAttribute('window') && node.getAttribute('window') !== '<generic>')
-          ? node.getAttribute('window') : 'generic';
-        const name = node.getAttribute('name');
-        const id = node.getAttribute('id');
-        WbWorld.instance.robots.push({id: id, name: name, window: window});
-      }
-    } else {
+    else {
       if (!isBoundingObject)
         isBoundingObject = getNodeAttribute(node, 'role', undefined) === 'boundingObject';
 

--- a/resources/web/wwi/Server.js
+++ b/resources/web/wwi/Server.js
@@ -74,7 +74,7 @@ export default class Server {
       const url = message.substring(7);
       this._httpServerUrl = url.replace(/ws/, 'http');
       if (typeof this._view.x3dScene !== 'undefined')
-        this._view.x3dScene.prefix = this._httpServerUrl + '/';
+        this._view.prefix = this._httpServerUrl + '/';
       this._view.stream = new Stream(url, this._view, this._onready);
       this._view.stream.connect();
     } else if (message.indexOf('controller:') === 0 || message.indexOf('reset controller:') === 0) {

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -57,7 +57,13 @@ export default class Stream {
 
   _onSocketMessage(event) {
     let data = event.data;
-    if (data.startsWith('robot:') || data.startsWith('robot window:'))
+
+    if (data.startsWith('robot window:')) {
+      console.log(data)
+      const json = JSON.parse(data.substring(14));
+      const robotWindow = json.window === '<generic>' ? 'generic' : json.window;
+      webots.currentView.robots.push({name: json.robot, window: robotWindow});
+    } else if (data.startsWith('robot:'))
       return 0; // We need to keep this condition, otherwise the robot window messages will be printed as errors.
     else if (data.startsWith('stdout:')) {
       this._view.onstdout(data.substring('stdout:'.length));

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -62,6 +62,8 @@ export default class Stream {
       const json = JSON.parse(data.substring(14));
       const robotWindow = json.window === '<generic>' ? 'generic' : json.window;
       webots.currentView.robots.push({name: json.robot, window: robotWindow, main: json.main});
+      if (document.getElementById('robot-window-button') !== null)
+        document.getElementsByTagName('webots-view')[0].toolbar.loadRobotWindows();
     } else if (data.startsWith('robot:'))
       return 0; // We need to keep this condition, otherwise the robot window messages will be printed as errors.
     else if (data.startsWith('stdout:')) {

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -64,15 +64,12 @@ export default class Stream {
 
       if (json.remove) {
         const robots = webots.currentView.robots;
-        let index;
         for (let i = 0; i < robots.length; i++) {
           if (robots[i].name === json.robot) {
-            index = i;
+            robots.splice(i, 1);
             break;
           }
         }
-        if (typeof index !== 'undefined')
-          robots.splice(index, 1);
       } else
         webots.currentView.robots.push({name: json.robot, window: robotWindow, main: json.main});
       if (document.getElementById('robot-window-button') !== null)

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -61,7 +61,7 @@ export default class Stream {
     if (data.startsWith('robot window:')) {
       const json = JSON.parse(data.substring(14));
       const robotWindow = json.window === '<generic>' ? 'generic' : json.window;
-      webots.currentView.robots.push({name: json.robot, window: robotWindow});
+      webots.currentView.robots.push({name: json.robot, window: robotWindow, main: json.main});
     } else if (data.startsWith('robot:'))
       return 0; // We need to keep this condition, otherwise the robot window messages will be printed as errors.
     else if (data.startsWith('stdout:')) {

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -61,7 +61,20 @@ export default class Stream {
     if (data.startsWith('robot window:')) {
       const json = JSON.parse(data.substring(14));
       const robotWindow = json.window === '<generic>' ? 'generic' : json.window;
-      webots.currentView.robots.push({name: json.robot, window: robotWindow, main: json.main});
+
+      if (json.remove) {
+        const robots = webots.currentView.robots;
+        let index;
+        for (let i = 0; i < robots.length; i++) {
+          if (robots[i].name === json.robot) {
+            index = i;
+            break;
+          }
+        }
+        if (typeof index !== 'undefined')
+          robots.splice(index, 1);
+      } else
+        webots.currentView.robots.push({name: json.robot, window: robotWindow, main: json.main});
       if (document.getElementById('robot-window-button') !== null)
         document.getElementsByTagName('webots-view')[0].toolbar.loadRobotWindows();
     } else if (data.startsWith('robot:'))

--- a/resources/web/wwi/Stream.js
+++ b/resources/web/wwi/Stream.js
@@ -59,7 +59,6 @@ export default class Stream {
     let data = event.data;
 
     if (data.startsWith('robot window:')) {
-      console.log(data)
       const json = JSON.parse(data.substring(14));
       const robotWindow = json.window === '<generic>' ? 'generic' : json.window;
       webots.currentView.robots.push({name: json.robot, window: robotWindow});

--- a/resources/web/wwi/Toolbar.js
+++ b/resources/web/wwi/Toolbar.js
@@ -512,8 +512,7 @@ export default class Toolbar {
     this.robotWindows = [];
     this._view.robots.forEach((robot) => {
       if (robot.window !== '<none>') {
-        let mainWindow = typeof WbWorld.instance !== 'undefined' && WbWorld.instance.window !== '<none>' &&
-          robot.window === WbWorld.instance.window;
+        let mainWindow = robot.main;
         let robotWindow = new FloatingRobotWindow(this.parentNode, robot.name, robotWindowUrl, robot.window, mainWindow);
         if (mainWindow)
           this.robotWindows.unshift(robotWindow);

--- a/resources/web/wwi/Toolbar.js
+++ b/resources/web/wwi/Toolbar.js
@@ -109,9 +109,9 @@ export default class Toolbar {
         this.robotWindowPane.style.transform = 'translateX(' + offset + 'px)';
       }
     });
-    const view3d = document.getElementById('view3d');
-    if (view3d)
-      this._toolbarResizeObserver.observe(view3d);
+    const viewElement = document.getElementsByClassName('webots-view')[0];
+    if (viewElement)
+      this._toolbarResizeObserver.observe(viewElement);
   }
 
   _mobileOrientationChangeFullscreen() {
@@ -388,7 +388,7 @@ export default class Toolbar {
   }
 
   _createIde() {
-    const url = this._view.x3dScene.prefix.slice(0, -1);
+    const url = this._view.prefix.slice(0, -1);
     this.ideWindow = new FloatingIde(this.parentNode, 'ide', url);
 
     const ideWidth = 0.6 * this.parentNode.offsetWidth;
@@ -509,7 +509,7 @@ export default class Toolbar {
   }
 
   _createRobotWindows() {
-    const robotWindowUrl = this._view.x3dScene.prefix.slice(0, -1);
+    const robotWindowUrl = this._view.prefix.slice(0, -1);
 
     this.robotWindows = [];
     if (typeof WbWorld.instance !== 'undefined' && WbWorld.instance.readyForUpdates) {
@@ -662,7 +662,7 @@ export default class Toolbar {
         fw.style.height = (fw.offsetHeight > maxHeight ? maxHeight : fw.offsetHeight) + 'px';
       });
     });
-    resizeObserver.observe(document.getElementById('view3d'));
+    resizeObserver.observe(document.getElementsByClassName('webots-view')[0]);
   }
 
   _createInfoButton() {

--- a/resources/web/wwi/Toolbar.js
+++ b/resources/web/wwi/Toolbar.js
@@ -407,21 +407,19 @@ export default class Toolbar {
   }
 
   _createRobotWindowButton() {
-    if (typeof WbWorld.instance !== 'undefined' && WbWorld.instance.readyForUpdates) {
-      if (WbWorld.instance.robots.length > 0) {
-        this.robotWindowButton = this._createToolBarButton('robot-window', 'Robot windows (w)');
-        this.toolbarRight.appendChild(this.robotWindowButton);
-        this.robotWindowButton.addEventListener('mouseup', this.mouseupRefWFirst = _ => this._showAllRobotWindows(),
-          {once: true});
-        document.addEventListener('keydown', this.keydownRefWFirst = _ => this._robotWindowPaneKeyboardHandler(_, true),
-          {once: true});
-        this.keydownRefW = undefined;
-        window.addEventListener('click', _ => this._closeRobotWindowPaneOnClick(_));
-        if (!(typeof this.parentNode.showRobotWindow === 'undefined' || this.parentNode.showRobotWindow))
-          this.robotWindowButton.style.display = 'none';
-        else
-          this.minWidth += 44;
-      }
+    if (this._view.robots.length > 0) {
+      this.robotWindowButton = this._createToolBarButton('robot-window', 'Robot windows (w)');
+      this.toolbarRight.appendChild(this.robotWindowButton);
+      this.robotWindowButton.addEventListener('mouseup', this.mouseupRefWFirst = _ => this._showAllRobotWindows(),
+        {once: true});
+      document.addEventListener('keydown', this.keydownRefWFirst = _ => this._robotWindowPaneKeyboardHandler(_, true),
+        {once: true});
+      this.keydownRefW = undefined;
+      window.addEventListener('click', _ => this._closeRobotWindowPaneOnClick(_));
+      if (!(typeof this.parentNode.showRobotWindow === 'undefined' || this.parentNode.showRobotWindow))
+        this.robotWindowButton.style.display = 'none';
+      else
+        this.minWidth += 44;
     }
   }
 
@@ -512,21 +510,21 @@ export default class Toolbar {
     const robotWindowUrl = this._view.prefix.slice(0, -1);
 
     this.robotWindows = [];
-    if (typeof WbWorld.instance !== 'undefined' && WbWorld.instance.readyForUpdates) {
-      WbWorld.instance.robots.forEach((robot) => {
-        if (robot.window !== '<none>') {
-          let mainWindow = WbWorld.instance.window !== '<none>' && robot.window === WbWorld.instance.window;
-          let robotWindow = new FloatingRobotWindow(this.parentNode, robot.name, robotWindowUrl, robot.window, mainWindow);
-          if (mainWindow)
-            this.robotWindows.unshift(robotWindow);
-          else
-            this.robotWindows.push(robotWindow);
-          this._addRobotWindowToPane(robot.name, mainWindow);
-        }
-      });
-      const buttonDisplay = (this.robotWindows.length === 0) ? 'none' : 'auto';
-      document.getElementById('robot-window-button').style.display = buttonDisplay;
-    }
+    this._view.robots.forEach((robot) => {
+      if (robot.window !== '<none>') {
+        let mainWindow = typeof WbWorld.instance !== 'undefined' && WbWorld.instance.window !== '<none>' &&
+          robot.window === WbWorld.instance.window;
+        let robotWindow = new FloatingRobotWindow(this.parentNode, robot.name, robotWindowUrl, robot.window, mainWindow);
+        if (mainWindow)
+          this.robotWindows.unshift(robotWindow);
+        else
+          this.robotWindows.push(robotWindow);
+        this._addRobotWindowToPane(robot.name, mainWindow);
+      }
+    });
+    const buttonDisplay = (this.robotWindows.length === 0) ? 'none' : 'auto';
+    document.getElementById('robot-window-button').style.display = buttonDisplay;
+
     this.robotWindowPane.style.right = '150px';
 
     const viewWidth = this.parentNode.offsetWidth;

--- a/resources/web/wwi/WebotsView.js
+++ b/resources/web/wwi/WebotsView.js
@@ -279,6 +279,8 @@ export default class WebotsView extends HTMLElement {
       this._view.onready = () => {
         if (typeof this.toolbar === 'undefined')
           this.toolbar = new Toolbar(this._view, 'streaming', this);
+        if (document.getElementById('robot-window-button') !== null)
+          document.getElementsByTagName('webots-view')[0].toolbar.loadRobotWindows();
         if (typeof this.onready === 'function')
           this.onready();
       };

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -15,13 +15,13 @@ import WbWorld from './nodes/WbWorld.js';
 export default class X3dScene {
   constructor(domElement) {
     this.domElement = domElement;
-    this._loader = new Parser(this.prefix);
+    this._loader = new Parser(webots.currentView.prefix);
     // Each time a render is needed, we ensure that there will be 10 additional renderings to avoid gtao artifacts
     this.remainingRenderings = 10;
   }
 
   init(texturePathPrefix = '') {
-    this.prefix = texturePathPrefix;
+    webots.currentView.prefix = texturePathPrefix;
     this.renderer = new WrenRenderer();
 
     this.resize();
@@ -128,7 +128,7 @@ export default class X3dScene {
   }
 
   loadWorldFile(url, onLoad, progress) {
-    const prefix = this.prefix;
+    const prefix = webots.currentView.prefix;
     const renderer = this.renderer;
     const xmlhttp = new XMLHttpRequest();
     xmlhttp.open('GET', url, true);
@@ -159,7 +159,7 @@ export default class X3dScene {
     }
 
     if (typeof this._loader === 'undefined')
-      this._loader = new Parser(this.prefix);
+      this._loader = new Parser(webots.currentView.prefix);
 
     this._loader.parse(x3dObject, this.renderer, parentNode, callback);
 

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -121,9 +121,6 @@ export default class X3dScene {
         WbWorld.instance.robots.splice(i, 1);
     });
 
-    if (document.getElementById('robot-window-button') !== null)
-      document.getElementsByTagName('webots-view')[0].toolbar.loadRobotWindows();
-
     this.render();
   }
 

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -143,8 +143,7 @@ webots.View = class View {
         } else { // url expected form: "ws://cyberbotics1.epfl.ch:80"
           const httpServerUrl = 'http' + this.url.slice(2); // replace 'ws'/'wss' with 'http'/'https'
           this.stream = new Stream(this.url, this, finalizeWorld);
-          if (typeof this.x3dScene !== 'undefined')
-            this.x3dScene.prefix = httpServerUrl + '/';
+          this.prefix = httpServerUrl + '/';
           this.stream.connect();
         }
       } else // assuming it's an URL to a .x3d file
@@ -202,7 +201,7 @@ webots.View = class View {
     } else {
       if (typeof this._x3dDiv !== 'undefined') {
         this.view3D.appendChild(this._x3dDiv);
-        this.x3dScene.prefix = texturePathPrefix;
+        this.prefix = texturePathPrefix;
       }
       if (typeof this.progress !== 'undefined') {
         if (document.getElementById('progress'))

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -90,6 +90,7 @@ webots.View = class View {
     this.timeout = 60 * 1000; // default to one minute
     this.currentState = false;
     this.quitting = false;
+    this.robots = [];
   }
 
   setTimeout(timeout) { // expressed in seconds

--- a/resources/web/wwi/webots.js
+++ b/resources/web/wwi/webots.js
@@ -316,6 +316,7 @@ webots.View = class View {
     if (typeof this.x3dScene !== 'undefined')
       this.x3dScene.destroyWorld();
     this.removeLabels();
+    this.robots = [];
 
     if (typeof this.mouseEvents !== 'undefined' && typeof this.mouseEvents.picker !== 'undefined') {
       this.mouseEvents.picker.selectedId = -1;

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -635,6 +635,8 @@ void WbTcpServer::sendRobotWindowInformation(QWebSocket *client, const WbRobot *
     QJsonObject windowObject;
     windowObject.insert("robot", robot->name());
     windowObject.insert("window", robot->window());
+    if (remove)
+      windowObject.insert("remove", true);
     if (WbWorld::instance()->worldInfo()->window() == robot->window())
       windowObject.insert("main", true);
     const QJsonDocument windowDocument(windowObject);

--- a/src/webots/gui/WbTcpServer.hpp
+++ b/src/webots/gui/WbTcpServer.hpp
@@ -70,6 +70,7 @@ protected:
   void destroy();
   void resetSimulation();
   void pauseClientIfNeeded(QWebSocket *client);
+  void sendRobotWindowInformation(QWebSocket *client, const WbRobot *robot, bool remove = false);
 
   QList<QWebSocket *> mWebSocketClients;
   double mPauseTimeout;
@@ -97,7 +98,6 @@ private:
   void sendWorldStateToClient(QWebSocket *client, const QString &state);
   void propagateLogToClients(WbLog::Level level, const QString &message);
   bool isControllerMessageIgnored(const QString &pattern, const QString &message) const;
-  void sendRobotWindowInformation(QWebSocket *client, const WbRobot *robot, bool remove = false);
 
   QWebSocketServer *mWebSocketServer;
   QTcpServer *mTcpServer;

--- a/src/webots/gui/WbTcpServer.hpp
+++ b/src/webots/gui/WbTcpServer.hpp
@@ -97,6 +97,7 @@ private:
   void sendWorldStateToClient(QWebSocket *client, const QString &state);
   void propagateLogToClients(WbLog::Level level, const QString &message);
   bool isControllerMessageIgnored(const QString &pattern, const QString &message) const;
+  void sendRobotWindowInformation(QWebSocket *client, const WbRobot *robot, bool remove = false);
 
   QWebSocketServer *mWebSocketServer;
   QTcpServer *mTcpServer;

--- a/src/webots/gui/WbTcpServer.hpp
+++ b/src/webots/gui/WbTcpServer.hpp
@@ -65,6 +65,7 @@ protected:
   virtual void sendWorldToClient(QWebSocket *client);
   virtual void sendTcpRequestReply(const QString &completeUrl, const QString &etag, const QString &host, QTcpSocket *socket);
   virtual void addNewTcpController(QTcpSocket *socket);
+  virtual void propagateNodeDeletion(WbNode *node);
 
   bool isActive() const { return mWebSocketServer != NULL; }
   void destroy();

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -28,9 +28,6 @@
 #include <QtWebSockets/QWebSocket>
 
 WbX3dStreamingServer::WbX3dStreamingServer() : WbTcpServer(true), mX3dWorldGenerationTime(-1.0) {
-  connect(WbNodeOperations::instance(), &WbNodeOperations::nodeDeleted, this, &WbX3dStreamingServer::propagateNodeDeletion);
-  connect(WbTemplateManager::instance(), &WbTemplateManager::preNodeRegeneration, this,
-          &WbX3dStreamingServer::propagateNodeDeletion);
 }
 
 WbX3dStreamingServer::~WbX3dStreamingServer() {
@@ -191,13 +188,10 @@ void WbX3dStreamingServer::propagateNodeDeletion(WbNode *node) {
   if (!isActive() || WbWorld::instance() == NULL)
     return;
 
+  WbTcpServer::propagateNodeDeletion(node);
   const WbNode *def = static_cast<const WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
-  foreach (QWebSocket *client, mWebSocketClients) {
+  foreach (QWebSocket *client, mWebSocketClients)
     client->sendTextMessage(QString("delete:%1").arg(def->uniqueId()));
-    const WbRobot *robot = dynamic_cast<const WbRobot *>(def);
-    if (robot)
-      sendRobotWindowInformation(client, robot, true);
-  }
 }
 
 void WbX3dStreamingServer::generateX3dWorld() {

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -18,6 +18,7 @@
 #include "WbHttpReply.hpp"
 #include "WbNodeOperations.hpp"
 #include "WbProject.hpp"
+#include "WbRobot.hpp"
 #include "WbSimulationState.hpp"
 #include "WbTemplateManager.hpp"
 #include "WbViewpoint.hpp"
@@ -191,8 +192,12 @@ void WbX3dStreamingServer::propagateNodeDeletion(WbNode *node) {
     return;
 
   const WbNode *def = static_cast<const WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
-  foreach (QWebSocket *client, mWebSocketClients)
+  foreach (QWebSocket *client, mWebSocketClients) {
     client->sendTextMessage(QString("delete:%1").arg(def->uniqueId()));
+    const WbRobot *robot = dynamic_cast<const WbRobot *>(def);
+    if (robot)
+      sendRobotWindowInformation(client, robot, true);
+  }
 }
 
 void WbX3dStreamingServer::generateX3dWorld() {

--- a/src/webots/gui/WbX3dStreamingServer.cpp
+++ b/src/webots/gui/WbX3dStreamingServer.cpp
@@ -18,7 +18,6 @@
 #include "WbHttpReply.hpp"
 #include "WbNodeOperations.hpp"
 #include "WbProject.hpp"
-#include "WbRobot.hpp"
 #include "WbSimulationState.hpp"
 #include "WbTemplateManager.hpp"
 #include "WbViewpoint.hpp"

--- a/src/webots/gui/WbX3dStreamingServer.hpp
+++ b/src/webots/gui/WbX3dStreamingServer.hpp
@@ -33,7 +33,7 @@ private slots:
   void sendUpdatePackageToClients() override;
   void processTextMessage(QString) override;
 
-  void propagateNodeDeletion(WbNode *node);
+  void propagateNodeDeletion(WbNode *node) override;
 
 private:
   void create(int port) override;

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1484,10 +1484,7 @@ void WbRobot::exportNodeFields(WbWriter &writer) const {
       writer << " controller=";
       writer.writeLiteralString(controllerName());
     }
-    if (findField("window") && !window().isEmpty()) {
-      writer << " window=";
-      writer.writeLiteralString(window());
-    }
+
     writer << " type='robot'";
   }
 }

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -1484,7 +1484,6 @@ void WbRobot::exportNodeFields(WbWriter &writer) const {
       writer << " controller=";
       writer.writeLiteralString(controllerName());
     }
-
     writer << " type='robot'";
   }
 }

--- a/src/webots/nodes/WbWorldInfo.cpp
+++ b/src/webots/nodes/WbWorldInfo.cpp
@@ -395,9 +395,6 @@ void WbWorldInfo::exportNodeFields(WbWriter &writer) const {
 
     writer << " basicTimeStep=\'" << mBasicTimeStep->value() << "\'";
     writer << " coordinateSystem=\'" << mCoordinateSystem->value() << "\'";
-
-    if (!findField("window")->isDefault())
-      writer << " window='" << mWindow->value() << "'";
   } else
     WbBaseNode::exportNodeFields(writer);
 }


### PR DESCRIPTION
**Description**
The internal windowing system and the robot windows were not supporting mjpeg streaming.
Moreover, the information regarding the robot window was sent in the `.x3d` file and by websocket messages with `robot window:`.

**Tasks**

- [x] Remove the information concerning the robot window in the `.x3d`
- [x] Modify the windowing system to support mjpeg
- [x] Modify webotsJS to get the information concerning the robot windows from the `robot window:` messages
- [x] Upgrade the `robot window: ` messages to allow
  - [x] The dynamic addition or removal of robot windows.
  - [x] To determine which window is the main on.