### PR TITLE
Improve default PROTO translation field documentation

### DIFF
--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -75,6 +75,7 @@ That means the origin of an object should not be at its 3D geometrical center, b
 However, there are some exceptions to this rule:
 - Legged robots should have their origin in their main body as it is difficult to know the extension of the legs of the robot towards the floor.
 - Balls should have their origin at their geometrical center, as they can roll and don't have an upright position.
+- Sensor objects that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the sensor shape rests on the ground even if the sensor itself is not located at the contact surface.
 - Any other object which doesn't have a clear or stable upright position.
 
 The rotation axis should be already well positioned, e.g., usually along the Z-axis with a 0 value for the angle, e.g., `0 0 1 0`, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.

--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -75,7 +75,7 @@ That means the origin of an object should not be at its 3D geometrical center, b
 However, there are some exceptions to this rule:
 - Legged robots should have their origin in their main body as it is difficult to know the extension of the legs of the robot towards the floor.
 - Balls should have their origin at their geometrical center, as they can roll and don't have an upright position.
-- Sensor objects that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the sensor shape rests on the ground even if the sensor itself is not located at the contact surface.
+- Devices that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the sensor shape rests on the ground even if the sensor itself is not located at the contact surface.
 - Any other object which doesn't have a clear or stable upright position.
 
 The rotation axis should be already well positioned, e.g., usually along the Z-axis with a 0 value for the angle, e.g., `0 0 1 0`, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.

--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -75,7 +75,7 @@ That means the origin of an object should not be at its 3D geometrical center, b
 However, there are some exceptions to this rule:
 - Legged robots should have their origin in their main body as it is difficult to know the extension of the legs of the robot towards the floor.
 - Balls should have their origin at their geometrical center, as they can roll and don't have an upright position.
-- Devices that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the device shape rests on the ground even if the sensor itself is not located at the contact surface.
+- Devices that are directly derived from base nodes (e.g., Lidar, Camera, etc.) can have a default translation different from `0 0 0` so that the device shape rests on the ground when created even if the sensor itself is not located at the contact surface.
 - Any other object which doesn't have a clear or stable upright position.
 
 The rotation axis should be already well positioned, e.g., usually along the Z-axis with a 0 value for the angle, e.g., `0 0 1 0`, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.

--- a/docs/reference/proto-design-guidelines.md
+++ b/docs/reference/proto-design-guidelines.md
@@ -75,7 +75,7 @@ That means the origin of an object should not be at its 3D geometrical center, b
 However, there are some exceptions to this rule:
 - Legged robots should have their origin in their main body as it is difficult to know the extension of the legs of the robot towards the floor.
 - Balls should have their origin at their geometrical center, as they can roll and don't have an upright position.
-- Devices that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the sensor shape rests on the ground even if the sensor itself is not located at the contact surface.
+- Devices that are directly derived from base nodes (e.g. Lidar, Camera, etc.) can have a default translation different from the origin so that the device shape rests on the ground even if the sensor itself is not located at the contact surface.
 - Any other object which doesn't have a clear or stable upright position.
 
 The rotation axis should be already well positioned, e.g., usually along the Z-axis with a 0 value for the angle, e.g., `0 0 1 0`, so that when you rotate a building for example, you should simply change the angle value to have it rotate along its vertical axis.


### PR DESCRIPTION
The default `translation` field for PROTOs should preferably be set at origin. PROTOs should also be created so that they lie on the ground when imported. However, in the case of devices derived from `Base Nodes` such as `Lidars`, `Cameras`, etc., the sensor itself may not be located at the center of the contact surface of the device shape. In this case, the PROTO can have a default translation to compensate for the offset, so that the device does not float in the air or sink into the ground.

This PR adds this exception to the documentation.

### Documentation
https://www.cyberbotics.com/doc/reference/proto-design-guidelines?version=documentation-improve-proto-translation-convention#translation-and-rotation
