### PR TITLE
Fix pointSet shader for web

### DIFF
--- a/resources/wren/shaders/point_set.frag
+++ b/resources/wren/shaders/point_set.frag
@@ -4,7 +4,8 @@ precision highp float;
 
 in vec3 color;
 
-out vec4 fragColor;
+layout(location = 0) out vec4 fragColor;
+layout(location = 1) out vec4 fragNormal;
 
 uniform bool colorPerVertex;
 uniform float pointSize;
@@ -33,4 +34,6 @@ void main() {
     fragColor = vec4(color, alpha);
   else
     fragColor = vec4(material.emissiveAndOpacity.xyz, alpha);
+
+  fragNormal = vec4(1, 1, 1, 1);
 }

--- a/resources/wren/shaders/point_set.frag
+++ b/resources/wren/shaders/point_set.frag
@@ -35,5 +35,5 @@ void main() {
   else
     fragColor = vec4(material.emissiveAndOpacity.xyz, alpha);
 
-  fragNormal = vec4(1, 1, 1, 1);
+  fragNormal = vec4(0, 0, 0, 0);
 }


### PR DESCRIPTION
The PointSet shader was working fine on desktop, but in some situations on the web it was crashing the simulation.

It is because webgl is less permissive than openGL when it comes to shaders.

The issue was that the draw buffer is expecting fragment output: `color` and `normal`, as for `Phong` shader for example.
However, the PointSet shader was only returning a `color` output because the `normal` one is not used.

I added a null `normal` output to fix the issue.