### PR TITLE
Fixed Qt6.4 deprecation warnings

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -7,6 +7,8 @@
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
    - Fixed the reset of the viewpoint in animation when the follow is activated ([5237](https://github.com/cyberbotics/webots/pull/5237)).
    - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
+ - Dependency Updates
+   - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 
 ## Webots R2022b
 Released on September, 13th, 2022.

--- a/src/webots/gui/WbMultimediaStreamingServer.cpp
+++ b/src/webots/gui/WbMultimediaStreamingServer.cpp
@@ -278,7 +278,7 @@ void WbMultimediaStreamingServer::processTextMessage(QString message) {
         } else
           type = QEvent::MouseMove;
       }
-      QMouseEvent event(type, point, buttonPressed, buttonsPressed, keyboardModifiers);
+      QMouseEvent event(type, point, QCursor::pos(), buttonPressed, buttonsPressed, keyboardModifiers);
       if (gView3D) {
         const WbMatter *contextMenuNode = gView3D->remoteMouseEvent(&event);
         if (contextMenuNode)

--- a/src/webots/gui/WbSimulationView.cpp
+++ b/src/webots/gui/WbSimulationView.cpp
@@ -510,7 +510,7 @@ void WbSimulationView::hideInappropriateToolBarItems() {
     // have blank action text and aren't parented by the toolbar. We need to check
     // the parent as menu separators have blank text but are always parented by the
     // QToolBar instance
-    if (action->text().isEmpty() && action->parentWidget() != mToolBar)
+    if (action->text().isEmpty() && qobject_cast<QWidget *>(action->parent()) != mToolBar)
       action->setVisible(false);
   }
 }


### PR DESCRIPTION
Qt6.4 arrived on MSYS2 with a couple of deprecation issues. This PR fixes them.
See https://doc.qt.io/qt-6/qmouseevent-obsolete.html#QMouseEvent-2