### PR TITLE
Fix incorrect documentation of RangeFinder maxRange field

### DIFF
--- a/docs/reference/rangefinder.md
+++ b/docs/reference/rangefinder.md
@@ -66,7 +66,7 @@ If the depth is smaller than the `minRange` value then infinity is returned.
 
 - The `maxRange` defines the distance between the range-finder and the far clipping plane of the OpenGL view frustum.
 This field defines the maximum range that a range-finder can achieve and so the maximum possible value of the range image (in meter).
-If the depth is bigger than the `maxRange` value then infinity is returned.
+If the depth is bigger than the `maxRange` value then `maxRange` is returned.
 
 - If the `motionBlur` field is greater than 0.0, the image is blurred by the motion of the range-finder or objects in the field of view.
 More information on motion blur is provided in the [motionBlur](camera.md) field description of the [Camera](camera.md) node.


### PR DESCRIPTION
Describe the Bug
RangeFinder sets range above maxRange to maxRange instead of infinity, as mentioned in the documentation. Please update the documentation.

The maxRange defines the distance between the range-finder and the far clipping plane of the OpenGL view frustum. This field defines the maximum range that a range-finder can achieve and so the maximum possible value of the range image (in meter). If the depth is bigger than the maxRange value then infinity is returned.

Steps to Reproduce
Check rangefinder image when distances above maxRange occur in scene

Expected behavior
Documentation should be updated to the following:

The maxRange defines the distance between the range-finder and the far clipping plane of the OpenGL view frustum. This field defines the maximum range that a range-finder can achieve and so the maximum possible value of the range image (in meter). If the depth is bigger than the maxRange value then maxRange is returned.

**Description**
Describe the bug you are fixing, the new feature your are introducing or the enhancement you are proposing.

**Related Issues**
This pull-request fixes issue #5303

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix RangeFinder maxRange field documentation

**Documentation**
If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
https://www.cyberbotics.com/doc/reference/rangefinder
