### PR TITLE
Fix lidar reset when extern controller changed

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -296,6 +296,9 @@ void WbLidar::handleMessage(QDataStream &stream) {
     if (!hasBeenSetup()) {
       setup();
       mSendMemoryMappedFile = true;
+    } else if (mHasExternControllerChanged) {
+      mSendMemoryMappedFile = true;
+      mHasExternControllerChanged = false;
     }
 
     return;


### PR DESCRIPTION
Fix #5298:
the shared memory file was not sent to the extern controller when connecting in the middle of the simulation if the extern controller was not terminating correctly.
It works correctly for range finders and camera because the WbLidar class overrides the WbAbstractCamera `C_SAMPLING_PERIOD` command.

TODO:
* [ ] fix or remove assertion failure when killing an extern controller 