### PR TITLE
Fix TCP extern controller connection when world is loading

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -3,10 +3,11 @@
 ## Webots R2022b Revision 1
  - Bug Fixes
    - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
-   - Fixes the export of lidar's rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
+   - Fixed the export of lidar's rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
    - Fixed the reset of the viewpoint in animation when the follow is activated ([5237](https://github.com/cyberbotics/webots/pull/5237)).
    - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
+   - Fixed a crash when trying to connect a remote extern controllers while a world is loading([5310](https://github.com/cyberbotics/webots/pull/5310)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -7,7 +7,7 @@
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
    - Fixed the reset of the viewpoint in animation when the follow is activated ([5237](https://github.com/cyberbotics/webots/pull/5237)).
    - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
-   - Fixed a crash when trying to connect a remote extern controllers while a world is loading([5310](https://github.com/cyberbotics/webots/pull/5310)).
+   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -130,8 +130,6 @@ void WbTcpServer::create(int port) {
   // - https://bugreports.qt.io/browse/QTBUG-54276
   mWebSocketServer = new QWebSocketServer("Webots Streaming Server", QWebSocketServer::NonSecureMode, this);
   mTcpServer = new QTcpServer();
-  if (!mTcpServer->listen(QHostAddress::Any, port))
-    throw tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString());
   connect(mWebSocketServer, &QWebSocketServer::newConnection, this, &WbTcpServer::onNewWebSocketConnection);
   connect(mTcpServer, &QTcpServer::newConnection, this, &WbTcpServer::onNewTcpConnection);
   connect(WbSimulationState::instance(), &WbSimulationState::controllerReadRequestsCompleted, this,
@@ -530,6 +528,8 @@ void WbTcpServer::newWorld() {
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();
   foreach (WbRobot *const robot, robots)
     connectNewRobot(robot);
+  if (!mTcpServer->isListening() && !mTcpServer->listen(QHostAddress::Any, mPort))
+    WbLog::error(tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString()));
 }
 
 void WbTcpServer::deleteWorld() {

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -528,11 +528,15 @@ void WbTcpServer::newWorld() {
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();
   foreach (WbRobot *const robot, robots)
     connectNewRobot(robot);
+
   if (!mTcpServer->isListening() && !mTcpServer->listen(QHostAddress::Any, mPort))
     WbLog::error(tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString()));
 }
 
 void WbTcpServer::deleteWorld() {
+  if (mTcpServer->isListening())
+    mTcpServer->close();
+
   if (mWebSocketServer == NULL)
     return;
   foreach (QWebSocket *client, mWebSocketClients)


### PR DESCRIPTION
If a TCP controller tries to connect to a Webots instance that is currently loading a world, Webots crashes.