### PR TITLE
 Add cadshape fieldmodel

### DIFF
--- a/resources/web/wwi/protoDesigner/classes/FieldModel.js
+++ b/resources/web/wwi/protoDesigner/classes/FieldModel.js
@@ -17,6 +17,10 @@ export const FieldModel = {
     'supported': {'size': VRML.SFVec3f},
     'unsupported': {}
   },
+  'CadShape': {
+    'supported': {'url': VRML.MFString, 'ccw': VRML.SFBool, 'castShadows': VRML.SFBool, 'isPickable': VRML.SFBool},
+    'unsupported': {}
+  },
   'Capsule': {
     'supported': {'bottom': VRML.SFBool, 'height': VRML.SFFloat, 'radius': VRML.SFFloat, 'side': VRML.SFBool, 'top': VRML.SFBool, 'subdivision': VRML.SFInt32},
     'unsupported': {}


### PR DESCRIPTION
Note: it does not bring full support for VRML cadshape (the texture urls are not passed to `x3d` for example), but just prevents an exception to be raised.