### PR TITLE
Fix black buttons in RangeFinder overlay

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -9,6 +9,7 @@
    - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
    - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([5305](https://github.com/cyberbotics/webots/pull/5305)).
    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
+   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([5337](https://github.com/cyberbotics/webots/pull/5337)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/resources/wren/shaders/overlay.frag
+++ b/resources/wren/shaders/overlay.frag
@@ -100,7 +100,8 @@ void main() {
         vec2 closeButtonTexUv = texUvFrame - vec2(closeButtonStartX, closeButtonStartY);
         closeButtonTexUv *= vec2(1.0 / closeButtonProportionX, 1.0 / closeButtonProportionY);
         vec4 color = texture(inputTextures[closeButtonTextureIndex], clamp(closeButtonTexUv, 0.0, 1.0));
-        fragColor = mix(fragColor, color, color.a);
+        if (color.a > 0.5)
+          fragColor = color;
       }
     }
 
@@ -113,7 +114,8 @@ void main() {
         vec2 resizeButtonTexUv = texUvFrame - vec2(resizeButtonStartX, 0.0);
         resizeButtonTexUv *= vec2(1.0 / resizeButtonProportionX, 1.0 / resizeButtonProportionY);
         vec4 color = texture(inputTextures[resizeButtonTextureIndex], clamp(resizeButtonTexUv, 0.0, 1.0));
-        fragColor = mix(fragColor, color, color.a);
+        if (color.a > 0.5)
+          fragColor = color;
       }
     }
   }


### PR DESCRIPTION
Resize and close buttons in RangeFinder overlay are sometimes completely black

![Screenshot from 2022-10-17 15-53-47](https://user-images.githubusercontent.com/5910449/196196990-b120917d-ddd0-4a44-9340-acf99ebb5eda.png)

It seems that this is because the `mix` function cannot properly handle the values (like FLT_MAX) of the RangeFinder image pixel color.
For the close and resize buttons where the alpha channel is 1 or 0 it is simpler to not mix the colors.