### PR TITLE
Fix PROTO declaration error when copy and pasting inserted nodes

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -5,12 +5,12 @@
    - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
    - Fixed the export of [Lidar](lidar.md)'s rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
-   - Fixed the reset of the viewpoint in animation when the follow is activated ([5237](https://github.com/cyberbotics/webots/pull/5237)).
-   - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
-   - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([5305](https://github.com/cyberbotics/webots/pull/5305)).
-   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
-   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([5337](https://github.com/cyberbotics/webots/pull/5337)).
-   - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([5341](https://github.com/cyberbotics/webots/pull/5341)).
+   - Fixed the reset of the viewpoint in animation when the follow is activated ([#5237](https://github.com/cyberbotics/webots/pull/5237)).
+   - Fixed a recursion bug in web animation ([#5260](https://github.com/cyberbotics/webots/pull/5260)).
+   - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
+   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
+   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
+   - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([#5341](https://github.com/cyberbotics/webots/pull/5341)).
    - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,6 +10,7 @@
    - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([5305](https://github.com/cyberbotics/webots/pull/5305)).
    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
    - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([5337](https://github.com/cyberbotics/webots/pull/5337)).
+   - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([5341](https://github.com/cyberbotics/webots/pull/5341)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -396,7 +396,7 @@ void WbNodeOperations::updateExternProtoDeclarations(WbField *field) {
   QList<const WbNode *> protoList(WbNodeUtilities::protoNodesInWorldFile(topProto));
   foreach (const WbNode *proto, protoList) {
     const QString previousUrl(
-      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, false));
+      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, true, false));
     if (!previousUrl.isEmpty())
       WbLog::warning(tr("Conflicting declarations for '%1' are provided: \"%2\" and \"%3\", the first one will be used after "
                         "saving and reverting the world. "

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -396,7 +396,7 @@ void WbNodeOperations::updateExternProtoDeclarations(WbField *field) {
   QList<const WbNode *> protoList(WbNodeUtilities::protoNodesInWorldFile(topProto));
   foreach (const WbNode *proto, protoList) {
     const QString previousUrl(
-      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, true, false));
+      WbProtoManager::instance()->declareExternProto(proto->modelName(), proto->proto()->url(), false, false));
     if (!previousUrl.isEmpty())
       WbLog::warning(tr("Conflicting declarations for '%1' are provided: \"%2\" and \"%3\", the first one will be used after "
                         "saving and reverting the world. "

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -683,7 +683,7 @@ void WbAddNodeDialog::accept() {
     return;
   }
 
-  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
+  const QList<WbExternProto *> &clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
   const QString protoName =
     QUrl(mTree->selectedItems().at(0)->text(FILE_NAME)).fileName().replace(".proto", "", Qt::CaseInsensitive);
 

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -731,7 +731,7 @@ void WbAddNodeDialog::accept() {
 
   // the insertion must be declared as EXTERNPROTO so that it is added to the world file when saving
   WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
-                                                 mSelectionPath, false);
+                                                 mSelectionPath, false, true);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -683,12 +683,12 @@ void WbAddNodeDialog::accept() {
     return;
   }
 
-  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
+  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
   const QString protoName =
     QUrl(mTree->selectedItems().at(0)->text(FILE_NAME)).fileName().replace(".proto", "", Qt::CaseInsensitive);
 
   bool conflict = false;
-  foreach (const WbExternProto *proto, cutBuffer) {
+  foreach (const WbExternProto *proto, clipboardBuffer) {
     if (proto && proto->name() == protoName && !mRetrievalTriggered) {
       conflict = true;
       break;
@@ -696,13 +696,13 @@ void WbAddNodeDialog::accept() {
   }
 
   if (conflict) {
-    const QMessageBox::StandardButton cutBufferWarningDialog = WbMessageBox::warning(
+    const QMessageBox::StandardButton clipboardBufferWarningDialog = WbMessageBox::warning(
       "One or more PROTO nodes with the same name as the one you are about to insert is contained in the clipboard. Do "
       "you want to continue? This operation will clear the clipboard.",
       this, "Warning", QMessageBox::Cancel, QMessageBox::Ok | QMessageBox::Cancel);
 
-    if (cutBufferWarningDialog == QMessageBox::Ok) {
-      WbProtoManager::instance()->clearExternProtoCutBuffer();
+    if (clipboardBufferWarningDialog == QMessageBox::Ok) {
+      WbProtoManager::instance()->clearExternProtoClipboardBuffer();
       WbClipboard::instance()->clear();
     } else
       return;
@@ -731,7 +731,7 @@ void WbAddNodeDialog::accept() {
 
   // the insertion must be declared as EXTERNPROTO so that it is added to the world file when saving
   WbProtoManager::instance()->declareExternProto(QUrl(mSelectionPath).fileName().replace(".proto", "", Qt::CaseInsensitive),
-                                                 mSelectionPath, false, true);
+                                                 mSelectionPath, false);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -207,7 +207,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // the addition must be declared as EXTERNPROTO so that it is added to the world file when saving
-  WbProtoManager::instance()->declareExternProto(mProto, mPath, true, true);
+  WbProtoManager::instance()->declareExternProto(mProto, mPath, true, false);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -156,7 +156,7 @@ void WbInsertExternProtoDialog::accept() {
   if (mTree->selectedItems().size() == 0 || !mInsertButton->isEnabled())
     return;
 
-  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
+  const QList<WbExternProto *> &clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
   bool conflict = false;
   foreach (const WbExternProto *proto, clipboardBuffer) {
     if (proto && proto->name() == mTree->selectedItems().at(0)->text(0) && !mRetrievalTriggered) {

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -207,7 +207,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // the addition must be declared as EXTERNPROTO so that it is added to the world file when saving
-  WbProtoManager::instance()->declareExternProto(mProto, mPath, true);
+  WbProtoManager::instance()->declareExternProto(mProto, mPath, true, true);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
+++ b/src/webots/scene_tree/WbInsertExternProtoDialog.cpp
@@ -156,9 +156,9 @@ void WbInsertExternProtoDialog::accept() {
   if (mTree->selectedItems().size() == 0 || !mInsertButton->isEnabled())
     return;
 
-  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
+  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
   bool conflict = false;
-  foreach (const WbExternProto *proto, cutBuffer) {
+  foreach (const WbExternProto *proto, clipboardBuffer) {
     if (proto && proto->name() == mTree->selectedItems().at(0)->text(0) && !mRetrievalTriggered) {
       conflict = true;
       break;
@@ -166,13 +166,13 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   if (conflict) {
-    const QMessageBox::StandardButton cutBufferWarningDialog = WbMessageBox::warning(
+    const QMessageBox::StandardButton clipboardBufferWarningDialog = WbMessageBox::warning(
       "One or more PROTO nodes with the same name as the one you are about to insert is contained in the clipboard. Do "
       "you want to continue? This operation will clear the clipboard.",
       this, "Warning", QMessageBox::Cancel, QMessageBox::Ok | QMessageBox::Cancel);
 
-    if (cutBufferWarningDialog == QMessageBox::Ok) {
-      WbProtoManager::instance()->clearExternProtoCutBuffer();
+    if (clipboardBufferWarningDialog == QMessageBox::Ok) {
+      WbProtoManager::instance()->clearExternProtoClipboardBuffer();
       WbClipboard::instance()->clear();
     } else
       return;
@@ -207,7 +207,7 @@ void WbInsertExternProtoDialog::accept() {
   }
 
   // the addition must be declared as EXTERNPROTO so that it is added to the world file when saving
-  WbProtoManager::instance()->declareExternProto(mProto, mPath, true, false);
+  WbProtoManager::instance()->declareExternProto(mProto, mPath, true);
 
   QDialog::accept();
 }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -345,7 +345,7 @@ void WbSceneTree::paste() {
 
   const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
   foreach (const WbExternProto *item, cutBuffer)
-    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable());
+    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable(), true);
 
   if (mSelectedItem->isField() && mSelectedItem->field()->isSingle())
     pasteInSFValue();
@@ -774,7 +774,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     // declare PROTO nodes that have become visible at the world level
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {
-      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false));
+      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, true, false));
       if (!previousUrl.isEmpty())
         WbLog::warning(tr("Conflicting declarations for '%1' are provided: %2 and %3, the first one will be used. "
                           "To use the other instead you will need to change it manually in the world file.")

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -341,7 +341,7 @@ void WbSceneTree::paste() {
   if (!mSelectedItem)
     return;
 
-  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
+  const QList<WbExternProto *> &clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
   foreach (const WbExternProto *item, clipboardBuffer)
     WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable());
 
@@ -769,7 +769,12 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     if (skipTemplateRegeneration)
       parentField->blockSignals(false);
 
+    // backup clipboard data
+    const QList<QString> previousClipboardBuffer(WbProtoManager::instance()->externProtoClipboardBufferUrls());
+
     // declare PROTO nodes that have become visible at the world level
+    QList<WbExternProto *> declaredProtoNodes;
+    WbProtoManager::instance()->clearExternProtoClipboardBuffer();
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {
       const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false));
@@ -779,6 +784,8 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
                          .arg(item.first)
                          .arg(previousUrl)
                          .arg(item.second));
+      else
+        WbProtoManager::instance()->saveToExternProtoClipboardBuffer(item.second);
     }
 
     // import new node
@@ -793,6 +800,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
         viewpoint->startFollowUp(dynamic_cast<WbSolid *>(node), true);
     }
     WbWorld::instance()->setModifiedFromSceneTree();
+    WbProtoManager::instance()->resetExternProtoClipboardBuffer(previousClipboardBuffer);
   }
   updateSelection();
   updateValue();

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -777,13 +777,14 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {
       const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false));
-      if (!previousUrl.isEmpty())
+      if (!previousUrl.isEmpty()) {
         WbLog::warning(tr("Conflicting declarations for '%1' are provided: %2 and %3, the first one will be used. "
                           "To use the other instead you will need to change it manually in the world file.")
                          .arg(item.first)
                          .arg(previousUrl)
                          .arg(item.second));
-      else
+        WbProtoManager::instance()->saveToExternProtoClipboardBuffer(previousUrl);
+      } else
         WbProtoManager::instance()->saveToExternProtoClipboardBuffer(item.second);
     }
 

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -299,12 +299,6 @@ void WbSceneTree::handleUserCommand(WbAction::WbActionKind actionKind) {
 }
 
 void WbSceneTree::cut() {
-  if (mSelectedItem->isNode()) {
-    const QList<const WbNode *> cutNodes = WbNodeUtilities::protoNodesInWorldFile(mSelectedItem->node());
-    if (!WbProtoManager::instance()->externProtoCutBuffer().isEmpty())
-      WbProtoManager::instance()->clearExternProtoCutBuffer();
-    WbProtoManager::instance()->saveToExternProtoCutBuffer(cutNodes);
-  }
   copy();
   del();
   updateToolbar();
@@ -327,9 +321,13 @@ void WbSceneTree::copy() {
 
   WbSingleValue *singleValue = dynamic_cast<WbSingleValue *>(value);
   WbMultipleValue *multipleValue = dynamic_cast<WbMultipleValue *>(value);
-  if (mSelectedItem->isNode() || mSelectedItem->isSFNode())
+  if (mSelectedItem->isNode() || mSelectedItem->isSFNode()) {
+    const QList<const WbNode *> clipboardNodes = WbNodeUtilities::protoNodesInWorldFile(mSelectedItem->node());
+    if (!WbProtoManager::instance()->externProtoClipboardBuffer().isEmpty())
+      WbProtoManager::instance()->clearExternProtoClipboardBuffer();
+    WbProtoManager::instance()->saveToExternProtoClipboardBuffer(clipboardNodes);
     mClipboard->setNode(mSelectedItem->node());
-  else if (singleValue)
+  } else if (singleValue)
     *mClipboard = singleValue->variantValue();
   else if (multipleValue)
     *mClipboard = multipleValue->variantValue(row);
@@ -343,9 +341,9 @@ void WbSceneTree::paste() {
   if (!mSelectedItem)
     return;
 
-  const QList<WbExternProto *> cutBuffer = WbProtoManager::instance()->externProtoCutBuffer();
-  foreach (const WbExternProto *item, cutBuffer)
-    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable(), true);
+  const QList<WbExternProto *> clipboardBuffer = WbProtoManager::instance()->externProtoClipboardBuffer();
+  foreach (const WbExternProto *item, clipboardBuffer)
+    WbProtoManager::instance()->declareExternProto(item->name(), item->url(), item->isImportable());
 
   if (mSelectedItem->isField() && mSelectedItem->field()->isSingle())
     pasteInSFValue();
@@ -774,7 +772,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     // declare PROTO nodes that have become visible at the world level
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {
-      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, true, false));
+      const QString previousUrl(WbProtoManager::instance()->declareExternProto(item.first, item.second, false, false));
       if (!previousUrl.isEmpty())
         WbLog::warning(tr("Conflicting declarations for '%1' are provided: %2 and %3, the first one will be used. "
                           "To use the other instead you will need to change it manually in the world file.")

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -773,7 +773,6 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     const QList<QString> previousClipboardBuffer(WbProtoManager::instance()->externProtoClipboardBufferUrls());
 
     // declare PROTO nodes that have become visible at the world level
-    QList<WbExternProto *> declaredProtoNodes;
     WbProtoManager::instance()->clearExternProtoClipboardBuffer();
     QPair<QString, QString> item;
     foreach (item, writer.declarations()) {

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -788,12 +788,10 @@ QString WbProtoManager::declareExternProto(const QString &protoName, const QStri
   return previousUrl;
 }
 
-#include <QtCore/QtDebug>
 void WbProtoManager::purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse) {
   for (int i = mExternProto.size() - 1; i >= 0; --i) {
     if (!protoNamesInUse.contains(mExternProto[i]->name()) && !mExternProto[i]->isImportable()) {
       // delete non-importable nodes that have no remaining visible instances
-      qDebug() << "purgeUnusedExternProtoDeclarations delete " << mExternProto[i];
       delete mExternProto[i];
       mExternProto.remove(i);
     }

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -108,7 +108,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
 
   // nodes imported from a supervisor should only check the IMPORTABLE list
   if (!mImportedFromSupervisor) {
-    // check the cut buffer
+    // check the clipboard buffer
     if (protoDeclaration.isEmpty() && !mExternProtoClipboardBuffer.isEmpty()) {
       foreach (const WbExternProto *item, mExternProtoClipboardBuffer) {
         if (item->name() == modelName)

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -109,8 +109,8 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
   // nodes imported from a supervisor should only check the IMPORTABLE list
   if (!mImportedFromSupervisor) {
     // check the cut buffer
-    if (protoDeclaration.isEmpty() && !mExternProtoCutBuffer.isEmpty()) {
-      foreach (const WbExternProto *item, mExternProtoCutBuffer) {
+    if (protoDeclaration.isEmpty() && !mExternProtoClipboardBuffer.isEmpty()) {
+      foreach (const WbExternProto *item, mExternProtoClipboardBuffer) {
         if (item->name() == modelName)
           protoDeclaration = item->url();
       }
@@ -124,7 +124,7 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
   // for IMPORTABLE proto nodes the declaration is in the EXTERNPROTO list, nodes added with add-node follow a different pipe
   if (protoDeclaration.isEmpty()) {
     foreach (const WbExternProto *proto, mExternProto) {
-      if (proto->name() == modelName && (proto->isImportable() || proto->isFromUserAction()))
+      if (proto->name() == modelName && (proto->isImportable() || proto->isFromRootNodeConversion()))
         protoDeclaration = proto->url();
     }
     // for supervisor imported nodes, only the first level should be exclusively checked in the IMPORTABLE list
@@ -415,7 +415,7 @@ void WbProtoManager::loadWorld() {
 
   // declare all root PROTO defined at the world level, and inferred by backwards compatibility, to the list of EXTERNPROTO
   foreach (const WbProtoTreeItem *const child, mTreeRoot->children())
-    declareExternProto(child->name(), child->url(), child->isImportable(), false);
+    declareExternProto(child->name(), child->url(), child->isImportable());
 
   // cleanup and load world at last
   mTreeRoot->deleteLater();
@@ -769,7 +769,7 @@ WbProtoInfo *WbProtoManager::generateInfoFromProtoFile(const QString &protoFileN
 }
 
 QString WbProtoManager::declareExternProto(const QString &protoName, const QString &protoPath, bool importable,
-                                           bool fromUserAction, bool forceUrlUpdate) {
+                                           bool forceUpdate) {
   QString previousUrl;
   const QString expandedProtoPath(WbUrl::resolveUrl(protoPath));
   for (int i = 0; i < mExternProto.size(); ++i) {
@@ -777,20 +777,20 @@ QString WbProtoManager::declareExternProto(const QString &protoName, const QStri
       mExternProto[i]->setImportable(mExternProto[i]->isImportable() || importable);
       if (mExternProto[i]->url() != expandedProtoPath) {
         previousUrl = mExternProto[i]->url();
-        if (forceUrlUpdate)
+        if (forceUpdate)
           mExternProto[i]->setUrl(expandedProtoPath);
       }
       return previousUrl;
     }
   }
 
-  mExternProto.push_back(new WbExternProto(protoName, expandedProtoPath, importable, fromUserAction));
+  mExternProto.push_back(new WbExternProto(protoName, expandedProtoPath, importable, !forceUpdate));
   return previousUrl;
 }
 
 void WbProtoManager::purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse) {
   for (int i = mExternProto.size() - 1; i >= 0; --i) {
-    mExternProto[i]->unflagFromUserAction();  // deactivate the flag as it's no longer needed
+    mExternProto[i]->unflagFromRootNodeConversion();  // deactivate the flag as it's no longer needed
 
     if (!protoNamesInUse.contains(mExternProto[i]->name()) && !mExternProto[i]->isImportable()) {
       // delete non-importable nodes that have no remaining visible instances
@@ -821,23 +821,23 @@ QString WbProtoManager::externProtoUrl(const WbNode *node, bool formatted) const
   return QString();
 }
 
-void WbProtoManager::saveToExternProtoCutBuffer(const QList<const WbNode *> &nodes) {
+void WbProtoManager::saveToExternProtoClipboardBuffer(const QList<const WbNode *> &nodes) {
   foreach (const WbNode *node, nodes) {
     if (!node->proto())
       continue;
 
     for (int i = 0; i < mExternProto.size(); ++i) {
       if (mExternProto[i]->url() == node->proto()->url()) {
-        mExternProtoCutBuffer << new WbExternProto(*mExternProto[i]);
+        mExternProtoClipboardBuffer << new WbExternProto(*mExternProto[i]);
         break;
       }
     }
   }
 }
 
-void WbProtoManager::clearExternProtoCutBuffer() {
-  qDeleteAll(mExternProtoCutBuffer);
-  mExternProtoCutBuffer.clear();
+void WbProtoManager::clearExternProtoClipboardBuffer() {
+  qDeleteAll(mExternProtoClipboardBuffer);
+  mExternProtoClipboardBuffer.clear();
 }
 
 void WbProtoManager::removeImportableExternProto(const QString &protoName) {

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -35,25 +35,25 @@ class WbVersion;
 
 class WbExternProto {
 public:
-  WbExternProto(const QString &name, const QString &url, bool isImportable, bool isFromRootNodeConversion = false) :
+  WbExternProto(const QString &name, const QString &url, bool isImportable, bool isFromUserAction) :
     mName(name),
     mUrl(url),
     mImportable(isImportable),
-    mFromRootNodeConversion(isFromRootNodeConversion) {}
+    mIsFromUserAction(isFromUserAction) {}
 
   const QString &name() const { return mName; }
   void setUrl(const QString &url) { mUrl = url; }
   const QString &url() const { return mUrl; }
   bool isImportable() const { return mImportable; }
   void setImportable(bool value) { mImportable = value; }
-  bool isFromRootNodeConversion() const { return mFromRootNodeConversion; }
-  void unflagFromRootNodeConversion() { mFromRootNodeConversion = false; }
+  bool isFromUserAction() const { return mIsFromUserAction; }
+  void unflagFromUserAction() { mIsFromUserAction = false; }
 
 private:
   QString mName;
   QString mUrl;
   bool mImportable;
-  bool mFromRootNodeConversion;
+  bool mIsFromUserAction;  // new node insertion, conversion to base nodes, etc.
 };
 
 class WbProtoInfo {
@@ -180,7 +180,8 @@ public:
 
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared
-  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool forceUpdate = true);
+  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool fromUserAction,
+                             bool forceUrlUpdate = true);
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -35,25 +35,25 @@ class WbVersion;
 
 class WbExternProto {
 public:
-  WbExternProto(const QString &name, const QString &url, bool isImportable, bool isFromUserAction) :
+  WbExternProto(const QString &name, const QString &url, bool isImportable, bool isFromRootNodeConversion = false) :
     mName(name),
     mUrl(url),
     mImportable(isImportable),
-    mIsFromUserAction(isFromUserAction) {}
+    mFromRootNodeConversion(isFromRootNodeConversion) {}
 
   const QString &name() const { return mName; }
   void setUrl(const QString &url) { mUrl = url; }
   const QString &url() const { return mUrl; }
   bool isImportable() const { return mImportable; }
   void setImportable(bool value) { mImportable = value; }
-  bool isFromUserAction() const { return mIsFromUserAction; }
-  void unflagFromUserAction() { mIsFromUserAction = false; }
+  bool isFromRootNodeConversion() const { return mFromRootNodeConversion; }
+  void unflagFromRootNodeConversion() { mFromRootNodeConversion = false; }
 
 private:
   QString mName;
   QString mUrl;
   bool mImportable;
-  bool mIsFromUserAction;  // new node insertion, conversion to base nodes, etc.
+  bool mFromRootNodeConversion;
 };
 
 class WbProtoInfo {
@@ -175,22 +175,21 @@ public:
   // list of all EXTERNPROTO (both importable and not), stored in a QVector as order matters when saving to file
   const QVector<WbExternProto *> &externProto() const { return mExternProto; };
 
-  // EXTERNPROTO stored after cutting an inserted node
-  const QList<WbExternProto *> externProtoCutBuffer() const { return mExternProtoCutBuffer; };
+  // EXTERNPROTO stored after copying or cutting an inserted node
+  const QList<WbExternProto *> externProtoClipboardBuffer() const { return mExternProtoClipboardBuffer; };
 
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared
-  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool fromUserAction,
-                             bool forceUrlUpdate = true);
+  QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool forceUpdate = true);
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;
-  void saveToExternProtoCutBuffer(const QList<const WbNode *> &nodes);
+  void saveToExternProtoClipboardBuffer(const QList<const WbNode *> &nodes);
 
   QString findExternProtoDeclarationInFile(const QString &url, const QString &modelName);
   void removeImportableExternProto(const QString &protoName);
 
-  void clearExternProtoCutBuffer();
+  void clearExternProtoClipboardBuffer();
   bool isImportableExternProtoDeclared(const QString &protoName);
 
   void updateExternProto(const QString &protoName, const QString &url);
@@ -234,8 +233,8 @@ private:
   // note: this list is reset before every world load and each time a node is deleted
   QVector<WbExternProto *> mExternProto;
 
-  // mExternProtoCutBuffer: contains the externProto reference of the last cut instance
-  QList<WbExternProto *> mExternProtoCutBuffer;
+  // mExternProtoClipboardBuffer: contains the externProto reference of the last copies or cut instance
+  QList<WbExternProto *> mExternProtoClipboardBuffer;
 
   // stores PROTO metadata
   QMap<QString, WbProtoInfo *> mWebotsProtoList;     // loaded from proto-list.xml

--- a/src/webots/vrml/WbProtoManager.hpp
+++ b/src/webots/vrml/WbProtoManager.hpp
@@ -35,25 +35,21 @@ class WbVersion;
 
 class WbExternProto {
 public:
-  WbExternProto(const QString &name, const QString &url, bool isImportable, bool isFromRootNodeConversion = false) :
+  WbExternProto(const QString &name, const QString &url, bool isImportable) :
     mName(name),
     mUrl(url),
-    mImportable(isImportable),
-    mFromRootNodeConversion(isFromRootNodeConversion) {}
+    mImportable(isImportable) {}
 
   const QString &name() const { return mName; }
   void setUrl(const QString &url) { mUrl = url; }
   const QString &url() const { return mUrl; }
   bool isImportable() const { return mImportable; }
   void setImportable(bool value) { mImportable = value; }
-  bool isFromRootNodeConversion() const { return mFromRootNodeConversion; }
-  void unflagFromRootNodeConversion() { mFromRootNodeConversion = false; }
 
 private:
   QString mName;
   QString mUrl;
   bool mImportable;
-  bool mFromRootNodeConversion;
 };
 
 class WbProtoInfo {
@@ -175,22 +171,26 @@ public:
   // list of all EXTERNPROTO (both importable and not), stored in a QVector as order matters when saving to file
   const QVector<WbExternProto *> &externProto() const { return mExternProto; };
 
-  // EXTERNPROTO stored after copying or cutting an inserted node
-  const QList<WbExternProto *> externProtoClipboardBuffer() const { return mExternProtoClipboardBuffer; };
-
   // EXTERNPROTO manipulators
   // declares EXTERNPROTO and returns the previous URL if is another PROTO with the same model if already declared
   QString declareExternProto(const QString &protoName, const QString &protoPath, bool importable, bool forceUpdate = true);
   void purgeUnusedExternProtoDeclarations(const QSet<QString> &protoNamesInUse);
   QString externProtoUrl(const WbNode *node, bool formatted = false) const;
   QString removeProtoUrl(const WbNode *node, bool formatted = false) const;
-  void saveToExternProtoClipboardBuffer(const QList<const WbNode *> &nodes);
 
   QString findExternProtoDeclarationInFile(const QString &url, const QString &modelName);
   void removeImportableExternProto(const QString &protoName);
 
-  void clearExternProtoClipboardBuffer();
   bool isImportableExternProtoDeclared(const QString &protoName);
+
+  // EXTERNPROTO stored after copying or cutting an inserted node
+  const QList<WbExternProto *> &externProtoClipboardBuffer() const { return mExternProtoClipboardBuffer; };
+  void saveToExternProtoClipboardBuffer(const QList<const WbNode *> &nodes);
+  void saveToExternProtoClipboardBuffer(const QString &url);
+  void clearExternProtoClipboardBuffer();
+  // save currnent clipboard buffer for restoring it later
+  QList<QString> externProtoClipboardBufferUrls() const;
+  void resetExternProtoClipboardBuffer(const QList<QString> &bufferUrls);
 
   void updateExternProto(const QString &protoName, const QString &url);
   QString formatExternProtoPath(const QString &url) const;


### PR DESCRIPTION
Fix  #5325:
generalize the `WbExternProto::isFromRootNodeConversion()` flag to apply for any user action (and including the node insertion) so that the PROTO declaration is correctly found also when copying and pasting a PROTO node inserted in the world from the add node dialog.