### PR TITLE
Restore the description of base node

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,7 +10,7 @@
    - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
    - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
-   - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
+   - Fixed the description of base nodes in the  "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,7 +10,7 @@
    - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
    - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
-   - Fixed the description of base nodes in the  "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
+   - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -10,6 +10,7 @@
    - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([5305](https://github.com/cyberbotics/webots/pull/5305)).
    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
    - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([5337](https://github.com/cyberbotics/webots/pull/5337)).
+   - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -5,11 +5,11 @@
    - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
    - Fixed the export of [Lidar](lidar.md)'s rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
-   - Fixed the reset of the viewpoint in animation when the follow is activated ([5237](https://github.com/cyberbotics/webots/pull/5237)).
-   - Fixed a recursion bug in web animation ([5260](https://github.com/cyberbotics/webots/pull/5260)).
-   - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([5305](https://github.com/cyberbotics/webots/pull/5305)).
-   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([5310](https://github.com/cyberbotics/webots/pull/5310)).
-   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([5337](https://github.com/cyberbotics/webots/pull/5337)).
+   - Fixed the reset of the viewpoint in animation when the follow is activated ([#5237](https://github.com/cyberbotics/webots/pull/5237)).
+   - Fixed a recursion bug in web animation ([#5260](https://github.com/cyberbotics/webots/pull/5260)).
+   - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
+   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
+   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
    - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
  - Dependency Updates
    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -371,37 +371,37 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
       mLicenseLabel->setText(tr("License: ") + license);
     }
 
-    mInfoText->clear();
-
-    if (!boundingObjectInfo.isEmpty())
-      mInfoText->appendHtml(tr("<font color=\"red\">WARNING: this node contains a Geometry with non-positive dimensions and "
-                               "hence cannot be inserted in a bounding object.</font><br/>"));
-
     description = info->description();
-    if (description.isEmpty())
-      mInfoText->setPlainText(tr("No info available."));
-    else {
-      // replace carriage returns with spaces where appropriate:
-      // "\n\n" => "\n\n": two consecutive carriage returns are preserved (new paragraph)
-      // "\n-"  => "\n-": a carriage return followed by a "-" are preserved (bullet list)
-      // "\n"   => " ": a single carriage return is transformed into a space (comment line wrap)
-      for (int i = 0; i < description.length(); i++) {
-        if (description[i] == '\n') {
-          if (i < (description.length() - 1)) {
-            if (description[i + 1] == '\n' || description[i + 1] == '-') {
-              i++;
-              continue;
-            }
-          }
-          description[i] = ' ';
-        }
-      }
-      mInfoText->appendPlainText(description.trimmed());
-    }
-    mInfoText->moveCursor(QTextCursor::Start);
-
     pixmapPath = QString("%1icons/%2.png").arg(QUrl(path).adjusted(QUrl::RemoveFilename).toString()).arg(modelName);
   }
+
+  mInfoText->clear();
+
+  if (!boundingObjectInfo.isEmpty())
+    mInfoText->appendHtml(tr("<font color=\"red\">WARNING: this node contains a Geometry with non-positive dimensions and "
+                             "hence cannot be inserted in a bounding object.</font><br/>"));
+
+  if (description.isEmpty())
+    mInfoText->setPlainText(tr("No info available."));
+  else {
+    // replace carriage returns with spaces where appropriate:
+    // "\n\n" => "\n\n": two consecutive carriage returns are preserved (new paragraph)
+    // "\n-"  => "\n-": a carriage return followed by a "-" are preserved (bullet list)
+    // "\n"   => " ": a single carriage return is transformed into a space (comment line wrap)
+    for (int i = 0; i < description.length(); i++) {
+      if (description[i] == '\n') {
+        if (i < (description.length() - 1)) {
+          if (description[i + 1] == '\n' || description[i + 1] == '-') {
+            i++;
+            continue;
+          }
+        }
+        description[i] = ' ';
+      }
+    }
+    mInfoText->appendPlainText(description.trimmed());
+  }
+  mInfoText->moveCursor(QTextCursor::Start);
 
   mPixmapLabel->hide();
   if (!pixmapPath.isEmpty()) {

--- a/src/webots/vrml/WbTokenizer.cpp
+++ b/src/webots/vrml/WbTokenizer.cpp
@@ -170,6 +170,9 @@ bool WbTokenizer::readFileInfo(bool headerRequired, bool displayWarning, const Q
       mInfo.append(splittedInfo[i].trimmed() + '\n');
     mInfo.chop(1);  // remove last '\n'
 
+    if (mFileType == MODEL)
+      return true;
+
     // do a forward compatibility test based on the file and webots versions without the maintenance id
     WbVersion forwardCompatiblityFileVersion = mFileVersion;
     forwardCompatiblityFileVersion.setRevision(0);
@@ -214,6 +217,8 @@ bool WbTokenizer::checkFileHeader() {
       return readFileInfo(true, true, "VRML_SIM");
     case PROTO:
       return readFileInfo(false, true, "VRML_SIM", true);
+    case MODEL:
+      return readFileInfo(false, false, "VRML");
     default:
       return true;
   }
@@ -554,6 +559,8 @@ WbTokenizer::FileType WbTokenizer::fileTypeFromFileName(const QString &fileName)
     return WORLD;
   else if (name.endsWith(".proto", Qt::CaseInsensitive))
     return PROTO;
+  else if (name.endsWith(".wrl", Qt::CaseInsensitive))
+    return MODEL;
   else
     return UNKNOWN;
 }

--- a/src/webots/vrml/WbTokenizer.hpp
+++ b/src/webots/vrml/WbTokenizer.hpp
@@ -33,8 +33,8 @@ public:
   WbTokenizer();
   ~WbTokenizer();
 
-  // files types: .wbt, or .proto
-  enum FileType { UNKNOWN, WORLD, PROTO };
+  // files types: .wbt, .proto or .wrl
+  enum FileType { UNKNOWN, WORLD, PROTO, MODEL };
   FileType fileType() const { return mFileType; }
 
   // build list of tokens


### PR DESCRIPTION
The description of base nodes in the `add node` dialog have been broken by both the removal of `WBO` and the introduction of `EXTERNPROTO`