### PR TITLE
Fix deprecated field in PR2 camera

### DIFF
--- a/projects/robots/clearpath/pr2/protos/Pr2.proto
+++ b/projects/robots/clearpath/pr2/protos/Pr2.proto
@@ -1159,7 +1159,6 @@ PROTO Pr2 [
                                                       width 1224
                                                       height 1025
                                                       near 0.1
-                                                      type "color"
                                                     }
                                                   ]
                                                 }
@@ -1233,7 +1232,6 @@ PROTO Pr2 [
                                                               width 640
                                                               height 480
                                                               near 0.1
-                                                              type "color"
                                                             }
                                                           ]
                                                         }
@@ -1270,7 +1268,6 @@ PROTO Pr2 [
                                                                   width 640
                                                                   height 480
                                                                   near 0.1
-                                                                  type "color"
                                                                 }
                                                               ]
                                                             }
@@ -2205,7 +2202,6 @@ PROTO Pr2 [
                                                               Camera {
                                                                 rotation -0.357557 0.357557 0.862732 1.717914
                                                                 name "r_forearm_cam_sensor"
-                                                                type "color"
                                                                 fieldOfView 1.57079632679
                                                                 width 640
                                                                 height 480
@@ -3091,7 +3087,6 @@ PROTO Pr2 [
                                                                   Camera {
                                                                     rotation 0.678689 -0.678689 0.280647 2.594375
                                                                     name "l_forearm_cam_sensor"
-                                                                    type "color"
                                                                     fieldOfView 1.57079632679
                                                                     width 640
                                                                     height 480


### PR DESCRIPTION
The [test-worlds](https://github.com/cyberbotics/webots/actions/runs/3277524121/jobs/5395245692) was broken by #5266. This PR fixes it.