### PR TITLE
Fix ChangeLog indent

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -1,18 +1,18 @@
 # Webots R2022 Change Log
 
 ## Webots R2022b Revision 1
- - Bug Fixes
-   - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
-   - Fixed the export of [Lidar](lidar.md)'s rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
-   - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
-   - Fixed the reset of the viewpoint in animation when the follow is activated ([#5237](https://github.com/cyberbotics/webots/pull/5237)).
-   - Fixed a recursion bug in web animation ([#5260](https://github.com/cyberbotics/webots/pull/5260)).
-   - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
-   - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
-   - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
-   - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
- - Dependency Updates
-   - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
+  - Bug Fixes
+    - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
+    - Fixed the export of [Lidar](lidar.md)'s rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).
+    - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
+    - Fixed the reset of the viewpoint in animation when the follow is activated ([#5237](https://github.com/cyberbotics/webots/pull/5237)).
+    - Fixed a recursion bug in web animation ([#5260](https://github.com/cyberbotics/webots/pull/5260)).
+    - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
+    - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
+    - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
+    - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
+  - Dependency Updates
+    - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 
 ## Webots R2022b
 Released on September, 13th, 2022.

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -7,7 +7,7 @@
     - Fixed behavior of `WbLightSensor::computeLightMeasurement` when spotlight is rotated ([#5231](https://github.com/cyberbotics/webots/pull/5231)).
     - Fixed the reset of the viewpoint in animation when the follow is activated ([#5237](https://github.com/cyberbotics/webots/pull/5237)).
     - Fixed a recursion bug in web animation ([#5260](https://github.com/cyberbotics/webots/pull/5260)).
-    - Fixed reset of [#Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
+    - Fixed reset of [Lidar](lidar.md) memory mapped file in an extern controller restarted during the simulation run ([#5305](https://github.com/cyberbotics/webots/pull/5305)).
     - Fixed a crash when trying to connect a remote extern controllers while a world is loading ([#5310](https://github.com/cyberbotics/webots/pull/5310)).
     - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
     - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).


### PR DESCRIPTION
In R2022b-rev1 changelog the indent in only by 1 space instead of 2 (as in the rest of the file).