### PR TITLE
Fix duplicated CadShape mesh load and improve warnings

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -12,6 +12,9 @@
     - Fixed close and resize buttons rendered in black in the [RangeFinder](rangefinder.md) overlay if underlying pixel value is `inf` ([#5337](https://github.com/cyberbotics/webots/pull/5337)).
     - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([#5341](https://github.com/cyberbotics/webots/pull/5341)).
     - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
+  - Enhancements
+    - Added warnings if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5313](https://github.com/cyberbotics/webots/pull/5313)).
+    - Added warning if external mesh used in [Mesh](mesh.md) node has more than 100'000 vertices ([#5313](https://github.com/cyberbotics/webots/pull/5313)).
   - Dependency Updates
     - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -13,7 +13,7 @@
     - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([#5341](https://github.com/cyberbotics/webots/pull/5341)).
     - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
   - Enhancements
-    - Added warnings if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5359](https://github.com/cyberbotics/webots/pull/5359)).
+    - Added warning if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5359](https://github.com/cyberbotics/webots/pull/5359)).
     - Added warning if external mesh used in [Mesh](mesh.md) node has more than 100'000 vertices ([#5359](https://github.com/cyberbotics/webots/pull/5359)).
   - Dependency Updates
     - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).

--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -13,8 +13,8 @@
     - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([#5341](https://github.com/cyberbotics/webots/pull/5341)).
     - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
   - Enhancements
-    - Added warnings if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5313](https://github.com/cyberbotics/webots/pull/5313)).
-    - Added warning if external mesh used in [Mesh](mesh.md) node has more than 100'000 vertices ([#5313](https://github.com/cyberbotics/webots/pull/5313)).
+    - Added warnings if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5359](https://github.com/cyberbotics/webots/pull/5359)).
+    - Added warning if external mesh used in [Mesh](mesh.md) node has more than 100'000 vertices ([#5359](https://github.com/cyberbotics/webots/pull/5359)).
   - Dependency Updates
     - Upgraded to Qt6.4 on Windows ([#5301](https://github.com/cyberbotics/webots/pull/5301)).
 

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -113,7 +113,7 @@ void WbCadShape::retrieveMaterials() {
   qDeleteAll(mMaterialDownloaders);
   mMaterialDownloaders.clear();
 
-  QStringList rawMaterials = objMaterialList(completeUrl);
+  const QStringList rawMaterials = objMaterialList(completeUrl);
   foreach (QString material, rawMaterials) {
     const QString newUrl = WbUrl::combinePaths(material, completeUrl);
     if (!newUrl.isEmpty()) {
@@ -183,13 +183,6 @@ void WbCadShape::postFinalize() {
 }
 
 void WbCadShape::updateUrl() {
-  const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0, true);
-  if (completeUrl.isEmpty() || completeUrl == WbUrl::missingTexture()) {
-    if (areWrenObjectsInitialized())
-      deleteWrenObjects();
-    return;
-  }
-
   // we want to replace the windows backslash path separators (if any) with cross-platform forward slashes
   const int n = mUrl->size();
   for (int i = 0; i < n; i++) {
@@ -197,6 +190,13 @@ void WbCadShape::updateUrl() {
     mUrl->blockSignals(true);
     mUrl->setItem(i, item.replace("\\", "/"));
     mUrl->blockSignals(false);
+  }
+
+  const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, 0, true);
+  if (completeUrl.isEmpty() || completeUrl == WbUrl::missingTexture()) {
+    if (areWrenObjectsInitialized())
+      deleteWrenObjects();
+    return;
   }
 
   if (WbUrl::isWeb(completeUrl)) {
@@ -226,9 +226,9 @@ void WbCadShape::updateUrl() {
     if (areMaterialAssetsAvailable(completeUrl)) {
       mObjMaterials.clear();
       // generate mapping between referenced files and cached files
-      QStringList rawMaterials = objMaterialList(completeUrl);
+      const QStringList rawMaterials = objMaterialList(completeUrl);
       foreach (QString material, rawMaterials) {
-        QString adjustedUrl = WbUrl::combinePaths(material, completeUrl);
+        const QString adjustedUrl = WbUrl::combinePaths(material, completeUrl);
         assert(WbNetwork::instance()->isCachedNoMapUpdate(adjustedUrl));
         if (!mObjMaterials.contains(material))
           mObjMaterials.insert(material, adjustedUrl);

--- a/src/webots/nodes/WbCadShape.hpp
+++ b/src/webots/nodes/WbCadShape.hpp
@@ -46,6 +46,7 @@ public:
   // reimplemented public functions
   int nodeType() const override { return WB_NODE_CAD_SHAPE; }
   void downloadAssets() override;
+  void preFinalize() override;
   void postFinalize() override;
   void updateSegmentationColor(const WbRgb &color) override { setSegmentationColor(color); }
 

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -191,6 +191,10 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
     if (mIsCollada && mMaterialIndex->value() >= 0 && mMaterialIndex->value() != (int)mesh->mMaterialIndex)
       continue;
 
+    if (mesh->mNumVertices > 100000)
+      warn(tr("Mesh '%1' has more than 100'000 vertices, it is recommended to reduce the number of vertices.")
+             .arg(mesh->mName.C_Str()));
+
     totalVertices += mesh->mNumVertices;
     totalFaces += mesh->mNumFaces;
   }


### PR DESCRIPTION
Address #5356 and ##5313:
* [x] Add the same warning about complex mesh with more than 100'000 vertices in the Mesh node
* [x] Add warning in CadShape node when the imported mesh is fully transparent -> otherwise users may think that the import is buggy
* [x] Avoid creating WREN objects twice when finalizing the CadShape node. 
