### PR TITLE
Fix isTemplate flag not passed from base PROTO

### DIFF
--- a/docs/reference/changelog-r2022.md
+++ b/docs/reference/changelog-r2022.md
@@ -13,6 +13,7 @@
     - Fixed error message about missing PROTO declaration when copying and pasting a PROTO node that was just added using the Add Node dialog ([#5341](https://github.com/cyberbotics/webots/pull/5341)).
     - Fixed the description of base nodes in the "Add node" dialog ([#5346](https://github.com/cyberbotics/webots/pull/5346)).
     - Fixed robot window updates when an extern controller reconnects ([#5367](https://github.com/cyberbotics/webots/pull/5367)).
+    - Fixed regeneration of PROTO nodes derived from a procedural PROTO ([#5413](https://github.com/cyberbotics/webots/pull/5413)).
   - Enhancements
     - Added additional checks for path validity in wizards and save world dialogs ([#5350](https://github.com/cyberbotics/webots/pull/5350)).
     - Added warning if external mesh used in [CadShape](cadshape.md) node is fully transparent ([#5359](https://github.com/cyberbotics/webots/pull/5359)).

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1782,8 +1782,12 @@ WbNode *WbNode::createProtoInstanceFromParameters(WbProtoModel *proto, const QVe
         WbField *aliasParam = aliasIt.next();
         if (aliasParam->name() == param->alias() && aliasParam->type() == param->type()) {
           aliasNotFound = false;
-          if (!aliasParam->isTemplateRegenerator())
-            aliasParam->setTemplateRegenerator(param->isTemplateRegenerator());
+          if (!aliasParam->isTemplateRegenerator()) {
+            const bool paramTemplate = param->isTemplateRegenerator();
+            aliasParam->setTemplateRegenerator(paramTemplate);
+            if (paramTemplate)
+              instance->mProto->setIsTemplate(true);
+          }
 
           WbNode *tmpParent = gParent;
           foreach (WbField *internalField, param->internalFields()) {
@@ -2322,10 +2326,12 @@ void WbNode::printDebugNodeStructure(int level) {
   for (int i = 0; i < level; ++i)
     indent += "  ";
 
-  QString line;
-  line.sprintf("%sNode %s %p id %d parameterNode %p", indent.toStdString().c_str(), usefulName().toStdString().c_str(), this,
-               uniqueId(), protoParameterNode());
-  qDebug() << line;
+  qDebug() << QString("%1Node %2 0x%3 id %4 parameterNode 0x%5")
+                .arg(indent.toStdString().c_str())
+                .arg(usefulName().toStdString().c_str())
+                .arg((quintptr)this, QT_POINTER_SIZE * 2, 16)
+                .arg(uniqueId())
+                .arg((quintptr)protoParameterNode(), 0, 16);
   printDebugNodeFields(level, true);
   printDebugNodeFields(level, false);
 }
@@ -2339,9 +2345,12 @@ void WbNode::printDebugNodeFields(int level, bool printParameters) {
   QString type = printParameters ? "Parameter" : "Field";
   QVector<WbField *> fieldList = printParameters ? parameters() : fields();
   foreach (WbField *p, fieldList) {
-    line.sprintf("%s%s %s %p (alias %p):", indent.toStdString().c_str(), type.toStdString().c_str(),
-                 p->name().toStdString().c_str(), p, p->parameter());
-    qDebug() << line;
+    qDebug() << QString("%1%2 %3 0x%4 (alias 0x%5):")
+                  .arg(indent.toStdString().c_str())
+                  .arg(type.toStdString().c_str())
+                  .arg(p->name().toStdString().c_str())
+                  .arg((quintptr)p, 0, 16)
+                  .arg((quintptr)p->parameter(), 0, 16);
     if (p->type() == WB_SF_NODE) {
       WbNode *n = dynamic_cast<WbSFNode *>(p->value())->value();
       if (n)
@@ -2353,10 +2362,9 @@ void WbNode::printDebugNodeFields(int level, bool printParameters) {
         if (n)
           n->printDebugNodeStructure(level + 1);
       }
-    } else {
-      line.sprintf("%s  %s", indent.toStdString().c_str(), p->toString(WbPrecision::GUI_LOW).toStdString().c_str());
-      qDebug() << line;
-    }
+    } else
+      qDebug()
+        << QString("%1 %2").arg(indent.toStdString().c_str()).arg(p->toString(WbPrecision::GUI_LOW).toStdString().c_str());
   }
 }
 */

--- a/src/webots/vrml/WbProtoModel.cpp
+++ b/src/webots/vrml/WbProtoModel.cpp
@@ -481,6 +481,13 @@ QStringList WbProtoModel::parameterNames() const {
   return names;
 }
 
+void WbProtoModel::setIsTemplate(bool value) {
+  mTemplate = value;
+  if (mTemplate && mIsDeterministic)
+    // if ancestor is nonDeterministic this proto can't be either
+    mIsDeterministic = mAncestorProtoModel->isDeterministic();
+}
+
 void WbProtoModel::verifyNodeAliasing(WbNode *node, WbFieldModel *param, WbTokenizer *tokenizer, bool searchInParameters,
                                       bool &ok) const {
   QVector<WbField *> fields;

--- a/src/webots/vrml/WbProtoModel.hpp
+++ b/src/webots/vrml/WbProtoModel.hpp
@@ -99,6 +99,8 @@ public:
 
   QStringList parameterNames() const;
 
+  void setIsTemplate(bool value);
+
   // add/remove a reference to this proto model from a proto instance
   // when the reference count reaches zero (in unref()) the proto model gets deleted
   // the optional argument defines if it is called from the creation of a proto instance


### PR DESCRIPTION
Fix #5214:
this is a regression from R2022a introduced in #5103 where the instruction to pass the `isTemplate` flag from the base to the inherited node has been removed.

Additionally I also updated some debug instructions throwing errors during compilation.