### PR TITLE
Removed obsolete dependency

### DIFF
--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -15,7 +15,6 @@
 /mingw64/bin/libmd4c.dll
 /mingw64/bin/libminizip-1.dll
 /mingw64/bin/libopenal-1.dll
-/mingw64/bin/libpcre-1.dll
 /mingw64/bin/libpcre2-16-0.dll
 /mingw64/bin/libpng16-16.dll
 /mingw64/bin/Qt6Core.dll


### PR DESCRIPTION
Webots doesn't depend any more on this DLL (probably due to some other DLL dependency change) and it doesn't get installed in the GitHub CI machine, causing the creation of the Windows package to fail.
Removing this obsolete dependency should fix the package creation on Windows in the CI.