### PR TITLE
Update axis orientation in wrl

### DIFF
--- a/resources/nodes/Capsule.wrl
+++ b/resources/nodes/Capsule.wrl
@@ -1,7 +1,7 @@
 # A Capsule is like a normal cylinder except it has half-sphere caps at its ends.
 # This primitive features particularly fast and accurate collision detection.
 # The cylinder's height, not counting the caps, is given by the height field.
-# The Capsule is aligned along the local y-axis.
+# The Capsule is aligned along the local z-axis.
 # The radius of the caps and of the cylinder itself is given by the radius field.
 
 Capsule {

--- a/resources/nodes/Cone.wrl
+++ b/resources/nodes/Cone.wrl
@@ -1,5 +1,5 @@
 # The Cone node specifies a cone which is centered in the local
-# coordinate system and whose central axis is aligned with the local y-axis.
+# coordinate system and whose central axis is aligned with the local z-axis.
 
 Cone {
   vrmlField SFFloat bottomRadius 1

--- a/resources/nodes/Cylinder.wrl
+++ b/resources/nodes/Cylinder.wrl
@@ -1,5 +1,5 @@
 # The Cylinder node specifies a cylinder centered at (0,0,0) in the local coordinate
-# system and with a central axis oriented along the local y-axis.
+# system and with a central axis oriented along the local z-axis.
 
 Cylinder {
   vrmlField SFBool  bottom      TRUE


### PR DESCRIPTION
When the FLU conversion took place we forgot to change the description of `Cone`/`Cylinder`/`Capsule` in the `.wrl` files.