### PR TITLE
Improvements on CMake template

### DIFF
--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -259,8 +259,8 @@ file(GLOB CPP_SOURCES *.cpp)
 set(SOURCES ${C_SOURCES} ${CPP_SOURCES})
 
 # Set the  Webots home path (change it according to your installation method)
-set(WEBOTS_HOME "/snap/webots/current/usr/share/webots")
-#set(WEBOTS_HOME "/usr/share/webots")
+set(WEBOTS_HOME "/usr/local/webots")
+#set(WEBOTS_HOME "/snap/webots/current/usr/share/webots")
 
 # Link with the Webots controller library.
 link_directories($ENV{WEBOTS_HOME}/lib/controller)

--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -258,7 +258,7 @@ file(GLOB C_SOURCES *.c)
 file(GLOB CPP_SOURCES *.cpp)
 set(SOURCES ${C_SOURCES} ${CPP_SOURCES})
 
-# Set the  Webots home path (Changed it based on your installation method)
+# Set the  Webots home path (change it according to your installation method)
 set(WEBOTS_HOME "/snap/webots/current/usr/share/webots")
 #set(WEBOTS_HOME "/usr/share/webots")
 

--- a/docs/guide/using-your-ide.md
+++ b/docs/guide/using-your-ide.md
@@ -258,9 +258,13 @@ file(GLOB C_SOURCES *.c)
 file(GLOB CPP_SOURCES *.cpp)
 set(SOURCES ${C_SOURCES} ${CPP_SOURCES})
 
+# Set the  Webots home path (Changed it based on your installation method)
+set(WEBOTS_HOME "/snap/webots/current/usr/share/webots")
+#set(WEBOTS_HOME "/usr/share/webots")
+
 # Link with the Webots controller library.
 link_directories($ENV{WEBOTS_HOME}/lib/controller)
-set (LIBRARIES ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX})
+set (LIBRARIES m ${CMAKE_SHARED_LIBRARY_PREFIX}Controller${CMAKE_SHARED_LIBRARY_SUFFIX} ${CMAKE_SHARED_LIBRARY_PREFIX}CppController${CMAKE_SHARED_LIBRARY_SUFFIX})
 include_directories($ENV{WEBOTS_HOME}/include/controller/c $ENV{WEBOTS_HOME}/include/controller/cpp)
 
 # Setup the target executable.


### PR DESCRIPTION
**Description**
Fixed a linking issue that may appear in some examples (I found it in the the crazyflie) in the CMake template. The issue was a missing link to libm. It will show the following linking error: 

undefined reference to symbol 'fmax@@glibc_2.2.5' 

Also added the WEBOTS_HOME variable in the CMake, just to avoid the hassle of having to export it in the console every time.