### PR TITLE
Fix SFNode field flagged empty in libController

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -19,6 +19,7 @@ Released on December, 12th, 2022.
   - New Examples
     - Added a sample world showing how to compute the attitude of a robot from IMU sensors ([#5256](https://github.com/cyberbotics/webots/pull/5256)).
   - Bug Fixes
+    - Fixed wrong warnings due to SFNode empty flag in the controller ([#5430](https://github.com/cyberbotics/webots/pull/5430)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize`, `type`, `colorNoise` fields of [Camera](camera.md) node ([#5266](https://github.com/cyberbotics/webots/pull/5266)).
   - Dependency Updates

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1204,7 +1204,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
           mFoundFieldType = field->type();
           mFoundFieldIsInternal = allowSearchInProto == 1;
           mFoundFieldName = field->name();
-          if (mv | sfNode) {
+          if (mv || sfNode) {
             mWatchedFields.append(WbUpdatedFieldInfo(node->uniqueId(), field->name(), mFoundFieldCount));
             field->listenToValueSizeChanges();
             connect(field, &WbField::valueSizeChanged, this, &WbSupervisorUtilities::notifyFieldUpdate, Qt::UniqueConnection);

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -476,8 +476,16 @@ void WbSupervisorUtilities::notifyFieldUpdate() {
   const WbField *field = static_cast<WbField *>(sender());
   if (!field->parentNode())
     return;
-  const int fieldCount = static_cast<WbMultipleValue *>(field->value())->size();
   const int listSize = mUpdatedFields.size();
+  const WbMultipleValue *mv = dynamic_cast<WbMultipleValue *>(field->value());
+  int fieldCount;
+  if (mv)
+    fieldCount = mv->size();
+  else {
+    const WbSFNode *sfNode = dynamic_cast<WbSFNode *>(field->value());
+    assert(sfNode);  // field should be a WbMultipleValue or a WbSFNode
+    fieldCount = sfNode->value() ? 1 : 0;
+  }
   const WbUpdatedFieldInfo info(field->parentNode()->uniqueId(), field->name(), fieldCount);
   for (int i = 0; i < listSize; ++i) {
     WbUpdatedFieldInfo &existingInfo = mUpdatedFields[i];
@@ -512,7 +520,7 @@ void WbSupervisorUtilities::updateProtoRegeneratedFlag(WbNode *node) {
   foreach (const WbUpdatedFieldInfo info, mWatchedFields) {
     if (info.nodeId == nodeId) {
       const WbField *field = node->findField(info.fieldName, false);
-      assert(field->isMultiple());
+      assert(field->isMultiple() || field->type() == WB_SF_NODE);
       field->listenToValueSizeChanges();
       connect(field, &WbField::valueSizeChanged, this, &WbSupervisorUtilities::notifyFieldUpdate, Qt::UniqueConnection);
     }
@@ -1143,19 +1151,24 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       mFoundFieldCount = -1;
       mFoundFieldIsInternal = false;
 
-      WbNode *const node = WbNode::findNode(id);
+      const WbNode *const node = WbNode::findNode(id);
       if (node) {
         id = node->findFieldId(name, allowSearchInProto == 1);
         if (id != -1) {
-          WbField *field = node->field(id, allowSearchInProto == 1);
+          const WbField *field = node->field(id, allowSearchInProto == 1);
           if (field) {
-            WbMultipleValue *mv = dynamic_cast<WbMultipleValue *>(field->value());
-            mFoundFieldCount = mv ? mv->size() : -1;
+            const WbMultipleValue *mv = dynamic_cast<WbMultipleValue *>(field->value());
+            const WbSFNode *sfNode = dynamic_cast<WbSFNode *>(field->value());
+            if (mv)
+              mFoundFieldCount = mv->size();
+            else if (sfNode)
+              mFoundFieldCount = sfNode->value() ? 1 : 0;
+
             mFoundFieldIndex = id;
             mFoundFieldType = field->type();
             mFoundFieldIsInternal = allowSearchInProto == 1;
             mFoundFieldName = field->name();
-            if (mv) {
+            if (mv || sfNode) {
               mWatchedFields.append(WbUpdatedFieldInfo(node->uniqueId(), field->name(), mFoundFieldCount));
               field->listenToValueSizeChanges();
               connect(field, &WbField::valueSizeChanged, this, &WbSupervisorUtilities::notifyFieldUpdate, Qt::UniqueConnection);
@@ -1177,17 +1190,21 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       mFoundFieldCount = -1;
       mFoundFieldIsInternal = false;
 
-      WbNode *const node = WbNode::findNode(nodeId);
+      const WbNode *const node = WbNode::findNode(nodeId);
       if (node) {
-        WbField *field = node->field(fieldIndex, allowSearchInProto == 1);
+        const WbField *field = node->field(fieldIndex, allowSearchInProto == 1);
         if (field) {
-          WbMultipleValue *mv = dynamic_cast<WbMultipleValue *>(field->value());
-          mFoundFieldCount = mv ? mv->size() : -1;
+          const WbMultipleValue *mv = dynamic_cast<WbMultipleValue *>(field->value());
+          const WbSFNode *sfNode = dynamic_cast<WbSFNode *>(field->value());
+          if (mv)
+            mFoundFieldCount = mv->size();
+          else if (sfNode)
+              mFoundFieldCount = sfNode->value() ? 1 : 0;
           mFoundFieldIndex = fieldIndex;
           mFoundFieldType = field->type();
           mFoundFieldIsInternal = allowSearchInProto == 1;
           mFoundFieldName = field->name();
-          if (mv) {
+          if (mv | sfNode) {
             mWatchedFields.append(WbUpdatedFieldInfo(node->uniqueId(), field->name(), mFoundFieldCount));
             field->listenToValueSizeChanges();
             connect(field, &WbField::valueSizeChanged, this, &WbSupervisorUtilities::notifyFieldUpdate, Qt::UniqueConnection);
@@ -1802,8 +1819,7 @@ void WbSupervisorUtilities::writeAnswer(WbDataStream &stream) {
     stream << (int)mFoundFieldIndex;
     stream << (int)mFoundFieldType;
     stream << (unsigned char)mFoundFieldIsInternal;
-    if (mFoundFieldCount != -1)
-      stream << (int)mFoundFieldCount;
+    stream << (int)mFoundFieldCount;
     const QByteArray ba = mFoundFieldName.toUtf8();
     stream.writeRawData(ba.constData(), ba.size() + 1);
     mFoundFieldIndex = -2;

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1199,7 +1199,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
           if (mv)
             mFoundFieldCount = mv->size();
           else if (sfNode)
-              mFoundFieldCount = sfNode->value() ? 1 : 0;
+            mFoundFieldCount = sfNode->value() ? 1 : 0;
           mFoundFieldIndex = fieldIndex;
           mFoundFieldType = field->type();
           mFoundFieldIsInternal = allowSearchInProto == 1;

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -80,6 +80,11 @@ WbField::~WbField() {
 }
 
 void WbField::listenToValueSizeChanges() const {
+  if (singleType() == WB_SF_NODE) {
+    WbSFNode *sfnode = static_cast<WbSFNode *>(mValue);
+    connect(sfnode, &WbSFNode::changed, this, &WbField::valueSizeChanged, Qt::UniqueConnection);
+    return;
+  }
   if (isSingle())
     return;
   const WbMultipleValue *mf = static_cast<WbMultipleValue *>(mValue);


### PR DESCRIPTION
Fix #5365:
use the WbFieldStruct::count variable in the libController to store if the SFNode value is NULL without having to request the field value.