### PR TITLE
Fix wrong .gitignore

### DIFF
--- a/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/.gitignore
+++ b/projects/samples/robotbenchmark/humanoid_marathon/controllers/marathon/.gitignore
@@ -1,1 +1,1 @@
-./marathon
+/marathon


### PR DESCRIPTION
There was a typo in the `.gitignore` file of the marathon controller.