### PR TITLE
Stop pending animation on close

### DIFF
--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -436,7 +436,7 @@ void WbAnimationRecorder::stopRecording() {
   out << "{\"time\":0,\"poses\":[";
   if (commandsChangedFromStart.isEmpty()) {
     WbLog::info(tr("Error: No animation content is available because no changes occurred in the simulation. "
-                   "If you just want a 3D environment file, consider exporting a scene instead"));
+                   "If you just want a 3D environment file, consider exporting a scene instead."));
     return;
   }
   foreach (WbAnimationCommand *command, commandsChangedFromStart) {

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1034,7 +1034,14 @@ void WbMainWindow::closeEvent(QCloseEvent *event) {
   // the perspective of the node editor is not correctly saved
   if (WbApplication::instance())
     savePerspective(false, true);
-
+  
+  // if there is a pending recording, stop it correctly
+  if (WbAnimationRecorder::instance()) {
+    // setting the gui flag to false to prevent the dialog box "exporting success" to pop-up
+    WbAnimationRecorder::instance()->setStartFromGuiFlag(false);
+    WbAnimationRecorder::instance()->stop();
+  }
+  
   // the scene tree qt model should be cleaned first
   // otherwise some signals can be fired after the
   // QCoreApplication::exit() call

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1034,14 +1034,14 @@ void WbMainWindow::closeEvent(QCloseEvent *event) {
   // the perspective of the node editor is not correctly saved
   if (WbApplication::instance())
     savePerspective(false, true);
-  
+
   // if there is a pending recording, stop it correctly
   if (WbAnimationRecorder::instance()) {
     // setting the gui flag to false to prevent the dialog box "exporting success" to pop-up
     WbAnimationRecorder::instance()->setStartFromGuiFlag(false);
     WbAnimationRecorder::instance()->stop();
   }
-  
+
   // the scene tree qt model should be cleaned first
   // otherwise some signals can be fired after the
   // QCoreApplication::exit() call


### PR DESCRIPTION
**Description**
If an animation recording is started and Webots is closed before it is stopped, the json animation file is not created. This adds a small check to stop the animation correctly when Webots is closed by the user in the GUI, with ctrl-C in the console or by a supervisor.
