### PR TITLE
Improved error message of empty animation

### DIFF
--- a/src/webots/engine/WbAnimationRecorder.cpp
+++ b/src/webots/engine/WbAnimationRecorder.cpp
@@ -435,7 +435,8 @@ void WbAnimationRecorder::stopRecording() {
   // write initial state
   out << "{\"time\":0,\"poses\":[";
   if (commandsChangedFromStart.isEmpty()) {
-    WbLog::info(tr("Error: No animation content is available because the simulation did not start."));
+    WbLog::info(tr("Error: No animation content is available because no changes occurred in the simulation. "
+                   "If you just want a 3D environment file, consider exporting a scene instead"));
     return;
   }
   foreach (WbAnimationCommand *command, commandsChangedFromStart) {


### PR DESCRIPTION
**Description**

When an animation is done in a simulation where nothing happens (for example when \<generic\> controllers are used for the robots), the error message incorrectly says:

> Error: No animation content is available because the simulation did not start

even though the simulation did start.

I changed the error message to be more specific and added a recommendation to use a scene instead

**Related Issues**
This pull-request fixes #4994 

