### PR TITLE
Fix crash double `root to base node`

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -22,6 +22,8 @@ Released on December, 12th, 2022.
     - Fixed wrong warnings due to SFNode empty flag in the controller ([#5430](https://github.com/cyberbotics/webots/pull/5430)).
     - Fixed processing concatenated messages in default robot window JS code ([#5442](https://github.com/cyberbotics/webots/pull/5442)).
     - Fixed missing check on required PROTO header ([#5453](https://github.com/cyberbotics/webots/pull/5453)).
+    - Fixed a crash when converting certain PROTOs to base node ([#5460](https://github.com/cyberbotics/webots/pull/5460)).
+    - Fixed the item selection in the scene tree after a conversion to base node ([#5460](https://github.com/cyberbotics/webots/pull/5460)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize`, `type`, `colorNoise` fields of [Camera](camera.md) node ([#5266](https://github.com/cyberbotics/webots/pull/5266)).
   - Dependency Updates

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -768,6 +768,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     // remove previous node
     mRowsAreAboutToBeRemoved = true;
     WbNodeOperations::instance()->deleteNode(currentNode);
+    mRowsAreAboutToBeRemoved = false;
     if (skipTemplateRegeneration)
       parentField->blockSignals(false);
 
@@ -794,10 +795,13 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     if (WbNodeOperations::instance()->importNode(parentNode, parentField, index, WbNodeOperations::DEFAULT, nodeString) ==
         WbNodeOperations::SUCCESS) {
       WbNode *node = NULL;
-      if (parentField->type() == WB_SF_NODE)
+      if (parentField->type() == WB_SF_NODE) {
         node = static_cast<WbSFNode *>(parentField->value())->value();
-      else if (parentField->type() == WB_MF_NODE)
+        mTreeView->setCurrentIndex(mModel->findModelIndexFromNode(node));
+      } else if (parentField->type() == WB_MF_NODE) {
         node = static_cast<WbMFNode *>(parentField->value())->item(index);
+        mTreeView->setCurrentIndex(mModel->findModelIndexFromNode(node));
+      }
       if (isFollowedNode)
         viewpoint->startFollowUp(dynamic_cast<WbSolid *>(node), true);
     }
@@ -809,7 +813,6 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
   updateToolbar();
 
   WbUndoStack::instance()->clear();
-  mRowsAreAboutToBeRemoved = false;
 }
 
 void WbSceneTree::moveViewpointToObject() {

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -766,6 +766,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
       // PROTO will be regenerated after importing the converted node
       parentField->blockSignals(true);
     // remove previous node
+    mRowsAreAboutToBeRemoved = true;
     WbNodeOperations::instance()->deleteNode(currentNode);
     if (skipTemplateRegeneration)
       parentField->blockSignals(false);
@@ -808,6 +809,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
   updateToolbar();
 
   WbUndoStack::instance()->clear();
+  mRowsAreAboutToBeRemoved = false;
 }
 
 void WbSceneTree::moveViewpointToObject() {


### PR DESCRIPTION
Fixes #5141.

The `updateSelection()` method of the `SceneTree` was called on a deleted node, leading to a crash in some cases (e.g. the one reported in the issue). This can be fixed by using the `mRowsAboutToBeRemoved` boolean, which is already used when simply deleting a node from the `SceneTree`.

In addition, this PR fixes another issue, where the newly created `Node` was not selected after the conversion.