### PR TITLE
Fix suggested project path

### DIFF
--- a/src/webots/gui/WbNewProjectWizard.cpp
+++ b/src/webots/gui/WbNewProjectWizard.cpp
@@ -48,7 +48,7 @@ QString WbNewProjectWizard::proposeNewProjectPath() const {
     path = WbPreferences::instance()->value("Directories/projects").toString();
     if (!path.isEmpty()) {
       if (WbFileUtil::isDirectoryWritable(path))
-        path += +"/my_project";
+        path += "my_project";
       else
         path = "";  // no valid default path found
     }


### PR DESCRIPTION
**Description**

1. open spot.wbt (or another project in a protected location)
2. `file > new > new project directory`
3. The path contains two `//`

doing the same in a non-protected location doesn't require the correction (line 58).