### PR TITLE
Fix motor sound on macOS

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -25,6 +25,7 @@ Released on December, 12th, 2022.
     - Fixed a crash when streaming and deleting a subnode ([#5457](https://github.com/cyberbotics/webots/pull/5457)).
     - Fixed a crash when converting certain PROTOs to base node ([#5460](https://github.com/cyberbotics/webots/pull/5460)).
     - Fixed the item selection in the scene tree after a conversion to base node ([#5460](https://github.com/cyberbotics/webots/pull/5460)).
+    - Fixed motor sound glitches when motor was stopped ([#5488](https://github.com/cyberbotics/webots/pull/5488)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize`, `type`, `colorNoise` fields of [Camera](camera.md) node ([#5266](https://github.com/cyberbotics/webots/pull/5266)).
   - Dependency Updates

--- a/src/webots/sound/WbMotorSoundManager.cpp
+++ b/src/webots/sound/WbMotorSoundManager.cpp
@@ -50,12 +50,6 @@ void WbMotorSoundManager::update() {
     double velocityCoefficient = qBound(0.0, fabs(motor->currentVelocity() / motor->maxVelocity()), 1.0);
 
     if (velocityCoefficient > 0.1) {
-      static const double GAIN_INFLUENCY = 0.1;                                   // 10%
-      double gain = 1.0 - GAIN_INFLUENCY + GAIN_INFLUENCY * velocityCoefficient;  // empirical
-
-      static const double PITCH_INFLUENCY = 0.8;                                           // 80%
-      double pitch = 1.0 - 0.5 * PITCH_INFLUENCY + PITCH_INFLUENCY * velocityCoefficient;  // empirical
-
       if (!source->isPlaying()) {
         source->setSoundClip(sound);
         source->play();
@@ -70,6 +64,12 @@ void WbMotorSoundManager::update() {
           source->setVelocity(solid->linearVelocity());
         }
       }
+
+      static const double GAIN_INFLUENCY = 0.1;                                   // 10%
+      double gain = 1.0 - GAIN_INFLUENCY + GAIN_INFLUENCY * velocityCoefficient;  // empirical
+
+      static const double PITCH_INFLUENCY = 0.8;                                           // 80%
+      double pitch = 1.0 - 0.5 * PITCH_INFLUENCY + PITCH_INFLUENCY * velocityCoefficient;  // empirical
 
       source->setPitch(pitch);
       source->setGain(gain);

--- a/src/webots/sound/WbMotorSoundManager.cpp
+++ b/src/webots/sound/WbMotorSoundManager.cpp
@@ -47,21 +47,6 @@ void WbMotorSoundManager::update() {
     }
     assert(source);
 
-    if (!source->isPlaying()) {
-      source->setSoundClip(sound);
-      source->play();
-      source->setLooping(false);
-    }
-
-    const WbJoint *joint = motor->joint();
-    if (joint) {
-      const WbSolid *solid = joint->solidParent();
-      if (solid) {
-        source->setPosition(solid->position());
-        source->setVelocity(solid->linearVelocity());
-      }
-    }
-
     double velocityCoefficient = qBound(0.0, fabs(motor->currentVelocity() / motor->maxVelocity()), 1.0);
 
     if (velocityCoefficient > 0.1) {
@@ -71,9 +56,24 @@ void WbMotorSoundManager::update() {
       static const double PITCH_INFLUENCY = 0.8;                                           // 80%
       double pitch = 1.0 - 0.5 * PITCH_INFLUENCY + PITCH_INFLUENCY * velocityCoefficient;  // empirical
 
+      if (!source->isPlaying()) {
+        source->setSoundClip(sound);
+        source->play();
+        source->setLooping(false);
+      }
+
+      const WbJoint *joint = motor->joint();
+      if (joint) {
+        const WbSolid *solid = joint->solidParent();
+        if (solid) {
+          source->setPosition(solid->position());
+          source->setVelocity(solid->linearVelocity());
+        }
+      }
+
       source->setPitch(pitch);
       source->setGain(gain);
-    } else
+    } else if (source->isPlaying())
       source->stop();
   }
 }


### PR DESCRIPTION
The text-to-speech sample demo was generating a motor sound whereas no motor was running.
This PR fix this problem which was noticed on macOS, but could be also on other platforms.
