### PR TITLE
Update doc specifying that we should not free some returned string.

### DIFF
--- a/docs/reference/device.md
+++ b/docs/reference/device.md
@@ -93,6 +93,8 @@ The `wb_device_get_model` function returns the model string of the device corres
 
 This function returns NULL if the WbDeviceTag does not match a valid device, or returns an empty string if the device is not a solid device (i.e. does not have a `model` field).
 
+> **Note** [C, C++]: The returned string is a pointer to the internal values managed by the [Device](#device) node, therefore it is illegal to free this pointer.
+
 ---
 
 #### `wb_device_get_name`
@@ -174,6 +176,8 @@ name = wb_device_get_name(tag)
 The `wb_device_get_name` function converts the WbDeviceTag given as parameter (`tag`) to its corresponding name.
 
 This function returns NULL if the WbDeviceTag does not match a valid device.
+
+> **Note** [C, C++]: The returned string is a pointer to the internal values managed by the [Device](#device) node, therefore it is illegal to free this pointer.
 
 ---
 

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -525,7 +525,7 @@ void robot_read_answer(WbDevice *d, WbRequest *r) {
   }
 }
 
-// Protected funtions available from other files of the client library
+// Protected functions available from other files of the client library
 
 const char *robot_get_device_name(WbDeviceTag tag) {
   if (tag < robot.n_device)


### PR DESCRIPTION
for function wb_device_get_name/type

just to be consistent, like the many returned array returned by the api (like vector speed in gps, for instance)