### PR TITLE
Clean-up python API

### DIFF
--- a/lib/controller/python/controller/accelerometer.py
+++ b/lib/controller/python/controller/accelerometer.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/altimeter.py
+++ b/lib/controller/python/controller/altimeter.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/ansi_codes.py
+++ b/lib/controller/python/controller/ansi_codes.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.constants import constant
+from .constants import constant
 
 
 class AnsiCodes:

--- a/lib/controller/python/controller/brake.py
+++ b/lib/controller/python/controller/brake.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.constants import constant
-from controller.device import Device
-from controller.wb import wb
+from .constants import constant
+from .device import Device
+from .wb import wb
 from typing import Union
 
 
@@ -42,13 +42,13 @@ class Brake(Device):
 
     @property
     def motor(self):
-        from controller.motor import Motor
+        from .motor import Motor
         tag = wb.wb_brake_get_motor(self._tag)
         return None if tag == 0 else Motor(tag)
 
     @property
     def position_sensor(self):
-        from controller.position_sensor import PositionSensor
+        from .position_sensor import PositionSensor
         tag = wb.wb_brake_get_position_sensor(self._tag)
         return None if tag == 0 else PositionSensor(tag)
 

--- a/lib/controller/python/controller/camera.py
+++ b/lib/controller/python/controller/camera.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import ctypes
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 from typing import List, Union
 
 

--- a/lib/controller/python/controller/compass.py
+++ b/lib/controller/python/controller/compass.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/connector.py
+++ b/lib/controller/python/controller/connector.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 from typing import Union
 
 

--- a/lib/controller/python/controller/constants.py
+++ b/lib/controller/python/controller/constants.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
+from .wb import wb
 
 
 def constant(name, type=int):

--- a/lib/controller/python/controller/device.py
+++ b/lib/controller/python/controller/device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
+from .wb import wb
 import ctypes
 from typing import Union
 

--- a/lib/controller/python/controller/display.py
+++ b/lib/controller/python/controller/display.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
-from controller.camera import Camera
-from controller.device import Device
+from .wb import wb
+from .camera import Camera
+from .device import Device
 from typing import Union, List
 
 

--- a/lib/controller/python/controller/distance_sensor.py
+++ b/lib/controller/python/controller/distance_sensor.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
-from controller.sensor import Sensor
+from .wb import wb
+from .sensor import Sensor
 from typing import Union, List
 
 

--- a/lib/controller/python/controller/emitter.py
+++ b/lib/controller/python/controller/emitter.py
@@ -14,8 +14,8 @@
 
 import struct
 import sys
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 import ctypes
 from typing import Union, List
 

--- a/lib/controller/python/controller/field.py
+++ b/lib/controller/python/controller/field.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
-from controller.constants import constant
+from .wb import wb
+from .constants import constant
 import struct
 import typing
 

--- a/lib/controller/python/controller/gps.py
+++ b/lib/controller/python/controller/gps.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/gyro.py
+++ b/lib/controller/python/controller/gyro.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/inertial_unit.py
+++ b/lib/controller/python/controller/inertial_unit.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/lib/controller/python/controller/joystick.py
+++ b/lib/controller/python/controller/joystick.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
+from .wb import wb
 import ctypes
 from typing import Union
 

--- a/lib/controller/python/controller/keyboard.py
+++ b/lib/controller/python/controller/keyboard.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.constants import constant
+from .wb import wb
+from .constants import constant
 from typing import Union
 
 

--- a/lib/controller/python/controller/led.py
+++ b/lib/controller/python/controller/led.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 from typing import Union
 
 

--- a/lib/controller/python/controller/lidar.py
+++ b/lib/controller/python/controller/lidar.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.sensor import Sensor
-from controller.lidar_point import LidarPoint
-from controller.wb import wb
+from .sensor import Sensor
+from .lidar_point import LidarPoint
+from .wb import wb
 from typing import List, Union
 
 

--- a/lib/controller/python/controller/light_sensor.py
+++ b/lib/controller/python/controller/light_sensor.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
-from controller.sensor import Sensor
+from .wb import wb
+from .sensor import Sensor
 from typing import Union, List
 
 

--- a/lib/controller/python/controller/motion.py
+++ b/lib/controller/python/controller/motion.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
+from .wb import wb
 
 
 class Motion:

--- a/lib/controller/python/controller/motor.py
+++ b/lib/controller/python/controller/motor.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.constants import constant
-from controller.device import Device
-from controller.wb import wb
+from .constants import constant
+from .device import Device
+from .wb import wb
 from typing import Union
 
 
@@ -132,13 +132,13 @@ class Motor(Device):
 
     @property
     def brake(self):
-        from controller.brake import Brake
+        from .brake import Brake
         tag = wb.wb_motor_get_brake(self._tag)
         return None if tag == 0 else Brake(tag)
 
     @property
     def position_sensor(self):
-        from controller.position_sensor import PositionSensor
+        from .position_sensor import PositionSensor
         tag = wb.wb_motor_get_position_sensor(self._tag)
         return None if tag == 0 else PositionSensor(tag)
 

--- a/lib/controller/python/controller/mouse.py
+++ b/lib/controller/python/controller/mouse.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
+from .wb import wb
 import ctypes
 import struct
 from typing import Union

--- a/lib/controller/python/controller/node.py
+++ b/lib/controller/python/controller/node.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.wb import wb
-from controller.constants import constant
-from controller import Field
+from .wb import wb
+from .constants import constant
+from .field import Field
 import struct
 import typing
 

--- a/lib/controller/python/controller/pen.py
+++ b/lib/controller/python/controller/pen.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 import ctypes
 from typing import Union
 

--- a/lib/controller/python/controller/position_sensor.py
+++ b/lib/controller/python/controller/position_sensor.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.constants import constant
-from controller.wb import wb
-from controller.sensor import Sensor
+from .constants import constant
+from .wb import wb
+from .sensor import Sensor
 from typing import Union
 
 
@@ -44,13 +44,13 @@ class PositionSensor(Sensor):
 
     @property
     def brake(self):
-        from controller.brake import Brake
+        from .brake import Brake
         tag = wb.wb_position_sensor_get_brake(self._tag)
         return None if tag == 0 else Brake(tag)
 
     @property
     def motor(self):
-        from controller.motor import Motor
+        from .motor import Motor
         tag = wb.wb_brake_get_motor(self._tag)
         return None if tag == 0 else Motor(tag)
 

--- a/lib/controller/python/controller/radar.py
+++ b/lib/controller/python/controller/radar.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import ctypes
-from controller.sensor import Sensor
-from controller.radar_target import RadarTarget
-from controller.wb import wb
+from .sensor import Sensor
+from .radar_target import RadarTarget
+from .wb import wb
 from typing import List, Union
 
 

--- a/lib/controller/python/controller/range_finder.py
+++ b/lib/controller/python/controller/range_finder.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import ctypes
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 from typing import List, Union
 
 

--- a/lib/controller/python/controller/receiver.py
+++ b/lib/controller/python/controller/receiver.py
@@ -15,8 +15,8 @@
 import ctypes
 import struct
 import sys
-from controller.wb import wb
-from controller.sensor import Sensor
+from .wb import wb
+from .sensor import Sensor
 from typing import Union, Tuple, List
 
 

--- a/lib/controller/python/controller/robot.py
+++ b/lib/controller/python/controller/robot.py
@@ -15,37 +15,37 @@
 import ctypes
 import sys
 import typing
-from controller.wb import wb
-from controller.node import Node
-from controller.device import Device
-from controller.accelerometer import Accelerometer
-from controller.altimeter import Altimeter
-from controller.brake import Brake
-from controller.camera import Camera
-from controller.compass import Compass
-from controller.connector import Connector
-from controller.display import Display
-from controller.distance_sensor import DistanceSensor
-from controller.emitter import Emitter
-from controller.gps import GPS
-from controller.gyro import Gyro
-from controller.inertial_unit import InertialUnit
-from controller.led import LED
-from controller.lidar import Lidar
-from controller.light_sensor import LightSensor
-from controller.motor import Motor
-from controller.pen import Pen
-from controller.position_sensor import PositionSensor
-from controller.radar import Radar
-from controller.range_finder import RangeFinder
-from controller.receiver import Receiver
-from controller.skin import Skin
-from controller.speaker import Speaker
-from controller.touch_sensor import TouchSensor
+from .wb import wb
+from .node import Node
+from .device import Device
+from .accelerometer import Accelerometer
+from .altimeter import Altimeter
+from .brake import Brake
+from .camera import Camera
+from .compass import Compass
+from .connector import Connector
+from .display import Display
+from .distance_sensor import DistanceSensor
+from .emitter import Emitter
+from .gps import GPS
+from .gyro import Gyro
+from .inertial_unit import InertialUnit
+from .led import LED
+from .lidar import Lidar
+from .light_sensor import LightSensor
+from .motor import Motor
+from .pen import Pen
+from .position_sensor import PositionSensor
+from .radar import Radar
+from .range_finder import RangeFinder
+from .receiver import Receiver
+from .skin import Skin
+from .speaker import Speaker
+from .touch_sensor import TouchSensor
 
-from controller.joystick import Joystick
-from controller.keyboard import Keyboard
-from controller.mouse import Mouse
+from .joystick import Joystick
+from .keyboard import Keyboard
+from .mouse import Mouse
 
 
 class Robot:

--- a/lib/controller/python/controller/sensor.py
+++ b/lib/controller/python/controller/sensor.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 from typing import Union
 
 

--- a/lib/controller/python/controller/skin.py
+++ b/lib/controller/python/controller/skin.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.device import Device
-from controller.wb import wb
+from .device import Device
+from .wb import wb
 import ctypes
 from typing import List, Union
 

--- a/lib/controller/python/controller/speaker.py
+++ b/lib/controller/python/controller/speaker.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.device import Device
+from .wb import wb
+from .device import Device
 import ctypes
 from typing import Union
 

--- a/lib/controller/python/controller/supervisor.py
+++ b/lib/controller/python/controller/supervisor.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.wb import wb
-from controller.node import Node
-from controller.robot import Robot
+from .wb import wb
+from .node import Node
+from .robot import Robot
 import ctypes
 
 

--- a/lib/controller/python/controller/touch_sensor.py
+++ b/lib/controller/python/controller/touch_sensor.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller.sensor import Sensor
-from controller.wb import wb
+from .sensor import Sensor
+from .wb import wb
 import ctypes
 import typing
 

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -130,7 +130,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // __linux__
-    shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
+  shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -130,7 +130,7 @@ QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &com
   if (pythonCommand == "!")
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);
 #else  // __linux__
-  shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
+      shortVersion = checkIfPythonCommandExist(pythonCommand, env, true);
   if (shortVersion.isEmpty()) {
     pythonCommand = "!";
     WbLog::warning(QObject::tr("Python was not found.\n") + advice);

--- a/src/webots/control/WbLanguageTools.cpp
+++ b/src/webots/control/WbLanguageTools.cpp
@@ -64,6 +64,12 @@ const QStringList WbLanguageTools::javaArguments() {
 
 QString WbLanguageTools::pythonCommand(QString &shortVersion, const QString &command, QProcessEnvironment &env) {
   QString pythonCommand = command;
+  if (pythonCommand.isEmpty())
+#ifdef _WIN32
+    pythonCommand = "python";
+#else
+    pythonCommand = "python3";
+#endif
   const QString advice =
 #ifdef __APPLE__
     "To fix the problem, you should set the full path of your python command in "


### PR DESCRIPTION
This PR:

- Simplifies the syntax for the local module import (e.g., remove the useless `controller` prefix in import statements).
- In case the Webots preferences have an empty string for the `Python command`, use the default system python command. The problem is that if you install and run Webots on Windows and there is no Python command in the PATH, Webots will set the `Python command` to an empty string in its preferences. If you install Python afterwards, the `Python command` string being empty and Webots will fail to use Python, unless you explicitly change the preferences.