### PR TITLE
Fixed camera image data type

### DIFF
--- a/lib/controller/python/controller/camera.py
+++ b/lib/controller/python/controller/camera.py
@@ -52,7 +52,7 @@ class Camera(Sensor):
         return self.height
 
     def getImage(self) -> bytes:
-        return self.image
+        return bytes(self.image[:self.width * self.height * 4])
 
     def getImageArray(self) -> List[List[List[int]]]:
         array = []
@@ -117,6 +117,10 @@ class Camera(Sensor):
     @property
     def image(self):
         return wb.wb_camera_get_image(self._tag)
+
+    @property
+    def segmentation_image(self):
+        return wb.wb_camera_recognition_get_segmentation_image(self._tag)
 
     @property
     def exposure(self) -> float:
@@ -249,7 +253,7 @@ class Camera(Sensor):
         return wb.wb_camera_recognition_is_segmentation_enabled(self._tag) != 0
 
     def getRecognitionSegmentationImage(self) -> bytes:
-        return wb.wb_camera_recognition_get_segmentation_image(self._tag)
+        return bytes(self.segmentation_image[:self.width * self.height * 4])
 
     def getRecognitionSegmentationImageArray(self) -> List[List[List[int]]]:
         array = []


### PR DESCRIPTION
This PR fixes a data type incompatibility in the new Python API reported by @vitormartins01 on Discord:
![image](https://user-images.githubusercontent.com/1264964/203083732-b2e9537e-c276-4f8e-a6fe-c058f095d1de.png)
That used to work with the previous version of the Python API and doesn't work any more in the R2023a nightly build.
This PR fixes it.

It also fixes the segmentation image getter in the same way.

**Note**: the new getter, e.g., `Camera.image` returns the raw value without any conversion and is therefore the fastest way to get image data. So we want to keep it like that and use of the old getter `Camera.getImage()` for backwards compatibility, not performance.