### PR TITLE
Upgraded to Python 3.11 on Windows CI

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -68,7 +68,7 @@ jobs:
         choco install -y visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |
-        export PYTHON_HOME=/C/hostedtoolcache/windows/Python/3.10.`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.10\.[0-9]\+$' | cut -c6- | sort -n | tail -n1`/x64
+        export PYTHON_HOME=/C/hostedtoolcache/windows/Python/3.11.`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.11\.[0-9]\+$' | cut -c6- | sort -n | tail -n1`/x64
         echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/`ls /C/Program\ Files/OpenJDK`' >> ~/.bash_profile
         echo 'export PYTHON_HOME='$PYTHON_HOME >> ~/.bash_profile
         echo 'export VISUAL_STUDIO_PATH="/C/Program Files (x86)/Microsoft Visual Studio/2017"' >> ~/.bash_profile

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -64,7 +64,7 @@ jobs:
         choco install -y visualcpp-build-tools
     - name: Install Webots Compilation Dependencies
       run: |
-        export PYTHON_HOME=/C/hostedtoolcache/windows/Python/3.10.`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.10\.[0-9]\+$' | cut -c6- | sort -n | tail -n1`/x64
+        export PYTHON_HOME=/C/hostedtoolcache/windows/Python/3.11.`ls $PYTHON_INSTALLATION_FOLDER | grep '^3\.11\.[0-9]\+$' | cut -c6- | sort -n | tail -n1`/x64
         echo 'export JAVA_HOME=/C/Program\ Files/OpenJDK/`ls /C/Program\ Files/OpenJDK`' >> ~/.bash_profile
         echo 'export PYTHON_HOME='$PYTHON_HOME >> ~/.bash_profile
         echo 'export VISUAL_STUDIO_PATH="/C/Program Files (x86)/Microsoft Visual Studio/2017"' >> ~/.bash_profile


### PR DESCRIPTION
The builds are currently failing in the Windows CI because this command fails:
```
python -m pip install requests PyGithub
```
It also fails on my local machine with Python 3.10 and 3.9, but works with Python 3.11.
This PR attempts to fix the failure in the CI by upgrading to Python 3.11.