### PR TITLE
Fix late TCP server start

### DIFF
--- a/src/controller/c/scheduler.c
+++ b/src/controller/c/scheduler.c
@@ -75,6 +75,9 @@ int scheduler_init_remote(const char *host, int port, const char *robot_name) {
             robot_name == NULL ? "Exactly one robot should be set with an <extern> controller in the Webots simulation" :
                                  "The specified robot is not in the list of robots with <extern> controllers");
     return false;
+  } else if (strncmp(acknowledge_message, "PROCESSING", 10) == 0) {
+    fprintf(stderr, "%s", "The Webots simulation world is not ready yet");
+    return false;
   } else if (strncmp(acknowledge_message, "FORBIDDEN", 9) == 0) {
     fprintf(
       stderr, "%s",

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -50,7 +50,8 @@ WbTcpServer::WbTcpServer(bool stream) :
   mPauseTimeout(-1),
   mWebSocketServer(NULL),
   mClientsReadyToReceiveMessages(false),
-  mStream(stream) {
+  mStream(stream),
+  mWorldReady(false) {
   connect(WbApplication::instance(), &WbApplication::postWorldLoaded, this, &WbTcpServer::newWorld);
   connect(WbApplication::instance(), &WbApplication::preWorldLoaded, this, &WbTcpServer::deleteWorld);
   connect(WbApplication::instance(), &WbApplication::worldLoadingHasProgressed, this, &WbTcpServer::setWorldLoadingProgress);
@@ -132,6 +133,8 @@ void WbTcpServer::create(int port) {
   // - https://bugreports.qt.io/browse/QTBUG-54276
   mWebSocketServer = new QWebSocketServer("Webots Streaming Server", QWebSocketServer::NonSecureMode, this);
   mTcpServer = new QTcpServer();
+  if (!mTcpServer->listen(QHostAddress::Any, port))
+    throw tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString());
   connect(mWebSocketServer, &QWebSocketServer::newConnection, this, &WbTcpServer::onNewWebSocketConnection);
   connect(mTcpServer, &QTcpServer::newConnection, this, &WbTcpServer::onNewTcpConnection);
   connect(WbSimulationState::instance(), &WbSimulationState::controllerReadRequestsCompleted, this,
@@ -210,6 +213,11 @@ void WbTcpServer::addNewTcpController(QTcpSocket *socket) {
   const QStringList tokens = QString(line).split(QRegularExpression("\\s+"));
   const int robotNameIndex = tokens.indexOf("Robot-Name:") + 1;
   QByteArray reply;
+  if (!mWorldReady) {
+    reply.append("PROCESSING");
+    socket->write(reply);
+    return;
+  }
 
   const QList<WbRobot *> &robots = WbWorld::instance()->robots();
   const QList<WbController *> &availableControllers = WbControlledWorld::instance()->disconnectedExternControllers();
@@ -530,14 +538,11 @@ void WbTcpServer::newWorld() {
   foreach (WbRobot *const robot, robots)
     connectNewRobot(robot);
 
-  if (!mTcpServer->isListening() && !mTcpServer->listen(QHostAddress::Any, mPort))
-    WbLog::error(tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString()));
+  mWorldReady = true;
 }
 
 void WbTcpServer::deleteWorld() {
-  if (mTcpServer->isListening())
-    mTcpServer->close();
-
+  mWorldReady = false;
   if (mWebSocketServer == NULL)
     return;
   foreach (QWebSocket *client, mWebSocketClients)

--- a/src/webots/gui/WbTcpServer.hpp
+++ b/src/webots/gui/WbTcpServer.hpp
@@ -109,6 +109,7 @@ private:
   bool mClientsReadyToReceiveMessages;
   bool mDisableTextStreams;
   bool mStream;
+  bool mWorldReady;
   int mPort;
 };
 


### PR DESCRIPTION
#5310 fixes a crash when remote external controllers (TCP) tried to connect to the simulation too early (world not yet loaded). The fix waited until the world was loaded to start the TCP server. 

This solution is problematic for web streaming and other services than TCP controllers, because they do not need the world to be loaded to connect. This PR uses an alternative solution to restrict controllers from connecting only when the world is not yet loaded, while starting the TCP server directly at Webots launch.