### PR TITLE
Fix `SFNode` removal and string insertion

### DIFF
--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -3554,7 +3554,7 @@ void wb_supervisor_field_remove_mf_node(WbFieldRef field, int position) {
 }
 
 void wb_supervisor_field_remove_sf(WbFieldRef field) {
-  if (field->count == 0 || field->data.sf_node_uid == 0) {
+  if (field->count == 0) {
     fprintf(stderr, "Error: %s() called for an empty field.\n", __FUNCTION__);
     return;
   }
@@ -3583,7 +3583,7 @@ void wb_supervisor_field_import_sf_node_from_string(WbFieldRef field, const char
     return;
   }
 
-  if (field->count == 1 || field->data.sf_node_uid != 0) {
+  if (field->count == 1) {
     fprintf(stderr, "Error: %s() called with a non-empty field.\n", __FUNCTION__);
     return;
   }

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -3554,7 +3554,7 @@ void wb_supervisor_field_remove_mf_node(WbFieldRef field, int position) {
 }
 
 void wb_supervisor_field_remove_sf(WbFieldRef field) {
-  if (field->count == 0 || field->data.sf_node_uid == 0) {
+  if (field->count == 0) {
     fprintf(stderr, "Error: %s() called for an empty field.\n", __FUNCTION__);
     return;
   }

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -3554,7 +3554,7 @@ void wb_supervisor_field_remove_mf_node(WbFieldRef field, int position) {
 }
 
 void wb_supervisor_field_remove_sf(WbFieldRef field) {
-  if (field->count == 0) {
+  if (field->count == 0 || field->data.sf_node_uid == 0) {
     fprintf(stderr, "Error: %s() called for an empty field.\n", __FUNCTION__);
     return;
   }
@@ -3564,6 +3564,7 @@ void wb_supervisor_field_remove_sf(WbFieldRef field) {
 
   field_operation(field, REMOVE, -1, __FUNCTION__);
   field->count = 0;
+  field->data.sf_node_uid = 0;
 }
 
 void wb_supervisor_field_import_sf_node_from_string(WbFieldRef field, const char *node_string) {
@@ -3583,7 +3584,7 @@ void wb_supervisor_field_import_sf_node_from_string(WbFieldRef field, const char
     return;
   }
 
-  if (field->count == 1) {
+  if (field->count == 1 || field->data.sf_node_uid != 0) {
     fprintf(stderr, "Error: %s() called with a non-empty field.\n", __FUNCTION__);
     return;
   }


### PR DESCRIPTION
**Description**

Fixes https://github.com/cyberbotics/webots/issues/5365

The `data.sf_node_uid` field is set only if the user explicitly requests the value of the field (with `.getSFNode()`), which is not a necessary step when one wants to remove the current value from a field (we don't care what it is, we just want it gone). After the removal however we need to ensure this variable is set back to 0 (i.e. NULL) on top of setting the counter to 0. Otherwise we cannot insert a new node in its place unless once again the user explicitly does a `getSFNode()` in order to "refresh" the data on the libcontroller side.

Alternatively, it would also be an option to only check for the count [here](https://github.com/cyberbotics/webots/blob/4a43cf70e6ad9cf5bdb8be09a4aceb7d1ee45f01/src/controller/c/supervisor.c#L3586) when the insertion takes place, but this seems less clean to me as we leave behind a `data.sf_node_uid` that is not representative of what the field contains.
