### PR TITLE
Fixed OpenAI Gym sample

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -22,6 +22,7 @@ Released on December, 12th, 2022.
   - New Examples
     - Added a sample world showing how to compute the attitude of a robot from IMU sensors ([#5256](https://github.com/cyberbotics/webots/pull/5256)).
   - Bug Fixes
+    - Fixed the OpenAI Gym example which was not converging after ENU/FLU conversion ([#5581](https://github.com/cyberbotics/webots/pull/5581)).
     - Fixed wrong warnings due to SFNode empty flag in the controller ([#5430](https://github.com/cyberbotics/webots/pull/5430)).
     - Fixed controller restart after crash ([#5284](https://github.com/cyberbotics/webots/pull/5284)).
     - Fixed the export of [Lidar](lidar.md)'s rotating head to X3D ([#5224](https://github.com/cyberbotics/webots/pull/5224)).

--- a/projects/samples/howto/openai_gym/controllers/openai_gym/openai_gym.py
+++ b/projects/samples/howto/openai_gym/controllers/openai_gym/openai_gym.py
@@ -94,8 +94,8 @@ class OpenAIGymEnvironment(Supervisor, gym.Env):
         # Observation
         robot = self.getSelf()
         endpoint = self.getFromDef("POLE_ENDPOINT")
-        self.state = np.array([robot.getPosition()[2], robot.getVelocity()[2],
-                               self.__pendulum_sensor.getValue(), endpoint.getVelocity()[3]])
+        self.state = np.array([robot.getPosition()[0], robot.getVelocity()[0],
+                               self.__pendulum_sensor.getValue(), endpoint.getVelocity()[4]])
 
         # Done
         done = bool(


### PR DESCRIPTION
The OpenAI Gym sample was not converging any more after the ENU/FLU conversion.
This PR fixes it after a report from a user:

>Dear Sir or Madam,
>
> I just started working with webots to build a simulation environment for robot reenforcement learning.
> I tested your openai_gym example which does not stabilize the pendulum correctly, because the vehicle always drifts away in one direction.
>
> After I changed the code in line 97 with the correct parameters (X instead of Z directions and rotation around Y axis), the pendulum is stabilized reliably.
>
> Old:
> ```python
>       self.state = np.array([robot.getPosition()[2], robot.getVelocity()[2],
>                               self.__pendulum_sensor.getValue(), endpoint.getVelocity()[3]])
> ```
>New:
> ```python
>        self.state = np.array([robot.getPosition()[0], robot.getVelocity()[0],
>                               self.__pendulum_sensor.getValue(), endpoint.getVelocity()[4]])
> ```
> I am still not quite sure if this is the best solution. Nevertheless, it is by far more stable than before.
> If you could make a tutorial for robots with direct and inverse kinematics, that would be very helpful.
> I hope I could help you with the issue from this example.
> Kind Regards

I confirm that applying this patch makes the inverted pendulum converge towards a pretty good solution.
