### PR TITLE
Fixed supervisor setLabel API function

### DIFF
--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -1977,7 +1977,7 @@ void wb_supervisor_set_label(int id, const char *text, double x, double y, doubl
 namespace webots {
   class Supervisor : public Robot {
     virtual void setLabel(int id, const std::string &label, double xpos, double ypos,
-      double size, int color, double transparency, const std::string &font="Arial");
+      double size, int color, double transparency = 0, const std::string &font = "Arial");
     // ...
   }
 }
@@ -2004,7 +2004,7 @@ import com.cyberbotics.webots.controller.Supervisor;
 
 public class Supervisor extends Robot {
   public void setLabel(int id, String label, double xpos, double ypos,
-     double size, int color, double transparency, String font);
+     double size, int color, double transparency = 0, String font = "Arial");
   // ...
 }
 ```
@@ -2014,7 +2014,7 @@ public class Supervisor extends Robot {
 %tab "MATLAB"
 
 ```MATLAB
-wb_supervisor_set_label(id, 'text', x, y, size, [r g b], transparency)
+wb_supervisor_set_label(id, 'text', x, y, size, [r g b], transparency, font)
 ```
 
 %tab-end

--- a/include/controller/cpp/webots/Supervisor.hpp
+++ b/include/controller/cpp/webots/Supervisor.hpp
@@ -51,7 +51,7 @@ namespace webots {
     bool movieFailed() const;
 
     virtual void setLabel(int id, const std::string &label, double xpos, double ypos, double size, int color,
-                          double transparency, const std::string &font = "Arial");
+                          double transparency = 0, const std::string &font = "Arial");
     Node *getRoot() const;
     Node *getSelf() const;
     Node *getFromDef(const std::string &name) const;


### PR DESCRIPTION
Address https://github.com/cyberbotics/webots/pull/5582#discussion_r1033197011

Set a default value of 0 for the transparency in the Supervisor setLabel method of the C++ and Java APIs.
In addition, this PR fixes a missing parameter in the documentation of the MATLAB API.