### PR TITLE
Add recognitionColors default value for some PROTO models

### DIFF
--- a/projects/objects/animals/protos/Cat.proto
+++ b/projects/objects/animals/protos/Cat.proto
@@ -229,5 +229,8 @@ PROTO Cat [
         }
       ]
     }
+    recognitionColors [
+      0.870 0.580 0
+    ]
   }
 }

--- a/projects/objects/animals/protos/Cow.proto
+++ b/projects/objects/animals/protos/Cow.proto
@@ -275,5 +275,8 @@ PROTO Cow [
         }
       ]
     }
+    recognitionColors [
+      0.380 0.220 0.137
+    ]
   }
 }

--- a/projects/objects/animals/protos/Deer.proto
+++ b/projects/objects/animals/protos/Deer.proto
@@ -226,5 +226,9 @@ PROTO Deer [
         }
       ]
     }
+
+    recognitionColors [
+      0.415 0.364 0.302
+    ]
   }
 }

--- a/projects/objects/animals/protos/Dog.proto
+++ b/projects/objects/animals/protos/Dog.proto
@@ -139,5 +139,8 @@ PROTO Dog [
         }
       ]
     }
+    recognitionColors [
+      0.937 0.921 0.862
+    ]
   }
 }

--- a/projects/objects/animals/protos/Fox.proto
+++ b/projects/objects/animals/protos/Fox.proto
@@ -240,5 +240,8 @@ PROTO Fox [
         }
       ]
     }
+    recognitionColors [
+      0.992 0.376 0.086
+    ]
   }
 }

--- a/projects/objects/animals/protos/Horse.proto
+++ b/projects/objects/animals/protos/Horse.proto
@@ -208,5 +208,8 @@ PROTO Horse [
         }
       ]
     }
+    recognitionColors [
+      0.333 0.290 0.243
+    ]
   }
 }

--- a/projects/objects/animals/protos/Rabbit.proto
+++ b/projects/objects/animals/protos/Rabbit.proto
@@ -89,5 +89,8 @@ PROTO Rabbit [
         }
       ]
     }
+    recognitionColors [
+      0.827 0.827 0.827
+    ]
   }
 }

--- a/projects/objects/animals/protos/Sheep.proto
+++ b/projects/objects/animals/protos/Sheep.proto
@@ -148,5 +148,8 @@ PROTO Sheep [
         }
       ]
     }
+    recognitionColors [
+      0.937 0.921 0.862
+    ]
   }
 }

--- a/projects/objects/buildings/protos/Barn.proto
+++ b/projects/objects/buildings/protos/Barn.proto
@@ -105,5 +105,8 @@ PROTO Barn [
         }
       ]
     }
+    recognitionColors [
+      0.625 0.293 0.226
+    ]
   }
 }

--- a/projects/objects/solids/protos/SolidBox.proto
+++ b/projects/objects/solids/protos/SolidBox.proto
@@ -15,7 +15,8 @@ PROTO SolidBox [
   field SFNode     appearance            PBRAppearance { baseColorMap ImageTexture { url [ "webots://projects/default/worlds/textures/tagged_wall.jpg" ] } metalness 0 roughness 0.5 }  # Defines the appearance of the box.
   field SFNode     physics               NULL                                                                                                          # Is `Solid.physics`.
   field SFBool     enableBoundingObject  TRUE                                                                                                          # Defines whether the solid should have a bounding object.
-  field SFBool     castShadows           TRUE                                                                                                          # Defines whether this object should cast shadows.
+  field SFBool     castShadows           TRUE
+  field MFColor    recognitionColors     []                                                                                                          # Defines whether this object should cast shadows.
 ]
 {
   %<
@@ -61,7 +62,7 @@ PROTO SolidBox [
         {x: -halfSize.x, y:  halfSize.y, z: -halfSize.z, u: ratio.y, v: 0       },
         {x:  halfSize.x, y:  halfSize.y, z: -halfSize.z, u: ratio.y, v: ratio.x }
       ],
-      // quadBack 
+      // quadBack
       [
         {x: -halfSize.x, y: -halfSize.y, z: -halfSize.z, u: ratio.y, v: 0       },
         {x: -halfSize.x, y: -halfSize.y, z:  halfSize.z, u: ratio.y, v: ratio.z },
@@ -136,5 +137,6 @@ PROTO SolidBox [
     }
     %< } >%
     physics IS physics
+    recognitionColors IS recognitionColors
   }
 }

--- a/projects/objects/trees/protos/Forest.proto
+++ b/projects/objects/trees/protos/Forest.proto
@@ -270,5 +270,8 @@ PROTO Forest [
         }
       %< } >%
     ]
+    recognitionColors [
+      0.324 0.468 0.336
+    ]
   }
 }

--- a/projects/vehicles/protos/generic/Tractor.proto
+++ b/projects/vehicles/protos/generic/Tractor.proto
@@ -1226,5 +1226,8 @@ Car {
   type "4x4"
   time0To100 20
   window IS window
+  recognitionColors [
+    0.24 0.53 0.79
+  ]
 }
 }


### PR DESCRIPTION
Add default `recognitionColors` in new animals, Barn PROTO models and a new `recognitionColors` parameter in SolidBox, Tractor and Forest.