### PR TITLE
Use better data types in the Python API

### DIFF
--- a/lib/controller/python/controller/camera.py
+++ b/lib/controller/python/controller/camera.py
@@ -62,8 +62,6 @@ class CameraRecognitionObject(ctypes.Structure):
 
 
 class Camera(Sensor):
-    wb.wb_camera_get_image.restype = ctypes.POINTER(ctypes.c_ubyte)
-    wb.wb_camera_recognition_get_segmentation_image.restype = ctypes.POINTER(ctypes.c_ubyte)
     wb.wb_camera_get_fov.restype = ctypes.c_double
     wb.wb_camera_get_exposure.restype = ctypes.c_double
     wb.wb_camera_get_focal_distance.restype = ctypes.c_double
@@ -78,6 +76,10 @@ class Camera(Sensor):
         self._enable = wb.wb_camera_enable
         self._get_sampling_period = wb.wb_camera_get_sampling_period
         super().__init__(name, sampling_period)
+        width = self.width
+        height = self.height
+        wb.wb_camera_get_image.restype = ctypes.POINTER(ctypes.c_ubyte * (4 * width * height))
+        wb.wb_camera_recognition_get_segmentation_image.restype = ctypes.POINTER(ctypes.c_ubyte * (4 * width * height))
 
     def getExposure(self) -> float:
         return self.exposure
@@ -95,7 +97,7 @@ class Camera(Sensor):
         return self.height
 
     def getImage(self) -> bytes:
-        return bytes(self.image[:self.width * self.height * 4])
+        return self.image
 
     def getImageArray(self) -> List[List[List[int]]]:
         array = []
@@ -158,12 +160,12 @@ class Camera(Sensor):
         self.fov = f
 
     @property
-    def image(self):
-        return wb.wb_camera_get_image(self._tag)
+    def image(self) -> bytes:
+        return bytes(wb.wb_camera_get_image(self._tag).contents)
 
     @property
-    def segmentation_image(self):
-        return wb.wb_camera_recognition_get_segmentation_image(self._tag)
+    def segmentation_image(self) -> bytes:
+        return bytes(wb.wb_camera_recognition_get_segmentation_image(self._tag).contents)
 
     @property
     def exposure(self) -> float:
@@ -254,7 +256,7 @@ class Camera(Sensor):
         return wb.wb_camera_recognition_is_segmentation_enabled(self._tag) != 0
 
     def getRecognitionSegmentationImage(self) -> bytes:
-        return bytes(self.segmentation_image[:self.width * self.height * 4])
+        return self.segmentation_image
 
     def getRecognitionSegmentationImageArray(self) -> List[List[List[int]]]:
         array = []


### PR DESCRIPTION
The new Python API converts the data returned by the libController API to Python data types such as lists of standard data types. This operation is sometimes costly (in case of images for example).
This PR aims at performing efficient cast operations rather than costly conversions.
