### PR TITLE
Removed useless Python installations on macOS

### DIFF
--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -43,24 +43,7 @@ jobs:
     - name: Install Webots Compilation Dependencies
       run: |
         # swig wget cmake python@3.8 python@3.9 and python@3.10 are already installed
-        if HOMEBREW_NO_INSTALL_CLEANUP=1 brew install python@3.7; then
-          echo "Installation of Python3.7 successful"
-        else
-          echo "Installation of Python3.7 failed"
-        fi
         npm install -g appdmg
-        # install regular Python 3.7
-        wget -qq https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg
-        sudo installer -pkg python-3.7.9-macosx10.9.pkg -target /
-        # install regular Python 3.8
-        wget -qq https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
-        sudo installer -pkg python-3.8.10-macos11.pkg -target /
-        # install regular Python 3.9
-        wget -qq https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
-        sudo installer -pkg python-3.9.13-macos11.pkg -target /
-        # install regular Python 3.10
-        wget -qq https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
-        sudo installer -pkg python-3.10.5-macos11.pkg -target /
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
@@ -107,10 +90,10 @@ jobs:
         hdiutil mount artifact/webots-*.dmg
         sudo cp -R /Volumes/Webots/Webots.app /Applications
         hdiutil unmount /Volumes/Webots
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Test
       run:
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -39,24 +39,7 @@ jobs:
     - name: Install Webots Compilation Dependencies
       run: |
         # swig wget cmake python@3.8 python@3.9 and python@3.10 are already installed
-        if HOMEBREW_NO_INSTALL_CLEANUP=1 brew install python@3.7; then
-          echo "Installation of Python3.7 successful"
-        else
-          echo "Installation of Python3.7 failed"
-        fi
         npm install -g appdmg
-        # install regular Python 3.7
-        wget -qq https://www.python.org/ftp/python/3.7.9/python-3.7.9-macosx10.9.pkg
-        sudo installer -pkg python-3.7.9-macosx10.9.pkg -target /
-        # install regular Python 3.8
-        wget -qq https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
-        sudo installer -pkg python-3.8.10-macos11.pkg -target /
-        # install regular Python 3.9
-        wget -qq https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg
-        sudo installer -pkg python-3.9.13-macos11.pkg -target /
-        # install regular Python 3.10
-        wget -qq https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
-        sudo installer -pkg python-3.10.5-macos11.pkg -target /
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')
@@ -105,10 +88,10 @@ jobs:
         hdiutil mount artifact/webots-*.dmg
         sudo cp -R /Volumes/Webots/Webots.app /Applications
         hdiutil unmount /Volumes/Webots
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Test
       run:
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true


### PR DESCRIPTION
It seems that Python 3.7 is now deprecated causing the nightly build to fail on macOS.
This PR cleans-up the installation of Python. Since the new Python API was introduced, is not needed any more to install all these versions.