### PR TITLE
Fix enable/disable SF tracking in Python API

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -8,6 +8,7 @@ Released on ??
     - Added `recognitionColors` field to [SolidBox](../guide/object-solids.md#solidbox) and Tractor PROTO models ([#5606](https://github.com/cyberbotics/webots/pull/5606)).
   - Bug Fixes
     - Fixed Python API `Supervisor.setSimulationMode` which was failing ([#5603](https://github.com/cyberbotics/webots/pull/5603)).
+    - Fixed Python API `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
     - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([5620](https://github.com/cyberbotics/webots/pull/5620)).
 
 ## Webots R2023a

--- a/lib/controller/python/controller/field.py
+++ b/lib/controller/python/controller/field.py
@@ -92,10 +92,10 @@ class Field:
         return self.count
 
     def enableSFTracking(self, samplingPeriod: int):
-        wb.wb_supervisor_field_enable_sf_tracking(samplingPeriod)
+        wb.wb_supervisor_field_enable_sf_tracking(self._ref, samplingPeriod)
 
     def disableSFTracking(self):
-        wb.wb_supervisor_field_disable_sf_tracking()
+        wb.wb_supervisor_field_disable_sf_tracking(self._ref)
 
     def getSFBool(self) -> bool:
         return self.value


### PR DESCRIPTION
Fix `Field.enableSFTracking` and `Field.disableSFTracking`:
add missing argument in Python API.