### PR TITLE
Distribute runtime.ini for BotStudio controllers

### DIFF
--- a/docs/guide/epuck.md
+++ b/docs/guide/epuck.md
@@ -291,6 +291,9 @@ A condition can be set on this value to get a line follower behavior.
 An example of BotStudio can be found by opening the "WEBOTS\_HOME/projects/robots/gctronic/e-puck/world/e-puck\_botstudio.wbt" world file (see below).
 The BotStudio window can be opened by selecting the "Show Robot Window" item in the e-puck [context menu](the-3d-window.md#context-menu) when the controller points on a *.bsg* file.
 
+BotStudio needs some additional Qt libraries to run, so it is necessary to add a [`runtime.ini` file](controller-programming.md#environment-variables) in the folder containing the BotStudio controller file.
+A sample `runtime.ini` specifiying the required libraries could be found at ""WEBOTS\_HOME/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini".
+
 #### Bluetooth Setup
 
 The e-puck has a Bluetooth interface allowing it to communicate with Webots.

--- a/docs/guide/epuck.md
+++ b/docs/guide/epuck.md
@@ -292,7 +292,7 @@ An example of BotStudio can be found by opening the "WEBOTS\_HOME/projects/robot
 The BotStudio window can be opened by selecting the "Show Robot Window" item in the e-puck [context menu](the-3d-window.md#context-menu) when the controller points on a *.bsg* file.
 
 BotStudio needs some additional Qt libraries to run, so it is necessary to add a [`runtime.ini` file](controller-programming.md#environment-variables) in the folder containing the BotStudio controller file.
-A sample `runtime.ini` specifiying the required libraries could be found at ""WEBOTS\_HOME/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini".
+A sample `runtime.ini` specifiying the required libraries could be found at "[WEBOTS\_HOME/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini]({{ url.github_tree }}/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini)".
 
 #### Bluetooth Setup
 

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -12,6 +12,7 @@ Released on ??
     - Fixed Python API field getters sometimes returning an invalid Field object ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
     - Fixed Python API `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
     - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([5620](https://github.com/cyberbotics/webots/pull/5620)).
+    - Fixed BotStudio robot window loading errors ([5651](https://github.com/cyberbotics/webots/pull/5651)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/projects/robots/gctronic/e-puck/controllers/line_follower/runtime.ini
+++ b/projects/robots/gctronic/e-puck/controllers/line_follower/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini
+++ b/projects/robots/gctronic/e-puck/controllers/obstacle/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_better_collision_avoidance_algorithm/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_better_collision_avoidance_algorithm/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_blinking_e-puck/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_blinking_e-puck/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_e-puck_dance/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_e-puck_dance/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_finite_state_machine/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_finite_state_machine/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_linear_camera/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_linear_camera/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_move_your_e-puck/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_move_your_e-puck/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/beginner_rally/runtime.ini
+++ b/projects/samples/curriculum/controllers/beginner_rally/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/novice_remain_in_shadow/runtime.ini
+++ b/projects/samples/curriculum/controllers/novice_remain_in_shadow/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"

--- a/projects/samples/curriculum/controllers/novice_train/runtime.ini
+++ b/projects/samples/curriculum/controllers/novice_train/runtime.ini
@@ -1,0 +1,7 @@
+; we need to include the path to the Qt libraries because of the native Qt robot window used by this robot
+[environment variables for Linux]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/lib/webots
+[environment variables for macOS]
+WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/Contents/Resources/projects/libraries/qt_utils:$(WEBOTS_HOME)/Contents/lib/webots
+[environment variables for Windows]
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)\resources\projects\libraries\qt_utils;$(WEBOTS_HOME)\msys64\mingw64\bin"


### PR DESCRIPTION
Address #5642:
BotStudio controllers need a `runtime.ini` file specifying the location of the qt_utils library to correctly be executed by Webots.
In this PR we add the `runtime.ini` file to all the distributed BotStudio controllers so that they work out of the box.

_Note: same `runtime.ini` also used for Robotis OP2_