### PR TITLE
Fix improve extern controller timer

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -11,8 +11,9 @@ Released on ??
     - Fixed Python API `Node.enableContactPointsTracking` which was failing ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
     - Fixed Python API field getters sometimes returning an invalid Field object ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
     - Fixed Python API `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
-    - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([5620](https://github.com/cyberbotics/webots/pull/5620)).
-    - Fixed BotStudio robot window loading errors ([5651](https://github.com/cyberbotics/webots/pull/5651)).
+    - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([#5620](https://github.com/cyberbotics/webots/pull/5620)).
+    - Fixed BotStudio robot window loading errors ([#5651](https://github.com/cyberbotics/webots/pull/5651)).
+    - Fixed the long connection delay for extern controller in complex simulations ([]()).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1319,20 +1319,21 @@ int wb_robot_init() {  // API initialization
       char *host, *robot_name;
       int port = -1;
       compute_remote_info(&host, &port, &robot_name);
-      success = scheduler_init_remote(host, port, robot_name);
+      char *error_message = malloc(128);
+      success = scheduler_init_remote(host, port, robot_name, error_message);
       if (success) {
         free(host);
         free(robot_name);
+        free(error_message);
         break;
       } else {
         if (retry % 5 == 0 && retry != 50)
-          fprintf(stderr, ", retrying for another %d seconds...\n", 50 - retry);
-        else
-          __fpurge(stderr);
+          fprintf(stderr, "%s, retrying for another %d seconds...\n", error_message, 50 - retry);
       }
 
       free(host);
       free(robot_name);
+      free(error_message);
     } else {  // Intern or IPC extern controller
       char *socket_filename = compute_socket_filename();
       success = socket_filename ? scheduler_init_local(socket_filename) : false;

--- a/src/controller/c/scheduler.c
+++ b/src/controller/c/scheduler.c
@@ -53,8 +53,8 @@ char *scheduler_meta = NULL;
 GPipe *scheduler_pipe = NULL;
 int scheduler_client = -1;
 
-int scheduler_init_remote(const char *host, int port, const char *robot_name) {
-  scheduler_client = tcp_client_new(host, port);
+int scheduler_init_remote(const char *host, int port, const char *robot_name, char *buffer) {
+  scheduler_client = tcp_client_new(host, port, buffer);
   if (scheduler_client == -1)
     return false;
 
@@ -71,18 +71,16 @@ int scheduler_init_remote(const char *host, int port, const char *robot_name) {
   char *acknowledge_message = malloc(10);
   tcp_client_receive(scheduler_client, acknowledge_message, 10);  // wait for ack message from Webots
   if (strncmp(acknowledge_message, "FAILED", 6) == 0) {
-    fprintf(stderr, "%s",
+    sprintf(buffer, "%s",
             robot_name == NULL ? "Exactly one robot should be set with an <extern> controller in the Webots simulation" :
                                  "The specified robot is not in the list of robots with <extern> controllers");
     return false;
   } else if (strncmp(acknowledge_message, "PROCESSING", 10) == 0) {
-    fprintf(stderr, "%s", "The Webots simulation world is not ready yet");
+    sprintf(buffer, "The Webots simulation world is not ready yet");
     return false;
   } else if (strncmp(acknowledge_message, "FORBIDDEN", 9) == 0) {
-    fprintf(
-      stderr, "%s",
-      "Error: The connection was closed by Webots. The robot is already connected or your IP address is not allowed by this "
-      "instance of Webots.\n");
+    fprintf(stderr, "Error: The connection was closed by Webots. The robot is already connected or your IP address is not "
+                    "allowed by this instance of Webots.\n");
     exit(EXIT_FAILURE);
   } else if (strncmp(acknowledge_message, "CONNECTED", 9) != 0) {
     fprintf(stderr, "Error: Unknown Webots response %s.\n", acknowledge_message);

--- a/src/controller/c/scheduler.h
+++ b/src/controller/c/scheduler.h
@@ -28,7 +28,7 @@ extern unsigned int scheduler_data_size;
 extern char *scheduler_date;
 extern unsigned int scheduler_actual_step;
 
-int scheduler_init_remote(const char *host, int port, const char *robot_name);
+int scheduler_init_remote(const char *host, int port, const char *robot_name, char *buffer);
 int scheduler_init_local(const char *pipe);
 void scheduler_cleanup();
 void scheduler_send_request(WbRequest *);

--- a/src/controller/c/tcp_client.h
+++ b/src/controller/c/tcp_client.h
@@ -27,9 +27,9 @@
 extern "C" {
 #endif
 
-int tcp_client_new(const char *host, int port);
-int tcp_client_open();
-int tcp_client_connect(int fd, const char *host, int port);
+int tcp_client_new(const char *host, int port, char *buffer);
+int tcp_client_open(char *buffer);
+int tcp_client_connect(int fd, const char *host, int port, char *buffer);
 bool tcp_client_send(int fd, const char *buffer, int size);
 int tcp_client_receive(int fd, char *buffer, int size);
 void tcp_client_close(int fd);


### PR DESCRIPTION
As raised in #5330, the `extern` controllers have an increasing delay if they cannot connect to the target Webots instance. It starts at 1 second and goes up to 10 seconds before giving up.

For complex worlds, which take a long time to load/download textures, the `extern` controller delay can go up to these kinds of values. This is especially a problem on webots.cloud, as for a few seconds the simulation seems to be interrupted/broken, until the controller finally connects to the robot.
