### PR TITLE
Disable Select button in WbExtendedStringEditor for restricted fields

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -7,6 +7,7 @@ Released on ??
     - Added default [Solid](solid.md).`recognitionColors` value for [animals](../guide/object-animals.md) and [Barn](../guide/object-buildings.md#barn) PROTO models ([#5606](https://github.com/cyberbotics/webots/pull/5606)).
     - Added `recognitionColors` field to [SolidBox](../guide/object-solids.md#solidbox) and Tractor PROTO models ([#5606](https://github.com/cyberbotics/webots/pull/5606)).
     - Improved warnings when passing invalid arguments to [`wb_supervisor_node_enable_pose_tracking`/`wb_supervisor_node_disable_pose_tracking`](supervisor.md#wb_supervisor_node_enable_pose_tracking), [`wb_supervisor_node_enable_contact_points_tracking`/`wb_supervisor_node_disable_contact_points_tracking`](supervisor.md#wb_supervisor_node_enable_contact_points_tracking) and [`wb_supervisor_field_enable_sf_tracking`/`wb_supervisor_field_disable_sf_tracking`](supervisor.md#wb_supervisor_field_enable_sf_tracking) ([5638](https://github.com/cyberbotics/webots/pull/5638)).
+    - Disable `Select..` button in SFString editor if the field has restricted values ([5663](https://github.com/cyberbotics/webots/pull/5663)).
   - Bug Fixes
     - Fixed Python API `Supervisor.setSimulationMode` which was failing ([#5603](https://github.com/cyberbotics/webots/pull/5603)).
     - Fixed Python API `Node.enableContactPointsTracking` which was failing ([#5633](https://github.com/cyberbotics/webots/pull/5633)).

--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -444,7 +444,7 @@ void WbExtendedStringEditor::updateWidgets() {
 
   // show/hide widgets
   lineEdit()->setReadOnly(!enableLineEdit);
-  mSelectButton->setVisible(showSelectButton);
+  mSelectButton->setVisible(!field()->hasRestrictedValues() && showSelectButton);
   mEditButton->setVisible(showEditButton);
 }
 
@@ -458,10 +458,6 @@ void WbExtendedStringEditor::edit(bool copyOriginalValue) {
 
     mStringType = fieldNameToStringType(effectiveField->name(), effectiveField->parentNode());
   }
-
-  const bool hasRetrictedValues = field()->hasRestrictedValues();
-  mEditButton->setVisible(!hasRetrictedValues);
-  mSelectButton->setVisible(!hasRetrictedValues);
 
   updateWidgets();
 }
@@ -567,7 +563,7 @@ bool WbExtendedStringEditor::selectItem() {
   return true;
 }
 
-bool WbExtendedStringEditor::isWorldInfoPluginType(StringType type) {
+bool WbExtendedStringEditor::isWorldInfoPluginType(StringType type) const {
   switch (type) {
     case PHYSICS_PLUGIN:
       return true;

--- a/src/webots/scene_tree/WbExtendedStringEditor.hpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.hpp
@@ -62,7 +62,7 @@ private:
   };
   StringType mStringType;
 
-  bool isWorldInfoPluginType(StringType type);
+  bool isWorldInfoPluginType(StringType type) const;
 
   // optional buttons below the string field
   QPushButton *mSelectButton, *mEditButton;


### PR DESCRIPTION
Address  #5466:
in the `WbExtendedStringEditor` class check if the current field has restricted values and, if it is the case, hide the `Select...` button.

I evaluated the possibility to check the list of accepted values and remove the ones that are not available.
But it seems clearer and easier to understand for the user if all the accepted values are shown in the combo box and Webots throws an error in the console if the requested resources is not found.
In case the value, for example the controller, is not found or not compiled Webots will still use the default one even if it is not in the list (e.g. the <generic> controller). 

![Screenshot from 2022-12-14 11-38-40](https://user-images.githubusercontent.com/5910449/207573254-a104313c-4ebf-4a21-8a7a-a46192f352f4.png)
