### PR TITLE
Fix crash enabling battery while simulatoin is running

### DIFF
--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -139,7 +139,7 @@ void WbMotor::preFinalize() {
 void WbMotor::postFinalize() {
   WbJointDevice::postFinalize();
   assert(robot());
-  if (!mMuscles->isEmpty() || robot()->maxEnergy() > 0)
+  if (!mMuscles->isEmpty() || robot()->currentEnergy() >= 0)
     setupJointFeedback();
 
   inferMotorCouplings();  // it also checks consistency across couplings

--- a/src/webots/nodes/WbMotor.hpp
+++ b/src/webots/nodes/WbMotor.hpp
@@ -79,6 +79,8 @@ public:
 
   static const QList<const WbMotor *> &motors() { return cMotors; }
 
+  void setupJointFeedback();
+
 signals:
   void minPositionChanged();
   void maxPositionChanged();
@@ -101,9 +103,6 @@ protected:
 protected slots:
   void updateMaxForceOrTorque();
   void updateMinAndMaxPosition();
-
-protected:
-  void setupJointFeedback();
 
 private:
   static QList<const WbMotor *> cMotors;

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -244,6 +244,8 @@ void WbRobot::postFinalize() {
   connect(mSupervisor, &WbSFString::changed, this, &WbRobot::updateSupervisor);
   connect(this, &WbMatter::matterModelChanged, this, &WbRobot::updateModel);
   connect(WbSimulationState::instance(), &WbSimulationState::modeChanged, this, &WbRobot::updateSimulationMode);
+  connect(mBattery, &WbMFDouble::itemInserted, this, [this]() { this->updateBattery(true); });
+  connect(mBattery, &WbMFDouble::itemRemoved, this, [this]() { this->updateBattery(false); });
 
   if (absoluteScale() != WbVector3(1.0, 1.0, 1.0))
     parsingWarn(tr("This Robot node is scaled: this is discouraged as it could compromise the correct physical behavior."));
@@ -604,6 +606,20 @@ void WbRobot::updateSupervisor() {
 
 void WbRobot::updateModel() {
   mModelNeedToWriteAnswer = true;
+}
+
+void WbRobot::updateBattery(bool itemInserted) {
+  if (mBattery->size() > (ENERGY_UPLOAD_SPEED + 1))
+    warn(tr("'battery' field can only contain three values. Remaining values are ignored."));
+  if (!itemInserted || mBattery->isEmpty())
+    return;
+
+  foreach (WbDevice *const device, mDevices) {
+    // setup motor joint feedback needed to compute energy consumption
+    WbMotor *motor = dynamic_cast<WbMotor *>(device);
+    if (motor)
+      motor->setupJointFeedback();
+  }
 }
 
 void WbRobot::removeRenderingDevice() {

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -286,6 +286,7 @@ private slots:
   void updateData();
   void updateSupervisor();
   void updateModel();
+  void updateBattery(bool itemInserted);
   void removeRenderingDevice();
   void handleMouseChange();
   void handleJoystickChange();


### PR DESCRIPTION
A user reported this crash:
> Everytime I introduce the battery to a new robot Webots crashes and afterwords the charger is not working anymore.

Steps to reproduce:
1. open "battery.wbt" in pause mode
2. reset the `MyRobot.battery` field to default (empty)
3. save and revert the world
4. run the simulation
5. add an item (default value is 0) to the `MyRobot.battery`
6. set the `MyRobot.battery` item to 100
-> Webots crashes

When the battery current energy is greater than 0 It is expected that the motor feedback is enabled, but the code only checks if a battery is used (and this if the motor feedback should be setup) when finalizing the motor node.

Also note that the documentation mentions that the `Robot.battery` field should contain three values.
However, the code is implemented in such a way that even if the `Robot.battery` has just one value, the battery energy is updated correctly. This is just a note, I won't change the documentation.