### PR TITLE
Fix wrong assertion failure for console redirection

### DIFF
--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -158,9 +158,12 @@ void stream_pipe_read(int fd, char **buffer) {
   if (len == -1)
     len = 0;
 #endif
-  (*buffer)[len] = '\0';
-  if (!len)
+  if (len != 0)
+    (*buffer)[len] = '\0';
+  else {
+    free(*buffer);
     *buffer = NULL;
+  }
 }
 
 static void init_robot_window_library() {

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -159,6 +159,8 @@ void stream_pipe_read(int fd, char **buffer) {
     len = 0;
 #endif
   (*buffer)[len] = '\0';
+  if (!len)
+    *buffer = NULL;
 }
 
 static void init_robot_window_library() {


### PR DESCRIPTION
When running an extern controller with WEBOTS_STDOUT_REDIRECT set to 1, the logs are redirected to the Webots console. However, this causes Webots to crash in debug compilation mode because of an assertion. 

If nothing is written to the buffer at a timestep, the buffer was not set back to NULL.