### PR TITLE
Fix cadshape move to viewpoint

### DIFF
--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -162,6 +162,7 @@ void WbCadShape::postFinalize() {
           &WbCadShape::createWrenObjects);
 
   mBoundingSphere = new WbBoundingSphere(this);
+  recomputeBoundingSphere();
 
   // apply segmentation color
   const WbSolid *solid = WbNodeUtilities::findUpperSolid(this);
@@ -506,9 +507,6 @@ void WbCadShape::createWrenObjects() {
     mWrenEncodeDepthMaterials.push_back(depthMaterial);
     mWrenSegmentationMaterials.push_back(segmentationMaterial);
   }
-
-  if (mBoundingSphere)
-    recomputeBoundingSphere();
 }
 
 void WbCadShape::updateAppearance() {


### PR DESCRIPTION
The `recomputeBoundingSphere` function in `WbCadShape` was called in a different place than in `WbGroup` and `WbGeometry` and I could not find out why.

This causes, since https://github.com/cyberbotics/webots/pull/5359, the `move Viewpoint to Object` to not work.

@ad-daniel maybe you remember why it was done differently in `WbCadShape`?