### PR TITLE
Fix infinite dictionary update

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -18,6 +18,8 @@ Released on ??
     - Fixed BotStudio robot window loading errors ([#5651](https://github.com/cyberbotics/webots/pull/5651)).
     - Lowered the connection retry delay for extern controllers ([#5656](https://github.com/cyberbotics/webots/pull/5656)).
     - Fixed a crash when setting the `Robot.battery` after the simulation start ([#5669](https://github.com/cyberbotics/webots/pull/5669)).
+    - Fixed crashes resulting from converting to base nodes a PROTO containing DEF and USE nodes ([#5676](https://github.com/cyberbotics/webots/pull/5676)).
+    - Fixed crashes resulting from updating a DEF node whose USE node is contained in a PROTO field triggering the regeneration ([#5676](https://github.com/cyberbotics/webots/pull/5676)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/projects/robots/franka_emika/panda/protos/Panda.proto
+++ b/projects/robots/franka_emika/panda/protos/Panda.proto
@@ -24,13 +24,6 @@ PROTO Panda [
   Robot {
     translation IS translation
     rotation IS rotation
-    controller IS controller
-    controllerArgs IS controllerArgs
-    window IS window
-    customData IS customData
-    supervisor IS supervisor
-    synchronization IS synchronization
-    selfCollision IS selfCollision
     name IS name
     children [
       Solid {
@@ -487,4 +480,11 @@ PROTO Panda [
       }
     ]
   }
+  controller IS controller
+  controllerArgs IS controllerArgs
+  customData IS customData
+  supervisor IS supervisor
+  synchronization IS synchronization
+  selfCollision IS selfCollision
+  window IS window
 }

--- a/projects/robots/franka_emika/panda/protos/Panda.proto
+++ b/projects/robots/franka_emika/panda/protos/Panda.proto
@@ -479,12 +479,12 @@ PROTO Panda [
         }
       }
     ]
+    controller IS controller
+    controllerArgs IS controllerArgs
+    customData IS customData
+    supervisor IS supervisor
+    synchronization IS synchronization
+    selfCollision IS selfCollision
+    window IS window
   }
-  controller IS controller
-  controllerArgs IS controllerArgs
-  customData IS customData
-  supervisor IS supervisor
-  synchronization IS synchronization
-  selfCollision IS selfCollision
-  window IS window
 }

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -162,6 +162,7 @@ void WbCadShape::postFinalize() {
           &WbCadShape::createWrenObjects);
 
   mBoundingSphere = new WbBoundingSphere(this);
+  recomputeBoundingSphere();
 
   // apply segmentation color
   const WbSolid *solid = WbNodeUtilities::findUpperSolid(this);
@@ -506,9 +507,6 @@ void WbCadShape::createWrenObjects() {
     mWrenEncodeDepthMaterials.push_back(depthMaterial);
     mWrenSegmentationMaterials.push_back(segmentationMaterial);
   }
-
-  if (mBoundingSphere)
-    recomputeBoundingSphere();
 }
 
 void WbCadShape::updateAppearance() {

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -369,10 +369,6 @@ void WbRobot::addDevices(WbNode *node) {
 }
 
 void WbRobot::clearDevices() {
-  foreach (const WbDevice *device, mDevices)
-    disconnect(dynamic_cast<const WbBaseNode *>(device), &WbBaseNode::destroyed, this, &WbRobot::updateDevicesAfterDestruction);
-  foreach (const WbRenderingDevice *device, mRenderingDevices)
-    disconnect(device, &WbBaseNode::isBeingDestroyed, this, &WbRobot::removeRenderingDevice);
   mDevices.clear();
   mRenderingDevices.clear();
   mActiveCameras.clear();

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -46,7 +46,14 @@ void WbDictionary::cleanup() {
   cInstance = NULL;
 }
 
-WbDictionary::WbDictionary() : mTargetNode(NULL), mTargetField(NULL), mTargetIndex(-1), mStopUpdate(false), mLoad(false) {
+WbDictionary::WbDictionary() :
+  mTargetNode(NULL),
+  mTargetField(NULL),
+  mTargetIndex(-1),
+  mStopUpdate(false),
+  mLoad(false),
+  mCurrentProtoRegeneration(false),
+  mCurrentProtoRegenerationNode(NULL) {
 }
 
 WbDictionary::~WbDictionary() {
@@ -56,19 +63,33 @@ WbDictionary::~WbDictionary() {
 // Updates of the DEF names dictionary //
 /////////////////////////////////////////
 
-void WbDictionary::update(bool load) {
+void WbDictionary::setRegeneratedNode(const WbNode *node) {
+  assert(!node || !mCurrentProtoRegenerationNode);  // nested dictionary updates should be avoided
+  mCurrentProtoRegenerationNode = node;
+}
+
+bool WbDictionary::update(bool load) {
   mLoad = load;
   clearNestedDictionaries();
   mSceneDictionary.clear();
+  assert(!mCurrentProtoRegeneration);  // nested dictionary updates should be avoided
+  mCurrentProtoRegeneration = false;
+  bool regenerationRequired = false;
+
   WbBaseNode *rootNode = WbWorld::instance()->root();
-  updateDef(rootNode);
+  updateDef(rootNode, NULL, NULL, -1, false, regenerationRequired);
+
+  mCurrentProtoRegeneration = false;
+  return regenerationRequired;
 }
 
-bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNode, int index) {
+bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNode, int index, bool isTemplateRegenerator,
+                             bool &regenerationRequired) {
   const QString &defName = node->defName();
   const QString &useName = node->useName();
   const bool useCase = !useName.isEmpty();
   const int useNestingDegree = mNestedDictionaries.size() - 1;
+  mCurrentProtoRegeneration |= node == mCurrentProtoRegenerationNode;
 
   // Solid, Device, JointParameters and BasicJoint DEF nodes are allowed but not registered in the dictionary,
   // Solid, Device, JointParameters and BasicJoint USE nodes are prohibited
@@ -122,57 +143,58 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
         }
       }
 
-      if (definitionNode && typeMatch) {
-        if (node->defNode() != definitionNode) {
-          QString deviceModelName;
-          if (node->isInBoundingObject() != definitionNode->isInBoundingObject() &&
-              !checkBoundingObjectConstraints(definitionNode, warning)) {
-            node->parentNode()->parsingWarn(QObject::tr("Deleted invalid USE %1 node: %3").arg(useName).arg(warning));
-            WbNodeOperations::instance()->deleteNode(node);
-            return false;
-          } else if (!checkChargerAndLedConstraints(node->parentNode(), definitionNode, deviceModelName, index == 0)) {
-            node->parsingWarn(
-              QObject::tr("Non-admissible USE %1 node inside first child of %2 node.\n"
-                          "Invalid USE nodes that refer to DEF nodes defined outside the %2 node are turned into DEF nodes "
-                          "otherwise the emissive color cannot be updated correctly.")
-                .arg(useName)
-                .arg(deviceModelName));
-            makeDefNodeAndUpdateDictionary(node, true);
-          } else {
-            if (!mLoad) {
-              WbNode *const parent = node->parentNode();
-              WbNode::setGlobalParentNode(parent);
-              WbBaseNode *const newUseNode = static_cast<WbBaseNode *>(definitionNode->cloneDefNode());
-              WbNode::setGlobalParentNode(NULL);
-              newUseNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
-              if (sfNode)
-                sfNode->setValue(newUseNode);
-              else if (mfNode) {
-                mfNode->removeItem(index);
-                mfNode->insertItem(index, newUseNode);  // TODO: replace by setItem(index, newUseNode) when it is fixed
-              }
-              newUseNode->finalize();
-              node = newUseNode;
+      if (definitionNode && typeMatch && node->defNode() != definitionNode) {
+        QString deviceModelName;
+        if (node->isInBoundingObject() != definitionNode->isInBoundingObject() &&
+            !checkBoundingObjectConstraints(definitionNode, warning)) {
+          node->parentNode()->parsingWarn(QObject::tr("Deleted invalid USE %1 node: %3").arg(useName).arg(warning));
+          WbNodeOperations::instance()->deleteNode(node);
+          if (node == mCurrentProtoRegenerationNode)
+            mCurrentProtoRegeneration = false;
+          return false;
+        } else if (!checkChargerAndLedConstraints(node->parentNode(), definitionNode, deviceModelName, index == 0)) {
+          node->parsingWarn(
+            QObject::tr("Non-admissible USE %1 node inside first child of %2 node.\n"
+                        "Invalid USE nodes that refer to DEF nodes defined outside the %2 node are turned into DEF nodes "
+                        "otherwise the emissive color cannot be updated correctly.")
+              .arg(useName)
+              .arg(deviceModelName));
+          makeDefNodeAndUpdateDictionary(node, true);
+        } else {
+          if (!mLoad && !mCurrentProtoRegeneration) {
+            WbNode *parent = node->parentNode();
+            WbNode::setGlobalParentNode(parent);
+            WbBaseNode *const newUseNode = static_cast<WbBaseNode *>(definitionNode->cloneDefNode());
+            WbNode::setGlobalParentNode(NULL);
+            newUseNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
+            if (sfNode)
+              sfNode->setValue(newUseNode);
+            else if (mfNode)
+              mfNode->setItem(index, newUseNode);
+            regenerationRequired |= isTemplateRegenerator;
+            while (parent) {
+              parent = parent->parentNode();
             }
-            node->makeUseNode(definitionNode);  // Sets USE name, DEF reference, unregisters from previous DEF reference and
-                                                // registers to the new one
-            mNestedUseNodes.append(node);
+            newUseNode->finalize();
+            node = newUseNode;
           }
+          node->makeUseNode(definitionNode);  // Sets USE name, DEF reference, unregisters from previous DEF reference and
+                                              // registers to the new one
+          mNestedUseNodes.append(node);
         }
       }
 
       if (matchingNode && matchingNode->isDefNode()) {
         if (!mLoad) {
-          WbNode *const parent = node->parentNode();
+          WbNode *parent = node->parentNode();
           WbNode::setGlobalParentNode(parent);
           WbBaseNode *const newDefNode = static_cast<WbBaseNode *>(matchingNode->cloneAndReferenceProtoInstance());
           newDefNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
           if (sfNode)
             sfNode->setValue(newDefNode);
-          else if (mfNode) {
-            mfNode->removeItem(index);
-            mfNode->insertItem(index, newDefNode);  // TODO: replace by setItem(index, newUseNode) when it is fixed
-          }
+          else if (mfNode)
+            mfNode->setItem(index, newDefNode);
+          regenerationRequired |= isTemplateRegenerator;
           newDefNode->finalize();
           node = newDefNode;
         }
@@ -193,6 +215,9 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       node->parsingWarn(warning + " " + QObject::tr("Non-admissible USE node turned into DEF node."));
       makeDefNodeAndUpdateDictionary(node, true);
     }
+
+    if (node == mCurrentProtoRegenerationNode)
+      mCurrentProtoRegeneration = false;
     return true;
   }
 
@@ -211,7 +236,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
         if (createDictionary)  // Appends a local dictionary which is limited to the scope of this USE node
           mNestedDictionaries.append(Dictionary());
 
-        bool success = updateDef(n, sf);
+        bool success = updateDef(n, sf, NULL, -1, field->isTemplateRegenerator(), regenerationRequired);
 
         // dictionary already removed if USE node has been turned into DEF node
         if (createDictionary && (!success || n->isUseNode())) {
@@ -236,7 +261,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
             if (createDictionary)  // Appends a local dictionary which is limited to the scope of this USE node
               mNestedDictionaries.append(Dictionary());
 
-            bool success = updateDef(n, NULL, mf, i);
+            bool success = updateDef(n, NULL, mf, i, field->isTemplateRegenerator(), regenerationRequired);
 
             // dictionary already removed if USE node has been turned into DEF node
             if (createDictionary && (!success || n->isUseNode())) {
@@ -250,6 +275,8 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
       }
     }
   }
+  if (node == mCurrentProtoRegenerationNode)
+    mCurrentProtoRegeneration = false;
   return true;
 }
 

--- a/src/webots/nodes/utils/WbDictionary.hpp
+++ b/src/webots/nodes/utils/WbDictionary.hpp
@@ -36,8 +36,12 @@ public:
   // Recompute all DEF-USE dependencies (but protos' dependencies) and update
   // them if needed according to the VRML rule:
   // a USE node refers to its closest previous DEF node if it exists (otherwise it is turned into a DEF node)
-  void update(bool load = false);
+  bool update(bool load = false);
   void updateProtosPrivateDef(WbBaseNode *&node);
+
+  // If dictionary update is called after PROTO regeneration, then store the upper template PROTO node to prevent infinite
+  // DEF/USE updates
+  void setRegeneratedNode(const WbNode *node);
 
   // Loop through current world and return all the available DEF nodes
   // that could be used in the specified field.
@@ -56,7 +60,8 @@ private:
   WbDictionary();
   ~WbDictionary();
 
-  bool updateDef(WbBaseNode *&node, WbSFNode *sfNode = NULL, WbMFNode *mfNode = NULL, int index = -1);
+  bool updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNode, int index, bool isTemplateRegenerator,
+                 bool &regenerationRequired);
   void updateProtosDef(WbBaseNode *&node, WbSFNode *sfNode = NULL, WbMFNode *mfNode = NULL, int index = -1);
   void updateForInsertion(const WbNode *const node, bool suitableOnly, QList<WbNode *> &defNodes);
   void makeDefNodeAndUpdateDictionary(WbBaseNode *node, bool updateSceneDictionary);
@@ -72,7 +77,9 @@ private:
   QList<WbBaseNode *> mNestedProtos;
   QList<WbBaseNode *> mNestedUseNodes;
   bool mStopUpdate;
-  bool mLoad;  // true if the update occurs right after world is loaded
+  bool mLoad;                      // true if the update occurs right after world is loaded
+  bool mCurrentProtoRegeneration;  // true if the update occurs due to a PROTO regeneration
+  const WbNode *mCurrentProtoRegenerationNode;
   bool isSuitable(const WbNode *defNode, const QString &type) const;
   static bool checkChargerAndLedConstraints(WbNode *useNodeParent, const WbBaseNode *defNode, QString &deviceModelName,
                                             bool isFirstChild);

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -329,15 +329,16 @@ void WbNodeOperations::requestUpdateDictionary() {
   updateDictionary(false, NULL);
 }
 
-void WbNodeOperations::updateDictionary(bool load, WbBaseNode *protoRoot) {
+bool WbNodeOperations::updateDictionary(bool load, WbBaseNode *protoRoot) {
   mSkipUpdates = true;
   WbNode::setDictionaryUpdateFlag(true);
   WbDictionary *dictionary = WbDictionary::instance();
-  dictionary->update(load);  // update all DEF-USE dependencies
+  const bool regenerationRequired = dictionary->update(load);  // update all DEF-USE dependencies
   if (protoRoot && !protoRoot->isUseNode())
     dictionary->updateProtosPrivateDef(protoRoot);
   WbNode::setDictionaryUpdateFlag(false);
   mSkipUpdates = false;
+  return regenerationRequired;
 }
 
 void WbNodeOperations::requestUpdateSceneDictionary(WbNode *node, bool fromUseToDef) {

--- a/src/webots/nodes/utils/WbNodeOperations.cpp
+++ b/src/webots/nodes/utils/WbNodeOperations.cpp
@@ -226,7 +226,7 @@ WbNodeOperations::OperationResult WbNodeOperations::initNewNode(WbNode *newNode,
   WbBaseNode *const baseNode = dynamic_cast<WbBaseNode *>(newNode);
   // set parent node
   newNode->setParentNode(parentNode);
-  WbNode *upperTemplate = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, parentNode);
+  WbNode *upperTemplate = WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, parentNode);
   bool isInsideATemplateRegenerator = upperTemplate && (upperTemplate != baseNode);
 
   // insert in parent field

--- a/src/webots/nodes/utils/WbNodeOperations.hpp
+++ b/src/webots/nodes/utils/WbNodeOperations.hpp
@@ -52,7 +52,7 @@ public:
   void notifyNodeDeleted(WbNode *node);
   void notifyNodeRegenerated();
 
-  void updateDictionary(bool load, WbBaseNode *protoRoot);  // called after every modification of the Scene Tree
+  bool updateDictionary(bool load, WbBaseNode *protoRoot);  // called after every modification of the Scene Tree
 
   bool areNodesAboutToBeInserted() { return mNodesAreAboutToBeInserted; }
   bool isSkipUpdates() { return mSkipUpdates; }

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -698,33 +698,6 @@ WbTransform *WbNodeUtilities::findUpperTransform(const WbNode *node) {
   return NULL;
 }
 
-WbNode *WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(WbField *modifiedField, WbNode *parentNode) {
-  if (parentNode == NULL || modifiedField == NULL)
-    return NULL;
-
-  if (parentNode->isTemplate() && modifiedField->isTemplateRegenerator())
-    return parentNode;
-
-  return findUpperTemplateNeedingRegeneration(parentNode);
-}
-
-WbNode *WbNodeUtilities::findUpperTemplateNeedingRegeneration(WbNode *modifiedNode) {
-  if (modifiedNode == NULL)
-    return NULL;
-
-  WbField *field = modifiedNode->parentField();
-  WbNode *node = modifiedNode->parentNode();
-  while (node && field && !node->isWorldRoot()) {
-    if (node->isTemplate() && field->isTemplateRegenerator())
-      return node;
-
-    field = node->parentField();
-    node = node->parentNode();
-  }
-
-  return NULL;
-}
-
 bool WbNodeUtilities::hasARobotDescendant(const WbNode *node) {
   const QList<WbNode *> &subNodes = node->subNodes(true);
 

--- a/src/webots/nodes/utils/WbNodeUtilities.hpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.hpp
@@ -47,14 +47,6 @@ namespace WbNodeUtilities {
   // find the closest WbTransform ancestor
   WbTransform *findUpperTransform(const WbNode *node);
 
-  // find the closest template ancestor in which the modified node is contained in template field
-  // which requires a template instance regeneration
-  WbNode *findUpperTemplateNeedingRegeneration(WbNode *modifiedNode);
-
-  // find the closest template ancestor of given field in which the modified field is contained
-  // in template field which requires a template instance regeneration
-  WbNode *findUpperTemplateNeedingRegenerationFromField(WbField *modifiedField, WbNode *parentNode);
-
   // find the closest WbSolid ancestor
   WbSolid *findUpperSolid(const WbNode *node);
 

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -35,6 +35,7 @@
 #include "WbSolid.hpp"
 #include "WbSolidReference.hpp"
 #include "WbViewpoint.hpp"
+#include "WbVrmlNodeUtilities.hpp"
 #include "WbWorld.hpp"
 
 #include <QtCore/QCoreApplication>
@@ -194,7 +195,7 @@ void WbTemplateManager::regenerateNodeFromParameterChange(WbField *field) {
 // Note: The security is probably overkill there, but its also safer for the first versions of the template mechanism
 void WbTemplateManager::regenerateNodeFromField(WbNode *templateNode, WbField *field, bool isParameter) {
   // 1. retrieve upper template node where the modification appeared in a template regenerator field
-  WbNode *upperTemplateNode = WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, templateNode);
+  WbNode *upperTemplateNode = WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, templateNode);
 
   if (!upperTemplateNode)
     return;
@@ -262,7 +263,7 @@ void WbTemplateManager::regenerateNode(WbNode *node, bool restarted) {
     followedSolidName = followedSolid->name();
 
   // 2. regenerate the new node
-  WbNode *upperTemplateNode = WbNodeUtilities::findUpperTemplateNeedingRegeneration(node);
+  WbNode *upperTemplateNode = WbVrmlNodeUtilities::findUpperTemplateNeedingRegeneration(node);
   bool nested = upperTemplateNode && upperTemplateNode != node;
   cRegeneratingNodeCount++;
   if (isWorldInitialized && !restarted)

--- a/src/webots/nodes/utils/WbTemplateManager.hpp
+++ b/src/webots/nodes/utils/WbTemplateManager.hpp
@@ -69,6 +69,7 @@ private:
 
   bool mBlockRegeneration;
   bool mTemplatesNeedRegeneration;
+  WbNode *mRegeneratingUpperTemplateNode;
 };
 
 #endif

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -1416,10 +1416,6 @@ void WbSceneTree::applyNodeRegeneration(WbNode *node) {
 
   setUpdatesEnabled(true);
 
-  // TODO: this shouldn't be done in the scene tree
-  // The best way to fix this would be to move WbDictionary in another module (vrml?)
-  WbNodeOperations::instance()->updateDictionary(false, dynamic_cast<WbBaseNode *>(node));
-
   if (mFocusWidgetBeforeNodeRegeneration) {
     mFocusWidgetBeforeNodeRegeneration->setFocus();
     mFocusWidgetBeforeNodeRegeneration = NULL;

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -674,7 +674,7 @@ void WbSceneTree::transform(const QString &modelName) {
   // reassign pointer in parent
   WbField *parentField = mSelectedItem->parent()->field();
   WbNode *upperTemplate =
-    WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, currentNode->parentNode());
+    WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, currentNode->parentNode());
   bool isInsideATemplateRegenerator = upperTemplate && upperTemplate != currentNode;
   if (mSelectedItem->isSFNode()) {
     WbSFNode *const sfnode = dynamic_cast<WbSFNode *>(mSelectedItem->field()->value());
@@ -761,7 +761,7 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
     }
 
     const bool skipTemplateRegeneration =
-      WbNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, parentNode);
+      WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, parentNode);
     if (skipTemplateRegeneration)
       // PROTO will be regenerated after importing the converted node
       parentField->blockSignals(true);

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -795,8 +795,11 @@ void WbNode::notifyFieldChanged() {
             continue;
           assert(parent);
           setGlobalParentNode(parent);
+          const bool isTemplateRegenerationRequired =
+            WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(subField, subField->parentNode());
           subField->copyValueFrom(field);
-          subField->defHasChanged();
+          if (!isTemplateRegenerationRequired)
+            subField->defHasChanged();
         }
 
         setGlobalParentNode(NULL);

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -303,6 +303,33 @@ bool WbVrmlNodeUtilities::existsVisibleProtoNodeNamed(const QString &modelName, 
   return false;
 }
 
+WbNode *WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(WbField *modifiedField, WbNode *parentNode) {
+  if (parentNode == NULL || modifiedField == NULL)
+    return NULL;
+
+  if (parentNode->isTemplate() && modifiedField->isTemplateRegenerator())
+    return parentNode;
+
+  return findUpperTemplateNeedingRegeneration(parentNode);
+}
+
+WbNode *WbVrmlNodeUtilities::findUpperTemplateNeedingRegeneration(WbNode *modifiedNode) {
+  if (modifiedNode == NULL)
+    return NULL;
+
+  WbField *field = modifiedNode->parentField();
+  WbNode *node = modifiedNode->parentNode();
+  while (node && field && !node->isWorldRoot()) {
+    if (node->isTemplate() && field->isTemplateRegenerator())
+      return node;
+
+    field = node->parentField();
+    node = node->parentNode();
+  }
+
+  return NULL;
+}
+
 bool WbVrmlNodeUtilities::hasAUseNodeAncestor(const WbNode *node) {
   const WbNode *p = node;
   while (p) {

--- a/src/webots/vrml/WbVrmlNodeUtilities.hpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.hpp
@@ -58,6 +58,14 @@ namespace WbVrmlNodeUtilities {
   // default fields that won't be written to the WBT file are skipped
   bool existsVisibleProtoNodeNamed(const QString &modelName, WbNode *root);
 
+  // find the closest template ancestor in which the modified node is contained in template field
+  // which requires a template instance regeneration
+  WbNode *findUpperTemplateNeedingRegeneration(WbNode *modifiedNode);
+
+  // find the closest template ancestor of given field in which the modified field is contained
+  // in template field which requires a template instance regeneration
+  WbNode *findUpperTemplateNeedingRegenerationFromField(WbField *modifiedField, WbNode *parentNode);
+
   //////////////////////////////
   // Non-permanent properties //
   //////////////////////////////


### PR DESCRIPTION
Fix #5360 and https://github.com/cyberbotics/webots/issues/5463:
Webots is blocked in an infinite loop when converting a PROTO node in a field triggering an upper PROTO node regeneration if it contains a DEF node and its USE node.

This is because updating the DEF node associated to the USE node triggers a PROTO regeneration and after the regeneration the new USE node needs to be updated again.

This fix prevents nested PROTO regeneration during the dictionary update.

TODO:
* [x] fix conversion to base nodes/ root to base node
* [x] fix crash when modifying the DEF node whose USE node is contained in a PROTO regenerator field
* [x] fix warning #5467: remove instructions to disconnect devices, Qt::UniqueConnection is used when adding the devices to the list