### PR TITLE
Add necessary first line in proto file examples

### DIFF
--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -31,7 +31,7 @@ Finally, save the PROTO file.
   **Solution**: You should have something like this:
 
 ```
-  #VRML_SIM R2023a utf8
+  #VRML_SIM {{ webots.version.major }} utf8
   PROTO FourWheelsRobot [
 
   ]

--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -12,6 +12,7 @@ Create a new empty text file in the `protos` folder of your project called `Four
 
 Any PROTO file should at least respect the following structure:
 ```
+#VRML_SIM R2023a utf8
 PROTO protoName [
   protoFields
 ]
@@ -30,6 +31,7 @@ Finally, save the PROTO file.
   **Solution**: You should have something like this:
 
 ```
+  #VRML_SIM R2023a utf8
   PROTO FourWheelsRobot [
 
   ]
@@ -80,6 +82,7 @@ And the `mass` field of the [Physics](../reference/physics.md) node of the [Robo
 ```
 Save your PROTO file, it should now look like this:
 ```
+#VRML_SIM R2023a utf8
 PROTO FourWheelsRobot [
   field SFVec3f    translation  0 0 0
   field SFRotation rotation     0 0 1 0

--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -12,7 +12,7 @@ Create a new empty text file in the `protos` folder of your project called `Four
 
 Any PROTO file should at least respect the following structure:
 ```
-#VRML_SIM R2023a utf8
+#VRML_SIM {{ webots.version.major }} utf8
 PROTO protoName [
   protoFields
 ]

--- a/docs/guide/tutorial-7-your-first-proto.md
+++ b/docs/guide/tutorial-7-your-first-proto.md
@@ -82,7 +82,7 @@ And the `mass` field of the [Physics](../reference/physics.md) node of the [Robo
 ```
 Save your PROTO file, it should now look like this:
 ```
-#VRML_SIM R2023a utf8
+#VRML_SIM {{ webots.version.major }} utf8
 PROTO FourWheelsRobot [
   field SFVec3f    translation  0 0 0
   field SFRotation rotation     0 0 1 0


### PR DESCRIPTION
**Description**
For a newbie it is not easy to find that the first line in a proto file has to be `#VRML_SIM R2023a utf8`.

**Documentation**
Current page is https://cyberbotics.com/doc/guide/tutorial-7-your-first-proto
Modified page is https://cyberbotics.com/doc/guide/tutorial-7-your-first-proto?version=stepkun:patch-1