### PR TITLE
Fix `openai_gym` instructions

### DIFF
--- a/projects/samples/howto/openai_gym/controllers/openai_gym/openai_gym.py
+++ b/projects/samples/howto/openai_gym/controllers/openai_gym/openai_gym.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     sys.exit(
         'Please make sure you have all dependencies installed. '
-        'Run: "pip3 install numpy gym stable_baselines3"'
+        'Run: "pip3 install numpy gym==0.21 stable_baselines3"'
     )
 
 


### PR DESCRIPTION
**Description**

`stable_baselines3` is only compatible with gym up to version 0.21.0, an error is currently thrown when following the instructions.