### PR TITLE
Fix error when running individual tests.

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -169,7 +169,7 @@ def generateWorldsList(groupName):
     if filesArguments:
         for file in filesArguments:
             if f'/tests/{groupName}/' in file:
-                worldsList.append([file])
+                worldsList.append(file)
 
     # generate the list from 'ls worlds/*.wbt'
     else:


### PR DESCRIPTION
**Description**
Change test_suite.py's generateWorldsList()  to return a list of strings instead of a list of lists when generating the list from file arguments. Returning a list of lists resulted in this error when running an individual test (e.g. `./test_suite.py api/worlds/center_of_mass_and_contact_points.wbt`):

```
Traceback (most recent call last):
  File "/home/brettle/git/webots/tests/./test_suite.py", line 345, in <module>
    f.write(world + '\n')
            ~~~~~~^~~~~~
TypeError: can only concatenate list (not "str") to list
```

