### PR TITLE
Fix race condition when testing node removal.

### DIFF
--- a/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
+++ b/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), initial_root_children_count + 1,
                       "The number of children of the root node is not correct after the insertion of SPHERE2.");
 
-  wb_robot_step(TIME_STEP);
+  wb_robot_step(2*TIME_STEP);
 
   // Try to remove root
   // this is an invalid action: nothing should be applied and Webots should not crash

--- a/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
+++ b/tests/api/controllers/supervisor_import_remove/supervisor_import_remove.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children_field), initial_root_children_count + 1,
                       "The number of children of the root node is not correct after the insertion of SPHERE2.");
 
-  wb_robot_step(2*TIME_STEP);
+  wb_robot_step(2 * TIME_STEP);
 
   // Try to remove root
   // this is an invalid action: nothing should be applied and Webots should not crash

--- a/tests/api/controllers/supervisor_notify_import_remove_mfnode/supervisor_notify_import_remove_mfnode.c
+++ b/tests/api/controllers/supervisor_notify_import_remove_mfnode/supervisor_notify_import_remove_mfnode.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
   const char *def_name = wb_supervisor_node_get_def(sphere2_node);
   ts_assert_string_equal(def_name, "SPHERE2", "Wrong DEF name for top node at index 5: found %s, expected SPHERE2.", def_name);
 
-  wb_robot_step(TIME_STEP);
+  wb_robot_step(2*TIME_STEP);
 
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children), node_count - 1,
                       "Wrong number of root nodes after removing SPHERE2.");

--- a/tests/api/controllers/supervisor_notify_import_remove_mfnode/supervisor_notify_import_remove_mfnode.c
+++ b/tests/api/controllers/supervisor_notify_import_remove_mfnode/supervisor_notify_import_remove_mfnode.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
   const char *def_name = wb_supervisor_node_get_def(sphere2_node);
   ts_assert_string_equal(def_name, "SPHERE2", "Wrong DEF name for top node at index 5: found %s, expected SPHERE2.", def_name);
 
-  wb_robot_step(2*TIME_STEP);
+  wb_robot_step(2 * TIME_STEP);
 
   ts_assert_int_equal(wb_supervisor_field_get_count(root_children), node_count - 1,
                       "Wrong number of root nodes after removing SPHERE2.");


### PR DESCRIPTION
**Description**

Change the controllers associated with the `supervisor_import_remove.wbt` test so that the `SPHERE2` node does not get removed by `wb_supervisor_node_remove()` until a full step after it's been checked for. This is necessary because `wb_supervisor_node_remove()` is immediate. Without this change, the test fails for me approximately 20% of the time with "Wrong DEF name for top node at index 5: found , expected SPHERE2."

