### PR TITLE
Keep track of selected node pane tab

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -9,6 +9,7 @@ Released on ??
     - Improved warnings when passing invalid arguments to [`wb_supervisor_node_enable_pose_tracking`/`wb_supervisor_node_disable_pose_tracking`](supervisor.md#wb_supervisor_node_enable_pose_tracking), [`wb_supervisor_node_enable_contact_points_tracking`/`wb_supervisor_node_disable_contact_points_tracking`](supervisor.md#wb_supervisor_node_enable_contact_points_tracking) and [`wb_supervisor_field_enable_sf_tracking`/`wb_supervisor_field_disable_sf_tracking`](supervisor.md#wb_supervisor_field_enable_sf_tracking) ([5638](https://github.com/cyberbotics/webots/pull/5638)).
     - Disable `Select..` button in SFString editor if the field has restricted values ([5663](https://github.com/cyberbotics/webots/pull/5663)).
     - Improved plot representation in default robot window when a NaN value is received from a device ([#5680](https://github.com/cyberbotics/webots/pull/5680)).
+    - Improved default selected tab in Field Editor when nodes are selected ([#5726](https://github.com/cyberbotics/webots/pull/5726)).
   - Bug Fixes
     - Fixed crash in Python API when a robot controller was using several cameras with different resolutions ([#5705](https://github.com/cyberbotics/webots/pull/5705)).
     - Fixed Python API `Supervisor.setSimulationMode` which was failing ([#5603](https://github.com/cyberbotics/webots/pull/5603)).

--- a/src/webots/scene_tree/WbNodePane.cpp
+++ b/src/webots/scene_tree/WbNodePane.cpp
@@ -94,9 +94,7 @@ void WbNodePane::stopEditing() {
   mPreviousTabName = mTabs->tabText(mTabs->currentIndex());
   // remove tabs
   disconnect(mTabs, &QTabWidget::currentChanged, this, &WbNodePane::updateSelectedTab);
-  const int tabsCount = mTabs->count();
-  for (int i = 0; i < tabsCount; ++i)
-    mTabs->removeTab(0);
+  mTabs->clear();
   connect(mTabs, &QTabWidget::currentChanged, this, &WbNodePane::updateSelectedTab);
 }
 

--- a/src/webots/scene_tree/WbNodePane.cpp
+++ b/src/webots/scene_tree/WbNodePane.cpp
@@ -36,7 +36,8 @@ WbNodePane::WbNodePane(QWidget *parent) :
   mNodeEditor(new WbNodeEditor()),
   mPhysicsViewer(new WbPhysicsViewer()),
   mPositionViewer(new WbPositionViewer()),
-  mVelocityViewer(new WbVelocityViewer()) {
+  mVelocityViewer(new WbVelocityViewer()),
+  mPreviousTabName(cTabNames[NODE_TAB]) {
   // tabs added only when this editor has focus
   // otherwise they affects the minimum size of other editors
   mLayout->addWidget(mTabs, 1, 1);
@@ -89,9 +90,11 @@ void WbNodePane::stopEditing() {
   mPositionViewer->clean();
   mVelocityViewer->clean();
   mNodeEditor->cleanValue();
+  // save last selected tab to restore it when a different node is selected
+  mPreviousTabName = mTabs->tabText(mTabs->currentIndex());
   // remove tabs
   disconnect(mTabs, &QTabWidget::currentChanged, this, &WbNodePane::updateSelectedTab);
-  int tabsCount = mTabs->count();
+  const int tabsCount = mTabs->count();
   for (int i = 0; i < tabsCount; ++i)
     mTabs->removeTab(0);
   connect(mTabs, &QTabWidget::currentChanged, this, &WbNodePane::updateSelectedTab);
@@ -159,13 +162,15 @@ void WbNodePane::enableTab(int index, QWidget *widget, bool enabled) {
     }
   }
 
-  int insertIndex = index;
-  if (insertIndex > mTabs->count())
-    insertIndex = mTabs->count();
-
   if (enabled) {
-    if (!tabExists)
-      mTabs->insertTab(insertIndex, widget, cTabNames[index]);
+    if (!tabExists) {
+      if (i > mTabs->count())
+        i = mTabs->count();
+      mTabs->insertTab(i, widget, cTabNames[index]);
+    }
+    if (cTabNames[index] == mPreviousTabName)
+      // restore previously selected tab
+      mTabs->setCurrentIndex(i);
   } else if (tabExists)
     mTabs->removeTab(i);
 }

--- a/src/webots/scene_tree/WbNodePane.hpp
+++ b/src/webots/scene_tree/WbNodePane.hpp
@@ -67,11 +67,11 @@ private:
   // save the selected tab name to restore it when a different node is selected
   QString mPreviousTabName;
 
+  void update();
   void enableTab(int index, QWidget *widget, bool enabled);
   void takeKeyboardFocus() override {}
 
 private slots:
-  void update();
   void updateSelectedTab();
 };
 

--- a/src/webots/scene_tree/WbNodePane.hpp
+++ b/src/webots/scene_tree/WbNodePane.hpp
@@ -64,6 +64,8 @@ private:
   WbPhysicsViewer *mPhysicsViewer;
   WbPositionViewer *mPositionViewer;
   WbVelocityViewer *mVelocityViewer;
+  // save the selected tab name to restore it when a different node is selected
+  QString mPreviousTabName;
 
   void enableTab(int index, QWidget *widget, bool enabled);
   void takeKeyboardFocus() override {}


### PR DESCRIPTION
Address #4925:
keep track of the selected tab in the Field Editor for nodes so that it can automatically restored when selecting a different node.