### PR TITLE
Enhancement sphere for appearances

### DIFF
--- a/resources/web/wwi/ProtoManager.js
+++ b/resources/web/wwi/ProtoManager.js
@@ -62,8 +62,7 @@ export default class ProtoManager {
     if (this.proto.isRoot && (this.proto.baseType.name === 'PBRAppearance' || this.proto.baseType.name === 'Appearance')) {
       const xml = document.implementation.createDocument('', '', null);
       const transform = xml.createElement('Transform');
-      this.proto.wrapperTransformID = getAnId();
-      transform.setAttribute('id', this.proto.wrapperTransformID);
+      transform.setAttribute('id', getAnId);
       transform.setAttribute('translation', '0 0 0.1');
 
       const shape = xml.createElement('Shape');

--- a/resources/web/wwi/ProtoManager.js
+++ b/resources/web/wwi/ProtoManager.js
@@ -59,7 +59,28 @@ export default class ProtoManager {
   async loadX3d() {
     let xml = this.getXmlOfMinimalScene();
     const scene = xml.getElementsByTagName('Scene')[0];
-    scene.appendChild(this.proto.toX3d());
+    if (this.proto.isRoot && (this.proto.baseType.name === 'PBRAppearance' || this.proto.baseType.name === 'Appearance')) {
+      const xml = document.implementation.createDocument('', '', null);
+      const transform = xml.createElement('Transform');
+      this.proto.wrapperTransformID = getAnId();
+      transform.setAttribute('id', this.proto.wrapperTransformID);
+      transform.setAttribute('translation', '0 0 0.1');
+
+      const shape = xml.createElement('Shape');
+      shape.setAttribute('id', getAnId());
+
+      const sphere = xml.createElement('Sphere');
+      sphere.setAttribute('id', getAnId());
+      sphere.setAttribute('radius', 0.1);
+      sphere.setAttribute('ico', 'FALSE');
+
+      shape.appendChild(sphere);
+      shape.appendChild(this.proto.toX3d());
+      transform.appendChild(shape);
+      scene.appendChild(transform);
+    } else
+      scene.appendChild(this.proto.toX3d());
+
     const x3d = new XMLSerializer().serializeToString(xml);
     this.#view.prefix = this.url.substr(0, this.url.lastIndexOf('/') + 1);
     this.#view.open(x3d, 'x3d', '', true);

--- a/resources/web/wwi/ProtoManager.js
+++ b/resources/web/wwi/ProtoManager.js
@@ -60,23 +60,8 @@ export default class ProtoManager {
     let xml = this.getXmlOfMinimalScene();
     const scene = xml.getElementsByTagName('Scene')[0];
     if (this.proto.isRoot && (this.proto.baseType.name === 'PBRAppearance' || this.proto.baseType.name === 'Appearance')) {
-      const xml = document.implementation.createDocument('', '', null);
-      const transform = xml.createElement('Transform');
-      transform.setAttribute('id', getAnId);
-      transform.setAttribute('translation', '0 0 0.1');
-
-      const shape = xml.createElement('Shape');
-      shape.setAttribute('id', getAnId());
-
-      const sphere = xml.createElement('Sphere');
-      sphere.setAttribute('id', getAnId());
-      sphere.setAttribute('radius', 0.1);
-      sphere.setAttribute('ico', 'FALSE');
-
-      shape.appendChild(sphere);
-      shape.appendChild(this.proto.toX3d());
-      transform.appendChild(shape);
-      scene.appendChild(transform);
+      const wrapper = this.createAppearanceWrapper();
+      scene.appendChild(wrapper);
     } else
       scene.appendChild(this.proto.toX3d());
 
@@ -220,5 +205,25 @@ export default class ProtoManager {
     xml.appendChild(scene);
 
     return xml;
+  }
+
+  createAppearanceWrapper() {
+    const xml = document.implementation.createDocument('', '', null);
+    const transform = xml.createElement('Transform');
+    transform.setAttribute('id', getAnId);
+    transform.setAttribute('translation', '0 0 0.1');
+
+    const shape = xml.createElement('Shape');
+    shape.setAttribute('id', getAnId());
+
+    const sphere = xml.createElement('Sphere');
+    sphere.setAttribute('id', getAnId());
+    sphere.setAttribute('radius', 0.1);
+    sphere.setAttribute('ico', 'FALSE');
+
+    shape.appendChild(sphere);
+    shape.appendChild(this.proto.toX3d());
+    transform.appendChild(shape);
+    return transform;
   }
 }

--- a/resources/web/wwi/protoVisualizer/Parameter.js
+++ b/resources/web/wwi/protoVisualizer/Parameter.js
@@ -124,7 +124,7 @@ export default class Parameter {
 
   removeNode(view, index) {
     if (this.type !== VRML.MFNode)
-      throw new Error('Item insertion is possible only for MFNodes.')
+      throw new Error('Item insertion is possible only for MFNodes.');
 
     for (const link of this.parameterLinks)
       link.removeNode(view, index);
@@ -173,7 +173,6 @@ export default class Parameter {
           // delete existing node
           const p = baseNode.getParameterByName(this.name);
           const id = p.value.value.getBaseNode().id;
-
           view.x3dScene.processServerMessage(`delete: ${id.replace('n', '')}`);
         }
 

--- a/resources/web/wwi/test.html
+++ b/resources/web/wwi/test.html
@@ -113,7 +113,7 @@
   // OBJECTS
   // webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/objects/road/protos/Road.proto");
   // webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/objects/road/protos/HelicoidalRoadSegment.proto");
-   webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/objects/buildings/protos/SimpleBuilding.proto"); // alias broken
+  //  webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/objects/buildings/protos/SimpleBuilding.proto"); // alias broken
   //  webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/vehicles/protos/tesla/TeslaModel3.proto"); works but super slow
   //  webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/vehicles/protos/generic/Truck.proto");
   //  webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/feature-web-proto/projects/objects/cabinet/protos/Cabinet.proto"); // wrong defs ?
@@ -122,6 +122,8 @@
   // webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/objects/balls/protos/SoccerBall.proto");
   //webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/objects/chairs/protos/OfficeChair.proto");
   // webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/samples/robotbenchmark/wall_following/protos/LinkedWalls.proto");
+  webotsView.loadProto("https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/appearances/protos/Grass.proto");
+
   // DEMO PROTO
   // webotsView.loadProto("protos/ProtoMf.proto");
   // webotsView.loadProto("protos/ProtoSensor.proto");


### PR DESCRIPTION
For proto web viewer, when the Proto is an `Appearance`/`PBRAppearance` we add a sphere geometry to be able to see the appearance, and a transform such that the sphere is not in the floor.

At first I tought I needed to keep the transform id to replace it on regeneration but finally we alway reuse the same so I think that it is useless.

preview: https://proto.webots.cloud/run?version=R2023b&url=https://github.com/BenjaminDeleze/sandbox/blob/master/protoExample/protos/Grass.proto&type=undefined