### PR TITLE
Fix notification after regeneration

### DIFF
--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -178,9 +178,7 @@ export default class X3dScene {
     let parentNode;
     if (typeof parentId !== 'undefined') {
       parentNode = WbWorld.instance.nodes.get('n' + parentId);
-      parentNode.isPreFinalizedCalled = false;
-      parentNode.wrenObjectsCreatedCalled = false;
-      parentNode.isPostFinalizedCalled = false;
+      parentNode.unfinalize();
     }
 
     const parser = new Parser(webots.currentView.prefix);

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -179,6 +179,7 @@ export default class X3dScene {
     if (typeof parentId !== 'undefined') {
       parentNode = WbWorld.instance.nodes.get('n' + parentId);
       parentNode.isPreFinalizedCalled = false;
+      parentNode.wrenObjectsCreatedCalled = false;
       parentNode.isPostFinalizedCalled = false;
     }
 
@@ -187,11 +188,9 @@ export default class X3dScene {
     await parser.parse(x3dObject, this.renderer, false, parentNode, callback);
 
     const node = WbWorld.instance.nodes.get(parser.rootNodeId);
-    if (typeof parentId !== 'undefined') {
-      node.finalize();
-      if (parentNode instanceof WbShape) // TODO: this might be improved with a onchange trigger
-        parentNode.updateAppearance();
-    } else
+    if (typeof parentId !== 'undefined')
+      parentNode.finalize();
+    else
       node.finalize();
   }
 

--- a/resources/web/wwi/nodes/WbBaseNode.js
+++ b/resources/web/wwi/nodes/WbBaseNode.js
@@ -24,6 +24,16 @@ export default class WbBaseNode {
     WbWorld.instance.nodes.delete(this.id);
   }
 
+  unfinalize() {
+    this.isPreFinalizedCalled = false;
+    this.wrenObjectsCreatedCalled = false;
+    this.isPostFinalizedCalled = false;
+    for (const useId of this.useList) {
+      const useNode = WbWorld.instance.nodes.get(useId);
+      useNode?.unfinalize();
+    }
+  }
+
   finalize() {
     if (!this.isPreFinalizedCalled)
       this.preFinalize();
@@ -36,6 +46,7 @@ export default class WbBaseNode {
 
     for (const useId of this.useList) {
       const useNode = WbWorld.instance.nodes.get(useId);
+      console.log('notifying', useNode.id)
       useNode.finalize();
     }
   }

--- a/resources/web/wwi/nodes/WbBaseNode.js
+++ b/resources/web/wwi/nodes/WbBaseNode.js
@@ -28,7 +28,7 @@ export default class WbBaseNode {
     this.isPreFinalizedCalled = false;
     this.wrenObjectsCreatedCalled = false;
     this.isPostFinalizedCalled = false;
-    for (const useId of this.useList) {
+    for (const useId of this.useList) { // notify USE nodes to do the same
       const useNode = WbWorld.instance.nodes.get(useId);
       useNode?.unfinalize();
     }
@@ -46,7 +46,6 @@ export default class WbBaseNode {
 
     for (const useId of this.useList) {
       const useNode = WbWorld.instance.nodes.get(useId);
-      console.log('notifying', useNode.id)
       useNode.finalize();
     }
   }


### PR DESCRIPTION
**Description**

Fixes `colorOverride` parameter not having an effect after regeneration. Specifically, it fixes the `Grass.proto`. The reason the change didn't happen is that the wren objects of the regenerated node were not created (`wrenObjectsCreatedCalled` was always true). Fixing this issue however broke the DEF-USE mechanism for the OfficeChair `legAppearance` (appearance changes no longer propagated to all legs). The issue was that the process of "unfinalizing" the parent (Shape) node to which we're changing the appearance occurred only for the DEF node, and we weren't doing the same for the parent of the USE ones. In short, when finalizing a DEF node we were notifying all USE nodes, however when "unfinalizing" it, we did so only for the DEF and not the USE ones, which resulted in the nodes existing on the webotsjs side but being white

The similar issue in `OfficeChair > BrushedAluminium > colorOverride` has a completely different source, in this case the problem is not the regeneration but rather that a non-existant webotsjs node is being notified, so this fix doesn't solve that. This issue is being handled separately 

https://proto.webots.cloud/run?version=R2023b&url=https://github.com/BenjaminDeleze/sandbox/blob/master/protoExample/protos/Grass.proto&type=undefined

https://proto.webots.cloud/run?version=R2023b&url=https://github.com/BenjaminDeleze/sandbox/blob/master/protoExample/protos/OfficeChair.proto
