### PR TITLE
WIKI: Update python image grab example code

### DIFF
--- a/docs/reference/rangefinder.md
+++ b/docs/reference/rangefinder.md
@@ -566,8 +566,8 @@ Their content are identical but their handling is of course different.
 > `buffer` is significantly faster than `list`, and can easily be wrapped using external libraries such as NumPy:
 
 > ```python
-> image_bytes = range_finder.getRangeImage(data_type="buffer")
-> image_np = np.frombuffer(image_bytes, dtype=np.float32)
+> image_c_ptr = range_finder.getRangeImage(data_type="buffer")
+> image_np = np.ctypeslib.as_array(image_c_ptr, (range_finder.getWidth()*range_finder.getHeight(),))
 > ```
 
 ---

--- a/docs/reference/rangefinder.md
+++ b/docs/reference/rangefinder.md
@@ -567,7 +567,7 @@ Their content are identical but their handling is of course different.
 
 > ```python
 > image_c_ptr = range_finder.getRangeImage(data_type="buffer")
-> image_np = np.ctypeslib.as_array(image_c_ptr, (range_finder.getWidth()*range_finder.getHeight(),))
+> image_np = np.ctypeslib.as_array(image_c_ptr, (range_finder.getWidth() * range_finder.getHeight(),))
 > ```
 
 ---


### PR DESCRIPTION

**Description**
The provided c array to numpy array code did not successfully receive the whole array for me, and instead I found success using numpy's conversion from  base ctypes. This I propose this change for future users.

**Documentation**
[If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
](https://cyberbotics.com/doc/reference/rangefinder?version=develop)