### PR TITLE
Improve message on package upload failure

### DIFF
--- a/scripts/packaging/publish_release.py
+++ b/scripts/packaging/publish_release.py
@@ -173,6 +173,6 @@ for release in repo.get_releases():
         break
 
 if not releaseFound:  # if it does not exist, it should have been created by the script itself
-    print('Error, release "%s" should exist by now but does not.' % release.title)
+    print('Error, release "%s" should exist by now but does not.' % title)
 else:
     print('Upload finished.')


### PR DESCRIPTION
Refers to: https://github.com/cyberbotics/webots/actions/runs/3915575940/jobs/6693885527#step:9:55

The message should reflect what we're looking for, not the last item checked