### PR TITLE
Improve Charger behavior

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -6,6 +6,7 @@ Released on ??
     - Deprecated the C and MATLAB API functions `wb_supervisor_node_enable/disable_contact_point_tracking` in favor of `wb_supervisor_node_enable/disable_contact_points_tracking` to be more consistent with other APIs ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
   - Enhancements
     - Improved the robots' grippers such that they use coupled motors ([#5694](https://github.com/cyberbotics/webots/pull/5694)).
+    - Improved the [Charger](charger.md) behavior ([#5771](https://github.com/cyberbotics/webots/pull/5771)).
 
 ## Webots R2023a Revision 1
 Released on ??

--- a/docs/reference/charger.md
+++ b/docs/reference/charger.md
@@ -20,6 +20,7 @@ Instead, it is a battery itself: it accumulates energy with time.
 It could be compared to a solar power panel charging a battery.
 When the robot comes to get energy, it can't get more than the charger has presently accumulated.
 Note that only one robot can be charged at a time.
+Additionally, if a robot is connected, the charger cannot recharge itself.
 
 The appearance of the [Charger](#charger) node can be altered by its current energy.
 When the [Charger](#charger) node is full, the resulting color corresponds to its `emissiveColor` field, while when the [Charger](#charger) node is empty, its resulting color corresponds to its original one.

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -49,7 +49,6 @@ void WbCharger::init() {
   mGradual = findSFBool("gradual");
   mParentRobot = NULL;
   mRobot = NULL;
-  mDone = true;
   mElementsUpdateRequired = true;
   if (mBattery->size() > CURRENT_ENERGY)
     mSavedEnergies[stateId()] = mBattery->item(CURRENT_ENERGY);
@@ -182,43 +181,42 @@ void WbCharger::prePhysicsStep(double ms) {
   foreach (WbRobot *const robot, robots)
     checkContact(robot);
 
-  double currentEnergy = mBattery->item(CURRENT_ENERGY);
+  const double currentEnergy = mBattery->item(CURRENT_ENERGY);
   const double maxEnergy = mBattery->item(MAX_ENERGY);
   const double energyUploadSpeed = mBattery->item(ENERGY_UPLOAD_SPEED);
+  double newEnergy = currentEnergy;
 
   // The Charger collects energy from the Nature (Sun, Earth, Water, etc.)
   if (mRobot == NULL || mRobot->battery().size() < 3) {
-    currentEnergy += energyUploadSpeed * ms / 1000;
-    if (currentEnergy > maxEnergy)
-      currentEnergy = maxEnergy;
+    newEnergy += energyUploadSpeed * ms / 1000;
+    if (newEnergy > maxEnergy)
+      newEnergy = maxEnergy;
   } else {  // exchange of energy from the Charger to the Robot
-    double e = (mRobot->energyUploadSpeed() * ms) / 1000.0;
+    double e = (mRobot->energyUploadSpeed() * ms) / 1000.0
     if (e > currentEnergy) {  // robot cannot take more than available
       e = currentEnergy;
-      currentEnergy = 0.0;
+      newEnergy = 0.0;
     } else
-      currentEnergy -= e;  // transfer
+      newEnergy = currentEnergy - e;  // transfer
 
-    if (mDone == false && mRobot->battery().size() > 2) {  // else energy is wasted
+    if (mRobot->battery().size() > 2) {  // else energy is wasted
       double robotCurrentEnergy = mRobot->currentEnergy();
       // special case:
       //   if the current energy of the robot is already bigger that its max energy
-      //   the robot battery cannot be filled (useful for ratslife)
-      if (robotCurrentEnergy > mRobot->maxEnergy())
-        mDone = true;
+      //   the robot battery cannot be filled
+      if (robotCurrentEnergy >= mRobot->maxEnergy())
+        newEnergy = currentEnergy;  // no energy is transferred
       else {
         robotCurrentEnergy += e;
-        if (robotCurrentEnergy > mRobot->maxEnergy()) {
+        if (robotCurrentEnergy > mRobot->maxEnergy())
           robotCurrentEnergy = mRobot->maxEnergy();
-          mDone = true;
-        }
       }
       mRobot->setCurrentEnergy(robotCurrentEnergy);
     }
   }
 
   // store value in battery
-  mBattery->setItem(CURRENT_ENERGY, currentEnergy);
+  mBattery->setItem(CURRENT_ENERGY, newEnergy);
 
   // energy level
   const double r = currentEnergy / maxEnergy;
@@ -240,24 +238,19 @@ void WbCharger::checkContact(WbRobot *const r) {
     r2 *= 1.1;  // tolerance to maintain contact
   r2 *= r2;
   // printf("range^2: %g <= %g\n", norm2, r2);
-  if (norm2 > r2) {
-    // test if current robot is leaving
-    if (mRobot == r)
-      mBattery->setItem(CURRENT_ENERGY, 0.0);  // emtpy the Charger
+  if (norm2 > r2)
+    // current robot is leaving
     mRobot = NULL;
-    mDone = true;
-  } else if (mRobot == NULL && mBattery->item(CURRENT_ENERGY) == mBattery->item(MAX_ENERGY)) {
+  else if (mRobot == NULL) {
     mRobot = r;
-    mDone = false;
+    // now Charger is busy with that robot...
+    // printf("found one robot %p\n", (void *)robot);
   }
-  // now Charger is busy with that robot...
-  // printf("found one robot %p\n", (void *)robot);
 }
 
 void WbCharger::reset(const QString &id) {
   WbSolid::reset(id);
   mRobot = NULL;
-  mDone = true;
   if (mBattery->size() > CURRENT_ENERGY)
     mBattery->setItem(CURRENT_ENERGY, mSavedEnergies[id]);
   if (mBattery->size() > MAX_ENERGY)

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -192,7 +192,7 @@ void WbCharger::prePhysicsStep(double ms) {
     if (newEnergy > maxEnergy)
       newEnergy = maxEnergy;
   } else {  // exchange of energy from the Charger to the Robot
-    double e = (mRobot->energyUploadSpeed() * ms) / 1000.0
+    double e = (mRobot->energyUploadSpeed() * ms) / 1000.0;
     if (e > currentEnergy) {  // robot cannot take more than available
       e = currentEnergy;
       newEnergy = 0.0;

--- a/src/webots/nodes/WbCharger.hpp
+++ b/src/webots/nodes/WbCharger.hpp
@@ -56,7 +56,6 @@ private:
   // private fields
   const WbRobot *mParentRobot;
   WbRobot *mRobot;  // robot currently connected to the Charger
-  bool mDone;
   bool mElementsUpdateRequired;
   QList<VisualElement *> mVisualElements;
   QMap<QString, double> mSavedEnergies;


### PR DESCRIPTION
Addresses #5765:
continues with the Charger behavior refactor (see also  #2879) and improve the discharging behavior.
Changes:
* [x] remove reset of Changer battery level to 0 when a robot disconnects
* [x] remove transfer of energy from Changer to Robot if Robot battery is fully loaded
* [x] continue to transfer energy from Charger to Robot even after Robot was fully loaded
* [x] allow the Charger to connect to a Robot for transferring energy even if the Charger is not fully loaded