### PR TITLE
Avoid having Field.type undefined

### DIFF
--- a/lib/controller/python/controller/field.py
+++ b/lib/controller/python/controller/field.py
@@ -78,6 +78,8 @@ class Field:
                 self._ref = ctypes.c_void_p(wb.wb_supervisor_node_get_field_by_index(node._ref, index))
         if self._ref:
             self.type = wb.wb_supervisor_field_get_type(self._ref)
+        else:
+            self.type = None
 
     def getName(self) -> str:
         return self.name


### PR DESCRIPTION
Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>

**Description**
If the field cannot be found during construction, `Field.type` is left undefined. This is a fix for that. It avoids a crash e.g. when accessing `Field.value`.

**Documentation**
Not relevant

**Screenshots**
Not relevant

**Additional context**
None
