### PR TITLE
Web Proto: revert change

### DIFF
--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -465,7 +465,6 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const hideShowButton = this.#createHideShowButtom(currentMfId, addButton);
 
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
-    console.log(p)
     resetButton.onclick = () => {
       const nodesToRemove = document.getElementsByClassName('mf-id-' + currentMfId);
       let maxRowNumber = 0;

--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -337,13 +337,13 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg/images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.inputs[0].value = p.previous[0];
         p.inputs[1].value = p.previous[1];
         p.inputs[2].value = p.previous[2];
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg/images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = [p.inputs[0].value, p.inputs[1].value, p.inputs[2].value];
         p.inputs[0].value = parameter.defaultValue.value.x;
         p.inputs[1].value = parameter.defaultValue.value.y;
@@ -369,11 +369,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         input.value = p.previous;
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = input.value;
 
         const defaultValue = parameter.defaultValue.value;
@@ -428,12 +428,12 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.inputs[0].value = p.previous[0];
         p.inputs[1].value = p.previous[1];
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = [p.inputs[0].value, p.inputs[1].value];
         p.inputs[0].value = parameter.defaultValue.value.x;
         p.inputs[1].value = parameter.defaultValue.value.y;
@@ -475,11 +475,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
         nodesToRemove[i].parentNode.removeChild(nodesToRemove[i]);
       }
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         parameter.value = p.previous;
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = parameter.value;
         parameter.value = parameter.defaultValue.clone();
       }
@@ -1010,14 +1010,14 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.inputs[0].value = p.previous[0];
         p.inputs[1].value = p.previous[1];
         p.inputs[2].value = p.previous[2];
         p.inputs[3].value = p.previous[3];
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = [p.inputs[0].value, p.inputs[1].value, p.inputs[2].value, p.inputs[3].value];
         p.inputs[0].value = parameter.defaultValue.value.x;
         p.inputs[1].value = parameter.defaultValue.value.y;
@@ -1054,7 +1054,7 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
   #resetReset(node, isReset) {
     if (!isReset) {
       node.previous = undefined;
-      node.resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+      node.resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
     }
   }
 
@@ -1179,11 +1179,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.input.value = p.previous;
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = p.input.value;
         input.value = this.#stringRemoveQuote(parameter.defaultValue.value);
       }
@@ -1238,11 +1238,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.input.value = p.previous;
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = p.input.value;
         input.value = parameter.defaultValue.value;
       }
@@ -1359,11 +1359,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg)';
         p.input.value = p.previous;
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/revert.svg)';
         p.previous = p.input.value;
         input.value = parameter.defaultValue.value;
       }

--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -187,7 +187,8 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
       !isCreatingParameters)
       this.updateDevicesTabs();
 
-    if (parameter.isDefault() && parameter.type === VRML.SFBool)
+    if (parameter.isDefault() && (parameter.type === VRML.SFBool || parameter.type === VRML.SFNode ||
+        parameter.type === VRML.MFNode))
       this.#disableResetButton(resetButton);
     else if (!parameter.isDefault())
       this.#enableResetButton(resetButton);

--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -337,13 +337,13 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
     const resetButton = this.#createResetButton(parent, p.style.gridRow, parameter.name);
     resetButton.onclick = () => {
       if (typeof p.previous !== 'undefined') {
-        resetButton.style.backgroundImage = 'url(../images/icons/reload.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg/images/icons/reload.svg)';
         p.inputs[0].value = p.previous[0];
         p.inputs[1].value = p.previous[1];
         p.inputs[2].value = p.previous[2];
         p.previous = undefined;
       } else {
-        resetButton.style.backgroundImage = 'url(../images/icons/revert.svg)';
+        resetButton.style.backgroundImage = 'url(https://cyberbotics.com/wwi/proto/images/icons/reload.svg/images/icons/revert.svg)';
         p.previous = [p.inputs[0].value, p.inputs[1].value, p.inputs[2].value];
         p.inputs[0].value = parameter.defaultValue.value.x;
         p.inputs[1].value = parameter.defaultValue.value.y;

--- a/resources/web/wwi/images/icons/revert.svg
+++ b/resources/web/wwi/images/icons/revert.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="reload-svg"
+   x="0px"
+   y="0px"
+   viewBox="0 0 512 512"
+   style="enable-background:new 0 0 512 512;"
+   xml:space="preserve"
+   sodipodi:docname="revert.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1595" /><sodipodi:namedview
+   id="namedview1593"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="0.65186406"
+   inkscape:cx="675.75439"
+   inkscape:cy="551.49535"
+   inkscape:window-width="1920"
+   inkscape:window-height="1016"
+   inkscape:window-x="1920"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="reload-svg" />
+<style
+   type="text/css"
+   id="style1588">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:40;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<polyline
+   id="arrow"
+   class="st0"
+   points="397.3,83.8 397.3,183 298.1,183 "
+   style="stroke:#ffffff;stroke-opacity:1"
+   transform="rotate(136.19693,232.40367,109.20461)" />
+
+<path
+   style="fill:none;stroke:#ffffff;stroke-width:38.75;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+   d="m 90.898141,170.86375 4.30837,-0.73394 c 351.602579,-23.62029 572.417279,221.9914 3.82354,238.67551"
+   id="path3687"
+   sodipodi:nodetypes="ccc" /></svg>


### PR DESCRIPTION
**Description**
This PR implements a feature discussed some time ago: when someone reset a field, the reset button is change to a revert one (instead of being disabled).
When clicking on it, it will revert to latest value set by the user.
If the user enters a new value after the reset, the revert button is replaced by the reset button.
The feature is available for all fields except for SFBool, SFNode and MFNode

You can test it here: https://proto.webots.cloud/run?version=R2023b&url=https://github.com/cyberbotics/webots/blob/feature-web-proto/projects/robots/softbank/nao/protos/Nao.proto&type=undefined