### PR TITLE
Speed up contact processing.

### DIFF
--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -668,11 +668,13 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   if (!p1 || !p2) {
     WbRobot *const robot1 = dynamic_cast<WbRobot *>(s1);
     WbRobot *const robot2 = dynamic_cast<WbRobot *>(s2);
+    // Ensure that the deepest contact point is first for calls to collideKinematicRobots() below.
+    std::nth_element(contact, contact, contact + n,
+                     [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
     if (robot1 && !p1 && !isRayGeom2 && robot1->kinematicDifferentialWheels()) {
       wg1->setColliding();
       cl->mCollisionedRobots.append(robot1->kinematicDifferentialWheels());
       if (robot2 && !p2 && robot2->kinematicDifferentialWheels()) {
-        dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));  // we want only one contact point
         wg2->setColliding();
         cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
         collideKinematicRobots(robot1->kinematicDifferentialWheels(), true, contact, true);
@@ -682,7 +684,6 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       return;
     }
     if (robot2 && !p2 && !isRayGeom1 && robot2->kinematicDifferentialWheels()) {
-      dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));
       wg2->setColliding();
       cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
       collideKinematicRobots(robot2->kinematicDifferentialWheels(), false, contact, false);

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -644,13 +644,12 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   if (n == MAX_CONTACTS)
-    WbLog::warning(QObject::tr("%1 contact points found so others might be ignored.").arg(MAX_CONTACTS), false, WbLog::ODE);
+    cl->warnMaxContactPointsFound();
 
   if (n > MAX_CONTACT_JOINTS) {
-    WbLog::warning(
-      QObject::tr("%1 contact points found but only the %2 deepest are used.").arg(MAX_CONTACTS).arg(MAX_CONTACT_JOINTS), false,
-      WbLog::ODE);
-    std::sort(contact, contact + n, [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
+    cl->warnMoreContactPointsThanContactJoints();
+    std::nth_element(contact, contact + MAX_CONTACT_JOINTS, contact + n,
+                     [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
     n = MAX_CONTACT_JOINTS;
   }
 

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -23,6 +23,9 @@
 #include <ode/ode.h>
 #include <QtCore/QList>
 
+#include "WbLog.hpp"
+#include "WbSimulationState.hpp"
+
 class WbContactProperties;
 class WbImmersionProperties;
 class WbOdeContext;
@@ -68,6 +71,23 @@ private:
   static void odeSensorRaysUpdate(int threadID);
   static const long long int WEBOTS_MAGIC_NUMBER;
   bool mSwapJointContactBuffer;
+
+  double lastMaxContactPointsFoundWarnTime = -INFINITY;
+  void warnMaxContactPointsFound() {
+    const double currentSimulationTime = WbSimulationState::instance()->time();
+    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+      WbLog::warning(QObject::tr("Maximum number of contact points found so others might be ignored."), false, WbLog::ODE);
+      lastMaxContactPointsFoundWarnTime = currentSimulationTime;
+    }
+  }
+  double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
+  void warnMoreContactPointsThanContactJoints() {
+    const double currentSimulationTime = WbSimulationState::instance()->time();
+    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+      WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
+      lastMoreContactPointsThanContactJointsWarnTime = currentSimulationTime;
+    }
+  }
 };
 
 #endif

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -83,7 +83,7 @@ private:
   double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
   void warnMoreContactPointsThanContactJoints() {
     const double currentSimulationTime = WbSimulationState::instance()->time();
-    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+    if (currentSimulationTime > lastMoreContactPointsThanContactJointsWarnTime + 1000.0) {
       WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
       lastMoreContactPointsThanContactJointsWarnTime = currentSimulationTime;
     }


### PR DESCRIPTION
Rate limit warnings.
Use std::nth_element() instead of std::sort().

**Description**
PR #5776 caused excessive warnings when there were more than 10 contact points and those warnings greatly slowed down physics . This PR rate limits those warnings and also adds a small optimization to the algorithm used to find the deepest contact points.

The remaining increase in physics time is overwhelmingly due to the time required for ODE to find the additional contact points. [Edit: See next comment for updated performance data.] ~A particularly challenging test is `collision_multiple_trimesh.wbt`. With this PR, the physics time for that test only increases by approximately 2.3x when using 100 (or even 1000) vs 10 for MAX_CONTACTS. On my machine, the speed factor goes from 22x to 11x.~

