### PR TITLE
Hotfix to find all contacts quickly

### DIFF
--- a/projects/robots/rec/fabtino/worlds/fabtino.wbt
+++ b/projects/robots/rec/fabtino/worlds/fabtino.wbt
@@ -321,7 +321,7 @@ PlasticCrate {
 CardboardBox {
   translation -6.187 -0.937 1.02
   rotation 1 0 0 1.5708
-  name "cardboard box(1)"
+  name "cardboard box(2)"
   size 0.3 0.23 0.23
 }
 SquareManhole {
@@ -429,7 +429,7 @@ CardboardBox {
 CardboardBox {
   translation -1.198389 2.100678 0.75
   rotation 0 0 1 0.523598
-  name "cardboard box(2)"
+  name "cardboard box(1)"
   size 0.6 0.4 0.3
 }
 RectangleArena {

--- a/projects/robots/rec/fabtino/worlds/fabtino.wbt
+++ b/projects/robots/rec/fabtino/worlds/fabtino.wbt
@@ -14,6 +14,7 @@ EXTERNPROTO "webots://projects/appearances/protos/GlossyPaint.proto"
 EXTERNPROTO "webots://projects/objects/kitchen/components/protos/Sink.proto"
 EXTERNPROTO "webots://projects/objects/factory/conveyors/protos/ConveyorBelt.proto"
 EXTERNPROTO "webots://projects/appearances/protos/CorrugatedMetal.proto"
+EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 EXTERNPROTO "webots://projects/objects/factory/containers/protos/PlasticCrate.proto"
 EXTERNPROTO "webots://projects/objects/factory/manhole/protos/SquareManhole.proto"
 EXTERNPROTO "webots://projects/objects/tables/protos/Table.proto"
@@ -318,11 +319,10 @@ PlasticCrate {
   name "plastic crate(5)"
   size 1 1 0.9
 }
-PlasticCrate {
-  translation -6.187 -0.937 0.9
-  name "Kasten(2)"
-  size 0.4 0.23 0.12
-  mass 0.92
+CardboardBox {
+  translation -6.187 -0.937 1.02
+  rotation 1 0 0 1.5708
+  size 0.3 0.23 0.23
 }
 SquareManhole {
   translation 0.560459 -1.782 -0.03

--- a/projects/robots/rec/fabtino/worlds/fabtino.wbt
+++ b/projects/robots/rec/fabtino/worlds/fabtino.wbt
@@ -14,7 +14,6 @@ EXTERNPROTO "webots://projects/appearances/protos/GlossyPaint.proto"
 EXTERNPROTO "webots://projects/objects/kitchen/components/protos/Sink.proto"
 EXTERNPROTO "webots://projects/objects/factory/conveyors/protos/ConveyorBelt.proto"
 EXTERNPROTO "webots://projects/appearances/protos/CorrugatedMetal.proto"
-EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 EXTERNPROTO "webots://projects/objects/factory/containers/protos/PlasticCrate.proto"
 EXTERNPROTO "webots://projects/objects/factory/manhole/protos/SquareManhole.proto"
 EXTERNPROTO "webots://projects/objects/tables/protos/Table.proto"
@@ -322,6 +321,7 @@ PlasticCrate {
 CardboardBox {
   translation -6.187 -0.937 1.02
   rotation 1 0 0 1.5708
+  name "cardboard box(1)"
   size 0.3 0.23 0.23
 }
 SquareManhole {
@@ -429,7 +429,7 @@ CardboardBox {
 CardboardBox {
   translation -1.198389 2.100678 0.75
   rotation 0 0 1 0.523598
-  name "cardboard box(1)"
+  name "cardboard box(2)"
   size 0.6 0.4 0.3
 }
 RectangleArena {

--- a/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
+++ b/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
@@ -14,7 +14,6 @@ EXTERNPROTO "webots://projects/appearances/protos/GlossyPaint.proto"
 EXTERNPROTO "webots://projects/objects/kitchen/components/protos/Sink.proto"
 EXTERNPROTO "webots://projects/objects/factory/conveyors/protos/ConveyorBelt.proto"
 EXTERNPROTO "webots://projects/appearances/protos/CorrugatedMetal.proto"
-EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 EXTERNPROTO "webots://projects/objects/factory/containers/protos/PlasticCrate.proto"
 EXTERNPROTO "webots://projects/objects/factory/manhole/protos/SquareManhole.proto"
 EXTERNPROTO "webots://projects/objects/tables/protos/Table.proto"
@@ -322,6 +321,7 @@ PlasticCrate {
 CardboardBox {
   translation -6.187 -0.937 1.02
   rotation 1 0 0 1.5708
+  name "cardboard box(2)"
   size 0.3 0.23 0.23
 }
 SquareManhole {

--- a/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
+++ b/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
@@ -14,6 +14,7 @@ EXTERNPROTO "webots://projects/appearances/protos/GlossyPaint.proto"
 EXTERNPROTO "webots://projects/objects/kitchen/components/protos/Sink.proto"
 EXTERNPROTO "webots://projects/objects/factory/conveyors/protos/ConveyorBelt.proto"
 EXTERNPROTO "webots://projects/appearances/protos/CorrugatedMetal.proto"
+EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 EXTERNPROTO "webots://projects/objects/factory/containers/protos/PlasticCrate.proto"
 EXTERNPROTO "webots://projects/objects/factory/manhole/protos/SquareManhole.proto"
 EXTERNPROTO "webots://projects/objects/tables/protos/Table.proto"
@@ -42,7 +43,6 @@ EXTERNPROTO "webots://projects/devices/robotiq/protos/Robotiq3fGripper.proto"
 EXTERNPROTO "webots://projects/robots/universal_robots/protos/UR5e.proto"
 EXTERNPROTO "webots://projects/robots/universal_robots/protos/UR10e.proto"
 EXTERNPROTO "webots://projects/objects/drinks/protos/Can.proto"
-EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 
 WorldInfo {
   info [

--- a/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
+++ b/projects/robots/robotnik/summit_xl_steel/worlds/summit_xl_steel.wbt
@@ -42,6 +42,7 @@ EXTERNPROTO "webots://projects/devices/robotiq/protos/Robotiq3fGripper.proto"
 EXTERNPROTO "webots://projects/robots/universal_robots/protos/UR5e.proto"
 EXTERNPROTO "webots://projects/robots/universal_robots/protos/UR10e.proto"
 EXTERNPROTO "webots://projects/objects/drinks/protos/Can.proto"
+EXTERNPROTO "webots://projects/objects/factory/containers/protos/CardboardBox.proto"
 
 WorldInfo {
   info [
@@ -318,11 +319,10 @@ PlasticCrate {
   name "plastic crate(5)"
   size 1 1 0.9
 }
-PlasticCrate {
-  translation -6.187 -0.937 0.903
-  name "Kasten(2)"
-  size 0.4 0.23 0.12
-  mass 0.92
+CardboardBox {
+  translation -6.187 -0.937 1.02
+  rotation 1 0 0 1.5708
+  size 0.3 0.23 0.23
 }
 SquareManhole {
   translation 0.560459 -1.782 -0.03

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -686,11 +686,13 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   if (!p1 || !p2) {
     WbRobot *const robot1 = dynamic_cast<WbRobot *>(s1);
     WbRobot *const robot2 = dynamic_cast<WbRobot *>(s2);
+    // Ensure that the deepest contact point is first for calls to collideKinematicRobots() below.
+    std::nth_element(contact, contact, contact + n,
+                     [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
     if (robot1 && !p1 && !isRayGeom2 && robot1->kinematicDifferentialWheels()) {
       wg1->setColliding();
       cl->mCollisionedRobots.append(robot1->kinematicDifferentialWheels());
       if (robot2 && !p2 && robot2->kinematicDifferentialWheels()) {
-        dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));  // we want only one contact point
         wg2->setColliding();
         cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
         collideKinematicRobots(robot1->kinematicDifferentialWheels(), true, contact, true);
@@ -700,7 +702,6 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
       return;
     }
     if (robot2 && !p2 && !isRayGeom1 && robot2->kinematicDifferentialWheels()) {
-      dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));
       wg2->setColliding();
       cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
       collideKinematicRobots(robot2->kinematicDifferentialWheels(), false, contact, false);

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -466,18 +466,12 @@ void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID
 
 void WbSimulationCluster::warnMoreContactPointsThanContactJoints() {
   static std::mutex mutex;
-  static std::atomic<double> lastWarningTime(-INFINITY);  // std::atomic<> just in case doubles are not atomic.
+  std::lock_guard<std::mutex> lock(mutex);
+  static double lastWarningTime = -INFINITY;
   const double currentSimulationTime = WbSimulationState::instance()->time();
   if (currentSimulationTime > lastWarningTime + 1000.0) {
-    // We almost definitely need to create the warning, but there is a small
-    // possibility that another thread has come to the same conclusion
-    // simultaneously, so redo the check using the mutex. We do this after the
-    // initial check, to minimize how often we need to acquire the lock.
-    std::lock_guard<std::mutex> lock(mutex);
-    if (currentSimulationTime > lastWarningTime + 1000.0) {
-      WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
-      lastWarningTime = currentSimulationTime;
-    }
+    WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
+    lastWarningTime = currentSimulationTime;
   }
 }
 

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -50,11 +50,6 @@
 // physics engine scales with the cube of the number of joints.
 #define MAX_CONTACT_JOINTS 10
 
-// The maximum number of contact points to look for when colliding 2 geometries. A larger number decreases the
-// chances that contact points in important areas won't be considered. Of the (at most) MAX_CONTACTS points that
-// might be found, joints will only be created for the deepest MAX_CONTACT_JOINTS points. -1 means all points.
-#define MAX_CONTACTS -1
-
 // "webots" where each character is replaced by its ascii hexadecimal number.
 const long long int WbSimulationCluster::WEBOTS_MAGIC_NUMBER = 0x7765626F7473LL;
 
@@ -638,12 +633,9 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     }
   }
 
-  int maxContactPoints = MAX_CONTACTS;
   const int maxContactJoints = MAX_CONTACT_JOINTS;
 
-  const bool findAllContactPoints = maxContactPoints == -1;
-  if (findAllContactPoints)
-    maxContactPoints = std::max<size_t>(100, cl->mContactVector.capacity());
+  int maxContactPoints = std::max<size_t>(100, cl->mContactVector.capacity());
 
   int n;
   dContact *contact;
@@ -653,12 +645,8 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     n = dCollide(o1, o2, maxContactPoints, &contact[0].geom, sizeof(dContact));
     if (n < maxContactPoints)
       break;
-    else if (findAllContactPoints)
+    else
       maxContactPoints *= 10;
-    else {
-      cl->warnMaxContactPointsFound();
-      break;
-    }
   }
 
   if (n == 0)

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -52,8 +52,8 @@
 
 // The maximum number of contact points to look for when colliding 2 geometries. A larger number decreases the
 // chances that contact points in important areas won't be considered. Of the (at most) MAX_CONTACTS points that
-// might be found, joints will only be created for the deepest MAX_CONTACT_JOINTS points.
-#define MAX_CONTACTS 100
+// might be found, joints will only be created for the deepest MAX_CONTACT_JOINTS points. -1 means all points.
+#define MAX_CONTACTS -1
 
 // "webots" where each character is replaced by its ascii hexadecimal number.
 const long long int WbSimulationCluster::WEBOTS_MAGIC_NUMBER = 0x7765626F7473LL;
@@ -638,19 +638,37 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     }
   }
 
-  dContact contact[MAX_CONTACTS];
-  int n = dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));
+  int maxContactPoints = MAX_CONTACTS;
+  const int maxContactJoints = MAX_CONTACT_JOINTS;
+
+  const bool findAllContactPoints = maxContactPoints == -1;
+  if (findAllContactPoints)
+    maxContactPoints = std::max<size_t>(100, cl->mContactVector.capacity());
+
+  int n;
+  dContact *contact;
+  while (true) {
+    cl->mContactVector.reserve(maxContactPoints);
+    contact = cl->mContactVector.data();
+    n = dCollide(o1, o2, maxContactPoints, &contact[0].geom, sizeof(dContact));
+    if (n < maxContactPoints)
+      break;
+    else if (findAllContactPoints)
+      maxContactPoints *= 10;
+    else {
+      cl->warnMaxContactPointsFound();
+      break;
+    }
+  }
+
   if (n == 0)
     return;
 
-  if (n == MAX_CONTACTS)
-    cl->warnMaxContactPointsFound();
-
-  if (n > MAX_CONTACT_JOINTS) {
+  if (n > maxContactJoints) {
     cl->warnMoreContactPointsThanContactJoints();
-    std::nth_element(contact, contact + MAX_CONTACT_JOINTS, contact + n,
+    std::nth_element(contact, contact + maxContactJoints, contact + n,
                      [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
-    n = MAX_CONTACT_JOINTS;
+    n = maxContactJoints;
   }
 
   WbTouchSensor *const ts1 = dynamic_cast<WbTouchSensor *>(s1);

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -465,7 +465,7 @@ void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID
 
 void WbSimulationCluster::warnMoreContactPointsThanContactJoints() {
   static QMutex mutex;
-  QMutexLocker lock(&mutex);
+  QMutexLocker<QMutex> lock(&mutex);
   static double lastWarningTime = -INFINITY;
   const double currentSimulationTime = WbSimulationState::instance()->time();
   if (currentSimulationTime > lastWarningTime + 1000.0) {

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -644,13 +644,12 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   if (n == MAX_CONTACTS)
-    WbLog::warning(QObject::tr("%1 contact points found so others might be ignored.").arg(MAX_CONTACTS), false, WbLog::ODE);
+    cl->warnMaxContactPointsFound();
 
   if (n > MAX_CONTACT_JOINTS) {
-    WbLog::warning(
-      QObject::tr("%1 contact points found but only the %2 deepest are used.").arg(MAX_CONTACTS).arg(MAX_CONTACT_JOINTS), false,
-      WbLog::ODE);
-    std::sort(contact, contact + n, [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
+    cl->warnMoreContactPointsThanContactJoints();
+    std::nth_element(contact, contact + MAX_CONTACT_JOINTS, contact + n,
+                     [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
     n = MAX_CONTACT_JOINTS;
   }
 

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -653,7 +653,7 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     return;
 
   if (n > maxContactJoints) {
-    cl->warnMoreContactPointsThanContactJoints();
+    WbSimulationCluster::warnMoreContactPointsThanContactJoints();
     std::nth_element(contact, contact + maxContactJoints, contact + n,
                      [](const dContact &c1, const dContact &c2) { return (c1.geom.depth > c2.geom.depth); });
     n = maxContactJoints;

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -39,14 +39,13 @@
 #include "WbWorldInfo.hpp"
 
 #include <QtCore/QMutex>
+#include <QtCore/QMutexLocker>
 
 #include <ode/fluid_dynamics/ode_fluid_dynamics.h>
 #include <ode/ode_MT.h>
 
 #include <cassert>
 #include <limits>
-#include <mutex>
-#include <vector>
 
 // The maximum number of contact joints to create. Note that the time to compute a physics timestep with the ODE
 // physics engine scales with the cube of the number of joints.
@@ -465,8 +464,8 @@ void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID
 }
 
 void WbSimulationCluster::warnMoreContactPointsThanContactJoints() {
-  static std::mutex mutex;
-  std::lock_guard<std::mutex> lock(mutex);
+  static QMutex mutex;
+  QMutexLocker lock(&mutex);
   static double lastWarningTime = -INFINITY;
   const double currentSimulationTime = WbSimulationState::instance()->time();
   if (currentSimulationTime > lastWarningTime + 1000.0) {
@@ -647,7 +646,7 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
   }
 
   const int maxContactJoints = MAX_CONTACT_JOINTS;
-  thread_local std::vector<dContact> contactVector;
+  thread_local QVector<dContact> contactVector;
 
   int maxContactPoints = std::max<size_t>(100, contactVector.capacity());
 

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -23,6 +23,8 @@
 #include <ode/ode.h>
 #include <QtCore/QList>
 
+#include <vector>
+
 #include "WbLog.hpp"
 #include "WbSimulationState.hpp"
 
@@ -71,6 +73,7 @@ private:
   static void odeSensorRaysUpdate(int threadID);
   static const long long int WEBOTS_MAGIC_NUMBER;
   bool mSwapJointContactBuffer;
+  std::vector<dContact> mContactVector;
 
   double lastMaxContactPointsFoundWarnTime = -INFINITY;
   void warnMaxContactPointsFound() {

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -23,9 +23,6 @@
 #include <ode/ode.h>
 #include <QtCore/QList>
 
-#include "WbLog.hpp"
-#include "WbSimulationState.hpp"
-
 class WbContactProperties;
 class WbImmersionProperties;
 class WbOdeContext;

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -75,7 +75,7 @@ private:
   bool mSwapJointContactBuffer;
   std::vector<dContact> mContactVector;
 
-  void warnMoreContactPointsThanContactJoints() {
+  static void warnMoreContactPointsThanContactJoints() {
     static double lastWarningTime = -INFINITY;
     const double currentSimulationTime = WbSimulationState::instance()->time();
     if (currentSimulationTime > lastWarningTime + 1000) {

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -75,14 +75,6 @@ private:
   bool mSwapJointContactBuffer;
   std::vector<dContact> mContactVector;
 
-  double lastMaxContactPointsFoundWarnTime = -INFINITY;
-  void warnMaxContactPointsFound() {
-    const double currentSimulationTime = WbSimulationState::instance()->time();
-    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
-      WbLog::warning(QObject::tr("Maximum number of contact points found so others might be ignored."), false, WbLog::ODE);
-      lastMaxContactPointsFoundWarnTime = currentSimulationTime;
-    }
-  }
   double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
   void warnMoreContactPointsThanContactJoints() {
     const double currentSimulationTime = WbSimulationState::instance()->time();

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -76,8 +76,8 @@ private:
   std::vector<dContact> mContactVector;
 
   void warnMoreContactPointsThanContactJoints() {
-      static double lastWarningTime = -INFINITY;
-      const double currentSimulationTime = WbSimulationState::instance()->time();
+    static double lastWarningTime = -INFINITY;
+    const double currentSimulationTime = WbSimulationState::instance()->time();
     if (currentSimulationTime > lastWarningTime + 1000) {
       WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
       lastWarningTime = currentSimulationTime;

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -23,6 +23,9 @@
 #include <ode/ode.h>
 #include <QtCore/QList>
 
+#include "WbLog.hpp"
+#include "WbSimulationState.hpp"
+
 class WbContactProperties;
 class WbImmersionProperties;
 class WbOdeContext;
@@ -68,6 +71,23 @@ private:
   static void odeSensorRaysUpdate(int threadID);
   static const long long int WEBOTS_MAGIC_NUMBER;
   bool mSwapJointContactBuffer;
+
+  double lastMaxContactPointsFoundWarnTime = -INFINITY;
+  void warnMaxContactPointsFound() {
+    const double currentSimulationTime = WbSimulationState::instance()->time();
+    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+      WbLog::warning(QObject::tr("Maximum number of contact points found so others might be ignored."), false, WbLog::ODE);
+      lastMaxContactPointsFoundWarnTime = currentSimulationTime;
+    }
+  }
+  double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
+  void warnMoreContactPointsThanContactJoints() {
+    const double currentSimulationTime = WbSimulationState::instance()->time();
+    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+      WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
+      lastMoreContactPointsThanContactJointsWarnTime = currentSimulationTime;
+    }
+  }
 };
 
 #endif

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -23,8 +23,6 @@
 #include <ode/ode.h>
 #include <QtCore/QList>
 
-#include <vector>
-
 #include "WbLog.hpp"
 #include "WbSimulationState.hpp"
 
@@ -73,16 +71,8 @@ private:
   static void odeSensorRaysUpdate(int threadID);
   static const long long int WEBOTS_MAGIC_NUMBER;
   bool mSwapJointContactBuffer;
-  std::vector<dContact> mContactVector;
 
-  static void warnMoreContactPointsThanContactJoints() {
-    static double lastWarningTime = -INFINITY;
-    const double currentSimulationTime = WbSimulationState::instance()->time();
-    if (currentSimulationTime > lastWarningTime + 1000) {
-      WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
-      lastWarningTime = currentSimulationTime;
-    }
-  }
+  static void warnMoreContactPointsThanContactJoints();
 };
 
 #endif

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -75,12 +75,12 @@ private:
   bool mSwapJointContactBuffer;
   std::vector<dContact> mContactVector;
 
-  double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
   void warnMoreContactPointsThanContactJoints() {
-    const double currentSimulationTime = WbSimulationState::instance()->time();
-    if (currentSimulationTime > lastMoreContactPointsThanContactJointsWarnTime + 1000.0) {
+      static double lastWarningTime = -INFINITY;
+      const double currentSimulationTime = WbSimulationState::instance()->time();
+    if (currentSimulationTime > lastWarningTime + 1000) {
       WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
-      lastMoreContactPointsThanContactJointsWarnTime = currentSimulationTime;
+      lastWarningTime = currentSimulationTime;
     }
   }
 };

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -83,7 +83,7 @@ private:
   double lastMoreContactPointsThanContactJointsWarnTime = -INFINITY;
   void warnMoreContactPointsThanContactJoints() {
     const double currentSimulationTime = WbSimulationState::instance()->time();
-    if (currentSimulationTime > lastMaxContactPointsFoundWarnTime + 1000.0) {
+    if (currentSimulationTime > lastMoreContactPointsThanContactJointsWarnTime + 1000.0) {
       WbLog::warning(QObject::tr("Contact joints will only be created for the deepest contact points."), false, WbLog::ODE);
       lastMoreContactPointsThanContactJointsWarnTime = currentSimulationTime;
     }


### PR DESCRIPTION
**Description**

This builds on PR #5790 by finding *all* of the contact points instead of just the first 100. It uses the same technique as PR #5769 to ensure that all contact points are found, but doesn't make the ABI-incompatible changes in that PR that are needed to add `maxContactPoints` and `maxContactJoints` to ContactProperties. Instead it hard-codes those to -1 (i.e. all) and 10, respectively.

**Additional context**
If this PR is merged, PR #5790 can be closed and PR #5769 can be easily changed to just add the new fields to `ContactProperties`.