### PR TITLE
Make robot collisions thread-safe.

### DIFF
--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -456,9 +456,11 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
   return false;
 }
 
-void WbSimulationCluster::appendCollisionedRobot(WbKinematicDifferentialWheels *robot) {
-  QMutexLocker lock(&mCollisionedRobotsMutex);
-  mCollisionedRobots.append(robot);
+  if (WbOdeContext::instance()->numberOfThreads() > 1) {
+    QMutexLocker lock(&mCollisionedRobotsMutex);
+    mCollisionedRobots.append(robot);
+  } else
+    mCollisionedRobots.append(robot);
 }
 
 void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID o2) {

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -458,7 +458,7 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
 
 void WbSimulationCluster::appendCollisionedRobot(WbKinematicDifferentialWheels *robot) {
   if (WbOdeContext::instance()->numberOfThreads() > 1) {
-    QMutexLocker lock(&mCollisionedRobotsMutex);
+    QMutexLocker<QMutex> lock(&mCollisionedRobotsMutex);
     mCollisionedRobots.append(robot);
   } else
     mCollisionedRobots.append(robot);

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -39,6 +39,7 @@
 #include "WbWorldInfo.hpp"
 
 #include <QtCore/QMutex>
+#include <QtCore/QMutexLocker>
 
 #include <ode/fluid_dynamics/ode_fluid_dynamics.h>
 #include <ode/ode_MT.h>
@@ -455,6 +456,11 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
   return false;
 }
 
+void WbSimulationCluster::appendCollisionedRobot(WbKinematicDifferentialWheels *robot) {
+  QMutexLocker lock(&mCollisionedRobotsMutex);
+  mCollisionedRobots.append(robot);
+}
+
 void WbSimulationCluster::handleCollisionIfSpace(void *data, dGeomID o1, dGeomID o2) {
   if (dGeomIsSpace(o1) || dGeomIsSpace(o2)) {
     // colliding a mContext->space() with something
@@ -671,11 +677,11 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     WbRobot *const robot2 = dynamic_cast<WbRobot *>(s2);
     if (robot1 && !p1 && !isRayGeom2 && robot1->kinematicDifferentialWheels()) {
       wg1->setColliding();
-      cl->mCollisionedRobots.append(robot1->kinematicDifferentialWheels());
+      cl->appendCollisionedRobot(robot1->kinematicDifferentialWheels());
       if (robot2 && !p2 && robot2->kinematicDifferentialWheels()) {
         dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));  // we want only one contact point
         wg2->setColliding();
-        cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
+        cl->appendCollisionedRobot(robot2->kinematicDifferentialWheels());
         collideKinematicRobots(robot1->kinematicDifferentialWheels(), true, contact, true);
         collideKinematicRobots(robot2->kinematicDifferentialWheels(), true, contact, false);
       } else
@@ -685,7 +691,7 @@ void WbSimulationCluster::odeNearCallback(void *data, dGeomID o1, dGeomID o2) {
     if (robot2 && !p2 && !isRayGeom1 && robot2->kinematicDifferentialWheels()) {
       dCollide(o1, o2, MAX_CONTACTS, &contact[0].geom, sizeof(dContact));
       wg2->setColliding();
-      cl->mCollisionedRobots.append(robot2->kinematicDifferentialWheels());
+      cl->appendCollisionedRobot(robot2->kinematicDifferentialWheels());
       collideKinematicRobots(robot2->kinematicDifferentialWheels(), false, contact, false);
       return;
     }

--- a/src/webots/engine/WbSimulationCluster.cpp
+++ b/src/webots/engine/WbSimulationCluster.cpp
@@ -456,6 +456,7 @@ static bool needCollisionDetection(WbSolid *solid, bool isOtherRayGeom) {
   return false;
 }
 
+void WbSimulationCluster::appendCollisionedRobot(WbKinematicDifferentialWheels *robot) {
   if (WbOdeContext::instance()->numberOfThreads() > 1) {
     QMutexLocker lock(&mCollisionedRobotsMutex);
     mCollisionedRobots.append(robot);

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -22,6 +22,7 @@
 #include <ode/fluid_dynamics/ode_fluid_dynamics.h>
 #include <ode/ode.h>
 #include <QtCore/QList>
+#include <QtCore/QMutex>
 
 class WbContactProperties;
 class WbImmersionProperties;
@@ -54,7 +55,9 @@ private:
   WbOdeContext *mContext;
   static QMutex *cJointCreationMutex;
 
+  QMutex mCollisionedRobotsMutex;
   QList<WbKinematicDifferentialWheels *> mCollisionedRobots;
+  void appendCollisionedRobot(WbKinematicDifferentialWheels *robot);
   void handleKinematicsCollisions();
   void swapBuffer();
   static void handleCollisionIfSpace(void *data, dGeomID o1, dGeomID o2);


### PR DESCRIPTION
**Description**
This fixes an issue where it was possible for 2 different ODE cluster threads to simulteously try to append to `mCollisionedRobots`.
