### PR TITLE
Laser visualization update rate differs from distance sensor rays #5492

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -16,6 +16,7 @@ Released on ??
     - Fixed Python API `Node.enableContactPointsTracking` which was failing ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
     - Fixed Python API field getters sometimes returning an invalid Field object ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
     - Fixed Python API `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
+    - Fixed Python API `Motor.enableForceFeedback` where the `sampling_period` argument was missing ([#5797](https://github.com/cyberbotics/webots/pull/5797)).
     - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([#5620](https://github.com/cyberbotics/webots/pull/5620)).
     - Fixed memory leaks, particularly when in no-rendering mode and spawning/deleting nodes ([#5639](https://github.com/cyberbotics/webots/pull/5639)).
     - Fixed crashes resulting from streaming pose, SF field values or contact points after deleting the tracked nodes ([#5638](https://github.com/cyberbotics/webots/pull/5638)).

--- a/lib/controller/python/controller/motor.py
+++ b/lib/controller/python/controller/motor.py
@@ -91,8 +91,8 @@ class Motor(Device):
     def getMultiplier(self) -> float:
         return self.multiplier
 
-    def enableForceFeedback(self):
-        wb.wb_motor_enable_force_feedback(self._tag)
+    def enableForceFeedback(self, sampling_period: int):
+        wb.wb_motor_enable_force_feedback(self._tag, sampling_period)
 
     def disableForceFeedback(self):
         wb.wb_motor_disable_force_feedback(self._tag)

--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -25,7 +25,7 @@
 #include <webots/motor.h>
 #include <webots/robot.h>
 
-#define TIME_STEP 64
+#define TIME_STEP 8
 
 int main() {
   // initialize webots stuff


### PR DESCRIPTION
**Description**
There is a difference in laser point visualization update rate (64 ms) the update rate of the distance sensor rays (8ms). This is causing a noticable difference in the pointer position and the sensor rays. Updating the laser pointer controller time step to 8ms.

**Related Issues**
This pull-request fixes issue #5492

**Tasks**
  - [ ] Task 1 : changed laser pointer controler time step from 64 to 8
