### PR TITLE
Remove unused material references

### DIFF
--- a/projects/default/worlds/meshes/suzanne.obj
+++ b/projects/default/worlds/meshes/suzanne.obj
@@ -1,6 +1,5 @@
 # Blender v2.76 (sub 0) OBJ File: ''
 # www.blender.org
-mtllib suzanne.mtl
 o Suzanne
 v 0.155960 0.998384 0.786757
 v -0.719040 0.998384 0.786757

--- a/projects/objects/toys/protos/PaperBoat/meshes/geom.obj
+++ b/projects/objects/toys/protos/PaperBoat/meshes/geom.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: ''
 # www.blender.org
-mtllib geom.mtl
 o geom.002
 v 0.163138 -0.011148 -0.000010
 v 0.102858 -0.052136 0.062664

--- a/projects/objects/toys/protos/RubberDuck/meshes/beak.obj
+++ b/projects/objects/toys/protos/RubberDuck/meshes/beak.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.4 OBJ File: ''
 # www.blender.org
-mtllib beak.mtl
 o beak
 v 0.004683 0.007117 0.007262
 v 0.004502 0.008069 0.006527

--- a/projects/objects/toys/protos/RubberDuck/meshes/body.obj
+++ b/projects/objects/toys/protos/RubberDuck/meshes/body.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.4 OBJ File: ''
 # www.blender.org
-mtllib body.mtl
 o geom.003
 v -0.031698 0.024886 0.007545
 v -0.030520 0.025896 0.007273

--- a/projects/robots/epson/scara_t6/protos/meshes/arm.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/arm.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'arm.blend'
 # www.blender.org
-mtllib arm.mtl
 o base_arm
 v -0.001993 -0.033253 -0.040427
 v 0.001744 -0.033264 -0.040427

--- a/projects/robots/epson/scara_t6/protos/meshes/arm_nuts.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/arm_nuts.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'arm.blend'
 # www.blender.org
-mtllib arm_nuts.mtl
 o base_arm.001
 v 0.087507 0.008556 0.184061
 v 0.086760 0.014206 0.184061

--- a/projects/robots/epson/scara_t6/protos/meshes/base.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/base.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'base.blend'
 # www.blender.org
-mtllib base.mtl
 o base
 v 0.061051 -0.041839 0.214405
 v 0.059250 0.041883 0.214405

--- a/projects/robots/epson/scara_t6/protos/meshes/base_arm.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/base_arm.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'base_arm.blend'
 # www.blender.org
-mtllib base_arm.mtl
 o arm
 v 0.079153 -0.006615 -0.007184
 v 0.079265 -0.006594 -0.007207

--- a/projects/robots/epson/scara_t6/protos/meshes/bulb.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/bulb.obj
@@ -1,6 +1,5 @@
 # Blender v3.1.2 OBJ File: ''
 # www.blender.org
-mtllib bulb.mtl
 o base.001
 v 0.000685 -0.000040 0.006999
 v 0.000580 0.000844 0.007011

--- a/projects/robots/epson/scara_t6/protos/meshes/bulb_socket.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/bulb_socket.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'base.blend'
 # www.blender.org
-mtllib bulb_socket.mtl
 o base.002
 v 0.022536 0.042318 0.445647
 v 0.023492 0.040908 0.445647

--- a/projects/robots/epson/scara_t6/protos/meshes/button.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/button.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'arm.blend'
 # www.blender.org
-mtllib button.mtl
 o base_arm.005
 v 0.068342 0.009522 0.187771
 v 0.068871 -0.001901 0.187771

--- a/projects/robots/epson/scara_t6/protos/meshes/button_socket.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/button_socket.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'arm.blend'
 # www.blender.org
-mtllib button_socket.mtl
 o base_arm.004
 v 0.069843 0.009338 0.184442
 v 0.071363 0.008707 0.184442

--- a/projects/robots/epson/scara_t6/protos/meshes/cable.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/cable.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'cable.blend'
 # www.blender.org
-mtllib cable.mtl
 o cable
 v 0.000949 0.017574 0.000000
 v -0.000053 -0.017600 -0.000000

--- a/projects/robots/epson/scara_t6/protos/meshes/connector.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/connector.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'bulb.blend'
 # www.blender.org
-mtllib connector.mtl
 o base.003
 v -0.101400 0.036130 0.196750
 v -0.101400 0.036643 0.196279

--- a/projects/robots/epson/scara_t6/protos/meshes/main_connector.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/main_connector.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'bulb.blend'
 # www.blender.org
-mtllib main_connector.mtl
 o main_connecter_base.005
 v -0.099116 0.004754 0.089193
 v -0.099116 0.000835 0.090082

--- a/projects/robots/epson/scara_t6/protos/meshes/nuts.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/nuts.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'bulb.blend'
 # www.blender.org
-mtllib nuts.mtl
 o base.004
 v -0.094266 0.032801 0.075638
 v -0.094266 0.038500 0.075121

--- a/projects/robots/epson/scara_t6/protos/meshes/shaft.obj
+++ b/projects/robots/epson/scara_t6/protos/meshes/shaft.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: 'shaft.blend'
 # www.blender.org
-mtllib shaft.mtl
 o shaft
 v 0.014224 0.010178 -0.395961
 v 0.013537 0.010178 -0.397321

--- a/projects/robots/festo/robotino3/protos/meshes/base_extension_plate.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/base_extension_plate.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib base_extension_plate.mtl
 o base_extension_plate.001
 v 0.056096 -0.197894 -0.014000
 v 0.054270 -0.198223 -0.014000

--- a/projects/robots/festo/robotino3/protos/meshes/base_ir_metal_ring_cover.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/base_ir_metal_ring_cover.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib base_ir_metal_ring_cover.mtl
 o base_ir_metal_ring_cover
 v 0.006265 -0.204904 0.043000
 v 0.012554 -0.223548 0.043000

--- a/projects/robots/festo/robotino3/protos/meshes/cap_1.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/cap_1.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib cap_1.mtl
 o cap_1
 v 0.062336 -0.064620 0.155000
 v 0.062332 -0.064607 0.156447

--- a/projects/robots/festo/robotino3/protos/meshes/head_bottom_support.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_bottom_support.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_bottom_support.mtl
 o head_bottom_support
 v 0.123552 0.012151 0.158000
 v 0.133596 0.013923 0.158000

--- a/projects/robots/festo/robotino3/protos/meshes/head_extension_plate.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_extension_plate.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_extension_plate.mtl
 o head_extension_plate
 v -0.036749 -0.006217 0.245000
 v -0.035883 -0.006717 0.156500

--- a/projects/robots/festo/robotino3/protos/meshes/head_festo_logo.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_festo_logo.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_festo_logo.mtl
 o head_festo_logo
 v -0.111436 0.037099 0.243884
 v -0.111503 0.037067 0.241902

--- a/projects/robots/festo/robotino3/protos/meshes/head_left_metal_cover.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_left_metal_cover.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_left_metal_cover.mtl
 o head_left_metal_cover
 v 0.121671 0.010754 0.230983
 v 0.135837 0.013251 0.238463

--- a/projects/robots/festo/robotino3/protos/meshes/head_right_metal_cover.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_right_metal_cover.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_right_metal_cover.mtl
 o head_right_metal_cover
 v -0.164123 0.018747 0.201700
 v -0.143169 0.015565 0.237437

--- a/projects/robots/festo/robotino3/protos/meshes/head_vga_port.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/head_vga_port.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib head_vga_port.mtl
 o head_vga_port
 v -0.194342 0.019444 0.216489
 v -0.192955 0.019183 0.217459

--- a/projects/robots/festo/robotino3/protos/meshes/side_sep.obj
+++ b/projects/robots/festo/robotino3/protos/meshes/side_sep.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: 'base_link_6.blend'
 # www.blender.org
-mtllib side_sep.mtl
 o side_sep
 v -0.188893 0.046164 -0.013937
 v -0.188387 0.045838 -0.015012

--- a/projects/robots/mir/mir100/protos/meshes/mir_100_base.obj
+++ b/projects/robots/mir/mir100/protos/meshes/mir_100_base.obj
@@ -1,6 +1,5 @@
 # Blender v2.92.0 OBJ File: ''
 # www.blender.org
-mtllib untitled.mtl
 o Mir100_Top_Unnamed-MiR100.006
 v 0.376729 -0.271877 0.213995
 v 0.376451 -0.270214 0.307778

--- a/projects/robots/mir/mir100/protos/meshes/mir_100_inside.obj
+++ b/projects/robots/mir/mir100/protos/meshes/mir_100_inside.obj
@@ -1,6 +1,5 @@
 # Blender v2.92.0 OBJ File: ''
 # www.blender.org
-mtllib mir_100_inside.mtl
 o Mir100_Base.022_Mir_100_Base.002
 v -0.068416 -0.154031 0.095233
 v -0.068636 -0.164854 0.096523

--- a/projects/vehicles/protos/mercedes_benz/meshes/bumper.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/bumper.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib bumper.mtl
 o bumper
 v -0.881851 0.329320 4.971750
 v -0.882952 0.321726 4.968420

--- a/projects/vehicles/protos/mercedes_benz/meshes/coachwork.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/coachwork.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib coachwork.mtl
 o coachwork_front_doors
 v 0.982100 0.993588 3.156850
 v 0.982378 0.984370 3.144300

--- a/projects/vehicles/protos/mercedes_benz/meshes/coachwork_front.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/coachwork_front.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib coachwork_front.mtl
 o coachwork_front
 v -0.851435 0.863028 4.892590
 v -0.856853 0.861444 4.885060

--- a/projects/vehicles/protos/mercedes_benz/meshes/front_logo.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/front_logo.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib front_logo.mtl
 o front_logo
 v -0.075030 0.693918 5.259330
 v -0.078216 0.680621 5.259800

--- a/projects/vehicles/protos/mercedes_benz/meshes/mirrors.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/mirrors.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib mirrors.mtl
 o mirrors_left_mirror
 v 1.172370 1.283159 3.892910
 v 1.168680 1.307719 3.893150

--- a/projects/vehicles/protos/mercedes_benz/meshes/plastic.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/plastic.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib plastic.mtl
 o plastic
 v -0.224677 0.437302 5.102580
 v 0.007860 0.424961 5.134790

--- a/projects/vehicles/protos/mercedes_benz/meshes/polymer.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/polymer.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib interior_plastic.mtl
 o windshield_frame
 v -0.838306 1.665829 3.761390
 v -0.833870 1.700899 3.720000

--- a/projects/vehicles/protos/mercedes_benz/meshes/roof_and_rear.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/roof_and_rear.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib roof_and_rear.mtl
 o roof_and_rear_roof
 v -0.707307 1.802609 3.649880
 v -0.707436 1.801199 3.649620

--- a/projects/vehicles/protos/mercedes_benz/meshes/windows.obj
+++ b/projects/vehicles/protos/mercedes_benz/meshes/windows.obj
@@ -1,6 +1,5 @@
 # Blender v2.93.1 OBJ File: ''
 # www.blender.org
-mtllib windows.mtl
 o windows
 v -0.954987 1.062119 2.636910
 v -0.955394 1.061920 2.636880

--- a/tests/cache/worlds/meshes/cube_0.05m.obj
+++ b/tests/cache/worlds/meshes/cube_0.05m.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: ''
 # www.blender.org
-mtllib cube_0.05m.mtl
 o Cube_Cube.001
 v -0.025000 -0.025000 0.025000
 v -0.025000 0.025000 0.025000

--- a/tests/cache/worlds/meshes/cube_0.1m.obj
+++ b/tests/cache/worlds/meshes/cube_0.1m.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: ''
 # www.blender.org
-mtllib cube_0.1m.mtl
 o Cube_Cube.001
 v -0.050000 -0.050000 0.050000
 v -0.050000 0.050000 0.050000

--- a/tests/rendering/worlds/meshes/colored_cube.obj
+++ b/tests/rendering/worlds/meshes/colored_cube.obj
@@ -1,6 +1,5 @@
 # Blender v3.0.1 OBJ File: ''
 # www.blender.org
-mtllib colored_cube.mtl
 o Cube_Cube.003
 v 1.000000 1.000000 -1.000000
 v 1.000000 1.000000 1.000000


### PR DESCRIPTION
**Description**

When streaming, if an `obj` file references an `mtl` file, this is loaded (or downloaded) from a location that is assumed to be the combination of the URL of the wavefront together with the relative URL of the material. In several cases however we don't distribute/use the material file, which results in 404s.