### PR TITLE
Laser visualization update rate differs from distance sensor rays #5492

### DIFF
--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -25,7 +25,7 @@
 #include <webots/motor.h>
 #include <webots/robot.h>
 
-#define TIME_STEP 8
+#define TIME_STEP wb_robot_get_basic_time_step() 
 
 int main() {
   // initialize webots stuff

--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -25,20 +25,20 @@
 #include <webots/motor.h>
 #include <webots/robot.h>
 
-#define TIME_STEP wb_robot_get_basic_time_step() 
-
 int main() {
+
   // initialize webots stuff
   wb_robot_init();
+  const int time_step = wb_robot_get_basic_time_step();
 
   // get camera tag and initialize
   WbDeviceTag camera = wb_robot_get_device("camera");
-  wb_camera_enable(camera, TIME_STEP);
+  wb_camera_enable(camera, time_step);
 
   WbDeviceTag laser0 = wb_robot_get_device("laser0");
   WbDeviceTag laser1 = wb_robot_get_device("laser1");
-  wb_distance_sensor_enable(laser0, TIME_STEP);
-  wb_distance_sensor_enable(laser1, TIME_STEP);
+  wb_distance_sensor_enable(laser0, time_step);
+  wb_distance_sensor_enable(laser1, time_step);
 
   // get a handler to the motors and set target position to infinity (speed control).
   WbDeviceTag left_motor = wb_robot_get_device("left wheel motor");
@@ -49,7 +49,7 @@ int main() {
   wb_motor_set_velocity(right_motor, 0.0);
 
   // control loop
-  while (wb_robot_step(TIME_STEP) != -1) {
+  while (wb_robot_step(time_step) != -1) {
     // update image
     (void)wb_camera_get_image(camera);
 

--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -25,7 +25,7 @@
 #include <webots/motor.h>
 #include <webots/robot.h>
 
-#define TIME_STEP 64
+#define TIME_STEP 8
 
 int main() {
   // initialize webots stuff

--- a/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
+++ b/projects/samples/devices/controllers/laser_pointer/laser_pointer.c
@@ -26,7 +26,6 @@
 #include <webots/robot.h>
 
 int main() {
-
   // initialize webots stuff
   wb_robot_init();
   const int time_step = wb_robot_get_basic_time_step();


### PR DESCRIPTION
**Description**
There is a difference in laser point visualization update rate (64 ms) the update rate of the distance sensor rays (8ms). This is causing a noticable difference in the pointer position and the sensor rays. Updating the laser pointer controller time step to the basic time step of robot (8ms).

**Related Issues**
This pull-request fixes issue #https://github.com/cyberbotics/webots/issues/5492
