### PR TITLE
Run httpd for test cache environment.

### DIFF
--- a/tests/cache/cache_environment.py
+++ b/tests/cache/cache_environment.py
@@ -33,21 +33,24 @@ else:
     ROOT_FOLDER = WEBOTS_HOME
 
 # Start an HTTP server to serve the contents of ROOT_FOLDER
+
+
 class WebotsHomeHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs, directory=Path(ROOT_FOLDER))
-    
+
     def log_request(self, code='-', size='-'):
         if (code == 200):
             return
         super().log_request(code=code, size=size)
 
 
-HTTP_PORT=8000
+HTTP_PORT = 8000
 httpd = http.server.HTTPServer(('', HTTP_PORT), WebotsHomeHTTPRequestHandler)
 atexit.register(http.server.HTTPServer.server_close, httpd)
 httpdThread = threading.Thread(target=http.server.HTTPServer.serve_forever, args=[httpd], daemon=True)
 httpdThread.start()
+
 
 def update_cache_urls(revert=False):
     paths = []


### PR DESCRIPTION
**Description**
Allow cache tests to get files from the local dir instead of web.

**Additional context**
Before this change, the cache tests retrieved the files from GitHub under the branch that the user was in. However, when working on PRs, this cause the cache tests to fail because the branch was not yet (and might never be) in the official repo. To address this and also ensure that the retrieved files are from the current work tree, this change starts a simple python http server on port 8000.