### PR TITLE
Fixed warning filters

### DIFF
--- a/resources/qt_warning_filters.conf
+++ b/resources/qt_warning_filters.conf
@@ -3,20 +3,5 @@
 # Each regular expression has to be written on a new line.
 # Empty lines are ignored.
 
-^QSslSocket:\ cannot\ resolve\ SSLv2_client_method$
-^QSslSocket:\ cannot\ resolve\ SSLv2_server_method$
-
-# This warning appears on Windows since Qt 5.9.0 when calling QWebView::load() with any content
-^libpng\ warning:\ iCCP:\ known\ incorrect\ sRGB\ profile$
-
-# reference: http://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfontengine.cpp#n653
-^.*Failed\ to\ compute\ left/right\ minimum\ bearings\ for\ "Roboto"$
-
-# This warning occurs on Retina display while the framebuffer dimension matches exactly with the 3D view area.
-^Window\ position\ outside\ any\ known\ screen,\ using\ primary\ screen$
-
-# This warning appeared on Windows after upgrading to Qt 5.12.0
-^QNetworkReplyHttpImplPrivate::_q_startOperation\ was\ called\ more\ than\ once\ QUrl\("https://www.cyberbotics.com/webots_current_version.txt"\)$
-
-# This warning appears from times to times after we introduced the disk cache (observed on Windows)
-^QNetworkDiskCache:\ couldn't\ remove\ the\ cache\ file\ \ \".*\"$
+# This warning appeared on Windows after upgrading to Qt 6.4.2
+^setDarkBorderToWindow:\ Unable\ to\ set\ dark\ window\ border.$

--- a/resources/qt_warning_filters.conf
+++ b/resources/qt_warning_filters.conf
@@ -3,5 +3,8 @@
 # Each regular expression has to be written on a new line.
 # Empty lines are ignored.
 
+# This warning occurs on Retina display while the framebuffer dimension matches exactly with the 3D view area.
+^Window\ position\ outside\ any\ known\ screen,\ using\ primary\ screen$
+
 # This warning appeared on Windows after upgrading to Qt 6.4.2
 ^setDarkBorderToWindow:\ Unable\ to\ set\ dark\ window\ border.$


### PR DESCRIPTION
It seems that the warning filters needed an update.
All the warnings currently filtered out don't seem to occur any more.
I introduced a new rule to filter out a warning occurring on Windows since the upgrade to Qt 6.4.2.
I kept the warning about retina display as I could not test it and it is likely still there.
I tested on both Windows and Linux and could not any warning popping-up.