### PR TITLE
Report system failures from test_suite.py.

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -355,12 +355,12 @@ for groupName in testGroups:
     if groupName == 'cache':
         update_cache_urls(True)
 
-appendToOutputFile('\n' + finalMessage + '\n')
-
 if len(systemFailures) > 0:
     appendToOutputFile('\nSystem Failures:\n')
     for message in systemFailures:
         appendToOutputFile(message)
+
+appendToOutputFile('\n' + finalMessage + '\n')
 
 time.sleep(1)
 if outputMonitor.command.isRunning():


### PR DESCRIPTION
**Description**
Add system failures to the output file before the final message because
the final message tells the outputMonitor to stop processing the output.
