### PR TITLE
Fix wrong save world warning

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -33,7 +33,7 @@ Released on ??
     - Fixed performance issues when retrieving multiple times a node's field defined in a PROTO body using the [Supervisor API](supervisor.md) ([#5774](https://github.com/cyberbotics/webots/pull/5774)).
     - Fixed failure to detect that a port was already in use on some platforms ([#5806](https://github.com/cyberbotics/webots/pull/5806)).
     - Fixed thread-safety issue when robots collide. This was only an issue if physics multi-threading was enabled (which is not the default and rarely used) ([#5796](https://github.com/cyberbotics/webots/pull/5796)).
-    - Fixed wrong warning message about parent "worlds" folder displayed when saving a world ([#5843 ](https://github.com/cyberbotics/webots/pull/5843)).
+    - Fixed wrong warning message about parent "worlds" folder displayed when saving a world ([#5843](https://github.com/cyberbotics/webots/pull/5843)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -33,6 +33,7 @@ Released on ??
     - Fixed performance issues when retrieving multiple times a node's field defined in a PROTO body using the [Supervisor API](supervisor.md) ([#5774](https://github.com/cyberbotics/webots/pull/5774)).
     - Fixed failure to detect that a port was already in use on some platforms ([#5806](https://github.com/cyberbotics/webots/pull/5806)).
     - Fixed thread-safety issue when robots collide. This was only an issue if physics multi-threading was enabled (which is not the default and rarely used) ([#5796](https://github.com/cyberbotics/webots/pull/5796)).
+    - Fixed wrong warning message about parent "worlds" folder displayed when saving a world ([#5843 ](https://github.com/cyberbotics/webots/pull/5843)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1474,7 +1474,7 @@ void WbMainWindow::saveWorldAs(bool skipSimulationHasRunWarning) {
     return;
   }
 
-  const QDir dir(fileName);
+  const QDir dir = QFileInfo(fileName).dir();
   if (dir.dirName() != "worlds") {
     const QString warning = tr("The selected directory for saving the world file is not named \"worlds\".\n"
                                "Thus it is not located in a valid Webots project.\n"

--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -1474,8 +1474,7 @@ void WbMainWindow::saveWorldAs(bool skipSimulationHasRunWarning) {
     return;
   }
 
-  const QDir dir = QFileInfo(fileName).dir();
-  if (dir.dirName() != "worlds") {
+  if (QFileInfo(fileName).dir().dirName() != "worlds") {
     const QString warning = tr("The selected directory for saving the world file is not named \"worlds\".\n"
                                "Thus it is not located in a valid Webots project.\n"
                                "As a consequence, some project-related functionalities may not work.");


### PR DESCRIPTION
The current code is not working correctly for me and `QDir(fileName).dirName()` is returning the file name instead of the directory name.
However, using QFileInfo for retrieving the directory from the file path works correctly.