### PR TITLE
Update Python receiver get data documentation

### DIFF
--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -337,7 +337,11 @@ namespace webots {
 from controller import Receiver
 
 class Receiver (Device):
-    def getData(self):
+    def getBytes(self):
+    def getString(self):
+    def getFloats(self):
+    def getInts(self):
+    def getBools(self):
     def getDataSize(self):
     # ...
 ```
@@ -388,20 +392,12 @@ It is illegal to call the `wb_receiver_get_data` function when the queue is empt
 The [Receiver](#receiver) node knows nothing about that structure of the data being sent but its byte size.
 The emitting and receiving code is responsible to agree on a specific format.
 
+
 The `wb_receiver_get_data_size` function returns the number of data bytes present in the head packet of the reception queue.
 The *data size* is always equal to the *size* argument of the corresponding `emitter_send_packet` function call.
 It is illegal to call the `wb_receiver_get_data_size` function when the queue is empty (i.e. when `wb_receiver_get_queue_length() == 0`).
 
-> **Note** [Python]: The `getData` function returns a string.
-Similarly to the `sendPacket` function of the [Emitter](emitter.md) device, using the functions of the struct module is recommended for sending primitive data types.
-Here is an example for getting the data:
-
-> ```python
-> import struct
-> #...
-> message=receiver.getData()
-> dataList=struct.unpack("chd",message)
-> ```
+> **Note** [Python]: In the Python API, instead of having a single function returning the data, multiple functions are defined that automatically convert the data to the expected return type (bytes, string , list of floats, list of integers, list of booleans).
 
 <!-- -->
 

--- a/docs/reference/receiver.md
+++ b/docs/reference/receiver.md
@@ -392,12 +392,11 @@ It is illegal to call the `wb_receiver_get_data` function when the queue is empt
 The [Receiver](#receiver) node knows nothing about that structure of the data being sent but its byte size.
 The emitting and receiving code is responsible to agree on a specific format.
 
-
 The `wb_receiver_get_data_size` function returns the number of data bytes present in the head packet of the reception queue.
 The *data size* is always equal to the *size* argument of the corresponding `emitter_send_packet` function call.
 It is illegal to call the `wb_receiver_get_data_size` function when the queue is empty (i.e. when `wb_receiver_get_queue_length() == 0`).
 
-> **Note** [Python]: In the Python API, instead of having a single function returning the data, multiple functions are defined that automatically convert the data to the expected return type (bytes, string , list of floats, list of integers, list of booleans).
+> **Note** [Python]: In the Python API, instead of having a single function returning the data, multiple functions are defined that automatically convert the data to the expected return type (bytes, string, list of floats, list of integers, list of booleans).
 
 <!-- -->
 


### PR DESCRIPTION
In the Python API the `Receiver.getData` function is deprecated but still documented.