### PR TITLE
Fix dependencies installations on Ubuntu 20.04

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+# exit when any command fails on CI
+if [[ -z "$CI" ]]; then
+       set -e
+fi
 
 if [[ $EUID -ne 0 ]]; then
        echo "This script must be run as root"

--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # exit when any command fails on CI
-if [[ -z "$CI" ]]; then
+if [[ ! -z "$CI" ]]; then
        set -e
 fi
 

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+# exit when any command fails on CI
+if [[ -z "$CI" ]]; then
+       set -e
+fi
 
 if [[ $EUID -ne 0 ]]; then
        echo "This script must be run as root"

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # exit when any command fails on CI
-if [[ -z "$CI" ]]; then
+if [[ ! -z "$CI" ]]; then
        set -e
 fi
 

--- a/scripts/install/linux_runtime_dependencies.sh
+++ b/scripts/install/linux_runtime_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+# exit when any command fails on CI
+if [[ -z "$CI" ]]; then
+       set -e
+fi
 
 if [[ $EUID -ne 0 ]]; then
        echo "This script must be run as root"

--- a/scripts/install/linux_runtime_dependencies.sh
+++ b/scripts/install/linux_runtime_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # exit when any command fails on CI
-if [[ -z "$CI" ]]; then
+if [[ ! -z "$CI" ]]; then
        set -e
 fi
 

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+# exit when any command fails on CI
+if [[ -z "$CI" ]]; then
+       set -e
+fi
 
 if [[ $EUID -ne 0 ]]; then
        echo "This script must be run as root"

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # exit when any command fails on CI
-if [[ -z "$CI" ]]; then
+if [[ ! -z "$CI" ]]; then
        set -e
 fi
 

--- a/scripts/install/linux_web_viewer_dependencies.sh
+++ b/scripts/install/linux_web_viewer_dependencies.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# exit when any command fails
-set -e
+# exit when any command fails on CI
+if [[ -z "$CI" ]]; then
+       set -e
+fi
 
 if [[ $EUID -ne 0 ]]; then
        echo "This script must be run as root"

--- a/scripts/install/linux_web_viewer_dependencies.sh
+++ b/scripts/install/linux_web_viewer_dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # exit when any command fails on CI
-if [[ -z "$CI" ]]; then
+if [[ ! -z "$CI" ]]; then
        set -e
 fi
 


### PR DESCRIPTION
After #5845, I am getting errors on Ubuntu 20.04 that can be safely ignored, so we don't want the script to fail in this case.
```
Err:5 http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BA6932366A755776
Reading package lists... Done
W: GPG error: http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BA6932366A755776
E: The repository 'http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```