### PR TITLE
Fix uninitialized set_exposure variable.

### DIFF
--- a/src/controller/c/camera.c
+++ b/src/controller/c/camera.c
@@ -87,6 +87,7 @@ static void wb_camera_new(WbDevice *d, unsigned int id, int w, int h, double fov
   c->has_recognition = has_recognition;
   c->set_focal_distance = false;
   c->set_fov = false;
+  c->set_exposure = false;
   c->enable_recognition = false;
   c->recognition_sampling_period = 0;
   c->recognized_object_number = 0;


### PR DESCRIPTION
Valgrind's memcheck tool reported this while I was doing some other testing.

It looks like at most this could cause a little bit of unnecessary communication between the controller and webots.

