### PR TITLE
Add missing space to cppcheck command line.

### DIFF
--- a/tests/sources/test_cppcheck.py
+++ b/tests/sources/test_cppcheck.py
@@ -167,7 +167,7 @@ class TestCppCheck(unittest.TestCase):
         ]
         command = 'cppcheck --enable=warning,style,performance,portability --inconclusive --force -q '
         command += '--inline-suppr --suppress=invalidPointerCast --suppress=useStlAlgorithm -UKROS_COMPILATION '
-        command += '--suppress=strdupCalled --suppress=ctuOneDefinitionRuleViolation --suppress=unknownMacro'
+        command += '--suppress=strdupCalled --suppress=ctuOneDefinitionRuleViolation --suppress=unknownMacro '
         # command += '--xml '  # Uncomment this line to get more information on the errors
         command += '--std=c++03 --output-file=\"' + self.reportFilename + '\"'
         sources = self.add_source_files(sourceDirs, skippedDirs, skippedfiles)


### PR DESCRIPTION
**Description**
Add missing space to separate options on cppcheck command line. I'm wondering if this is related to some of the test-sources errors I'm seeing in CI.

