### PR TITLE
Fix delete physic

### DIFF
--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -136,7 +136,8 @@ export default class X3dScene {
 
   #deleteObject(id) {
     const object = WbWorld.instance.nodes.get('n' + id);
-    object.delete();
+    if (typeof object !== 'undefined')
+      object.delete();
 
     WbWorld.instance.robots.forEach((robot, i) => {
       if (robot.id === 'n' + id)

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -183,11 +183,13 @@ export default class X3dScene {
     await parser.parse(x3dObject, this.renderer, false, parentNode, callback);
 
     const node = WbWorld.instance.nodes.get(parser.rootNodeId);
-    if (parentNode instanceof WbShape) {
-      parentNode.unfinalize();
-      parentNode.finalize();
-    } else
-      node.finalize();
+    if (typeof node !== 'undefined') {
+      if (parentNode instanceof WbShape) {
+        parentNode.unfinalize();
+        parentNode.finalize();
+      } else
+        node.finalize();
+    }
   }
 
   applyUpdate(update) {


### PR DESCRIPTION
In the kukubox example (https://webots.cloud/run?version=R2023b&url=https://github.com/cyberbotics/webots/blob/doc-add-robots/projects/robots/kuka/youbot/protos/KukaBox.proto&type=undefined) we can delete and reset the physic node.

However this have no influence over WebotsJS as the physic node is just ignored by it.
So it results no new node and we need to check it before attempting to `delete` or `finalize` it.