### PR TITLE
Prepend libController path to environment

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -37,6 +37,7 @@ Released on ??
     - Fixed retrieval of sibling devices from [`BallJoint.device3`](balljoint.md) list. Previously, the devices retrieved were from the `device` list instead ([#5839](https://github.com/cyberbotics/webots/pull/5839)).
     - Fixed crash during PROTO regeneration triggered by nested PROTO in parameter ([#5724](https://github.com/cyberbotics/webots/pull/5724)).
     - Fixed wrong warning message about parent "worlds" folder displayed when saving a world ([#5843](https://github.com/cyberbotics/webots/pull/5843)).
+    - Fixed the issue of Webots occasionally loading the incorrect libController. ([#5885](https://github.com/cyberbotics/webots/pull/5885)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -434,7 +434,7 @@ void WbController::setProcessEnvironment() {
   // Add the Webots lib path to be able to load (at least) libController
   QString ldLibraryPath = WbStandardPaths::controllerLibPath();
   ldLibraryPath.chop(1);
-  addToPathEnvironmentVariable(env, ldEnvironmentVariable, ldLibraryPath, false);
+  addToPathEnvironmentVariable(env, ldEnvironmentVariable, ldLibraryPath, false, true);
   // Remove paths needed by Webots only
 #ifdef _WIN32
   const QString msys64 = QDir::toNativeSeparators(WbStandardPaths::webotsMsys64Path());


### PR DESCRIPTION
Currently the libController path is appended at the end of the existing `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH` and `Path` (respectively on Linux, macOS and Windows). This can lead to the wrong libController being used by Webots.