### PR TITLE
Connector: Fix status after reset

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -11,6 +11,7 @@ Released on ??
     - Improved plot representation in default robot window when a NaN value is received from a device ([#5680](https://github.com/cyberbotics/webots/pull/5680)).
     - Improved default selected tab in Field Editor when nodes are selected ([#5726](https://github.com/cyberbotics/webots/pull/5726)).
   - Bug Fixes
+    - Fix the behavior of the [Connector](connector.md) after a reset to return to the controller the correct status ([#5889](https://github.com/cyberbotics/webots/pull/5889))
     - Fixed redirection of stdout/stderr for Python controllers on Windows ([#5807](https://github.com/cyberbotics/webots/pull/5807)).
     - Fixed crash in Python API when a robot controller was using several cameras with different resolutions ([#5705](https://github.com/cyberbotics/webots/pull/5705)).
     - Fixed Python API `Supervisor.setSimulationMode` which was failing ([#5603](https://github.com/cyberbotics/webots/pull/5603)).

--- a/docs/reference/supervisor.md
+++ b/docs/reference/supervisor.md
@@ -2557,6 +2557,13 @@ The following table summarizes the behavior of different reset functions:
       <td>N/A</td>
     </tr>
     <tr>
+      <td><strong><a href="connector.md">Connector</a></strong></td>
+      <td>Resets</td>
+      <td colspan=3>Resets the <code>isLocked</code> field</td>
+      <td>N/A</td>
+      <td>N/A</td>
+    </tr>
+    <tr>
       <td><strong><a href="display.md">Display</a></strong></td>
       <td>Resets</td>
       <td>Clears</td>

--- a/src/webots/nodes/WbConnector.cpp
+++ b/src/webots/nodes/WbConnector.cpp
@@ -742,6 +742,7 @@ void WbConnector::reset(const QString &id) {
   if (mPeer)
     detachFromPeer();
   mStartup = true;
+  mNeedToReconfigure = true;
 }
 
 void WbConnector::save(const QString &id) {


### PR DESCRIPTION
After a reset, the value returned by `wb_connector_is_locked` was not updated, because the controller
didn't received new value.
I can't emphasis enough the fact that I'm asking for help to assess this fix, and moreover ensure that this bug is not present in others node. This could be a pattern issue, and might have been reproduced elsewhere.
However, it's seems that is a specific bug of the Connector : it's the only one to make use of both `mNeedToReconfigure` and a custom `reset()` function. I do think it's because contrary to others node that are pure sensor, this one actively impact the simulation, hence the code pattern change a bit. Am I right ?

**Description**
Ensure that after a reset the correct status is sent to a controller. 

**Related Issues**
This pull-request fixes issue https://github.com/cyberbotics/webots/issues/5890

**Tasks**
Add the list of tasks of this PR.
  - [ ] Ensure that it's the correct fix
  - [ ] Ensure that the other nodes don't have this issue, and fix them accordingly
