### PR TITLE
WebotsJS: fix web mf

### DIFF
--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -477,12 +477,12 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
 
       let value;
       if (parameter.type === VRML.MFVec3f) {
-        value = {x: this.#sanitizeNumber(elements[i].childNodes[0].childNodes[1].value),
-          y: this.#sanitizeNumber(elements[i].childNodes[1].childNodes[1].value),
-          z: this.#sanitizeNumber(elements[i].childNodes[2].childNodes[1].value)};
+        value = {x: this.#sanitizeNumber(elements[i].childNodes[0].childNodes[0].value),
+          y: this.#sanitizeNumber(elements[i].childNodes[1].childNodes[0].value),
+          z: this.#sanitizeNumber(elements[i].childNodes[2].childNodes[0].value)};
       } else if (parameter.type === VRML.MFVec2f) {
-        value = {x: this.#sanitizeNumber(elements[i].childNodes[0].childNodes[1].value),
-          y: this.#sanitizeNumber(elements[i].childNodes[1].childNodes[1].value)};
+        value = {x: this.#sanitizeNumber(elements[i].childNodes[0].childNodes[0].value),
+          y: this.#sanitizeNumber(elements[i].childNodes[1].childNodes[0].value)};
       } else if (parameter.type === VRML.MFString)
         value = elements[i].childNodes[0].value;
       else if (parameter.type === VRML.MFFloat || parameter.type === VRML.MFInt32)
@@ -490,10 +490,10 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
       else if (parameter.type === VRML.MFBool)
         value = elements[i].childNodes[0].checked;
       else if (parameter.type === VRML.MFRotation) {
-        value = {'x': this.#sanitizeNumber(elements[i].childNodes[0].childNodes[1].value),
-          'y': this.#sanitizeNumber(elements[i].childNodes[1].childNodes[1].value),
-          'z': this.#sanitizeNumber(elements[i].childNodes[2].childNodes[1].value),
-          'a': this.#sanitizeNumber(elements[i].childNodes[3].childNodes[1].value)};
+        value = {'x': this.#sanitizeNumber(elements[i].childNodes[0].childNodes[0].value),
+          'y': this.#sanitizeNumber(elements[i].childNodes[1].childNodes[0].value),
+          'z': this.#sanitizeNumber(elements[i].childNodes[2].childNodes[0].value),
+          'a': this.#sanitizeNumber(elements[i].childNodes[3].childNodes[0].value)};
       } else if (parameter.type === VRML.MFColor) {
         const hexValue = elements[i].childNodes[0].value;
         const red = parseInt(hexValue.substring(1, 3), 16) / 255;


### PR DESCRIPTION
- [x] Fix MfVector2/3 and rotation. It was broken when we removed the `x: y: z:`
- [x] Fix MFNode reset. It was not offsetting the following rows if the default was not null.

Test it here: https://testing.webots.cloud/run?version=R2023b&url=https://github.com/cyberbotics/webots/blob/doc-add-robots/projects/robots/pal_robotics/tiagopp/protos/Tiagopp.proto&type=undefined