### PR TITLE
Add version comparison between libController and Webots

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -4,6 +4,7 @@
 Released on ??
   - New Features
     - Added a new launcher to simplify the start of extern controllers ([#5629](https://github.com/cyberbotics/webots/pull/5629)).
+    - Added a warning when Webots and controller library versions are different ([#5896](https://github.com/cyberbotics/webots/pull/5896)).
   - Cleanup
     - Deprecated the C and MATLAB API functions `wb_supervisor_node_enable/disable_contact_point_tracking` in favor of `wb_supervisor_node_enable/disable_contact_points_tracking` to be more consistent with other APIs ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
   - Enhancements

--- a/src/controller/c/Makefile
+++ b/src/controller/c/Makefile
@@ -35,10 +35,14 @@ include $(WEBOTS_HOME_PATH)/resources/Makefile.include
 
 WEBOTS_DEPENDENCY_PATH ?= $(WEBOTS_HOME_PATH)/dependencies
 
+ifeq ($(OSTYPE),darwin)
+LIBCONTROLLER_VERSION := "$(shell cat $(WEBOTS_HOME_PATH)/Contents/Resources/version.txt)"
+else
 LIBCONTROLLER_VERSION := "$(shell cat $(WEBOTS_HOME_PATH)/resources/version.txt)"
+endif
 
 ifeq ($(OSTYPE),darwin)
-CFLAGS      = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -fpascal-strings -Wno-deprecated-declarations -I/Developer/Headers/FlatCarbon -Wall -fno-common
+CFLAGS      = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -fpascal-strings -Wno-deprecated-declarations -I/Developer/Headers/FlatCarbon -Wall -fno-common -D LIBCONTROLLER_VERSION='$(LIBCONTROLLER_VERSION)'
 INCLUDE     = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include
 LD_FLAGS    = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -dynamiclib -install_name @rpath/Contents/lib/controller/libController.dylib -compatibility_version 1.0 -current_version 1.0.0
 SHARED_LIBS = -lz

--- a/src/controller/c/Makefile
+++ b/src/controller/c/Makefile
@@ -55,7 +55,7 @@ TARGET      = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.so
 endif
 
 ifeq ($(OSTYPE),windows)
-CFLAGS      = -Wall -mwindows -frandom-seed=0
+CFLAGS      = -Wall -mwindows -frandom-seed=0 -D LIBCONTROLLER_VERSION='$(LIBCONTROLLER_VERSION)'
 INCLUDE     = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include -I/mingw64/include
 LD_FLAGS    = -shared -mwindows --def Controller.def -lws2_32
 PLATFORM    = win32

--- a/src/controller/c/Makefile
+++ b/src/controller/c/Makefile
@@ -35,6 +35,8 @@ include $(WEBOTS_HOME_PATH)/resources/Makefile.include
 
 WEBOTS_DEPENDENCY_PATH ?= $(WEBOTS_HOME_PATH)/dependencies
 
+LIBCONTROLLER_VERSION := "$(shell cat $(WEBOTS_HOME_PATH)/resources/version.txt)"
+
 ifeq ($(OSTYPE),darwin)
 CFLAGS      = -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -fpascal-strings -Wno-deprecated-declarations -I/Developer/Headers/FlatCarbon -Wall -fno-common
 INCLUDE     = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include
@@ -45,7 +47,7 @@ CC          = gcc
 endif
 
 ifeq ($(OSTYPE),linux)
-CFLAGS      = -fPIC -Wall -Wno-stringop-truncation
+CFLAGS      = -fPIC -Wall -Wno-stringop-truncation -D LIBCONTROLLER_VERSION='$(LIBCONTROLLER_VERSION)'
 INCLUDE     = -I$(WEBOTS_HOME_PATH)/include/controller/c -I$(WEBOTS_HOME_PATH)/include
 LD_FLAGS    = -shared -Wl,-soname,libController.so
 SHARED_LIBS = -lm -lpthread -ldl -lrt

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -353,6 +353,17 @@ static void robot_send_request(unsigned int step_duration) {
 
 // rebuild the device list
 static void robot_configure(WbRequest *r) {
+  free(robot.device[0]->name);
+  robot.device[0]->name = request_read_string(r);
+
+  WEBOTS_VERSION = request_read_string(r);
+  if (strlen(WEBOTS_VERSION) && (strlen(WEBOTS_VERSION) != strlen(LIBCONTROLLER_VERSION) ||
+                                 strncmp(WEBOTS_VERSION, LIBCONTROLLER_VERSION, strlen(WEBOTS_VERSION))))
+    fprintf(stderr,
+            "Warning: Webots [%s] and libController [%s] versions are not the same for Robot '%s'! Different versions can lead "
+            "to undefined behavior.\n",
+            WEBOTS_VERSION, LIBCONTROLLER_VERSION, robot.device[0]->name);
+
   // delete all the devices except the robot
   WbDeviceTag tag;
   for (tag = 1; tag < robot.n_device; tag++)
@@ -371,8 +382,6 @@ static void robot_configure(WbRequest *r) {
   robot.device[0] = d;  // restore pointer to root device
   robot.device[0]->node = request_read_uint16(r);
   simulation_time = request_read_double(r);
-  free(robot.device[0]->name);
-  robot.device[0]->name = request_read_string(r);
 
   // printf("robot.is_supervisor = %d\n", robot.is_supervisor);
   // printf("robot.synchronization = %d\n", robot.synchronization);
@@ -393,13 +402,6 @@ static void robot_configure(WbRequest *r) {
   init_devices_from_tag(r, 1);
 
   robot.configure = 1;
-  WEBOTS_VERSION = request_read_string(r);
-  if (strlen(WEBOTS_VERSION) && (strlen(WEBOTS_VERSION) != strlen(LIBCONTROLLER_VERSION) ||
-                                 strncmp(WEBOTS_VERSION, LIBCONTROLLER_VERSION, strlen(WEBOTS_VERSION))))
-    fprintf(stderr,
-            "Warning: Webots [%s] and libController [%s] versions are not the same for Robot '%s'! Different versions can lead "
-            "to undefined behavior.\n",
-            WEBOTS_VERSION, LIBCONTROLLER_VERSION, robot.device[0]->name);
   robot.basic_time_step = request_read_double(r);
   robot.project_path = request_read_string(r);
   robot.world_path = request_read_string(r);

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -74,6 +74,10 @@
 #define WEBOTS_EXIT_NOW 1
 #define WEBOTS_EXIT_LATER 2
 
+#ifndef LIBCONTROLLER_VERSION
+#error "Missing declaration of LIBCONTROLLER_VERSION preprocessor macro in the Makefile."
+#endif
+
 typedef struct {
   WbDevice **device;  // array of devices
   double battery_value;
@@ -119,6 +123,7 @@ typedef struct {
   WbSimulationMode simulation_mode;  // WB_SUPERVISOR_SIMULATION_MODE_FAST, etc.
 } WbRobot;
 
+static char *WEBOTS_VERSION;
 static bool robot_init_was_done = false;
 static WbRobot robot;
 static WbMutexRef robot_step_mutex;
@@ -388,6 +393,11 @@ static void robot_configure(WbRequest *r) {
   init_devices_from_tag(r, 1);
 
   robot.configure = 1;
+  WEBOTS_VERSION = request_read_string(r);
+  if (strlen(WEBOTS_VERSION) && (strlen(WEBOTS_VERSION) != strlen(LIBCONTROLLER_VERSION) ||
+                                 strncmp(WEBOTS_VERSION, LIBCONTROLLER_VERSION, strlen(WEBOTS_VERSION))))
+    fprintf(stderr, "Warning: Webots version %s is not the same as the one from the libController %s!\n", WEBOTS_VERSION,
+            LIBCONTROLLER_VERSION);
   robot.basic_time_step = request_read_double(r);
   robot.project_path = request_read_string(r);
   robot.world_path = request_read_string(r);

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -396,8 +396,10 @@ static void robot_configure(WbRequest *r) {
   WEBOTS_VERSION = request_read_string(r);
   if (strlen(WEBOTS_VERSION) && (strlen(WEBOTS_VERSION) != strlen(LIBCONTROLLER_VERSION) ||
                                  strncmp(WEBOTS_VERSION, LIBCONTROLLER_VERSION, strlen(WEBOTS_VERSION))))
-    fprintf(stderr, "Warning: Webots version %s is not the same as the one from the libController %s!\n", WEBOTS_VERSION,
-            LIBCONTROLLER_VERSION);
+    fprintf(stderr,
+            "Warning: Webots [%s] and libController [%s] versions are not the same for Robot '%s'! Different versions can lead "
+            "to undefined behavior.\n",
+            WEBOTS_VERSION, LIBCONTROLLER_VERSION, robot.device[0]->name);
   robot.basic_time_step = request_read_double(r);
   robot.project_path = request_read_string(r);
   robot.world_path = request_read_string(r);

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -15,6 +15,7 @@
 #include "WbRobot.hpp"
 
 #include "WbAbstractCamera.hpp"
+#include "WbApplicationInfo.hpp"
 #include "WbBinaryIncubator.hpp"
 #include "WbControllerPlugin.hpp"
 #include "WbDataStream.hpp"
@@ -773,6 +774,9 @@ void WbRobot::writeConfigure(WbDataStream &stream) {
   stream.writeRawData(n.constData(), n.size() + 1);
 
   writeDeviceConfigure(mDevices, stream);
+
+  n = WbApplicationInfo::version().toString().toUtf8();
+  stream.writeRawData(n.constData(), n.size() + 1);
 
   stream << (double)WbWorld::instance()->basicTimeStep();
 

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -764,19 +764,17 @@ void WbRobot::writeConfigure(WbDataStream &stream) {
   mBatterySensor->connectToRobotSignal(this);
   stream << (short unsigned int)0;
   stream << (unsigned char)C_CONFIGURE;
+  QByteArray n = name().toUtf8();
+  stream.writeRawData(n.constData(), n.size() + 1);
+  n = WbApplicationInfo::version().toString().toUtf8();
+  stream.writeRawData(n.constData(), n.size() + 1);
   stream << (unsigned char)(mSupervisorUtilities ? 1 : 0);
   stream << (unsigned char)(synchronization() ? 1 : 0);
   stream << (short int)(1 + deviceCount());
   stream << (short int)nodeType();
   stream << (double)0.001 * WbSimulationState::instance()->time();
 
-  QByteArray n = name().toUtf8();
-  stream.writeRawData(n.constData(), n.size() + 1);
-
   writeDeviceConfigure(mDevices, stream);
-
-  n = WbApplicationInfo::version().toString().toUtf8();
-  stream.writeRawData(n.constData(), n.size() + 1);
 
   stream << (double)WbWorld::instance()->basicTimeStep();
 


### PR DESCRIPTION
Resolves #3505.

With extern controllers (namely TCP ones) and the `webots_ros2` package it happens that the user uses different versions of Webots and of the libController, which is forbidden, as both could be incompatible with each other.

Webots is now sending its version in the configure message of the robot. The version is compared on the libController side and a warning is displayed if they are not equal.