### PR TITLE
Fix typos in Python Car Lib

### DIFF
--- a/lib/controller/python/vehicle/car.py
+++ b/lib/controller/python/vehicle/car.py
@@ -100,7 +100,7 @@ class Car(Supervisor):
         return self.type
 
     def getWheelbase(self):
-        return self.wheel_base
+        return self.wheelbase
 
     def getWheelEncoder(self, wheel_index):
         return self.api.wbu_car_get_wheel_encoder(wheel_index)
@@ -174,5 +174,5 @@ class Car(Supervisor):
         return self.api.wbu_car_get_type()
 
     @property
-    def wheel_base(self) -> float:
+    def wheelbase(self) -> float:
         return self.api.wbu_car_get_wheelbase()

--- a/lib/controller/python/vehicle/car.py
+++ b/lib/controller/python/vehicle/car.py
@@ -50,14 +50,14 @@ class Car(Supervisor):
         self.api.wbu_car_get_right_steering_angle.restype = ctypes.c_double
         self.api.wbu_car_get_track_front.restype = ctypes.c_double
         self.api.wbu_car_get_track_rear.restype = ctypes.c_double
-        self.api.wbu_car_get_wheel_base.restype = ctypes.c_double
+        self.api.wbu_car_get_wheelbase.restype = ctypes.c_double
         self.api.wbu_car_get_wheel_encoder.restype = ctypes.c_double
         self.api.wbu_car_get_wheel_speed.restype = ctypes.c_double
 
         self.api.wbu_car_init()
 
     def __del__(self):
-        self.api.wbu_can_cleanup()
+        self.api.wbu_car_cleanup()
         super().__del__()
 
     def enableIndicatorAutoDisabling(self, enable: bool):
@@ -175,4 +175,4 @@ class Car(Supervisor):
 
     @property
     def wheel_base(self) -> float:
-        return self.api.wbu_car_get_wheel_base()
+        return self.api.wbu_car_get_wheelbase()


### PR DESCRIPTION
The wheel_base vs wheelbase part might want some further looking into for the sake of consistency