### PR TITLE
Fix Camera recognition for scaled objects

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -40,6 +40,7 @@ Released on ??
     - Fixed wrong warning message about parent "worlds" folder displayed when saving a world ([#5843](https://github.com/cyberbotics/webots/pull/5843)).
     - Fixed the issue of Webots occasionally loading the incorrect libController ([#5885](https://github.com/cyberbotics/webots/pull/5885)).
     - Fixed the incorrect parent link of SliderJoints when exporting to URDF ([#5899](https://github.com/cyberbotics/webots/pull/5899)).
+    - Fixed computation of relative position for [Camera recognition objects](camera.md#camera-recognition-object) if they have a parent [Transform](transform.md) node ([#5905](https://github.com/cyberbotics/webots/pull/5905)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -279,7 +279,7 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
       const double size = 2 * boundingSphere->radius() * std::max(std::max(scale.x(), scale.y()), scale.z());
       objectSize.setXyz(size, size, size);
       // correct the object center
-      objectPosition += boundingSphere->center();
+      objectPosition += scale * boundingSphere->center();
     } else {
       double height = 0;
       double radius = 0;

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -279,7 +279,7 @@ bool WbObjectDetection::computeBounds(const WbVector3 &devicePosition, const WbM
       const double size = 2 * boundingSphere->radius() * std::max(std::max(scale.x(), scale.y()), scale.z());
       objectSize.setXyz(size, size, size);
       // correct the object center
-      objectPosition += scale * boundingSphere->center();
+      objectPosition = transform->matrix() * boundingSphere->center();
     } else {
       double height = 0;
       double radius = 0;


### PR DESCRIPTION
Detected object center was not computed correctly for scaled objects or in general if the Solid with recognition enabled has a parent Transform node with a non-default scale or rotation.

This is a first bug fix to the Camera recognition but there are other in case the bounding object (and not the bounding sphere) is used to compute the position.
Additionally, the Camera recognition only works for planar projections (not for spherical and cylindrical).