### PR TITLE
Robots insertion

### DIFF
--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -762,9 +762,8 @@ bool WbNodeUtilities::isDescendantOfBillboard(const WbNode *node) {
     return true;
 
   WbNode *n = node->parentNode();
-  WbField *field = node->parentField(true);
-  while (n && !n->isWorldRoot() && field) {
-    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(field->parentNode());
+  while (n && !n->isWorldRoot()) {
+    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(n);
 
     if (!baseNode)
       return false;
@@ -772,7 +771,6 @@ bool WbNodeUtilities::isDescendantOfBillboard(const WbNode *node) {
     if (baseNode->nodeType() == WB_NODE_BILLBOARD)
       return true;
 
-    field = n->parentField(true);
     n = n->parentNode();
   }
 

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -136,7 +136,7 @@ namespace {
 
     // No robot can be inserted in helix of propellers.
     if (WbNodeUtilities::isRobotTypeName(nodeName) && WbNodeUtilities::isDescendantOfPropeller(node))
-        return false;
+      return false;
 
     if (dynamic_cast<const WbSlot *>(node) && (fieldName == "endPoint")) {  // add something in the endPoint field of a slot
       if (dynamic_cast<const WbSlot *>(node->parentNode())) {  // pair of slots, we can add everything that is allowed in the

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -325,7 +325,7 @@ namespace {
     }
 
     if (fieldName == "endPoint") {
-      if (WbNodeUtilities::isSolidButRobotTypeName(nodeName) || nodeName == "SolidReference")
+      if (WbNodeUtilities::isSolidTypeName(nodeName) || nodeName == "SolidReference")
         return true;
       else if (nodeName == "Slot")
         return true;

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -792,9 +792,8 @@ bool WbNodeUtilities::isDescendantOfPropeller(const WbNode *node) {
     return true;
 
   WbNode *n = node->parentNode();
-  WbField *field = node->parentField(true);
-  while (n && !n->isWorldRoot() && field) {
-    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(field->parentNode());
+  while (n && !n->isWorldRoot()) {
+    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(n);
 
     if (!baseNode)
       return false;
@@ -802,7 +801,6 @@ bool WbNodeUtilities::isDescendantOfPropeller(const WbNode *node) {
     if (baseNode->nodeType() == WB_NODE_PROPELLER)
       return true;
 
-    field = n->parentField(true);
     n = n->parentNode();
   }
 

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -753,15 +753,7 @@ bool WbNodeUtilities::isDescendantOfBillboard(const WbNode *node) {
   if (node == NULL)
     return false;
 
-  const WbBaseNode *initialNode = dynamic_cast<const WbBaseNode *>(node);
-
-  if (!initialNode)
-    return false;
-
-  if (initialNode->nodeType() == WB_NODE_BILLBOARD)
-    return true;
-
-  WbNode *n = node->parentNode();
+  WbNode *n = const_cast<WbNode *>(node);
   while (n && !n->isWorldRoot()) {
     WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(n);
 
@@ -781,17 +773,9 @@ bool WbNodeUtilities::isDescendantOfPropeller(const WbNode *node) {
   if (node == NULL)
     return false;
 
-  const WbBaseNode *initialNode = dynamic_cast<const WbBaseNode *>(node);
-
-  if (!initialNode)
-    return false;
-
-  if (initialNode->nodeType() == WB_NODE_PROPELLER)
-    return true;
-
-  WbNode *n = node->parentNode();
+  WbNode *n = const_cast<WbNode *>(node);
   while (n && !n->isWorldRoot()) {
-    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(n);
+    const WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(n);
 
     if (!baseNode)
       return false;

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -134,6 +134,10 @@ namespace {
       return false;
     }
 
+    // No robot can be inserted in helix of propellers.
+    if (WbNodeUtilities::isRobotTypeName(nodeName) && WbNodeUtilities::isDescendantOfPropeller(node))
+        return false;
+
     if (dynamic_cast<const WbSlot *>(node) && (fieldName == "endPoint")) {  // add something in the endPoint field of a slot
       if (dynamic_cast<const WbSlot *>(node->parentNode())) {  // pair of slots, we can add everything that is allowed in the
                                                                // children field of the parent of first Slot node
@@ -331,10 +335,10 @@ namespace {
         return true;
 
     } else if (fieldName == "rotatingHead") {
-      if (WbNodeUtilities::isSolidButRobotTypeName(nodeName))
+      if (WbNodeUtilities::isSolidTypeName(nodeName))
         return true;
     } else if (fieldName.endsWith("Helix")) {
-      if (WbNodeUtilities::isSolidButRobotTypeName(nodeName))
+      if (WbNodeUtilities::isSolidTypeName(nodeName))
         return true;
 
     } else if (fieldName == "device") {
@@ -766,6 +770,36 @@ bool WbNodeUtilities::isDescendantOfBillboard(const WbNode *node) {
       return false;
 
     if (baseNode->nodeType() == WB_NODE_BILLBOARD)
+      return true;
+
+    field = n->parentField(true);
+    n = n->parentNode();
+  }
+
+  return false;
+}
+
+bool WbNodeUtilities::isDescendantOfPropeller(const WbNode *node) {
+  if (node == NULL)
+    return false;
+
+  const WbBaseNode *initialNode = dynamic_cast<const WbBaseNode *>(node);
+
+  if (!initialNode)
+    return false;
+
+  if (initialNode->nodeType() == WB_NODE_PROPELLER)
+    return true;
+
+  WbNode *n = node->parentNode();
+  WbField *field = node->parentField(true);
+  while (n && !n->isWorldRoot() && field) {
+    WbBaseNode *baseNode = dynamic_cast<WbBaseNode *>(field->parentNode());
+
+    if (!baseNode)
+      return false;
+
+    if (baseNode->nodeType() == WB_NODE_PROPELLER)
       return true;
 
     field = n->parentField(true);
@@ -1266,19 +1300,12 @@ bool WbNodeUtilities::isSolidDeviceTypeName(const QString &modelName) {
   return false;
 }
 
-bool WbNodeUtilities::isSolidButRobotTypeName(const QString &modelName) {
+bool WbNodeUtilities::isSolidTypeName(const QString &modelName) {
   if (modelName == "Solid")
     return true;
   if (modelName == "Charger")
     return true;
   if (WbNodeUtilities::isSolidDeviceTypeName(modelName))
-    return true;
-
-  return false;
-}
-
-bool WbNodeUtilities::isSolidTypeName(const QString &modelName) {
-  if (isSolidButRobotTypeName(modelName))
     return true;
   if (isRobotTypeName(modelName))
     return true;

--- a/src/webots/nodes/utils/WbNodeUtilities.hpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.hpp
@@ -87,6 +87,9 @@ namespace WbNodeUtilities {
   // is this node located directly or indirectly under a Billboard
   bool isDescendantOfBillboard(const WbNode *node);
 
+  // is this node located directly or indirectly under a Propeller
+  bool isDescendantOfPropeller(const WbNode *node);
+
   // is this node located in the boundingObject field of a Solid
   // use checkNodeUse() to inspect USE nodes and PROTO parameter instances
   bool isInBoundingObject(const WbNode *node);
@@ -139,7 +142,6 @@ namespace WbNodeUtilities {
   bool isDeviceTypeName(const QString &modelName);
   bool isSolidDeviceTypeName(const QString &modelName);
   bool isSolidTypeName(const QString &modelName);
-  bool isSolidButRobotTypeName(const QString &modelName);
   bool isMatterTypeName(const QString &modelName);
   QString slotType(const WbNode *node);
 


### PR DESCRIPTION
Allow robots in joints endpoint.

While checking that, I saw that it was also not possible to insert `robot` in 

- `fastHelix` and `slowHelix` of a propeller
- `rotatingHead` of a lidar.

But I am not sure if we want to change it.
I do not really see a utility but on the other point it is strange that:
- `fastHelix` -> `robot` is wrong
- `fastHelix` -> `solid` -> `robot` is correct

What do you think @omichel @stefaniapedrazzi ?