### PR TITLE
WebotsJS: Fix nested templateregenerator

### DIFF
--- a/resources/web/wwi/protoVisualizer/Node.js
+++ b/resources/web/wwi/protoVisualizer/Node.js
@@ -130,6 +130,8 @@ export default class Node {
             const p = tokenizer.proto.parameters.get(alias);
             fieldValue.value = p.value;
             p.addAliasLink(fieldValue);
+            if (fieldValue instanceof Parameter && !p.isTemplateRegenerator)
+              p.isTemplateRegenerator = fieldValue.isTemplateRegenerator;
           } else
             fieldValue.value.setValueFromTokenizer(tokenizer);
         }


### PR DESCRIPTION
In the case of the RobotisOp2, the `backlash` parameter was not flagged as template regenerator also it should have.
It was correctly flagged in its subproto (`Darwin-op`) but the information was not transmitted to the upper level.


Test it here: https://testing.webots.cloud/run?version=R2023b&url=https://github.com/cyberbotics/webots/blob/doc-add-robots/projects/robots/robotis/darwin-op/protos/RobotisOp2.proto&type=undefined