### PR TITLE
Fix PROTO USE info in Add Node dialog

### DIFF
--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -321,13 +321,13 @@ void WbAddNodeDialog::showNodeInfo(const QString &nodeFileName, NodeType nodeTyp
     // set icon path
     pixmapPath = "icons:" + fileInfo.baseName() + ".png";
   } else {
-    assert(variant > 0);
+    assert(nodeType == USE || variant > 0);
     // the node is a PROTO
     QMap<QString, WbProtoInfo *> list;
     if (variant == WbProtoManager::PROTO_WEBOTS)
       list = WbProtoManager::instance()->webotsProtoList();
     else
-      list = WbProtoManager::instance()->protoInfoMap(variant);
+      list = WbProtoManager::instance()->protoInfoMap(nodeType == USE ? WbProtoManager::PROTO_WORLD : variant);
 
     if (!list.contains(fileName)) {
       WbLog::error(tr("'%1' is not a known proto in category '%2'.\n").arg(fileName).arg(variant));


### PR DESCRIPTION
Fix #5820:
in the Add Node dialog, if the selected USE node is a PROTO node it was not defined in which PROTO list the method had to search to retrieve the node information.

In case of USE nodes, the corresponding DEF node is already used by the world, so node info should be looked in the current world PROTO list.