### PR TITLE
Fix `get_pose` requests hanging webots when multiple nodes are being tracked

### DIFF
--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2042,15 +2042,16 @@ const double *wb_supervisor_node_get_pose(WbNodeRef node, WbNodeRef from_node) {
   }
 
   WbPoseStruct *tmp_pose = pose_collection;
-  while (tmp_pose)
+  while (tmp_pose) {
     if (tmp_pose->from_node == from_node && tmp_pose->to_node == node) {
       if (tmp_pose->last_update == wb_robot_get_time())
         return tmp_pose->pose;
       else
         break;
-
-      tmp_pose = tmp_pose->next;
     }
+
+    tmp_pose = tmp_pose->next;
+  }
 
   robot_mutex_lock();
   pose_requested = true;


### PR DESCRIPTION
**Description**

Fixes: https://github.com/cyberbotics/webots/issues/5882

The issue ended up being on the libcontroller side, not webots. Basically a chained structure holds the pose information of each tracked node, and whenever a pose request was made by the controller, the libcontroller would go through this chain and return the pose of the matching node (the chain is being fed updated pose information from the tracking). The process however went wrong when two (or more) pose requests occurred (while two nodes were being tracked) because when requesting the pose of the second, that request never had the chance of being met since the matching node could not be found on the chain (or rather, the iteration didn't even get there).
It also explains why tracking two objects but request only the pose of the first appeared to be working, since the loop did explore the first item in the chain at least.