### PR TITLE
Prevent long server names and non-ascii robot names

### DIFF
--- a/projects/objects/buildings/protos/RandomBuilding.proto
+++ b/projects/objects/buildings/protos/RandomBuilding.proto
@@ -69,7 +69,7 @@ PROTO RandomBuilding [
     name IS name
     floorHeight IS floorHeight
     floorNumber IS floorNumber
-    startingFloor IS startingFloor§
+    startingFloor IS startingFloor
     corners IS corners
     groundFloor IS groundFloor
     groundFloorScale IS groundFloorScale

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -313,6 +313,11 @@ void WbController::start() {
   file.write("");
   file.close();
 #endif
+  if (serverName.length() > 106) { // limit imposed by QLocalServer
+    WbLog::error(tr("Server name is too long, please shorten the robot name (server name = '%1').").arg(serverName));
+    return;
+  }
+
   // recover from a crash, when the previous server instance has not been cleaned up
   bool success = QLocalServer::removeServer(serverName);
   if (!success) {

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -313,7 +313,7 @@ void WbController::start() {
   file.write("");
   file.close();
 #endif
-  if (serverName.length() > 106) { // limit imposed by QLocalServer
+  if (serverName.length() > 106) {  // limit imposed by QLocalServer
     WbLog::error(tr("Server name is too long, please shorten the robot name (server name = '%1').").arg(serverName));
     return;
   }

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -225,6 +225,7 @@ void WbRobot::preFinalize() {
     }
     parsingWarn(tr("Robot.controllerArgs data type changed from SFString to MFString in Webots R2020b. %1").arg(message));
   }
+  updateName();
   updateSupervisor();
   updateWindow();
   updateRemoteControl();
@@ -589,6 +590,14 @@ void WbRobot::setWaitingForWindow(bool waiting) {
 
 void WbRobot::updateData() {
   mDataNeedToWriteAnswer = true;
+}
+
+void WbRobot::updateName() {
+  if (name().contains(QRegularExpression(QStringLiteral("[^\\x{0000}-\\x{007F}]")))) {
+    WbLog::error(tr("Robot name contains non-ASCII characters, this is not supported. Resetting value to 'robot'."));
+    mName->setValue("robot");
+  }
+  WbSolid::updateName();
 }
 
 void WbRobot::updateSupervisor() {

--- a/src/webots/nodes/WbRobot.hpp
+++ b/src/webots/nodes/WbRobot.hpp
@@ -167,6 +167,8 @@ protected:
   void postPhysicsStep() override;
   virtual void writeConfigure(WbDataStream &);
 
+  void updateName() override;
+
   // export
   void exportNodeFields(WbWriter &writer) const override;
   const QString urdfName() const override;


### PR DESCRIPTION
**Description**

Fixes https://github.com/cyberbotics/webots/issues/5452

- Shows an error when the server name is too long (QLocalServer has a hard limit at 106 characters)
- Forces robot names to be ASCII. Connecting to a huge percentage-encoded string seems silly