### PR TITLE
Fix basetype for role attribution

### DIFF
--- a/resources/web/wwi/protoVisualizer/Vrml.js
+++ b/resources/web/wwi/protoVisualizer/Vrml.js
@@ -392,15 +392,7 @@ export class SFNode extends SingleValue {
     const nodeX3d = this.value.toX3d(parameterName);
 
     // handle exceptions
-    let name;
-    if (!this.value.isProto)
-      name = this.value.name;
-    else {
-      let baseType = this.value.baseType;
-      while (baseType.isProto)
-        baseType = baseType.baseType;
-      name = baseType.name;
-    }
+    const name = this.value.getBaseNode().name;
     if (this.value.name === 'ImageTexture')
       nodeX3d.setAttribute('role', parameterName);
     else if (['Shape', 'Group', 'Transform', 'Solid', 'Robot'].includes(name)) {

--- a/resources/web/wwi/protoVisualizer/Vrml.js
+++ b/resources/web/wwi/protoVisualizer/Vrml.js
@@ -392,14 +392,23 @@ export class SFNode extends SingleValue {
     const nodeX3d = this.value.toX3d(parameterName);
 
     // handle exceptions
+    let name;
+    if (!this.value.isProto)
+      name = this.value.name;
+    else {
+      let baseType = this.value.baseType;
+      while (baseType.isProto)
+        baseType = baseType.baseType;
+      name = baseType.name;
+    }
     if (this.value.name === 'ImageTexture')
       nodeX3d.setAttribute('role', parameterName);
-    else if (['Shape', 'Group', 'Transform', 'Solid', 'Robot'].includes(this.value.name)) {
+    else if (['Shape', 'Group', 'Transform', 'Solid', 'Robot'].includes(name)) {
       if (parameterName === 'boundingObject')
         nodeX3d.setAttribute('role', 'boundingObject');
-    } else if (['BallJointParameters', 'JointParameters', 'HingeJointParameters'].includes(this.value.name))
+    } else if (['BallJointParameters', 'JointParameters', 'HingeJointParameters'].includes(name))
       nodeX3d.setAttribute('role', parameterName); // identifies which jointParameter slot the node belongs to
-    else if (['Brake', 'PositionSensor', 'RotationalMotor', 'LinearMotor'].includes(this.value.name))
+    else if (['Brake', 'PositionSensor', 'RotationalMotor', 'LinearMotor'].includes(name))
       nodeX3d.setAttribute('role', parameterName); // identifies which device slot the node belongs to
 
     if (typeof nodeX3d !== 'undefined')


### PR DESCRIPTION
As it was just checking the name of the current node, it was not attributing the correct role to protos.
For example in the `Eyescrew.proto`, the `TorusBoundingObject.proto` was not given the role `boundingObject` and it was crashing webotsJS.

Test it here: https://testing.webots.cloud/run?version=R2023b&url=https://github.com/cyberbotics/webots/blob/doc-add-objects/projects/objects/factory/tools/protos/EyeScrew.proto&type=undefined