### PR TITLE
Fix USE node setup in WbDictionary

### DIFF
--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -171,7 +171,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
               sfNode->setValue(newUseNode);
             else if (mfNode) {
               mfNode->removeItem(index);
-              mfNode->insertItem(index, newUseNode);
+              mfNode->insertItem(index, newUseNode);  // TODO: replace by setItem(index, newUseNode) when it is fixed
             }
             regenerationRequired |= isTemplateRegenerator;
             while (parent) {
@@ -196,7 +196,7 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
             sfNode->setValue(newDefNode);
           else if (mfNode) {
             mfNode->removeItem(index);
-            mfNode->insertItem(index, newDefNode);
+            mfNode->insertItem(index, newDefNode);  // TODO: replace by setItem(index, newUseNode) when it is fixed
           }
           regenerationRequired |= isTemplateRegenerator;
           newDefNode->finalize();

--- a/src/webots/nodes/utils/WbDictionary.cpp
+++ b/src/webots/nodes/utils/WbDictionary.cpp
@@ -169,8 +169,10 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
             newUseNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
             if (sfNode)
               sfNode->setValue(newUseNode);
-            else if (mfNode)
-              mfNode->setItem(index, newUseNode);
+            else if (mfNode) {
+              mfNode->removeItem(index);
+              mfNode->insertItem(index, newUseNode);
+            }
             regenerationRequired |= isTemplateRegenerator;
             while (parent) {
               parent = parent->parentNode();
@@ -192,8 +194,10 @@ bool WbDictionary::updateDef(WbBaseNode *&node, WbSFNode *sfNode, WbMFNode *mfNo
           newDefNode->setUseName(useName);  // Deactivates the creation of children items triggered by insertion
           if (sfNode)
             sfNode->setValue(newDefNode);
-          else if (mfNode)
-            mfNode->setItem(index, newDefNode);
+          else if (mfNode) {
+            mfNode->removeItem(index);
+            mfNode->insertItem(index, newDefNode);
+          }
           regenerationRequired |= isTemplateRegenerator;
           newDefNode->finalize();
           node = newDefNode;


### PR DESCRIPTION
Fix #5821 (introduced in #5676 ):
currently the `WbMFNode::setItem` function doesn't work correctly because the `itemChanged` signal is not correctly handled.

A more complete fix for `WbMFNode::setItem` is inspected in #5950 but should target the develop branch.
