### PR TITLE
Fix update of joint endPoint after regeneration

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -44,6 +44,7 @@ Released on ??
     - Fixed [`wb_supervisor_export_image`](supervisor.md#wb_supervisor_export_image) not exporting until [`wb_robot_step`](robot.md#wb_robot_step) was called ([#5902](https://github.com/cyberbotics/webots/pull/5902)).
     - Fixed node information shown in the Add Node dialog when selecting a PROTO USE node ([#5946](https://github.com/cyberbotics/webots/pull/5946)).
     - Fixed bug causing Webots to hang when requesting multiple poses while pose-tracking multiple nodes ([#5952](https://github.com/cyberbotics/webots/pull/5952)).
+    - Fixed physics state updates of [Solid](solid.md) nodes added to a descendant [`Joint.endPoint`](joint.md) during simulation ([#5961](https://github.com/cyberbotics/webots/pull/5961)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/nodes/WbBasicJoint.cpp
+++ b/src/webots/nodes/WbBasicJoint.cpp
@@ -242,8 +242,8 @@ void WbBasicJoint::updateEndPoint() {
     if (s != NULL && isPostFinalizedCalled())
       WbBoundingSphere::addSubBoundingSphereToParentNode(this);
   } else {
-    connect(s, &WbBaseNode::finalizationCompleted, this, &WbBasicJoint::endPointChanged);
-    connect(s, &WbBaseNode::finalizationCompleted, this, &WbBasicJoint::updateBoundingSphere);
+    connect(s, &WbBaseNode::finalizationCompleted, this, &WbBasicJoint::endPointChanged, Qt::UniqueConnection);
+    connect(s, &WbBaseNode::finalizationCompleted, this, &WbBasicJoint::updateBoundingSphere, Qt::UniqueConnection);
   }
 }
 

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1590,8 +1590,8 @@ void WbSolid::updateChildren() {
     connect(solid, &WbSolid::destroyed, this, &WbSolid::refreshPhysicsRepresentation, Qt::UniqueConnection);
     connect(solid, &WbSolid::physicsPropertiesChanged, this, &WbSolid::refreshPhysicsRepresentation, Qt::UniqueConnection);
   }
-  foreach (WbBasicJoint *const joint, mJointChildren)
-    connect(joint, &WbBasicJoint::endPointChanged, this, &WbSolid::updateChildrenAfterJointEndPointChange,
+  foreach (WbBasicJoint *const jointChild, mJointChildren)
+    connect(jointChild, &WbBasicJoint::endPointChanged, this, &WbSolid::updateChildrenAfterJointEndPointChange,
             Qt::UniqueConnection);
 }
 

--- a/src/webots/nodes/WbSolid.cpp
+++ b/src/webots/nodes/WbSolid.cpp
@@ -1574,6 +1574,11 @@ void WbSolid::updateDynamicSolidDescendantFlag() {
     us->updateDynamicSolidDescendantFlag();
 }
 
+void WbSolid::updateChildrenAfterJointEndPointChange(WbBaseNode *node) {
+  if (node)
+    updateChildren();
+}
+
 void WbSolid::updateChildren() {
   mSolidChildren.clear();
   mJointChildren.clear();
@@ -1585,6 +1590,9 @@ void WbSolid::updateChildren() {
     connect(solid, &WbSolid::destroyed, this, &WbSolid::refreshPhysicsRepresentation, Qt::UniqueConnection);
     connect(solid, &WbSolid::physicsPropertiesChanged, this, &WbSolid::refreshPhysicsRepresentation, Qt::UniqueConnection);
   }
+  foreach (WbBasicJoint *const joint, mJointChildren)
+    connect(joint, &WbBasicJoint::endPointChanged, this, &WbSolid::updateChildrenAfterJointEndPointChange,
+            Qt::UniqueConnection);
 }
 
 bool WbSolid::resetJointPositions(bool allParents) {

--- a/src/webots/nodes/WbSolid.hpp
+++ b/src/webots/nodes/WbSolid.hpp
@@ -455,6 +455,7 @@ private:
   void setGeomMatter(dGeomID g, WbBaseNode *node = NULL) override;
 
 private slots:
+  void updateChildrenAfterJointEndPointChange(WbBaseNode *node);
   void updatePhysics();
   void updateRadarCrossSection();
   void updateRecognitionColors();


### PR DESCRIPTION
Fix #5951:
listen to changes in descendant joint `endPoint` field and update the children list when needed.

Note that given that the joint solid end point is also added to the `WbSolid::mSolidChildren` list, the `WbSolid::updateChildren` function is automatically called when the end point is deleted. Thus, it is not needed to call `WbSolid::updateChildren` when the `WbBasicJoint::endPointChanged` node argument is NULL.