### PR TITLE
Fix contact points

### DIFF
--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2876,7 +2876,7 @@ void wb_supervisor_node_enable_contact_points_tracking(WbNodeRef node, int sampl
   node->contact_points[descendants].last_update = -DBL_MAX;
   node->contact_points[descendants].sampling_period = sampling_period;
   wb_robot_flush_unlocked(__FUNCTION__);
-  pose_change_tracking_requested = false;
+  contact_point_change_tracking_requested = false;
   robot_mutex_unlock();
 }
 
@@ -2908,7 +2908,7 @@ void wb_supervisor_node_disable_contact_points_tracking(WbNodeRef node) {
   contact_point_change_tracking.enable = false;
   contact_point_change_tracking.include_descendants = false;
   wb_robot_flush_unlocked(__FUNCTION__);
-  pose_change_tracking_requested = false;
+  contact_point_change_tracking_requested = false;
   robot_mutex_unlock();
 }
 

--- a/src/controller/cpp/Node.cpp
+++ b/src/controller/cpp/Node.cpp
@@ -132,7 +132,7 @@ const double *Node::getPose(const Node *fromNode) const {
 }
 
 void Node::enableContactPointsTracking(int samplingPeriod, bool includeDescendants) const {
-  wb_supervisor_node_enable_contact_points_tracking(nodeRef, samplingPeriod, false);
+  wb_supervisor_node_enable_contact_points_tracking(nodeRef, samplingPeriod, includeDescendants);
 }
 
 void Node::disableContactPointsTracking(bool includeDescendants) const {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -1283,7 +1283,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
 
       int trackingInfoIndex = -1;
       for (int i = 0; i < mTrackedContactPoints.size(); i++) {
-        if (mTrackedContactPoints[i].solid == solid && mTrackedContactPoints[i].includeDescendants == includeDescendants) {
+        if (mTrackedContactPoints[i].solid == solid) {
           trackingInfoIndex = i;
           break;
         }
@@ -1300,6 +1300,7 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
           mTrackedContactPoints.append(trackedContactPoint);
           connect(solid, &WbSolid::destroyed, this, &WbSupervisorUtilities::removeTrackedContactPoints);
         } else {
+          mTrackedContactPoints[trackingInfoIndex].includeDescendants = includeDescendants;
           mTrackedContactPoints[trackingInfoIndex].samplingPeriod = samplingPeriod;
           mTrackedContactPoints[trackingInfoIndex].lastUpdate = -INFINITY;
         }


### PR DESCRIPTION
**Description**
I found three issues with contact points:

- [x] Since the first `wb_supervisor_node_enable_contact_points_tracking`, a `wb_supervisor_node_enable_contact_points_tracking` or  `wb_supervisor_node_disable_contact_points_tracking` command was sent at every timeStep. It was because we were not resetting the right boolean. This issue was present since this feature was introduced, but it was only recently made visible because of new warning messages (#5638).
- [x] The second issue is related with the changes from #5633.
  - It seems that the idea was to remove the `include_descendants` of the `wb_supervisor_node_disable_contact_points_tracking` function.
  - However, we use both the `solid` and the `include_descendants` parameters to disable the tracking in the Webots side: https://github.com/cyberbotics/webots/blob/d995dbc073c7d370a95ce56aff8c0b51d43a3e73/src/webots/nodes/utils/WbSupervisorUtilities.cpp#L1286
  - The result is that if we use `wb_supervisor_node_enable_contact_point_tracking` with `include_descendants` = True, then it is not possible to disable it later (and worse we risk to disable the tracking of the same solid but without the descendants
  - It seems consistent (but still wrong) with the python and matlab API. However when looking in the C++ one, it turns out that its ignore the `include_descendants` parameter also for the `enableContactPointsTracking` which is a loss of functionality (but does not seem new): https://github.com/cyberbotics/webots/blob/d995dbc073c7d370a95ce56aff8c0b51d43a3e73/src/controller/cpp/Node.cpp#L135

@omichel  do you have an idea of why you wanted to remove the `include_descendants` parameter?

-  The test `API/contact_points_and_center_of_mass` issues a lot of warnings but the test still succeed:

```
WARNING: DEF contact_points_and_center_of_mass Robot: No active contact points tracking could be found for the node 'Robot'.
WARNING: DEF contact_points_and_center_of_mass Robot: 'wb_supervisor_node_enable_contact_point_tracking' called for an invalid node.
Error: wb_supervisor_node_disable_pose_tracking() called with a NULL or invalid 'node' argument.
```

As discussed, we will not fix the test for now