### PR TITLE
WebotsJS: Comparison without value

### DIFF
--- a/resources/web/wwi/protoVisualizer/Parameter.js
+++ b/resources/web/wwi/protoVisualizer/Parameter.js
@@ -32,7 +32,7 @@ export default class Parameter extends Field {
         for (const value of newValue.value) {
           let found = false;
           for (const item of this.restrictions[0].value) {
-            if (item.equals(value, true)) {
+            if (item.url === value.url) {
               found = true;
               break;
             }
@@ -48,7 +48,7 @@ export default class Parameter extends Field {
         }
       } else {
         for (const item of this.restrictions) {
-          if ((newValue instanceof SFNode && newValue.value === null) || item.equals(newValue, true)) {
+          if ((newValue instanceof SFNode && newValue.value === null) || item.url === newValue.url) {
             super.value = newValue;
             return;
           }

--- a/resources/web/wwi/protoVisualizer/Parameter.js
+++ b/resources/web/wwi/protoVisualizer/Parameter.js
@@ -32,7 +32,7 @@ export default class Parameter extends Field {
         for (const value of newValue.value) {
           let found = false;
           for (const item of this.restrictions[0].value) {
-            if (item.equals(value)) {
+            if (item.equals(value, true)) {
               found = true;
               break;
             }
@@ -48,7 +48,7 @@ export default class Parameter extends Field {
         }
       } else {
         for (const item of this.restrictions) {
-          if ((newValue instanceof SFNode && newValue.value === null) || item.equals(newValue)) {
+          if ((newValue instanceof SFNode && newValue.value === null) || item.equals(newValue, true)) {
             super.value = newValue;
             return;
           }

--- a/resources/web/wwi/protoVisualizer/Vrml.js
+++ b/resources/web/wwi/protoVisualizer/Vrml.js
@@ -431,7 +431,7 @@ export class SFNode extends SingleValue {
     return this.value.toVrml();
   }
 
-  equals(other) {
+  equals(other, ignoreValue) {
     if (this.value === null && other.value === null)
       return true;
 
@@ -449,7 +449,7 @@ export class SFNode extends SingleValue {
         return false;
 
       const otherParameter = other.value.parameters.get(parameterName);
-      if (!parameter.value.equals(otherParameter.value))
+      if (!ignoreValue && !parameter.value.equals(otherParameter.value))
         return false;
       if (!parameter.defaultValue.equals(otherParameter.defaultValue))
         return false;

--- a/resources/web/wwi/protoVisualizer/Vrml.js
+++ b/resources/web/wwi/protoVisualizer/Vrml.js
@@ -431,7 +431,7 @@ export class SFNode extends SingleValue {
     return this.value.toVrml();
   }
 
-  equals(other, ignoreValue) {
+  equals(other) {
     if (this.value === null && other.value === null)
       return true;
 
@@ -449,7 +449,7 @@ export class SFNode extends SingleValue {
         return false;
 
       const otherParameter = other.value.parameters.get(parameterName);
-      if (!ignoreValue && !parameter.value.equals(otherParameter.value))
+      if (!parameter.value.equals(otherParameter.value))
         return false;
       if (!parameter.defaultValue.equals(otherParameter.defaultValue))
         return false;


### PR DESCRIPTION
Introduce a more permissive definition of `equals` to use in the context of restrictions.

Example:
In the `AddLaneRoadSegment` proto, the `lines` parameter is restricted and accept only one type of node: `RoadLine { }`.

It seems to work as intended at first glance: we can insert new `RoadLine { }`.
However, if we modify a `RoadLine { }`, let's say we change the line `type` from `dashed` to `double` and later we trigger a regeneration of the proto, it will not work.
This is the case because now we are comparing `RoadLine { }` with  `RoadLine { type double }`