### PR TITLE
Fix bounding sphere radius for Sphere and CadShape

### DIFF
--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -554,15 +554,12 @@ void WbCadShape::recomputeBoundingSphere() const {
   assert(mBoundingSphere);
   mBoundingSphere->empty();
 
-  const WbVector3 &scale = absoluteScale();
   for (WrStaticMesh *mesh : mWrenMeshes) {
     float sphere[4];
     wr_static_mesh_get_bounding_sphere(mesh, sphere);
 
     const WbVector3 center(sphere[0], sphere[1], sphere[2]);
-    double radius = sphere[3];
-    radius = radius / std::max(std::max(scale.x(), scale.y()), scale.z());
-    const WbBoundingSphere meshBoundingSphere(NULL, center, radius);
+    const WbBoundingSphere meshBoundingSphere(NULL, center, sphere[3]);
     mBoundingSphere->enclose(&meshBoundingSphere);
   }
 }

--- a/src/webots/nodes/WbSphere.cpp
+++ b/src/webots/nodes/WbSphere.cpp
@@ -311,7 +311,7 @@ bool WbSphere::computeCollisionPoint(WbVector3 &point, const WbRay &ray) const {
 
 void WbSphere::recomputeBoundingSphere() const {
   assert(mBoundingSphere);
-  mBoundingSphere->set(WbVector3(), scaledRadius());
+  mBoundingSphere->set(WbVector3(), radius());
 }
 
 ////////////////////////


### PR DESCRIPTION
Complete #5980:
fix bounding sphere radius for Sphere and CadShape geometries that are still scaled.