### PR TITLE
Fix instructions for the location of the webots.yml file

### DIFF
--- a/docs/guide/webots-cloud.md
+++ b/docs/guide/webots-cloud.md
@@ -55,7 +55,7 @@ COPY . $PROJECT_PATH
 
 #### YAML File
 
-A file named `webots.yml` must be included at the root level of a repository to determine publishing permissions, the type of project, as well as if an IDE should be present.
+A file named `webots.yml` must be included at the root level of a project to determine publishing permissions, the type of project, as well as if an IDE should be present.
 A typical example of a `webots.yml` file is the following:
 ```yaml
 publish: true


### PR DESCRIPTION
The `webots.yml` file should be located at the root level of the project, not the repository.