### PR TITLE
Fix mesh double loading

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -12,7 +12,7 @@ Released on ??
     - Improved default selected tab in Field Editor when nodes are selected ([#5726](https://github.com/cyberbotics/webots/pull/5726)).
     - Change the Windows version of SUMO to 1.13 to match the one used on Linux and MacOS and avoid a potiental Log4J vulnerability ([#6010](https://github.com/cyberbotics/webots/pull/6010)).
   - Bug Fixes
-    - Fixed the clean-up of the motion API which was firing warnings in Python ([#6029](https://github.com/cyberbotics/webots/pull/6029)). 
+    - Fixed the clean-up of the motion API which was firing warnings in Python ([#6029](https://github.com/cyberbotics/webots/pull/6029)).
     - Fixed the behavior of the [Connector](connector.md) after a reset to return to the controller the correct status ([#5889](https://github.com/cyberbotics/webots/pull/5889))
     - Fixed redirection of stdout/stderr for Python controllers on Windows ([#5807](https://github.com/cyberbotics/webots/pull/5807)).
     - Fixed crash in Python API when a robot controller was using several cameras with different resolutions ([#5705](https://github.com/cyberbotics/webots/pull/5705)).
@@ -52,6 +52,7 @@ Released on ??
     - Fixed physics state updates of [Solid](solid.md) nodes added to a descendant [`Joint.endPoint`](joint.md) during simulation ([#5961](https://github.com/cyberbotics/webots/pull/5961)).
     - Fixed unwanted altitude change when reaching a target waypoint in `mavic2pro_patrol.c` ([#5981](https://github.com/cyberbotics/webots/pull/5981)).
     - Fixed the extern controller connection to a target Webots instance when a snap one is running ([#6002](https://github.com/cyberbotics/webots/pull/6002)).
+    - Fixed the double downloading of meshes ([#6034](https://github.com/cyberbotics/webots/pull/6034)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/core/WbDownloader.cpp
+++ b/src/webots/core/WbDownloader.cpp
@@ -29,6 +29,10 @@ WbDownloader::WbDownloader(const QUrl &url, const WbDownloader *existingDownload
 
 WbDownloader::~WbDownloader() {
   if (mNetworkReply) {
+    if (mExistingDownload)
+      disconnect(mExistingDownload->networkReply(), &QNetworkReply::finished, this, &WbDownloader::finished);
+    disconnect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished);
+    mNetworkReply->abort();
     mNetworkReply->deleteLater();
 
     // properties used by WbDownloadManager

--- a/src/webots/core/WbDownloader.cpp
+++ b/src/webots/core/WbDownloader.cpp
@@ -29,10 +29,6 @@ WbDownloader::WbDownloader(const QUrl &url, const WbDownloader *existingDownload
 
 WbDownloader::~WbDownloader() {
   if (mNetworkReply) {
-    if (mExistingDownload)
-      disconnect(mExistingDownload->networkReply(), &QNetworkReply::finished, this, &WbDownloader::finished);
-    disconnect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished);
-    mNetworkReply->abort();
     mNetworkReply->deleteLater();
 
     // properties used by WbDownloadManager

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -336,7 +336,9 @@ void WbMesh::updateUrl() {
           mDownloader = NULL;
         }
 
-        downloadAssets();  // URL was changed from the scene tree or supervisor
+        if (!mDownloader || mDownloader->url().toString() != mUrl->item(0))
+          downloadAssets();  // URL was changed from the scene tree or supervisor
+
         return;
       }
     }


### PR DESCRIPTION
Fix #6032 

The meshes where sometimes loaded twice and the first downloader was deleted before it was finished, resulting in a infinite loading.

After further testing, it turns out that the issue came from `mNetworkReply` of [WbDownloader.cpp](https://github.com/cyberbotics/webots/blob/fix-mesh-double-loading/src/webots/core/WbDownloader.cpp).
When a download is triggered before the previous one is finished (because of double loading in our case), we need to delete the downloader and create a new one.
The problem is that we use `deleteLater()` for the `mNetworkReply`  of the downloader, which is right according to the [doc](https://doc.qt.io/qt-6.2/qnetworkreply.html#finished). But for some reasons (bug?) in a very specific edge case:
- ubuntu 20 or 22
- no other meshes or textures downloaded before (during the loading of the world for example)
- the mesh should not be in the cash

The QNetworkReply seems to never be deleted and it causes the next request to hang on.

I tried to bypass this issue by improving the delete function of `WbDownload.cpp` like:
```
WbDownloader::~WbDownloader() {
  if (mNetworkReply) {
    disconnect(mNetworkReply, &QNetworkReply::finished, this, &WbDownloader::finished);
    mNetworkReply->abort();
    mNetworkReply->deleteLater();

    // properties used by WbDownloadManager
    setProperty("url", mUrl);
  }
  if (mExistingDownload)
    disconnect(mExistingDownload->networkReply(), &QNetworkReply::finished, this, &WbDownloader::finished);

  setProperty("finished", mFinished);
}
```

It seems to kind of work, but if we load a proto with two meshes, the first one will work, but the second one will have the same problem as before.

Another possible solution that seems to work is to simply replace the `deleteLater()` by `destroyed()` but as it is explicitly stated in the Qt documentation to use `deleteLater()`...

Finally, I fixed the problem by fixing the double loading which was wrong