### PR TITLE
Fix Motor setAcceleration bug in Python.

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -24,7 +24,6 @@ Released on ??
       - `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
       - `Motor.enableForceFeedback` where the `sampling_period` argument was missing ([#5797](https://github.com/cyberbotics/webots/pull/5797)).
       - `Motor.setAcceleration` was missing the device tag parameter ([#6036](https://github.com/cyberbotics/webots/pull/6036)).
-
     - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([#5620](https://github.com/cyberbotics/webots/pull/5620)).
     - Fixed memory leaks, particularly when in no-rendering mode and spawning/deleting nodes ([#5639](https://github.com/cyberbotics/webots/pull/5639)).
     - Fixed crashes resulting from streaming pose, SF field values or contact points after deleting the tracked nodes ([#5638](https://github.com/cyberbotics/webots/pull/5638)).

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -23,6 +23,8 @@ Released on ??
       - Field getters sometimes returning an invalid Field object ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
       - `Field.enableSFTracking` and `Field.disableSFTracking` which were failing ([#5640](https://github.com/cyberbotics/webots/pull/5640)).
       - `Motor.enableForceFeedback` where the `sampling_period` argument was missing ([#5797](https://github.com/cyberbotics/webots/pull/5797)).
+      - `Motor.setAcceleration` was missing the device tag parameter ([#6036](https://github.com/cyberbotics/webots/pull/6036)).
+
     - Fixed crash resulting from requesting pose tracking of unsuitable nodes ([#5620](https://github.com/cyberbotics/webots/pull/5620)).
     - Fixed memory leaks, particularly when in no-rendering mode and spawning/deleting nodes ([#5639](https://github.com/cyberbotics/webots/pull/5639)).
     - Fixed crashes resulting from streaming pose, SF field values or contact points after deleting the tracked nodes ([#5638](https://github.com/cyberbotics/webots/pull/5638)).
@@ -50,8 +52,7 @@ Released on ??
     - Fixed bug causing Webots to hang when requesting multiple poses while pose-tracking multiple nodes ([#5952](https://github.com/cyberbotics/webots/pull/5952)).
     - Fixed physics state updates of [Solid](solid.md) nodes added to a descendant [`Joint.endPoint`](joint.md) during simulation ([#5961](https://github.com/cyberbotics/webots/pull/5961)).
     - Fixed unwanted altitude change when reaching a target waypoint in `mavic2pro_patrol.c` ([#5981](https://github.com/cyberbotics/webots/pull/5981)).
-    - Fixed the extern controller connection to a target Webots instance when a snap one is running. ([#6002](https://github.com/cyberbotics/webots/pull/6002)).
-    - Fixed motor node setAcceleration function missed device tag parameter in Python controller lib. ([#6036](https://github.com/cyberbotics/webots/pull/6036)).
+    - Fixed the extern controller connection to a target Webots instance when a snap one is running ([#6002](https://github.com/cyberbotics/webots/pull/6002)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -51,6 +51,7 @@ Released on ??
     - Fixed physics state updates of [Solid](solid.md) nodes added to a descendant [`Joint.endPoint`](joint.md) during simulation ([#5961](https://github.com/cyberbotics/webots/pull/5961)).
     - Fixed unwanted altitude change when reaching a target waypoint in `mavic2pro_patrol.c` ([#5981](https://github.com/cyberbotics/webots/pull/5981)).
     - Fixed the extern controller connection to a target Webots instance when a snap one is running. ([#6002](https://github.com/cyberbotics/webots/pull/6002)).
+    - Fixed motor node setAcceleration function missed device tag parameter in Python controller lib. ([#6036](https://github.com/cyberbotics/webots/pull/6036)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/lib/controller/python/controller/motor.py
+++ b/lib/controller/python/controller/motor.py
@@ -216,7 +216,7 @@ class Motor(Device):
 
     @target_acceleration.setter
     def target_acceleration(self, acceleration: float):
-        wb.wb_motor_set_acceleration(acceleration)
+        wb.wb_motor_set_acceleration(self._tag, ctypes.c_double(acceleration))
 
     force = property(fset=setForce)
     torque = property(fset=setTorque)


### PR DESCRIPTION
**Description**
Motor setAcceleration missed device tag parameter in Python controller lib.
