### PR TITLE
Fixed CeilingSpotLight SolidPipe translation

### DIFF
--- a/projects/objects/lights/protos/CeilingSpotLight.proto
+++ b/projects/objects/lights/protos/CeilingSpotLight.proto
@@ -38,6 +38,7 @@ PROTO CeilingSpotLight [
         castShadows IS spotLightCastShadows
       }
       SolidPipe {
+        translation 0 0 0
         height 0.08
         radius 0.05
         thickness 0.01

--- a/projects/robots/mir/mir100/protos/Mir100.proto
+++ b/projects/robots/mir/mir100/protos/Mir100.proto
@@ -308,6 +308,7 @@ PROTO Mir100 [
                   }
                 }
                 SolidTorus {
+                  translation 0 0 0
                   majorRadius 0.0465
                   minorRadius 0.016
                   enableBoundingObject FALSE
@@ -362,6 +363,7 @@ PROTO Mir100 [
               children [
                 USE RIM
                 SolidTorus {
+                  translation 0 0 0
                   majorRadius 0.0465
                   minorRadius 0.016
                   enableBoundingObject FALSE
@@ -431,6 +433,7 @@ PROTO Mir100 [
                     children [
                       USE RIM
                       SolidTorus {
+                        translation 0 0 0
                         majorRadius 0.0465
                         minorRadius 0.016
                         enableBoundingObject FALSE
@@ -513,6 +516,7 @@ PROTO Mir100 [
                     children [
                       USE RIM
                       SolidTorus {
+                        translation 0 0 0
                         majorRadius 0.0465
                         minorRadius 0.016
                         enableBoundingObject FALSE
@@ -592,6 +596,7 @@ PROTO Mir100 [
                     children [
                       USE RIM
                       SolidTorus {
+                        translation 0 0 0
                         majorRadius 0.0465
                         minorRadius 0.016
                         enableBoundingObject FALSE
@@ -671,6 +676,7 @@ PROTO Mir100 [
                     children [
                       USE RIM
                       SolidTorus {
+                        translation 0 0 0
                         majorRadius 0.0465
                         minorRadius 0.016
                         enableBoundingObject FALSE

--- a/projects/samples/devices/worlds/hinge_2_joint_with_backlash.wbt
+++ b/projects/samples/devices/worlds/hinge_2_joint_with_backlash.wbt
@@ -39,12 +39,14 @@ DEF WITHOUT_BACKLASH Robot {
   translation 0.1 0 0
   children [
     SolidRoundedBox {
+      translation 0 0 0
       size 0.2 0.2 0.01
       borderRadius 0.005
       appearance GalvanizedMetal {
       }
     }
     SolidTorus {
+      translation 0 0 0
       majorRadius 0.03
       minorRadius 0.02
       appearance BrushedAluminium {
@@ -247,12 +249,14 @@ DEF WITH_BACKLASH Robot {
   rotation 0 0 1 -1.570795
   children [
     SolidRoundedBox {
+      translation 0 0 0
       size 0.2 0.2 0.01
       borderRadius 0.005
       appearance GalvanizedMetal {
       }
     }
     SolidTorus {
+      translation 0 0 0
       majorRadius 0.03
       minorRadius 0.02
       appearance BrushedAluminium {

--- a/projects/samples/devices/worlds/motor2.wbt
+++ b/projects/samples/devices/worlds/motor2.wbt
@@ -37,12 +37,14 @@ RectangleArena {
 Robot {
   children [
     SolidRoundedBox {
+      translation 0 0 0
       size 0.2 0.2 0.01
       borderRadius 0.005
       appearance GalvanizedMetal {
       }
     }
     SolidTorus {
+      translation 0 0 0
       majorRadius 0.03
       minorRadius 0.02
       appearance BrushedAluminium {

--- a/projects/samples/devices/worlds/motor3.wbt
+++ b/projects/samples/devices/worlds/motor3.wbt
@@ -36,12 +36,14 @@ RectangleArena {
 Robot {
   children [
     SolidRoundedBox {
+      translation 0 0 0
       size 0.2 0.2 0.01
       borderRadius 0.005
       appearance GalvanizedMetal {
       }
     }
     SolidTorus {
+      translation 0 0 0
       majorRadius 0.03
       minorRadius 0.02
       appearance BrushedAluminium {

--- a/projects/samples/environments/factory/worlds/hall.wbt
+++ b/projects/samples/environments/factory/worlds/hall.wbt
@@ -1160,6 +1160,7 @@ Robot {
       }
     }
     SolidRoundedBox {
+      translation 0 0 0
       name "rounded box(1)"
       size 0.08 0.011 0.08
       borderRadius 0.005
@@ -4755,6 +4756,7 @@ Robot {
       }
     }
     SolidRoundedBox {
+      translation 0 0 0
       name "rounded box(1)"
       size 0.08 0.011 0.08
       borderRadius 0.005

--- a/projects/samples/geometries/worlds/extended_solids.wbt
+++ b/projects/samples/geometries/worlds/extended_solids.wbt
@@ -32,6 +32,7 @@ SolidBox {
   }
 }
 SolidPipe {
+  translation 0 0 0
   rotation 0.5773489358556708 0.5773509358554485 0.5773509358554485 -2.094395307179586
   subdivision 48
   physics Physics {

--- a/projects/vehicles/worlds/village_center.wbt
+++ b/projects/vehicles/worlds/village_center.wbt
@@ -2406,6 +2406,7 @@ DEF TREE Transform {
   rotation 0 0 1 1.8584073176408265
   children [
     SolidPipe {
+      translation 0 0 0
       height 0.2
       appearance PBRAppearance {
         baseColorMap ImageTexture {
@@ -2439,6 +2440,7 @@ DEF TREE Transform {
   rotation 0 0 1 2.6438054786408265
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(1)"
       height 0.2
       appearance PBRAppearance {
@@ -2474,6 +2476,7 @@ DEF TREE Transform {
   rotation 0 0 1 5.785398122640827
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(2)"
       height 0.2
       appearance PBRAppearance {
@@ -2509,6 +2512,7 @@ DEF TREE Transform {
   rotation 0 0 1 3.6910030266408267
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(3)"
       height 0.2
       appearance PBRAppearance {
@@ -2544,6 +2548,7 @@ DEF TREE Transform {
   rotation 0 0 -1 6.257373717718359
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(4)"
       height 0.2
       appearance PBRAppearance {
@@ -2579,6 +2584,7 @@ DEF TREE Transform {
   rotation 0 0 1 3.1674042526408264
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(5)"
       height 0.2
       appearance PBRAppearance {
@@ -2614,6 +2620,7 @@ DEF TREE Transform {
   rotation 0 0 -1 5.9955743307183464
   children [
     SolidPipe {
+      translation 0 0 0
       name "pipe(6)"
       height 0.2
       appearance PBRAppearance {


### PR DESCRIPTION
Fixes #6027.
I checked all the use of the SolidPipe, SolidBox, SolidRoundedBox and SolidTorus in proto and world files and found these 8 files which had one or several default translation value.