### PR TITLE
Enhancement camera recognition occlusion

### DIFF
--- a/docs/reference/camera.md
+++ b/docs/reference/camera.md
@@ -1417,7 +1417,7 @@ structs.WbCameraRecognitionObject.members = struct(
 
 The `id` represents the node id corresponding to the object, and it is possible to use this id directly in the [`wb_supervisor_node_get_from_id`](supervisor.md#wb_supervisor_node_get_from_def) supervisor function.
 The `position` and `orientation` are expressed relatively to the camera (the relative position is the one of the center of the object which can differ from its origin) and the units are meter and radian.
-The `size` represents the X and Y sizes in meters relatively to the camera (it is of course impossible to know the depth of the object).
+The `size` represents the Y and Z sizes in meters relatively to the camera (it is of course impossible to know the depth of the object along the [Camera](camera.md) X axis).
 The `position_on_image` and `size_on_image` can be used to determine the bounding box of the object in the camera image, the units are pixels.
 The `number_of_colors` and `colors` returns respectively the number of colors of the objects and pointer to the colors array, each color is represented by 3 doubles (R, G and B), therefore the size of the array is equal to 3 * `number_of_colors`.
 Finally `model` returns the `model` field of the [Solid](solid.md) node.

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -109,7 +109,7 @@ private:
   bool refreshRecognitionSensorIfNeeded();
   void removeOccludedRecognizedObjects();
   WbVector2 projectOnImage(const WbVector3 &position);
-  void computeRecognizedObjects(bool finalSetup, bool needCollisionDetection);
+  void computeRecognizedObjects(bool needCollisionDetection);
   bool setRecognizedObjectProperties(WbRecognizedObject *recognizedObject);
   void updateRaysSetupIfNeeded() override;
   short mRecognitionRefreshRate;

--- a/src/webots/nodes/WbRadar.cpp
+++ b/src/webots/nodes/WbRadar.cpp
@@ -302,9 +302,12 @@ void WbRadar::prePhysicsStep(double ms) {
     // create rays
     computeTargets(false, true);
 
-    if (!mRadarTargets.isEmpty())
+    if (!mRadarTargets.isEmpty()) {
       // radar or targets could move during physics step
-      subscribeToRaysUpdate(mRadarTargets[0]->geom());
+      const QList<dGeomID> &rays = mRadarTargets[0]->geoms();
+      if (!rays.isEmpty())
+        subscribeToRaysUpdate(rays.first());
+    }
   }
 }
 
@@ -343,10 +346,10 @@ void WbRadar::updateRaysSetupIfNeeded() {
 void WbRadar::rayCollisionCallback(dGeomID geom, WbSolid *collidingSolid, double depth) {
   foreach (WbRadarTarget *target, mRadarTargets) {
     // check if this target is the one that collides
-    if (target->geom() == geom) {
+    if (target->contains(geom)) {
       // make sure the colliding solid is not the target itself
       if (target->object() != collidingSolid && !target->object()->solidChildren().contains(collidingSolid))
-        target->setCollided(depth);
+        target->setCollided(geom, depth);
       return;
     }
   }

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -66,7 +66,6 @@ void WbObjectDetection::createRays(const WbVector3 &origin, const QList<WbVector
     dGeomSetData(geom, mOdeGeomData);
     mRayGeoms << geom;
     mRaysCollisionDepth << 0.0;
-    return;
   }
 }
 
@@ -412,7 +411,6 @@ WbAffinePlane *WbObjectDetection::computeFrustumPlanes(const WbSolid *device, co
 
 QList<WbVector3> WbObjectDetection::computeCorners() const {
   QList<WbVector3> points;
-  points << (WbVector3(0, 0, 0));  // center
   WbVector3 size = 0.5 * mObjectSize;
   if (mUseBoundingSphereOnly) {  // 7 rays for bounding sphere
     points << (WbVector3(size.x(), 0, 0));


### PR DESCRIPTION
The existing object detection code uses just one ray pointing at the object center to determine if an object is occluded or not.
This method is quite limited and in complex scene often results in missing many objects that are visible.

I investigated using multiple rays (8 for bounding boxes and 6 for bounding sphere) for determine the object occlusion and this method gives much better results for example in the following agricultural environment.

Using 1 ray:
![Screenshot from 2023-04-04 18-16-32](https://user-images.githubusercontent.com/5910449/229854165-cb86c8ec-8d0d-4e7e-a75d-9a967ce0fe3a.png)

Using 6/8 rays:
![Screenshot from 2023-04-04 18-18-45](https://user-images.githubusercontent.com/5910449/229854682-9e93328c-ff95-4435-a84b-3a06998e9739.png)


However the performance drops from 0.4x to 0.25x.
In this example there are many objects to be detected so a performance drop is quite normal.
But no difference is visible in the simple camera_recognition.wbt simulation.