### PR TITLE
Cleanup wrong code

### DIFF
--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -321,9 +321,6 @@ void WbController::start() {
   }
   file.write("");
   file.close();
-
-  // FIXME: from Qt 6.4 onwards, QDir::mkdir can be used to set the permissions
-  QProcess::execute("sh", QStringList() << "-c" << QString("chmod -R 777 %1").arg(mIpcPath));
 #endif
   // recover from a crash, when the previous server instance has not been cleaned up
   bool success = QLocalServer::removeServer(serverName);


### PR DESCRIPTION
I don't understand the purpose of this line and it seems wrong for several reasons:
1. It is executed on Windows only and rely on `sh` and `chmod` which are not available on Windows.
2. Everything works well without it.
3. Removing these lines doesn't change anything to the rights of this folder:
```
$ ls -l /C/Users/Olivier/AppData/Local/Temp/webots-1234/ipc/
total 0
drwxr-xr-x 1 Olivier Aucun 0 Apr 13 10:35 ea4c880fba3d97f56c30ebf6519137ef73b77b2d
```
Note: it was introduced in #5959.