### PR TITLE
Fixed load progress dialog parenting

### DIFF
--- a/src/webots/gui/WbMainWindow.cpp
+++ b/src/webots/gui/WbMainWindow.cpp
@@ -2465,11 +2465,11 @@ void WbMainWindow::createWorldLoadingProgressDialog() {
   cancelButton->setDefault(false);
   cancelButton->setChecked(false);
 
-  mWorldLoadingProgressDialog = new QProgressDialog();
+  mWorldLoadingProgressDialog = new QProgressDialog(this);
   mWorldLoadingProgressDialog->setModal(true);
   mWorldLoadingProgressDialog->setAutoClose(false);
-  WbGuiApplication::setWindowsDarkMode(mWorldLoadingProgressDialog);
   mWorldLoadingProgressDialog->show();
+  WbGuiApplication::setWindowsDarkMode(mWorldLoadingProgressDialog);
   mWorldLoadingProgressDialog->setValue(0);
   mWorldLoadingProgressDialog->setWindowTitle(tr("Loading world"));
   mWorldLoadingProgressDialog->setLabelText(tr("Opening world file"));


### PR DESCRIPTION
The load progress dialog was not a child window of the main window. As a consequence, it may appear on a different screen as the main window. This PR fixes this small problem.