### PR TITLE
Fix contact points warnings

### DIFF
--- a/projects/robots/nasa/worlds/sojourner.wbt
+++ b/projects/robots/nasa/worlds/sojourner.wbt
@@ -18,6 +18,9 @@ WorldInfo {
   gravity 3.73
   basicTimeStep 16
   lineScale 0.2
+  contactProperties ContactProperties {
+    maxContactJoints 21
+  }
 }
 Viewpoint {
   fieldOfView 0.895398
@@ -108,7 +111,7 @@ Rock10cm {
 }
 Rock10cm {
   translation 0.1779 -0.3873 -0.1161
-  rotation 0 0 1 -1.8325953071795862
+  rotation 0 0 -1 1.0472
   name "rock 10 cm(2)"
   color 0.9 0.4 0.3
 }

--- a/projects/samples/rendering/worlds/animated_skin.wbt
+++ b/projects/samples/rendering/worlds/animated_skin.wbt
@@ -43,6 +43,17 @@ WorldInfo {
       material2 "ping pong ball material"
       bounce 0.9
     }
+    ContactProperties {
+      material1 "body"
+      maxContactJoints 26
+    }
+    ContactProperties {
+      material1 "leg"
+      maxContactJoints 17
+    }
+    ContactProperties {
+      maxContactJoints 17
+    }
   ]
 }
 Viewpoint {

--- a/src/webots/engine/WbSimulationCluster.hpp
+++ b/src/webots/engine/WbSimulationCluster.hpp
@@ -72,7 +72,7 @@ private:
   static void odeSensorRaysUpdate(int threadID);
   static const long long int WEBOTS_MAGIC_NUMBER;
   bool mSwapJointContactBuffer;
-  static void warnMoreContactPointsThanContactJoints();
+  static void warnMoreContactPointsThanContactJoints(const QString &material1, const QString &material2, int max, int n);
 };
 
 #endif


### PR DESCRIPTION
Fix #5819 and display more useful information in the contact point warnings allowing the user to understand which contacts properties should be updated to handle more contact points.