### PR TITLE
Fixes build badges on develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ If you prefer to [compile Webots from source](https://github.com/cyberbotics/web
 [![macOS build (master)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac.yml/badge.svg?event=schedule&label=macOS)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac.yml?query=event%3Aschedule)<br>
 [![develop branch](https://img.shields.io/badge/branch-develop-blue)](https://github.com/cyberbotics/webots/tree/develop)
 [![Linux build (develop)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_linux_develop.yml/badge.svg?event=schedule)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_linux_develop.yml?query=event%3Aschedule)
-[![Windows build (develop)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_windows.yml/badge.svg?event=schedule)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_windows_develop.yml?query=event%3Aschedule)
-[![macOS build (develop)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac.yml/badge.svg?event=schedule)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac_develop.yml?query=event%3Aschedule)
+[![Windows build (develop)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_windows_develop.yml/badge.svg?event=schedule)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_windows_develop.yml?query=event%3Aschedule)
+[![macOS build (develop)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac_develop.yml/badge.svg?event=schedule)](https://github.com/cyberbotics/webots/actions/workflows/test_suite_mac_develop.yml?query=event%3Aschedule)
 
 ### About us
 


### PR DESCRIPTION
It seems the build badges on the develop branch were referring to the master branch. This PR fixes that.