### PR TITLE
Fix profile compilation

### DIFF
--- a/src/ode/Makefile
+++ b/src/ode/Makefile
@@ -17,7 +17,6 @@ space := $(null) $(null)
 WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
-TARGET_LIB_DIR=$(WEBOTS_LIB_PATH)
 ifeq ($(OSTYPE),darwin)
 INSTALL_NAME = @rpath/Contents/lib/webots/libode.dylib
 endif
@@ -33,6 +32,8 @@ endif
 
 ifeq ($(MAKECMDGOALS),profile)
   STATIC_LIBRARY = true
+else
+  TARGET_LIB_DIR=$(WEBOTS_LIB_PATH)
 endif
 
 FILES_TO_REMOVE = $(MAIN_TARGET_COPY) libode.a ode.a


### PR DESCRIPTION
Currently, compiling Webots in profile mode is not working, as the static library `libode.a` is not found.