### PR TITLE
Restore missing const

### DIFF
--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -433,8 +433,8 @@ bool WbObjectDetection::computeObject(const WbVector3 &devicePosition, const WbM
 }
 
 WbAffinePlane *WbObjectDetection::computeFrustumPlanes(const WbVector3 &devicePosition, const WbMatrix3 &deviceRotation,
-                                                       double verticalFieldOfView, double horizontalFieldOfView,
-                                                       double maxRange, bool isPlanarProjection) {
+                                                       const double verticalFieldOfView, const double horizontalFieldOfView,
+                                                       const double maxRange, bool isPlanarProjection) {
   // construct the 4 planes defining the sides of the frustum
   const float halfFovX = horizontalFieldOfView / 2.0;
   const float halfFovY = verticalFieldOfView / 2.0;

--- a/src/webots/nodes/utils/WbObjectDetection.hpp
+++ b/src/webots/nodes/utils/WbObjectDetection.hpp
@@ -52,8 +52,8 @@ public:
                      const WbAffinePlane *frustumPlanes);
 
   static WbAffinePlane *computeFrustumPlanes(const WbVector3 &devicePosition, const WbMatrix3 &deviceRotation,
-                                             double verticalFieldOfView, double horizontalFieldOfView, double maxRange,
-                                             bool isPlanarProjection);
+                                             const double verticalFieldOfView, const double horizontalFieldOfView,
+                                             const double maxRange, bool isPlanarProjection);
 
 protected:
   static void mergeBounds(WbVector3 &referenceObjectSize, WbVector3 &referenceObjectRelativePosition,


### PR DESCRIPTION
As discussed in #6095, this PR restores the missing `const` keywords.