### PR TITLE
Fix tmp path to include username on Linux and macOS

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -9,6 +9,7 @@ Released on ??
   - Cleanup
     - Deprecated the C and MATLAB API functions `wb_supervisor_node_enable/disable_contact_point_tracking` in favor of `wb_supervisor_node_enable/disable_contact_points_tracking` to be more consistent with other APIs ([#5633](https://github.com/cyberbotics/webots/pull/5633)).
   - Enhancements
+    - Restructured the Webots temporary folder to avoid permission problems with multiple users on Linux and macOS ([#6103](https://github.com/cyberbotics/webots/pull/6103)).
     - Improved the robots' grippers such that they use coupled motors ([#5694](https://github.com/cyberbotics/webots/pull/5694)).
     - Improved the [Charger](charger.md) behavior ([#5771](https://github.com/cyberbotics/webots/pull/5771)).
     - Added `maxContactJoints` field to `ContactProperties` node to give users control over the tradeoff between collision accuracy and performance ([#5769](https://github.com/cyberbotics/webots/pull/5769)).

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1203,7 +1203,7 @@ static char *compute_socket_filename() {
       username = "default";
     }
   }
-  int length = strlen(TMP_DIR) + strlen(username) + 25; // TMP_DIR + '/webots/' + username + '/12345678901/ipc' 
+  int length = strlen(TMP_DIR) + strlen(username) + 25;  // TMP_DIR + '/webots/' + username + '/12345678901/ipc' 
 #endif
   char *folder = malloc(length);
 #ifdef _WIN32

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1199,8 +1199,8 @@ static char *compute_socket_filename() {
   if (USERNAME == NULL || USERNAME[0] == '\0') {
     USERNAME = wbu_system_getenv("USERNAME");
     if (USERNAME == NULL || USERNAME[0] == '\0') {
-      fprintf(stderr, "Error: missing USER or USERNAME environment variable.");
-      exit(EXIT_FAILURE);
+      fprintf(stderr, "Error: USER or USERNAME environment variable not set, falling back to 'default' username.");
+      username = "default";
     }
   }
   int length = strlen(TMP_DIR) + strlen(USERNAME) + 25; // TMP_DIR + '/webots/' + USERNAME + '/12345678901/ipc' 

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1195,21 +1195,21 @@ static char *compute_socket_filename() {
 #ifdef _WIN32
   int length = strlen(TMP_DIR) + 24;  // TMP_DIR + "/webots-12345678901/ipc"
 #else
-  const char *USERNAME = wbu_system_getenv("USER");
-  if (USERNAME == NULL || USERNAME[0] == '\0') {
-    USERNAME = wbu_system_getenv("USERNAME");
-    if (USERNAME == NULL || USERNAME[0] == '\0') {
+  const char *username = wbu_system_getenv("USER");
+  if (username == NULL || username[0] == '\0') {
+    username = wbu_system_getenv("USERNAME");
+    if (username == NULL || username[0] == '\0') {
       fprintf(stderr, "Error: USER or USERNAME environment variable not set, falling back to 'default' username.");
       username = "default";
     }
   }
-  int length = strlen(TMP_DIR) + strlen(USERNAME) + 25; // TMP_DIR + '/webots/' + USERNAME + '/12345678901/ipc' 
+  int length = strlen(TMP_DIR) + strlen(username) + 25; // TMP_DIR + '/webots/' + username + '/12345678901/ipc' 
 #endif
   char *folder = malloc(length);
 #ifdef _WIN32
   snprintf(folder, length, "%s/webots-%d/ipc", TMP_DIR, number);
 #else
-  snprintf(folder, length, "%s/webots/%s/%d/ipc", TMP_DIR, USERNAME, number);
+  snprintf(folder, length, "%s/webots/%s/%d/ipc", TMP_DIR, username, number);
 #endif
   free(robot_name);
   char *sub_string = strstr(&WEBOTS_CONTROLLER_URL[6], "/");

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1198,6 +1198,10 @@ static char *compute_socket_filename() {
   const char *USERNAME = wbu_system_getenv("USER");
   if (USERNAME == NULL || USERNAME[0] == '\0')
     USERNAME = wbu_system_getenv("USERNAME");
+  if (USERNAME == NULL || USERNAME[0] == '\0') {
+    fprintf(stderr, "Error: missing USER or USERNAME environment variable.");
+    exit(EXIT_FAILURE);
+  }
   int length = strlen(TMP_DIR) + strlen(USERNAME) + 25; // TMP_DIR + '/webots/' + USERNAME + '/12345678901/ipc' 
 #endif
   char *folder = malloc(length);

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1196,11 +1196,12 @@ static char *compute_socket_filename() {
   int length = strlen(TMP_DIR) + 24;  // TMP_DIR + "/webots-12345678901/ipc"
 #else
   const char *USERNAME = wbu_system_getenv("USER");
-  if (USERNAME == NULL || USERNAME[0] == '\0')
-    USERNAME = wbu_system_getenv("USERNAME");
   if (USERNAME == NULL || USERNAME[0] == '\0') {
-    fprintf(stderr, "Error: missing USER or USERNAME environment variable.");
-    exit(EXIT_FAILURE);
+    USERNAME = wbu_system_getenv("USERNAME");
+    if (USERNAME == NULL || USERNAME[0] == '\0') {
+      fprintf(stderr, "Error: missing USER or USERNAME environment variable.");
+      exit(EXIT_FAILURE);
+    }
   }
   int length = strlen(TMP_DIR) + strlen(USERNAME) + 25; // TMP_DIR + '/webots/' + USERNAME + '/12345678901/ipc' 
 #endif

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1203,7 +1203,7 @@ static char *compute_socket_filename() {
       username = "default";
     }
   }
-  int length = strlen(TMP_DIR) + strlen(username) + 25;  // TMP_DIR + '/webots/' + username + '/12345678901/ipc' 
+  int length = strlen(TMP_DIR) + strlen(username) + 25;  // TMP_DIR + '/webots/' + username + '/12345678901/ipc'
 #endif
   char *folder = malloc(length);
 #ifdef _WIN32

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1192,9 +1192,20 @@ static char *compute_socket_filename() {
     fprintf(stderr, "Error: invalid WEBOTS_CONTROLLER_URL: %s (missing or wrong port value)\n", WEBOTS_CONTROLLER_URL);
     exit(EXIT_FAILURE);
   }
-  int length = strlen(TMP_DIR) + 24;  // TMPDIR + "/webots-12345678901/ipc"
+#ifdef _WIN32
+  int length = strlen(TMP_DIR) + 24;  // TMP_DIR + "/webots-12345678901/ipc"
+#else
+  const char *USERNAME = wbu_system_getenv("USER");
+  if (USERNAME == NULL || USERNAME[0] == '\0')
+    USERNAME = wbu_system_getenv("USERNAME");
+  int length = strlen(TMP_DIR) + strlen(USERNAME) + 25; // TMP_DIR + '/webots/' + USERNAME + '/12345678901/ipc' 
+#endif
   char *folder = malloc(length);
+#ifdef _WIN32
   snprintf(folder, length, "%s/webots-%d/ipc", TMP_DIR, number);
+#else
+  snprintf(folder, length, "%s/webots/%s/%d/ipc", TMP_DIR, USERNAME, number);
+#endif
   free(robot_name);
   char *sub_string = strstr(&WEBOTS_CONTROLLER_URL[6], "/");
   robot_name = encode_robot_name(sub_string ? sub_string + 1 : NULL);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -306,8 +306,21 @@ void WbController::start() {
     }
   }
 
-  mIpcPath = WbStandardPaths::webotsTmpPath() + "ipc/" + mRobot->encodedName();
-  QDir().mkpath(mIpcPath);
+  mIpcPath = WbStandardPaths::webotsTmpPath() + "ipc/";
+  QDir().mkdir(mIpcPath);
+
+  // FIXME: from Qt6.4 onwards, this can be done directly with mkdir
+  QFile(mIpcPath)
+    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
+                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
+                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
+  mIpcPath += mRobot->encodedName();
+  QDir().mkdir(mIpcPath);
+  // FIXME: from Qt6.4 onwards, this can be done directly with mkdir
+  QFile(mIpcPath)
+    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
+                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
+                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
   const QString fileName = mIpcPath + '/' + (mExtern ? "extern" : "intern");
 #ifndef _WIN32
   const QString &serverName = fileName;
@@ -321,6 +334,10 @@ void WbController::start() {
   }
   file.write("");
   file.close();
+  QFile(fileName)
+    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
+                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
+                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
 #endif
   // recover from a crash, when the previous server instance has not been cleaned up
   bool success = QLocalServer::removeServer(serverName);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -306,21 +306,8 @@ void WbController::start() {
     }
   }
 
-  mIpcPath = WbStandardPaths::webotsTmpPath() + "ipc/";
-  QDir().mkdir(mIpcPath);
-
-  // FIXME: from Qt6.4 onwards, this can be done directly with mkdir
-  QFile(mIpcPath)
-    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
-                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
-                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
-  mIpcPath += mRobot->encodedName();
-  QDir().mkdir(mIpcPath);
-  // FIXME: from Qt6.4 onwards, this can be done directly with mkdir
-  QFile(mIpcPath)
-    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
-                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
-                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
+  mIpcPath = WbStandardPaths::webotsTmpPath() + "ipc/" + mRobot->encodedName();
+  QDir().mkpath(mIpcPath);
   const QString fileName = mIpcPath + '/' + (mExtern ? "extern" : "intern");
 #ifndef _WIN32
   const QString &serverName = fileName;
@@ -334,10 +321,6 @@ void WbController::start() {
   }
   file.write("");
   file.close();
-  QFile(fileName)
-    .setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
-                    QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
-                    QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
 #endif
   // recover from a crash, when the previous server instance has not been cleaned up
   bool success = QLocalServer::removeServer(serverName);

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -220,8 +220,13 @@ bool WbStandardPaths::webotsTmpPathCreate(const int id) {
   cWebotsTmpPath =
     QDir::fromNativeSeparators(WbSysInfo::environmentVariable("LOCALAPPDATA")) + QString("/Temp/webots-%1/").arg(id);
 #else
-  const QStringList homePath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
-  const QString username = homePath.first().split(QDir::separator()).last();
+  QString username = qgetenv("USER");
+  if (username.isEmpty())
+    username = qgetenv("USERNAME");
+  if (username.isEmpty()) {
+    WbLog::error(QObject::tr("USER or USERNAME environment variable not set, falling back to 'default' username."));
+    username = "default";
+  }
 #if defined(__APPLE__)
   cWebotsTmpPath = QString("/tmp/webots/%1/%1/").arg(username).arg(id);
 #else  // __linux__

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -221,11 +221,12 @@ bool WbStandardPaths::webotsTmpPathCreate(const int id) {
     QDir::fromNativeSeparators(WbSysInfo::environmentVariable("LOCALAPPDATA")) + QString("/Temp/webots-%1/").arg(id);
 #else
   QString username = qgetenv("USER");
-  if (username.isEmpty())
-    username = qgetenv("USERNAME");
   if (username.isEmpty()) {
-    WbLog::error(QObject::tr("USER or USERNAME environment variable not set, falling back to 'default' username."));
-    username = "default";
+    username = qgetenv("USERNAME");
+    if (username.isEmpty()) {
+      WbLog::error(QObject::tr("USER or USERNAME environment variable not set, falling back to 'default' username."));
+      username = "default";
+    }
   }
 #if defined(__APPLE__)
   cWebotsTmpPath = QString("/tmp/webots/%1/%2/").arg(username).arg(id);

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -220,20 +220,19 @@ bool WbStandardPaths::webotsTmpPathCreate(const int id) {
   cWebotsTmpPath =
     QDir::fromNativeSeparators(WbSysInfo::environmentVariable("LOCALAPPDATA")) + QString("/Temp/webots-%1/").arg(id);
 #else
-    const QStringList homePath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
-    const QString username = homePath.first().split(QDir::separator()).last();
+  const QStringList homePath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
+  const QString username = homePath.first().split(QDir::separator()).last();
 #if defined(__APPLE__)
-    cWebotsTmpPath = QString("/tmp/webots/%1/%1/").arg(username).arg(id);
+  cWebotsTmpPath = QString("/tmp/webots/%1/%1/").arg(username).arg(id);
 #else  // __linux__
-    const QString WEBOTS_TMPDIR = WbSysInfo::environmentVariable("WEBOTS_TMPDIR");
-    if (!WEBOTS_TMPDIR.isEmpty() && QDir(WEBOTS_TMPDIR).exists())
-      cWebotsTmpPath = QString("%1/webots/%2/%3/").arg(WEBOTS_TMPDIR).arg(username).arg(id);
-    else {
-      cWebotsTmpPath = QString("/tmp/webots/%1/%2/").arg(username).arg(id);
-      WbLog::error(
-        QObject::tr("Webots has not been started regularly. Some features may not work. "
-                    "Please start Webots from its launcher."));
-    }
+  const QString WEBOTS_TMPDIR = WbSysInfo::environmentVariable("WEBOTS_TMPDIR");
+  if (!WEBOTS_TMPDIR.isEmpty() && QDir(WEBOTS_TMPDIR).exists())
+    cWebotsTmpPath = QString("%1/webots/%2/%3/").arg(WEBOTS_TMPDIR).arg(username).arg(id);
+  else {
+    cWebotsTmpPath = QString("/tmp/webots/%1/%2/").arg(username).arg(id);
+    WbLog::error(QObject::tr("Webots has not been started regularly. Some features may not work. "
+                             "Please start Webots from its launcher."));
+  }
 #endif
 #endif
   // cleanup old and unused tmp directories

--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -228,7 +228,7 @@ bool WbStandardPaths::webotsTmpPathCreate(const int id) {
     username = "default";
   }
 #if defined(__APPLE__)
-  cWebotsTmpPath = QString("/tmp/webots/%1/%1/").arg(username).arg(id);
+  cWebotsTmpPath = QString("/tmp/webots/%1/%2/").arg(username).arg(id);
 #else  // __linux__
   const QString WEBOTS_TMPDIR = WbSysInfo::environmentVariable("WEBOTS_TMPDIR");
   if (!WEBOTS_TMPDIR.isEmpty() && QDir(WEBOTS_TMPDIR).exists())

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -73,16 +73,8 @@ void WbTemplateEngine::initializeJavaScript() {
     if (jsModulesPath.exists()) {
       QStringList filter("*.js");
       QFileInfoList files = jsModulesPath.entryInfoList(filter, QDir::Files | QDir::NoSymLinks);
-      foreach (const QFileInfo &file, files) {
+      foreach (const QFileInfo &file, files)
         QFile::copy(file.absoluteFilePath(), WbStandardPaths::webotsTmpPath() + file.fileName());
-#if defined(__APPLE__) || defined(__linux__)
-        QFile::setPermissions(WbStandardPaths::webotsTmpPath() + file.fileName(),
-                              QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
-                                QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup |
-                                QFileDevice::WriteGroup | QFileDevice::ExeGroup | QFileDevice::ReadOther |
-                                QFileDevice::WriteOther | QFileDevice::ExeOther);
-#endif
-      }
     }
   }
 
@@ -277,11 +269,6 @@ bool WbTemplateEngine::generateJavascript(QHash<QString, QString> tags, const QS
 
   QTextStream outputStream(&outputFile);
   outputStream << javaScriptTemplate;
-#if defined(__APPLE__) || defined(__linux__)
-  outputFile.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner | QFileDevice::ReadUser |
-                            QFileDevice::WriteUser | QFileDevice::ExeUser | QFileDevice::ReadGroup | QFileDevice::WriteGroup |
-                            QFileDevice::ExeGroup | QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther);
-#endif
   outputFile.close();
 
   // create engine and define global space

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -535,10 +535,6 @@ void WbVideoRecorder::createMpeg() {
     // close file
     ffmpegScript.close();
 
-    // change file properties
-    QFile::setPermissions(mScriptPath, QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner | QFile::ReadGroup |
-                                         QFile::WriteGroup | QFile::ExeGroup | QFile::ReadOther | QFile::WriteOther |
-                                         QFile::ExeOther);
     // run script
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert("AV_LOG_FORCE_COLOR", "1");  // force output message to use ANSI Escape sequences


### PR DESCRIPTION
See discussion at https://github.com/cyberbotics/webots/pull/6067#issuecomment-1521257898

The problem affects only Linux and macOS where the Webots temporary files are stored in the global `/tmp` folder, which is necessary for shared memory segments and pipes.

On Windows the temporary directory used by Webots already contains the user name (as it is located in the local `AppData` folder).

If user A crashes Webots, it a `/tmp/webots-1234` folder will remain which user B cannot delete and hence they cannot launch a new instance of Webots on this port, although the port is available.

Changing the permissions of this folder and its contents to allow anyone to write/delete is not a good solution because it would allow any user to kill another one's simulation by deleting these files.

It seems that a cleaner solution would be to store the temporary files inside `/tmp/webots/USERNAME/ID/` instead of `/tmp/webots-ID/` and not change the permissions for this folder and its content to prevent others from deleting/modifying it.

This PR implements this cleaner solution.
