### PR TITLE
Update TIAGo finger joint names

### DIFF
--- a/projects/robots/pal_robotics/tiago_extensions/protos/TiagoGripper.proto
+++ b/projects/robots/pal_robotics/tiago_extensions/protos/TiagoGripper.proto
@@ -364,13 +364,13 @@ PROTO TiagoGripper [
           }
           device [
             LinearMotor {
-              name %<= '"' + side + 'gripper_finger_joint::left"' >%
+              name %<= '"' + side + 'gripper_left_finger_joint"' >%
               maxVelocity 0.05
               maxPosition 0.045
               maxForce 16
             }
             PositionSensor {
-              name %<= '"' + side + 'gripper_finger_joint::left_sensor"' >%
+              name %<= '"' + side + 'gripper_left_sensor_finger_joint"' >%
             }
           ]
           endPoint DEF LEFT_GRIPPER Solid {
@@ -474,13 +474,13 @@ PROTO TiagoGripper [
           }
           device [
             LinearMotor {
-              name %<= '"' + side + 'gripper_finger_joint::right"' >%
+              name %<= '"' + side + 'gripper_right_finger_joint"' >%
               maxVelocity 0.05
               maxPosition 0.045
               maxForce 16
             }
             PositionSensor {
-              name %<= '"' + side + 'gripper_finger_joint::right_sensor"' >%
+              name %<= '"' + side + 'gripper_right_sensor_finger_joint"' >%
             }
           ]
           endPoint DEF RIGHT_GRIPPER Solid {

--- a/tests/api/controllers/robot_urdf/tiago_reference.urdf
+++ b/tests/api/controllers/robot_urdf/tiago_reference.urdf
@@ -908,7 +908,7 @@
     <child link="left"/>
     <origin xyz="0.016 0 0" rpy="-2.356193 1.570792 0.785393"/>
   </joint>
-  <joint name="left_hand_gripper_finger_joint::right" type="prismatic">
+  <joint name="left_hand_gripper_right_finger_joint" type="prismatic">
     <parent link="left"/>
     <child link="gripper_right_finger_link"/>
     <axis xyz="1 0 0"/>
@@ -953,7 +953,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="left_hand_gripper_finger_joint::left" type="prismatic">
+  <joint name="left_hand_gripper_left_finger_joint" type="prismatic">
     <parent link="left"/>
     <child link="gripper_left_finger_link"/>
     <axis xyz="1 0.000093 0"/>
@@ -1510,7 +1510,7 @@
     <child link="right"/>
     <origin xyz="0.016 0 0" rpy="-2.356193 1.570792 0.785393"/>
   </joint>
-  <joint name="right_hand_gripper_finger_joint::right" type="prismatic">
+  <joint name="right_hand_gripper_right_finger_joint" type="prismatic">
     <parent link="right"/>
     <child link="gripper_right_finger_link_3"/>
     <axis xyz="1 0 0"/>
@@ -1555,7 +1555,7 @@
       </geometry>
     </collision>
   </link>
-  <joint name="right_hand_gripper_finger_joint::left" type="prismatic">
+  <joint name="right_hand_gripper_left_finger_joint" type="prismatic">
     <parent link="right"/>
     <child link="gripper_left_finger_link_4"/>
     <axis xyz="1 0.000093 0"/>


### PR DESCRIPTION
In the process of updating the TIAGo to improve the compatibility with the real robot, the joints of the gripper fingers must be updated.

See #6046, #6082 and #6093 for related PRs and issues.