### PR TITLE
Fix ODE hinge joints limits

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -63,6 +63,7 @@ Released on ??
     - Fixed crash during conversion of PROTO to base nodes in case of Mesh nodes with invalid scale values ([#6088](https://github.com/cyberbotics/webots/pull/6088)).
     - Fixed object's relative orientation returned by the [Recognition](recognition.md) functionality ([#6100](https://github.com/cyberbotics/webots/pull/6100)).
     - Fixed conversion of joints' axis in `pedal_racer.wbt` to FLU/ENU coordinate system ([#6115](https://github.com/cyberbotics/webots/pull/6115)).
+    - Fixed a bug in ODE that caused minStop and maxStop limits to be violated in HingeJoints ([#6118](https://github.com/cyberbotics/webots/pull/6118)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/ode/ode/src/joints/joint.cpp
+++ b/src/ode/ode/src/joints/joint.cpp
@@ -497,6 +497,7 @@ void dxJointLimitMotor::init( dxWorld *world )
     stop_erp = world->global_erp;
     stop_cfm = world->global_cfm;
     bounce = 0;
+    previous_angle = 0;
     limit = 0;
     limit_err = 0;
 }
@@ -564,6 +565,11 @@ dReal dxJointLimitMotor::get( int num )
 
 int dxJointLimitMotor::testRotationalLimit( dReal angle )
 {
+    dReal delta_angle = angle - previous_angle;
+    if ( delta_angle > M_PI ) angle -= 2 * M_PI;
+    else if ( delta_angle < -M_PI ) angle += 2 * M_PI;
+    previous_angle = angle;
+
     if ( angle <= lostop )
     {
         limit = 1;

--- a/src/ode/ode/src/joints/joint.h
+++ b/src/ode/ode/src/joints/joint.h
@@ -193,6 +193,7 @@ struct dxJointLimitMotor
     dReal normal_cfm;       // cfm to use when not at a stop
     dReal stop_erp, stop_cfm; // erp and cfm for when at joint limit
     dReal bounce;           // restitution factor
+    dReal previous_angle;   // joint angle at previous step for limit calculation
     // variables used between getInfo1() and getInfo2()
     int limit;          // 0=free, 1=at lo limit, 2=at hi limit
     dReal limit_err;    // if at limit, amount over limit


### PR DESCRIPTION
Fixes #3947.

There was a singularity in ODE, when the min and max limits were set close to PI (or -PI). Depending on the basicTimeStep and on the torque applied, if the next computed angle was above PI or under -PI, it was directly clamped in range [-PI; +PI], switching the sign and messing with the limit computation. The fix uses the delta with the previous angle to correctly compute the limit to use for the LCP contraints algorithm.