### PR TITLE
Fix errors loading template PROTO nodes

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -64,6 +64,7 @@ Released on ??
     - Fixed object's relative orientation returned by the [Recognition](recognition.md) functionality ([#6100](https://github.com/cyberbotics/webots/pull/6100)).
     - Fixed conversion of joints' axis in `pedal_racer.wbt` to FLU/ENU coordinate system ([#6115](https://github.com/cyberbotics/webots/pull/6115)).
     - Fixed a bug in ODE that caused minStop and maxStop limits to be violated in HingeJoints ([#6118](https://github.com/cyberbotics/webots/pull/6118)).
+    - Fixed errors loading template PROTO if the system user name contains the `'` character ([#6131](https://github.com/cyberbotics/webots/pull/6131)).
 
 ## Webots R2023a
 Released on November 29th, 2022.

--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -38,6 +38,11 @@
 
 static QString gCoordinateSystem;
 
+QString escapeString(const QString &string) {
+  QString escaped(string);
+  return escaped.replace("'", "//'");
+}
+
 WbProtoTemplateEngine::WbProtoTemplateEngine(const QString &templateContent) : WbTemplateEngine(templateContent) {
 }
 
@@ -70,11 +75,11 @@ bool WbProtoTemplateEngine::generate(const QString &logHeaderName, const QVector
 #ifdef __APPLE__
   tags["context"] = QString("os: 'mac', ");
 #endif
-  tags["context"] += QString("world: '%1', ").arg(worldPath);
-  tags["context"] += QString("proto: '%1', ").arg(protoPath);
-  tags["context"] += QString("webots_home: '%1', ").arg(WbStandardPaths::webotsHomePath());
-  tags["context"] += QString("project_path: '%1', ").arg(WbProject::current()->path());
-  tags["context"] += QString("temporary_files_path: '%1', ").arg(WbStandardPaths::webotsTmpPath());
+  tags["context"] += QString("world: '%1', ").arg(escapeString(worldPath));
+  tags["context"] += QString("proto: '%1', ").arg(escapeString(protoPath));
+  tags["context"] += QString("webots_home: '%1', ").arg(escapeString(WbStandardPaths::webotsHomePath()));
+  tags["context"] += QString("project_path: '%1', ").arg(escapeString(WbProject::current()->path()));
+  tags["context"] += QString("temporary_files_path: '%1', ").arg(escapeString(WbStandardPaths::webotsTmpPath()));
   tags["context"] += QString("id: '%1', ").arg(id);
   tags["context"] += QString("coordinate_system: '%1', ").arg(gCoordinateSystem);
   WbVersion version = WbApplicationInfo::version();

--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -38,7 +38,7 @@
 
 static QString gCoordinateSystem;
 
-QString escapeString(const QString &string) {
+static QString escapeString(const QString &string) {
   QString escaped(string);
   return escaped.replace("'", "//'");
 }

--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -40,7 +40,7 @@ static QString gCoordinateSystem;
 
 static QString escapeString(const QString &string) {
   QString escaped(string);
-  return escaped.replace("'", "//'");
+  return escaped.replace("'", "\\'");
 }
 
 WbProtoTemplateEngine::WbProtoTemplateEngine(const QString &templateContent) : WbTemplateEngine(templateContent) {


### PR DESCRIPTION
Fix #6060:
if a path used in the Javascript (or Lua) template file contains the `'` character, the code becomes invalid and it is not possible to load the template PROTO.
All the paths need to be correctly escaped before writing them in the template file. 