### PR TITLE
Enhancement backward compatibility pose

### DIFF
--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -16,7 +16,7 @@
 
 """Convert Transforms with no scale or the default one into Poses"""
 
-# usage: put the script in the root folder of the project you want to convert and run it.
+# usage: copy this script and `webots_parser.py` in the root folder of the project you want to convert and run it.
 from webots_parser import WebotsParser
 from pathlib import Path
 
@@ -52,6 +52,8 @@ def convert_children(node):
             node['name'] = 'Pose'
 
     for field in node['fields']:
+        if field['type'] == 'IS':
+            continue
         if field['name'] in 'children':
             for child in field['value']:
                 convert_children(child)

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -20,6 +20,7 @@
 from webots_parser import WebotsParser
 from pathlib import Path
 
+
 def convert_to_enu(filename):
     world = WebotsParser()
     world.load(filename)
@@ -33,6 +34,7 @@ def convert_to_enu(filename):
 
     world.save(filename)
     print('Conversion done')
+
 
 def convert_children(node):
     if 'USE' in node:
@@ -61,6 +63,7 @@ def convert_children(node):
             convert_children(field['value'])
         elif field['name'] in 'boundingObject':
             convert_children(field['value'])
+
 
 if __name__ == "__main__":
     files = []

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import sys
 
+
 def convert_to_enu(filename):
     file = WebotsParser()
     try:

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import sys
 
 
-def convert_to_enu(filename):
+def convert_to_pose(filename):
     file = WebotsParser()
     try:
         file.load(filename)

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -82,6 +82,6 @@ if __name__ == "__main__":
 
         for file, path in local_files.items():
             print('Loading ' + str(path))
-            convert_to_enu(str(path))
+            convert_to_pose(str(path))
     except IndexError:
         print("Argument missing: path to the webots project to convert.")

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -16,24 +16,26 @@
 
 """Convert Transforms with no scale or the default one into Poses"""
 
-# usage: copy this script and `webots_parser.py` in the root folder of the project you want to convert and run it.
+# usage: python convert_transform_to_pose.py /path/to/your/webots/project
 from webots_parser import WebotsParser
 from pathlib import Path
 
+import sys
 
 def convert_to_enu(filename):
-    world = WebotsParser()
-    world.load(filename)
-
-    print('Scan for transforms')
-    if filename.endswith('.proto'):
-        convert_children(world.content['root'][0]['root'][0])
-    else:
-        for node in world.content['root']:
-            convert_children(node)
-
-    world.save(filename)
-    print('Conversion done')
+    file = WebotsParser()
+    try:
+        file.load(filename)
+        print('Scan for transforms')
+        if filename.endswith('.proto'):
+            convert_children(file.content['root'][0]['root'][0])
+        else:
+            for node in file.content['root']:
+                convert_children(node)
+        file.save(filename)
+        print('Conversion done')
+    except Exception as e:
+        print("Failed to convert " + filename + ": " + str(e))
 
 
 def convert_children(node):
@@ -66,14 +68,19 @@ def convert_children(node):
 
 
 if __name__ == "__main__":
-    files = []
-    files.extend(Path('./protos').rglob('*.proto'))
-    files.extend(Path('./worlds').rglob('*.wbt'))
+    try:
+        path = sys.argv[1]
 
-    local_files = {}
-    for file in files:
-        local_files[file.stem] = file.resolve()
+        files = []
+        files.extend(Path(path + '/protos').rglob('*.proto'))
+        files.extend(Path(path + '/worlds').rglob('*.wbt'))
 
-    for file, path in local_files.items():
-        print('Loading ' + str(path))
-        convert_to_enu(str(path))
+        local_files = {}
+        for file in files:
+            local_files[file.stem] = file.resolve()
+
+        for file, path in local_files.items():
+            print('Loading ' + str(path))
+            convert_to_enu(str(path))
+    except IndexError:
+        print("Argument missing: path to the webots project to convert.")

--- a/scripts/converter/convert_transform_to_pose.py
+++ b/scripts/converter/convert_transform_to_pose.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright 1996-2023 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert Transforms with no scale or the default one into Poses"""
+
+# usage: put the script in the root folder of the project you want to convert and run it.
+from webots_parser import WebotsParser
+from pathlib import Path
+
+def convert_to_enu(filename):
+    world = WebotsParser()
+    world.load(filename)
+
+    print('Scan for transforms')
+    if filename.endswith('.proto'):
+        convert_children(world.content['root'][0]['root'][0])
+    else:
+        for node in world.content['root']:
+            convert_children(node)
+
+    world.save(filename)
+    print('Conversion done')
+
+def convert_children(node):
+    if 'USE' in node:
+        return
+    if node['name'] == 'Transform':
+        canConvert = True
+        for field in node['fields']:
+            if field['name'] == 'scale':
+                if field['value'] == ['1', '1', '1']:
+                    node['fields'].remove(field)
+                else:
+                    print('Transform found but not replaced due to a non-default scale')
+                    canConvert = False
+
+        if canConvert:
+            print('Transform found and replaced')
+            node['name'] = 'Pose'
+
+    for field in node['fields']:
+        if field['name'] in 'children':
+            for child in field['value']:
+                convert_children(child)
+        elif field['name'] in 'endPoint':
+            convert_children(field['value'])
+        elif field['name'] in 'boundingObject':
+            convert_children(field['value'])
+
+if __name__ == "__main__":
+    files = []
+    files.extend(Path('./protos').rglob('*.proto'))
+    files.extend(Path('./worlds').rglob('*.wbt'))
+
+    local_files = {}
+    for file in files:
+        local_files[file.stem] = file.resolve()
+
+    for file, path in local_files.items():
+        print('Loading ' + str(path))
+        convert_to_enu(str(path))

--- a/scripts/converter/webots_parser.py
+++ b/scripts/converter/webots_parser.py
@@ -192,6 +192,10 @@ class WebotsParser:
             return node
         else:
             node['name'] = words[0]
+
+        lastWord = words[len(words) - 1]
+        if  lastWord == '}' or lastWord == '{}':
+            return node
         for line in self.file:
             line = self._prepare_line(line)
             self.line_count += 1
@@ -244,7 +248,7 @@ class WebotsParser:
         return node
 
     def _prepare_line(self, line):
-        if '%<' in line or '>%' in line:
+        if '%<' in line or '>%' in line or '%{' in line or '}%' in line:
             raise Exception(
                 f'JavaScript fragment found at line {self.line_count}. This script cannot handle JavaScript fragments.')
         return line.split('#')[0].strip()

--- a/scripts/converter/webots_parser.py
+++ b/scripts/converter/webots_parser.py
@@ -30,6 +30,7 @@ class WebotsParser:
     def load(self, filename):
         with open(filename, 'r') as self.file:
             self.content['header'] = []
+            self.content['externprotos'] = []
             self.line_count = 0
 
             self.content['header'] = []
@@ -40,6 +41,9 @@ class WebotsParser:
                 if line.startswith('#') or not line.strip():
                     self.line_count += 1
                     self.content['header'].append(line.strip())
+                elif line.startswith('EXTERNPROTO') or line.startswith('IMPORTABLE EXTERNPROTO'):
+                    self.line_count += 1
+                    self.content['externprotos'].append(line.strip())
                 else:
                     self.file.seek(revert_position)
                     self.line_count = revert_line_count

--- a/scripts/converter/webots_parser.py
+++ b/scripts/converter/webots_parser.py
@@ -64,6 +64,8 @@ class WebotsParser:
         with open(filename, 'w', newline='\n') as self.file:
             for header_line in self.content['header']:
                 self.file.write(header_line + '\n')
+            for externproto_line in self.content['externprotos']:
+                self.file.write(externproto_line + '\n')
             for node in self.content['root']:
                 if node['type'] == 'node':
                     self._write_node(node)

--- a/scripts/converter/webots_parser.py
+++ b/scripts/converter/webots_parser.py
@@ -196,7 +196,7 @@ class WebotsParser:
             node['name'] = words[0]
 
         lastWord = words[len(words) - 1]
-        if  lastWord == '}' or lastWord == '{}':
+        if lastWord == '}' or lastWord == '{}':
             return node
         for line in self.file:
             line = self._prepare_line(line)

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
@@ -281,8 +281,41 @@ WbNode *WbConcreteNodeFactory::createNode(const QString &modelName, WbTokenizer 
     return new WbTrack(tokenizer);
   if (modelName == "TrackWheel")
     return new WbTrackWheel(tokenizer);
-  if (modelName == "Transform")
-    return new WbTransform(tokenizer);
+  if (modelName == "Transform") {
+    if (tokenizer) {
+      int initalIndex = tokenizer->pos();
+      bool inChildren = false;
+      int bracketCount = 0;
+      while (tokenizer->hasMoreTokens()) {
+        QString token = tokenizer->nextWord();
+        if (inChildren) {
+          if (token == "[")
+            bracketCount++;
+          else if (token == "]") {
+            bracketCount--;
+            if (bracketCount == 0)
+              inChildren = false;
+          }
+        } else if (token == "children") {
+          inChildren = true;
+        } else if (!inChildren && token == "scale") {
+          for (int i = 0; i < 3; i++) {
+            if (tokenizer->nextWord() != '1') {
+              tokenizer->seek(initalIndex);
+              return new WbTransform(tokenizer);
+            }
+          }
+          // We have identified that the scale is the default one.
+          break;
+          // End of the Transform
+        } else if (token == "}" && !inChildren)
+          break;
+      }
+      tokenizer->seek(initalIndex);
+    }
+
+    return new WbPose(tokenizer);
+  }
   if (modelName == "Viewpoint")
     return new WbViewpoint(tokenizer);
   if (modelName == "WorldInfo")

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
@@ -282,8 +282,12 @@ WbNode *WbConcreteNodeFactory::createNode(const QString &modelName, WbTokenizer 
     return new WbTrack(tokenizer);
   if (modelName == "TrackWheel")
     return new WbTrackWheel(tokenizer);
-  if (modelName == "Transform")
-    return WbVrmlNodeUtilities::transformBackwardCompatibility(tokenizer) ? new WbPose(tokenizer) : new WbTransform(tokenizer);
+  if (modelName == "Transform") {
+    if (WbWorld::instance() && WbWorld::instance()->isLoading())
+      return WbVrmlNodeUtilities::transformBackwardCompatibility(tokenizer) ? new WbPose(tokenizer) :
+                                                                              new WbTransform(tokenizer);
+    return new WbTransform(tokenizer);
+  }
   if (modelName == "Viewpoint")
     return new WbViewpoint(tokenizer);
   if (modelName == "WorldInfo")

--- a/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
+++ b/src/webots/nodes/utils/WbConcreteNodeFactory.cpp
@@ -104,6 +104,7 @@
 #include "WbTransform.hpp"
 #include "WbUrl.hpp"
 #include "WbViewpoint.hpp"
+#include "WbVrmlNodeUtilities.hpp"
 #include "WbWorld.hpp"
 #include "WbWorldInfo.hpp"
 #include "WbZoom.hpp"
@@ -281,41 +282,8 @@ WbNode *WbConcreteNodeFactory::createNode(const QString &modelName, WbTokenizer 
     return new WbTrack(tokenizer);
   if (modelName == "TrackWheel")
     return new WbTrackWheel(tokenizer);
-  if (modelName == "Transform") {
-    if (tokenizer) {
-      int initalIndex = tokenizer->pos();
-      bool inChildren = false;
-      int bracketCount = 0;
-      while (tokenizer->hasMoreTokens()) {
-        QString token = tokenizer->nextWord();
-        if (inChildren) {
-          if (token == "[")
-            bracketCount++;
-          else if (token == "]") {
-            bracketCount--;
-            if (bracketCount == 0)
-              inChildren = false;
-          }
-        } else if (token == "children") {
-          inChildren = true;
-        } else if (!inChildren && token == "scale") {
-          for (int i = 0; i < 3; i++) {
-            if (tokenizer->nextWord() != '1') {
-              tokenizer->seek(initalIndex);
-              return new WbTransform(tokenizer);
-            }
-          }
-          // We have identified that the scale is the default one.
-          break;
-          // End of the Transform
-        } else if (token == "}" && !inChildren)
-          break;
-      }
-      tokenizer->seek(initalIndex);
-    }
-
-    return new WbPose(tokenizer);
-  }
+  if (modelName == "Transform")
+    return WbVrmlNodeUtilities::transformBackwardCompatibility(tokenizer) ? new WbPose(tokenizer) : new WbTransform(tokenizer);
   if (modelName == "Viewpoint")
     return new WbViewpoint(tokenizer);
   if (modelName == "WorldInfo")

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -580,9 +580,7 @@ namespace {
     return false;
   }
 
-  bool isSolidNode(WbBaseNode *node) {
-    return dynamic_cast<WbSolid *>(node);
-  }
+  bool isSolidNode(WbBaseNode *node) { return dynamic_cast<WbSolid *>(node); }
 
   bool doesFieldRestrictionAcceptNode(const WbField *const field, const QStringList &nodeNames) {
     assert(field->hasRestrictedValues());

--- a/src/webots/nodes/utils/WbNodeUtilities.cpp
+++ b/src/webots/nodes/utils/WbNodeUtilities.cpp
@@ -580,7 +580,9 @@ namespace {
     return false;
   }
 
-  bool isSolidNode(WbBaseNode *node) { return dynamic_cast<WbSolid *>(node); }
+  bool isSolidNode(WbBaseNode *node) {
+    return dynamic_cast<WbSolid *>(node);
+  }
 
   bool doesFieldRestrictionAcceptNode(const WbField *const field, const QStringList &nodeNames) {
     assert(field->hasRestrictedValues());

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1604,7 +1604,6 @@ WbNode *WbNode::createProtoInstance(WbProtoModel *proto, WbTokenizer *tokenizer,
   parametersDefMap.clear();
 
   return createProtoInstanceFromParameters(proto, parametersList, worldPath);
-  ;
 }
 
 WbNode *WbNode::createProtoInstanceFromParameters(WbProtoModel *proto, const QList<WbField *> &parameters,

--- a/src/webots/vrml/WbNodeReader.cpp
+++ b/src/webots/vrml/WbNodeReader.cpp
@@ -54,8 +54,7 @@ WbNode *WbNodeReader::createNode(const QString &modelName, WbTokenizer *tokenize
     return WbVrmlNodeUtilities::transformBackwardCompatibility(tokenizer) ? new WbNode("Pose", worldPath, tokenizer) :
                                                                             new WbNode("Transform", worldPath, tokenizer);
   else {
-    WbNodeModel *const model = WbNodeModel::findModel(modelName);
-    if (model)
+    if (WbNodeModel::findModel(modelName))
       return new WbNode(modelName, worldPath, tokenizer);
   }
   WbProtoModel *const proto = WbProtoManager::instance()->findModel(modelName, worldPath, fileName);

--- a/src/webots/vrml/WbNodeReader.cpp
+++ b/src/webots/vrml/WbNodeReader.cpp
@@ -49,10 +49,45 @@ WbNode *WbNodeReader::createNode(const QString &modelName, WbTokenizer *tokenize
   if (mMode == NORMAL)
     return WbNodeFactory::instance()->createNode(WbNodeModel::compatibleNodeName(modelName), tokenizer);
 
-  WbNodeModel *const model = WbNodeModel::findModel(modelName);
-  if (model)
-    return new WbNode(modelName, worldPath, tokenizer);
+  if (modelName == "Transform") {
+    if (tokenizer) {
+      int initalIndex = tokenizer->pos();
+      bool inChildren = false;
+      int bracketCount = 0;
+      while (tokenizer->hasMoreTokens()) {
+        QString token = tokenizer->nextWord();
+        if (inChildren) {
+          if (token == "[")
+            bracketCount++;
+          else if (token == "]") {
+            bracketCount--;
+            if (bracketCount == 0)
+              inChildren = false;
+          }
+        } else if (token == "children") {
+          inChildren = true;
+        } else if (!inChildren && token == "scale") {
+          for (int i = 0; i < 3; i++) {
+            if (tokenizer->nextWord() != '1') {
+              tokenizer->seek(initalIndex);
+              return new WbNode("Transform", worldPath, tokenizer);
+            }
+          }
+          // We have identified that the scale is the default one.
+          break;
+          // End of the Transform
+        } else if (token == "}" && !inChildren)
+          break;
+      }
+      tokenizer->seek(initalIndex);
+    }
 
+    return new WbNode("Pose", worldPath, tokenizer);
+  } else {
+    WbNodeModel *const model = WbNodeModel::findModel(modelName);
+    if (model)
+      return new WbNode(modelName, worldPath, tokenizer);
+  }
   WbProtoModel *const proto = WbProtoManager::instance()->findModel(modelName, worldPath, fileName);
   if (proto)
     return WbNode::createProtoInstance(proto, tokenizer, worldPath);

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -505,7 +505,7 @@ bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer)
       inChildren = true;
     } else if (token == "scale") {
       for (int i = 0; i < 3; i++) {
-        if (tokenizer->nextWord().toFloat() != 1) {
+        if (tokenizer->nextWord().toFloat() != 1.0f) {
           tokenizer->seek(initalIndex);
           return false;
         }

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -487,36 +487,36 @@ QString WbVrmlNodeUtilities::exportNodeToString(WbNode *node) {
 bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer) {
   if (!tokenizer)
     return true;
-    const int initalIndex = tokenizer->pos();
-    bool inChildren = false;
-    int bracketCount = 0;
-    while (tokenizer->hasMoreTokens()) {
-      const QString token = tokenizer->nextWord();
-      if (inChildren) {
-        if (token == "[")
-          bracketCount++;
-        else if (token == "]") {
-          bracketCount--;
-          if (bracketCount == 0)
-            inChildren = false;
+
+  const int initalIndex = tokenizer->pos();
+  bool inChildren = false;
+  int bracketCount = 0;
+  while (tokenizer->hasMoreTokens()) {
+    const QString token = tokenizer->nextWord();
+    if (inChildren) {
+      if (token == "[")
+        bracketCount++;
+      else if (token == "]") {
+        bracketCount--;
+        if (bracketCount == 0)
+          inChildren = false;
+      }
+    } else if (token == "children") {
+      inChildren = true;
+    } else if (token == "scale") {
+      for (int i = 0; i < 3; i++) {
+        if (tokenizer->nextWord().toFloat() != '1') {
+          tokenizer->seek(initalIndex);
+          return false;
         }
-      } else if (token == "children") {
-        inChildren = true;
-      } else if (token == "scale") {
-        for (int i = 0; i < 3; i++) {
-          if (tokenizer->nextWord() != '1') {
-            tokenizer->seek(initalIndex);
-            return false;
-          }
-        }
-        // We have identified that the scale is the default one.
-        break;
-        // End of the Transform
-      } else if (token == "}")
-        break;
-    }
-    tokenizer->seek(initalIndex);
+      }
+      // We have identified that the scale is the default one.
+      break;
+      // End of the Transform
+    } else if (token == "}")
+      break;
   }
+  tokenizer->seek(initalIndex);
 
   return true;
 }

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -501,7 +501,7 @@ bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer)
         }
       } else if (token == "children") {
         inChildren = true;
-      } else if (!inChildren && token == "scale") {
+      } else if (token == "scale") {
         for (int i = 0; i < 3; i++) {
           if (tokenizer->nextWord() != '1') {
             tokenizer->seek(initalIndex);
@@ -511,7 +511,7 @@ bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer)
         // We have identified that the scale is the default one.
         break;
         // End of the Transform
-      } else if (token == "}" && !inChildren)
+      } else if (token == "}")
         break;
     }
     tokenizer->seek(initalIndex);

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -505,7 +505,7 @@ bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer)
       inChildren = true;
     } else if (token == "scale") {
       for (int i = 0; i < 3; i++) {
-        if (tokenizer->nextWord().toFloat() != '1') {
+        if (tokenizer->nextWord().toFloat() != 1) {
           tokenizer->seek(initalIndex);
           return false;
         }

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -486,11 +486,11 @@ QString WbVrmlNodeUtilities::exportNodeToString(WbNode *node) {
 // Return true if we can convert the Transform to a Pose.
 bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer) {
   if (tokenizer) {
-    int initalIndex = tokenizer->pos();
+    const int initalIndex = tokenizer->pos();
     bool inChildren = false;
     int bracketCount = 0;
     while (tokenizer->hasMoreTokens()) {
-      QString token = tokenizer->nextWord();
+      const QString token = tokenizer->nextWord();
       if (inChildren) {
         if (token == "[")
           bracketCount++;

--- a/src/webots/vrml/WbVrmlNodeUtilities.cpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.cpp
@@ -485,7 +485,8 @@ QString WbVrmlNodeUtilities::exportNodeToString(WbNode *node) {
 
 // Return true if we can convert the Transform to a Pose.
 bool WbVrmlNodeUtilities::transformBackwardCompatibility(WbTokenizer *tokenizer) {
-  if (tokenizer) {
+  if (!tokenizer)
+    return true;
     const int initalIndex = tokenizer->pos();
     bool inChildren = false;
     int bracketCount = 0;

--- a/src/webots/vrml/WbVrmlNodeUtilities.hpp
+++ b/src/webots/vrml/WbVrmlNodeUtilities.hpp
@@ -26,6 +26,7 @@
 class WbField;
 class WbNode;
 class WbProtoModel;
+class WbTokenizer;
 
 namespace WbVrmlNodeUtilities {
   //////////////////////////
@@ -87,5 +88,6 @@ namespace WbVrmlNodeUtilities {
   ///////////
   QString exportNodeToString(WbNode *node);
 
+  bool transformBackwardCompatibility(WbTokenizer *tokenizer);
 }  // namespace WbVrmlNodeUtilities
 #endif

--- a/tests/parser/expected_results.txt
+++ b/tests/parser/expected_results.txt
@@ -25,7 +25,7 @@ parser/worlds/proto_missing_ending_curly_bracket.wbt "Expected field name or '}'
 parser/worlds/proto_missing_item_value_in_field.wbt "Expected floating point value, found 'field'."
 parser/worlds/proto_nested_parameter.wbt VOID
 parser/worlds/proto_not_allowed_field_value.wbt "Invalid 'translation' changed to 0 0 0. The value should be in the list: {0 0 0}."
-parser/worlds/proto_not_allowed_mf_field_value.wbt "Invalid 'Transform' removed from 'extensionSlot' field. The values should be in the list: {Solid, Group}."
+parser/worlds/proto_not_allowed_mf_field_value.wbt "Invalid 'Pose' removed from 'extensionSlot' field. The values should be in the list: {Solid, Group}."
 parser/worlds/proto_parameter_missing_ending_curly_bracket.wbt "Expected field name or '}', found ']'."
 parser/worlds/proto_typo_in_alias.wbt "PROTO parameter 'rotation' has no matching IS field."
 parser/worlds/proto_typo_in_is_keyword.wbt "Expected floating point value, found 'ISNOT'."


### PR DESCRIPTION
The introduction of the `Pose` node breaks the backward compatibility.

This PR adds:

- [x] A mechanism in Webots that convert `Transform` without scale (or with the default one) into `Pose` when parsing a world. It works both for worlds and protos. If the user saves the world, the conversions will be saved for the world, but not for the protos.
- [x] A script to convert the `Transform` withtout scale from proto/worlds to `Pose`.
  - The script has several known limitations: 
    - it does not support protos with templating
    - it requires the protos/worlds to be well formated. 
    - it does not convert the parameters of the protos

I could not see a performance impact.