### PR TITLE
Fix node comparison

### DIFF
--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1342,7 +1342,11 @@ bool WbNode::operator==(const WbNode &other) const {
   const QVector<WbField *> fieldsList = fieldsOrParameters();
   const QVector<WbField *> otherFieldsList = other.fieldsOrParameters();
   const int size = fieldsList.size();
-  assert(size == otherFieldsList.size());
+
+  // It is possible to have two nodes with the same name but not the same fields because of remote protos.
+  if (size != otherFieldsList.size())
+    return false;
+
   for (int i = 0; i < size; ++i) {
     const WbField *const f1 = fieldsList[i];
     const WbField *const f2 = otherFieldsList[i];

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1344,6 +1344,11 @@ bool WbNode::operator==(const WbNode &other) const {
   const int size = fieldsList.size();
 
   // It is possible to have two nodes with the same name but not the same fields because of remote protos.
+  // e.g. for the Door.proto, we have the DoorLever.proto that is the default parameter of the `doorHandle` field.
+  // But we can define a local DoorLever.proto and we can declare it as an EXTERNPROTO in the world file,
+  // then put it in the `doorHandle` field of the door. So when Webots will check if the `doorHandle` has the default value,
+  // it will compare the actual value of the doorHandle that is the local DoorLever.proto declared in the world and
+  // the default value, which is another DoorLever.proto, defined in the proto file.
   if (size != otherFieldsList.size())
     return false;
 


### PR DESCRIPTION
**Description**
An assert checking that two nodes with the same name should have the same number of fields was triggered in some cases, resulting in a Webots crash.

When it was introduced, the assert made sense.

However it is not true anymore since the introduction of extern protos.

Here is the example I used to debug it:

- I have a world with a classic `Door.proto` .
- I added a `DoorLever.proto` to the door, but not the default one, a custom one that has one more fields than the default one.
- This custom `DoorLever.proto` is declared via the EXTERNPROTO mechanism: 
```
EXTERNPROTO "../protos/DoorLever.proto"
 ```

When trying to open this world, if Webots was compiled in debug mode, it was crashing it.

The reason is:

- At some time during the loading, Webots checks if the fields of protos have their default value or not.
- To do that it will compare the current node with the default one, so the custom `DoorLever.proto` with the default one.
- As they are very similar (same name,...), the comparison will reach the assert that checks for the number of fields.
- As our custom proto has 14 fields and the default one 13, it will crash.

**Fix**
I think that the situation I used to make Webots crash is a legal one.
So in the case where the number of fields differ, we should simply return that the two nodes are not equal.

