### PR TITLE
Better fix to comparison issue

### DIFF
--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1333,7 +1333,7 @@ void WbNode::writeExport(WbWriter &writer) const {
 
 bool WbNode::operator==(const WbNode &other) const {
   if (mModel != other.mModel || isProtoInstance() != other.isProtoInstance() ||
-      (mProto && mProto->name() != other.mProto->name()) || mDefName != other.mDefName)
+      (mProto && mProto->url() != other.mProto->url()) || mDefName != other.mDefName)
     return false;
 
   if (this == &other)
@@ -1343,14 +1343,7 @@ bool WbNode::operator==(const WbNode &other) const {
   const QVector<WbField *> otherFieldsList = other.fieldsOrParameters();
   const int size = fieldsList.size();
 
-  // It is possible to have two nodes with the same name but not the same fields because of remote protos.
-  // e.g. for the Door.proto, we have the DoorLever.proto that is the default parameter of the `doorHandle` field.
-  // But we can define a local DoorLever.proto and we can declare it as an EXTERNPROTO in the world file,
-  // then put it in the `doorHandle` field of the door. So when Webots will check if the `doorHandle` has the default value,
-  // it will compare the actual value of the doorHandle that is the local DoorLever.proto declared in the world and
-  // the default value, which is another DoorLever.proto, defined in the proto file.
-  if (size != otherFieldsList.size())
-    return false;
+  assert(size == otherFieldsList.size());
 
   for (int i = 0; i < size; ++i) {
     const WbField *const f1 = fieldsList[i];


### PR DESCRIPTION
Better patch than #6141.
The previous fix did not work correctly when the two protos had the same fields, but not the same bodies.