### PR TITLE
Fix compilation warnings on macOS

### DIFF
--- a/projects/robots/epfl/lis/controllers/blimp/js.h
+++ b/projects/robots/epfl/lis/controllers/blimp/js.h
@@ -464,7 +464,7 @@ public:
     snprintf(fname, fname_length, "/dev/joy%d", ident);
 #else
     const size_t fname_length = snprintf(NULL, 0, "/dev/js%d", ident);
-    snprintf(fname, fname_length, "/dev/js%d", ident);    
+    snprintf(fname, fname_length, "/dev/js%d", ident);
 #endif
     open();
 #endif

--- a/projects/robots/epfl/lis/controllers/blimp/js.h
+++ b/projects/robots/epfl/lis/controllers/blimp/js.h
@@ -326,8 +326,7 @@ class jsJoystick {
     if (error)
       return;
 
-    const size_t joyfname_length = snprintf(NULL, 0, "%s/.joy%drc", ::getenv("HOME"), id);
-    snprintf(joyfname, joyfname_length, "%s/.joy%drc", ::getenv("HOME"), id);
+    snprintf(joyfname, sizeof(joyfname), "%s/.joy%drc", ::getenv("HOME"), id);
 
     joyfile = fopen(joyfname, "r");
     if (joyfile == NULL)
@@ -460,11 +459,9 @@ public:
     fd = -1;
 #if defined(__FreeBSD__) || defined(__NetBSD__)
     id = ident;
-    const size_t fname_length = snprintf(NULL, 0, "/dev/joy%d", ident);
-    snprintf(fname, fname_length, "/dev/joy%d", ident);
+    snprintf(fname, sizeof(fname), "/dev/joy%d", ident);
 #else
-    const size_t fname_length = snprintf(NULL, 0, "/dev/js%d", ident);
-    snprintf(fname, fname_length, "/dev/js%d", ident);
+    snprintf(fname, sizeof(fname), "/dev/js%d", ident);
 #endif
     open();
 #endif

--- a/projects/robots/epfl/lis/controllers/blimp/js.h
+++ b/projects/robots/epfl/lis/controllers/blimp/js.h
@@ -326,7 +326,8 @@ class jsJoystick {
     if (error)
       return;
 
-    sprintf(joyfname, "%s/.joy%drc", ::getenv("HOME"), id);
+    const size_t joyfname_length = snprintf(NULL, 0, "%s/.joy%drc", ::getenv("HOME"), id);
+    snprintf(joyfname, joyfname_length, "%s/.joy%drc", ::getenv("HOME"), id);
 
     joyfile = fopen(joyfname, "r");
     if (joyfile == NULL)
@@ -459,9 +460,11 @@ public:
     fd = -1;
 #if defined(__FreeBSD__) || defined(__NetBSD__)
     id = ident;
-    sprintf(fname, "/dev/joy%d", ident);
+    const size_t fname_length = snprintf(NULL, 0, "/dev/joy%d", ident);
+    snprintf(fname, fname_length, "/dev/joy%d", ident);
 #else
-    sprintf(fname, "/dev/js%d", ident);
+    const size_t fname_length = snprintf(NULL, 0, "/dev/js%d", ident);
+    snprintf(fname, fname_length, "/dev/js%d", ident);    
 #endif
     open();
 #endif

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -855,13 +855,10 @@ namespace wren {
 
   StaticMesh *StaticMesh::createUnitIcosphere(int subdivision, bool outline) {
     char uniqueName[25];
-    if (outline) {
-      const size_t uniqueNameLength = snprintf(NULL, 0, "IcosphereOutline%d", subdivision);
-      snprintf(uniqueName, uniqueNameLength, "IcosphereOutline%d", subdivision);
-    } else {
-      const size_t uniqueNameLength = snprintf(NULL, 0, "Icosphere%d", subdivision);
-      snprintf(uniqueName, uniqueNameLength, "Icosphere%d", subdivision);
-    }
+    if (outline)
+      snprintf(uniqueName, sizeof(uniqueName), "IcosphereOutline%d", subdivision);
+    else
+      snprintf(uniqueName, sizeof(uniqueName), "Icosphere%d", subdivision);
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;
@@ -911,13 +908,10 @@ namespace wren {
 
   StaticMesh *StaticMesh::createUnitUVSphere(int subdivision, bool outline) {
     char uniqueName[24];
-    if (outline) {
-      const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphereOutline%d", subdivision);
-      snprintf(uniqueName, uniqueNameLength, "UVSphereOutline%d", subdivision);
-    } else {
-      const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphere%d", subdivision);
-      snprintf(uniqueName, uniqueNameLength, "UVSphere%d", subdivision);
-    }
+    if (outline)
+      snprintf(uniqueName, sizeof(uniqueName), "UVSphereOutline%d", subdivision);
+    else
+      snprintf(uniqueName, sizeof(uniqueName), "UVSphere%d", subdivision);
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -855,12 +855,14 @@ namespace wren {
 
   StaticMesh *StaticMesh::createUnitIcosphere(int subdivision, bool outline) {
     char uniqueName[25];
-    if (outline)
+    if (outline) {
       const size_t uniqueNameLength = snprintf(NULL, 0, "IcosphereOutline%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "IcosphereOutline%d", subdivision);
-    else
+    }
+    else {
       const size_t uniqueNameLength = snprintf(NULL, 0, "Icosphere%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "Icosphere%d", subdivision);
+    }
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;
@@ -910,12 +912,14 @@ namespace wren {
 
   StaticMesh *StaticMesh::createUnitUVSphere(int subdivision, bool outline) {
     char uniqueName[24];
-    if (outline)
+    if {
       const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphereOutline%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "UVSphereOutline%d", subdivision);
-    else
+    }
+    else {
       const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphere%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "UVSphere%d", subdivision);
+    }
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -858,8 +858,7 @@ namespace wren {
     if (outline) {
       const size_t uniqueNameLength = snprintf(NULL, 0, "IcosphereOutline%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "IcosphereOutline%d", subdivision);
-    }
-    else {
+    } else {
       const size_t uniqueNameLength = snprintf(NULL, 0, "Icosphere%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "Icosphere%d", subdivision);
     }
@@ -915,8 +914,7 @@ namespace wren {
     if (outline) {
       const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphereOutline%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "UVSphereOutline%d", subdivision);
-    }
-    else {
+    } else {
       const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphere%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "UVSphere%d", subdivision);
     }

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -912,7 +912,7 @@ namespace wren {
 
   StaticMesh *StaticMesh::createUnitUVSphere(int subdivision, bool outline) {
     char uniqueName[24];
-    if {
+    if (outline) {
       const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphereOutline%d", subdivision);
       snprintf(uniqueName, uniqueNameLength, "UVSphereOutline%d", subdivision);
     }

--- a/src/wren/StaticMesh.cpp
+++ b/src/wren/StaticMesh.cpp
@@ -856,9 +856,11 @@ namespace wren {
   StaticMesh *StaticMesh::createUnitIcosphere(int subdivision, bool outline) {
     char uniqueName[25];
     if (outline)
-      sprintf(uniqueName, "IcosphereOutline%d", subdivision);
+      const size_t uniqueNameLength = snprintf(NULL, 0, "IcosphereOutline%d", subdivision);
+      snprintf(uniqueName, uniqueNameLength, "IcosphereOutline%d", subdivision);
     else
-      sprintf(uniqueName, "Icosphere%d", subdivision);
+      const size_t uniqueNameLength = snprintf(NULL, 0, "Icosphere%d", subdivision);
+      snprintf(uniqueName, uniqueNameLength, "Icosphere%d", subdivision);
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;
@@ -909,9 +911,11 @@ namespace wren {
   StaticMesh *StaticMesh::createUnitUVSphere(int subdivision, bool outline) {
     char uniqueName[24];
     if (outline)
-      sprintf(uniqueName, "UVSphereOutline%d", subdivision);
+      const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphereOutline%d", subdivision);
+      snprintf(uniqueName, uniqueNameLength, "UVSphereOutline%d", subdivision);
     else
-      sprintf(uniqueName, "UVSphere%d", subdivision);
+      const size_t uniqueNameLength = snprintf(NULL, 0, "UVSphere%d", subdivision);
+      snprintf(uniqueName, uniqueNameLength, "UVSphere%d", subdivision);
     const cache::Key key(cache::sipHash13c(uniqueName, strlen(uniqueName)));
 
     StaticMesh *mesh;


### PR DESCRIPTION
`sprintf` is deprecated and `snprintf` should be used instead. This is triggering warnings on macOS preventing the manual creation of packages.