### PR TITLE
Upgrade action version to solve deprecation errors

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Install Webots Dependencies
       run: sudo scripts/install/linux_test_dependencies.sh --exclude-ros
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Test Suite
@@ -153,7 +153,7 @@ jobs:
     - name: Install Webots Dependencies
       run: sudo scripts/install/linux_test_dependencies.sh
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Run Test
@@ -185,7 +185,7 @@ jobs:
         mkdir -p ~/.cache/Cyberbotics/Webots/
         unzip -q artifact/assets-*.zip -d ~/.cache/Cyberbotics/Webots/assets
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Update World, Check Warnings and Validate Cache

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -74,14 +74,14 @@ jobs:
         sudo python -m pip install requests PyGithub
         pip install pyopenssl --upgrade
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test worlds') }}
       with:
         name: build-${{ matrix.os }}
         path: |
           distribution/*.tar.bz2
           distribution/*.zip
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'test suite') && !contains(github.event.pull_request.labels.*.name, 'test ros') && !contains(github.event.pull_request.labels.*.name, 'test worlds') }}
       with:
         name: build-${{ matrix.os }}
@@ -100,7 +100,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-ubuntu-20.04
         path: artifact
@@ -121,7 +121,7 @@ jobs:
         export TESTS_HOME=$PWD # required by cache group in the test suite
         export BRANCH_HASH=$(git log -1 --format='%H')
         xvfb-run --auto-servernum python tests/test_suite.py
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: test-results-${{ matrix.os }}
@@ -144,7 +144,7 @@ jobs:
       with:
          submodules: true
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-${{ matrix.os }}
         path: artifact
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-ubuntu-20.04
         path: artifact

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -70,14 +70,14 @@ jobs:
         sudo python -m pip install requests PyGithub
         pip install pyopenssl --upgrade
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test ros') || contains(github.event.pull_request.labels.*.name, 'test worlds') }}
       with:
         name: build-${{ matrix.os }}
         path: |
           distribution/*.tar.bz2
           distribution/*.zip
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'test suite') && !contains(github.event.pull_request.labels.*.name, 'test ros') && !contains(github.event.pull_request.labels.*.name, 'test worlds') }}
       with:
         name: build-${{ matrix.os }}
@@ -98,7 +98,7 @@ jobs:
       with:
          ref: develop
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-ubuntu-20.04
         path: artifact
@@ -137,7 +137,7 @@ jobs:
          submodules: true
          ref: develop
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-${{ matrix.os }}
         path: artifact
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-ubuntu-20.04
         path: artifact

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -83,7 +83,7 @@ jobs:
         sudo cp -R /Volumes/Webots/Webots.app /Applications
         hdiutil unmount /Volumes/Webots
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
     - name: Test

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo python -m pip install requests PyGithub
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:
         name: build-${{ matrix.os }}
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-${{ matrix.os }}
         path: artifact

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         sudo python -m pip install requests PyGithub
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:
         name: build-${{ matrix.os }}
@@ -71,7 +71,7 @@ jobs:
       with:
          ref: develop
     - name: Download Artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-${{ matrix.os }}
         path: artifact

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -81,7 +81,7 @@ jobs:
         sudo cp -R /Volumes/Webots/Webots.app /Applications
         hdiutil unmount /Volumes/Webots
     - name: Set up Python 3.11
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
     - name: Test

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         python -m pip install requests PyGithub
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         python -m pip install requests PyGithub
         scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$(git log -1 --format='%H') --tag=${{ github.ref }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test distribution') }}
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/tests_doc.yml
+++ b/.github/workflows/tests_doc.yml
@@ -17,7 +17,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+        uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths: '["docs/**"]'
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Tests

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -23,7 +23,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+        uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths_ignore: '["docs/**"]'
@@ -49,7 +49,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "::set-output name=job_needed::true"
+        echo "{job_needed}={true} >> $GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'
@@ -60,7 +60,7 @@ jobs:
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}
       if: steps.os_check.outputs.job_needed == 'true'
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Tests

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -56,6 +56,13 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
+    - name: Test variable
+      run: |
+        echo "the variable valuer is ${{ steps.os_check.outputs.job_needed }}"
+    - name: Test True
+      if: steps.os_check.outputs.job_needed == 'true'
+      run: |
+        echo "the output is TRUE"
     - uses: actions/checkout@v3
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -49,7 +49,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "{job_needed}={'true'}" >> "$GITHUB_OUTPUT"
+        echo "job_needed='true'" >> "$GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -49,7 +49,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "{job_needed}={true}" >> "$GITHUB_OUTPUT"
+        echo "{job_needed}={'true'}" >> "$GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}
       if: steps.os_check.outputs.job_needed == 'true'

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -56,13 +56,6 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - name: Test variable
-      run: |
-        echo "the variable valuer is ${{ steps.os_check.outputs.job_needed }}"
-    - name: Test True
-      if: steps.os_check.outputs.job_needed == 'true'
-      run: |
-        echo "the output is TRUE"
     - uses: actions/checkout@v3
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -49,7 +49,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "job_needed='true'" >> "$GITHUB_OUTPUT"
+        echo "job_needed=true" >> "$GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -49,7 +49,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "{job_needed}={true} >> $GITHUB_OUTPUT"
+        echo "{job_needed}={true}" >> "$GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}
       if: steps.os_check.outputs.job_needed == 'true'

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -19,7 +19,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+        uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           paths_ignore: '["docs/**"]'
@@ -45,7 +45,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "::set-output name=job_needed::true"
+        echo "{job_needed}={true} >> $GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'
@@ -56,7 +56,7 @@ jobs:
       if: steps.os_check.outputs.job_needed == 'true'
     - name: Set up Python ${{ matrix.python }}
       if: steps.os_check.outputs.job_needed == 'true'
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Tests

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -45,7 +45,7 @@ jobs:
     - name: OS check
       if: (matrix.os == 'ubuntu-22.04' && matrix.python == '3.9') || github.event_name == 'schedule' || github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'test sources')
       run: |
-        echo "{job_needed}={true} >> $GITHUB_OUTPUT"
+        echo "job_needed=true" >> "$GITHUB_OUTPUT"
       id: os_check
     - name: Set git to use LF
       if: matrix.os == 'windows-2019'


### PR DESCRIPTION
Upgrade upload/download artifacts and checkout actions to version 3.

Version 2 is throwing errors due to the deprecation of Node.js 12:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```