### PR TITLE
Ignore missing member copy

### DIFF
--- a/tests/sources/test_cppcheck.py
+++ b/tests/sources/test_cppcheck.py
@@ -184,6 +184,7 @@ class TestCppCheck(unittest.TestCase):
         command += self.platformOptions
         command += ' --library=qt --inline-suppr --suppress=invalidPointerCast --suppress=useStlAlgorithm -UKROS_COMPILATION'
         command += ' --suppress=strdupCalled --suppress=ctuOneDefinitionRuleViolation --suppress=unknownMacro'
+        command += ' --suppress=missingMemberCopy'
         # command += ' --xml'  # Uncomment this line to get more information on the errors
         command += ' --std=c++03 --output-file=\"' + self.reportFilename + '\"'
         sources = self.add_source_files(sourceDirs, skippedDirs, skippedfiles)


### PR DESCRIPTION
The missing member copy warning is issued when we copy an object and we do not initialize a member variable in the copy constructor.
However, in Webots case, this warning is thrown a lot of time due to QList or QMap that do not need to be initialized in constructor, so we chose to ignore it.