### PR TITLE
Fix checkbox check mark first launch

### DIFF
--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -25,8 +25,6 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/dark";
 }
-
-
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid black;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -28,7 +28,7 @@ WbNewVersionDialog {
 
 
 QCheckBox#telemetryCheckBox:indicator:checked {
-  border: 1px solid dimgrey;
+  border: 1px solid black;
   image: url(newVersionIconPath:checkboxCheckmark.png);
 }
 

--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -22,6 +22,10 @@ WbSplashScreen {
   qproperty-loadingColor: #666;
 }
 
+WbNewVersionDialog {
+  qproperty-enabledIconPath: "icons/dark";
+}
+
 WbMainWindow {
   qproperty-enabledIconPath: "icons/dark";
   qproperty-disabledIconPath: "icons/light";

--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -25,6 +25,7 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/dark";
 }
+
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid black;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -23,7 +23,13 @@ WbSplashScreen {
 }
 
 WbNewVersionDialog {
-  qproperty-enabledIconPath: "icons/dark";
+  qproperty-newVersionIconPath: "icons/dark";
+}
+
+
+QCheckBox#telemetryCheckBox:indicator:checked {
+  border: 1px solid dimgrey;
+  image: url(newVersionIconPath:checkboxCheckmark.png);
 }
 
 WbMainWindow {
@@ -130,7 +136,7 @@ QCheckBox:indicator {
   border: 1px solid black;
 }
 
-QCheckBox:indicator:checked {
+WbMainWindow QCheckBox:indicator:checked {
   border: 1px solid black;
   image: url(enabledIcons:checkboxCheckmark.png);
 }

--- a/resources/webots_dusk.qss
+++ b/resources/webots_dusk.qss
@@ -25,8 +25,6 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/light";
 }
-
-
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_dusk.qss
+++ b/resources/webots_dusk.qss
@@ -25,6 +25,7 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/light";
 }
+
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_dusk.qss
+++ b/resources/webots_dusk.qss
@@ -23,7 +23,13 @@ WbSplashScreen {
 }
 
 WbNewVersionDialog {
-  qproperty-enabledIconPath: "icons/light";
+  qproperty-newVersionIconPath: "icons/light";
+}
+
+
+QCheckBox#telemetryCheckBox:indicator:checked {
+  border: 1px solid dimgrey;
+  image: url(newVersionIconPath:checkboxCheckmark.png);
 }
 
 WbMainWindow {
@@ -130,7 +136,7 @@ QCheckBox:indicator {
   border: 1px solid dimgrey;
 }
 
-QCheckBox:indicator:checked {
+WbMainWindow QCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(enabledIcons:checkboxCheckmark.png);
 }

--- a/resources/webots_dusk.qss
+++ b/resources/webots_dusk.qss
@@ -22,6 +22,10 @@ WbSplashScreen {
   qproperty-loadingColor: #b4b4b4;
 }
 
+WbNewVersionDialog {
+  qproperty-enabledIconPath: "icons/light";
+}
+
 WbMainWindow {
   qproperty-enabledIconPath: "icons/light";
   qproperty-disabledIconPath: "icons/dark";

--- a/resources/webots_night.qss
+++ b/resources/webots_night.qss
@@ -25,8 +25,6 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/light";
 }
-
-
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_night.qss
+++ b/resources/webots_night.qss
@@ -25,6 +25,7 @@ WbSplashScreen {
 WbNewVersionDialog {
   qproperty-newVersionIconPath: "icons/light";
 }
+
 QCheckBox#telemetryCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(newVersionIconPath:checkboxCheckmark.png);

--- a/resources/webots_night.qss
+++ b/resources/webots_night.qss
@@ -23,7 +23,13 @@ WbSplashScreen {
 }
 
 WbNewVersionDialog {
-  qproperty-enabledIconPath: "icons/light";
+  qproperty-newVersionIconPath: "icons/light";
+}
+
+
+QCheckBox#telemetryCheckBox:indicator:checked {
+  border: 1px solid dimgrey;
+  image: url(newVersionIconPath:checkboxCheckmark.png);
 }
 
 WbMainWindow {
@@ -130,7 +136,7 @@ QCheckBox:indicator {
   border: 1px solid dimgrey;
 }
 
-QCheckBox:indicator:checked {
+WbMainWindow QCheckBox:indicator:checked {
   border: 1px solid dimgrey;
   image: url(enabledIcons:checkboxCheckmark.png);
 }

--- a/resources/webots_night.qss
+++ b/resources/webots_night.qss
@@ -22,6 +22,10 @@ WbSplashScreen {
   qproperty-loadingColor: #b4b4b4;
 }
 
+WbNewVersionDialog {
+  qproperty-enabledIconPath: "icons/light";
+}
+
 WbMainWindow {
   qproperty-enabledIconPath: "icons/light";
   qproperty-disabledIconPath: "icons/dark";

--- a/src/webots/gui/WbNewVersionDialog.cpp
+++ b/src/webots/gui/WbNewVersionDialog.cpp
@@ -20,6 +20,8 @@
 #include "WbStandardPaths.hpp"
 #include "WbVersion.hpp"
 
+#include <QtCore/QDir>
+
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QGroupBox>
@@ -45,6 +47,8 @@ bool WbNewVersionDialog::run() {
 }
 
 WbNewVersionDialog::WbNewVersionDialog() {
+  style()->polish(this);
+  QDir::addSearchPath("enabledIcons", WbStandardPaths::resourcesPath() + enabledIconPath());
   style()->polish(this);
 
   const WbVersion &version = WbApplicationInfo::version();

--- a/src/webots/gui/WbNewVersionDialog.cpp
+++ b/src/webots/gui/WbNewVersionDialog.cpp
@@ -48,7 +48,7 @@ bool WbNewVersionDialog::run() {
 
 WbNewVersionDialog::WbNewVersionDialog() {
   style()->polish(this);
-  QDir::addSearchPath("enabledIcons", WbStandardPaths::resourcesPath() + enabledIconPath());
+  QDir::addSearchPath("newVersionIconPath", WbStandardPaths::resourcesPath() + newVersionIconPath());
   style()->polish(this);
 
   const WbVersion &version = WbApplicationInfo::version();
@@ -125,6 +125,7 @@ WbNewVersionDialog::WbNewVersionDialog() {
   telemetryLayout->addWidget(label);
   telemetryLayout->addStretch();
   mTelemetryCheckBox = new QCheckBox(tr("Allow to send lightweight anonymous technical data to Webots developers."));
+  mTelemetryCheckBox->setObjectName("telemetryCheckBox");
   mTelemetryCheckBox->setChecked(true);
   telemetryLayout->addWidget(mTelemetryCheckBox);
   telemetryBox->setLayout(telemetryLayout);

--- a/src/webots/gui/WbNewVersionDialog.hpp
+++ b/src/webots/gui/WbNewVersionDialog.hpp
@@ -31,17 +31,17 @@ class QRadioButton;
 class WbNewVersionDialog : public QDialog {
   Q_OBJECT
   Q_PROPERTY(QColor backgroundColor MEMBER mBackgroundColor READ backgroundColor WRITE setBackgroundColor)
-  Q_PROPERTY(QString enabledIconPath MEMBER mEnabledIconPath READ enabledIconPath WRITE setEnabledIconPath)
+  Q_PROPERTY(QString newVersionIconPath MEMBER mNewVersionIconPath READ newVersionIconPath WRITE setNewVersionIconPath)
 
 public:
   static bool run();
 
   // qproperty methods
   const QColor &backgroundColor() const { return mBackgroundColor; }
-  const QString &enabledIconPath() const { return mEnabledIconPath; }
+  const QString &newVersionIconPath() const { return mNewVersionIconPath; }
 
   void setBackgroundColor(const QColor &color) { mBackgroundColor = color; }
-  void setEnabledIconPath(const QString &path) { mEnabledIconPath = path; }
+  void setNewVersionIconPath(const QString &path) { mNewVersionIconPath = path; }
 
 private slots:
   void startButtonPressed();
@@ -52,7 +52,7 @@ private:
   virtual ~WbNewVersionDialog() {}
 
   QColor mBackgroundColor;
-  QString mEnabledIconPath;
+  QString mNewVersionIconPath;
   QRadioButton *mRadioButtons[NUMBER_OF_THEMES];
   QLabel *mPreviewLabel;
   QCheckBox *mTelemetryCheckBox;

--- a/src/webots/gui/WbNewVersionDialog.hpp
+++ b/src/webots/gui/WbNewVersionDialog.hpp
@@ -31,14 +31,17 @@ class QRadioButton;
 class WbNewVersionDialog : public QDialog {
   Q_OBJECT
   Q_PROPERTY(QColor backgroundColor MEMBER mBackgroundColor READ backgroundColor WRITE setBackgroundColor)
+  Q_PROPERTY(QString enabledIconPath MEMBER mEnabledIconPath READ enabledIconPath WRITE setEnabledIconPath)
 
 public:
   static bool run();
 
   // qproperty methods
   const QColor &backgroundColor() const { return mBackgroundColor; }
+  const QString &enabledIconPath() const { return mEnabledIconPath; }
 
   void setBackgroundColor(const QColor &color) { mBackgroundColor = color; }
+  void setEnabledIconPath(const QString &path) { mEnabledIconPath = path; }
 
 private slots:
   void startButtonPressed();
@@ -49,6 +52,7 @@ private:
   virtual ~WbNewVersionDialog() {}
 
   QColor mBackgroundColor;
+  QString mEnabledIconPath;
   QRadioButton *mRadioButtons[NUMBER_OF_THEMES];
   QLabel *mPreviewLabel;
   QCheckBox *mTelemetryCheckBox;


### PR DESCRIPTION
**Description**
The checkbox check mark was not displayed during the first launch of Webots: neither in the new version window, neither in the preferences and so on.

It was working in qt 6.2 because we were using the default check mark of qt (not working anymore since 6.4)

The reason of the issue is:

1. We define the path to the check mark icon with a q-property that is in the qss (because the path depends on the theme.
2. We add the path to qt when creating the main window, however, the new version window is created *before* the main window.
3. It seems that once qt tried to access a wrong image (the check mark in the version window) it will still display it wrongly even if, in the meantime, the path became correct: which explain why the check mark does not appear in preferences  for the first launch. (Note that it does not throw any error)
 
The solution to fix this is a bit convoluted:
Attach a name to the checkbox that is in the new version window and build a specific path property for this checkbox while excluding the default one for being applied to it.

Why the solution is not simpler:
a. Put the q-property in `GuiApplication` to initialize it only once for both the new version and the main window: does not work as `GuiApplication` is not a descendant of QWidget.
b. Initialize all q-property in the new-version window: works only if the new version window is opened which happen only during the first launch.
c. Just copy paste the q-property in the new version window and initialize it twice: does not work because, the new version window will opened with the night theme (on ubuntu), but if we select another theme, it will not update the path as it is already set.
d. Why add `WbMainWindow` before the general `QCheckBox` property: even if the image applied in the new version window is the one defined in QCheckBox#telemetryCheckBox:indicator:checked, the qss will go through the generic `QCheckBox:indicator:checked` (if we do not explicitly prevent it with the `WbMainWindow`) and thus will resolve the not yet defined image url and we go back to point 3.