### PR TITLE
Fixes random crashes with skins and meshes

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -44,6 +44,7 @@ Released on ??
     - Added `proto_formatter.py` script to automatically indent PROTO files ([#6167](https://github.com/cyberbotics/webots/pull/6167)).
     - Disabled the computation of shadow reception on meshes when shadows are globally disabled([#6201](https://github.com/cyberbotics/webots/pull/6201)).
   - Bug Fixes
+    - Fixed random crashes while creating [Skin](skin.md) and Mesh(mesh.md) nodes ([#6218](https://github.com/cyberbotics/webots/pull/6218)).
     - Fixed the MATLAB `wb_camera_recognition_get_objects` API function ([#6172](https://github.com/cyberbotics/webots/pull/6172)).
     - Fixed the clean-up of the motion API which was firing warnings in Python ([#6029](https://github.com/cyberbotics/webots/pull/6029)).
     - Fixed the behavior of the [Connector](connector.md) after a reset to return to the controller the correct status ([#5889](https://github.com/cyberbotics/webots/pull/5889))

--- a/src/webots/app/WbPerspective.cpp
+++ b/src/webots/app/WbPerspective.cpp
@@ -287,7 +287,8 @@ bool WbPerspective::save() const {
 
 #ifdef _WIN32
   // set hidden attribute to WBPROJ file
-  LPCSTR nativePath = QDir::toNativeSeparators(fileName()).toUtf8().constData();
+  const QByteArray nativePathByteArray = QDir::toNativeSeparators(fileName()).toUtf8();
+  const LPCSTR nativePath = nativePathByteArray.constData();
   SetFileAttributes(nativePath, GetFileAttributes(nativePath) | FILE_ATTRIBUTE_HIDDEN);
 #endif
 

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -134,9 +134,9 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
   importer.SetPropertyInteger(AI_CONFIG_PP_RVC_FLAGS, aiComponent_CAMERAS | aiComponent_LIGHTS | aiComponent_BONEWEIGHTS |
                                                         aiComponent_ANIMATIONS | aiComponent_TEXTURES | aiComponent_COLORS);
   const aiScene *scene;
-  unsigned int flags = aiProcess_ValidateDataStructure | aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                       aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent |
-                       aiProcess_FlipUVs;
+  const unsigned int flags = aiProcess_ValidateDataStructure | aiProcess_Triangulate | aiProcess_GenSmoothNormals |
+                             aiProcess_JoinIdenticalVertices | aiProcess_OptimizeGraph | aiProcess_RemoveComponent |
+                             aiProcess_FlipUVs;
 
   if (WbUrl::isWeb(filePath)) {
     if (!WbNetwork::instance()->isCachedWithMapUpdate(filePath)) {
@@ -151,8 +151,8 @@ void WbMesh::updateTriangleMesh(bool issueWarnings) {
       return;
     }
     const QByteArray data = file.readAll();
-    const char *hint = filePath.mid(filePath.lastIndexOf('.') + 1).toUtf8().constData();
-    scene = importer.ReadFileFromMemory(data.constData(), data.size(), flags, hint);
+    const QByteArray hint = filePath.mid(filePath.lastIndexOf('.') + 1).toUtf8();
+    scene = importer.ReadFileFromMemory(data.constData(), data.size(), flags, hint.constData());
   } else
     scene = importer.ReadFile(filePath.toUtf8().constData(), flags);
 

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -559,8 +559,9 @@ void WbSkin::createWrenSkeleton() {
       if (!file.open(QIODevice::ReadOnly))
         return;
       const QByteArray &data = file.readAll();
-      const char *hint = meshFilePath.mid(meshFilePath.lastIndexOf('.') + 1).toUtf8().constData();
-      error = wr_import_skeleton_from_memory(data.constData(), data.size(), hint, &mSkeleton, &meshes, &materialNames, &count);
+      const QByteArray hint = meshFilePath.mid(meshFilePath.lastIndexOf('.') + 1).toUtf8();
+      error = wr_import_skeleton_from_memory(data.constData(), data.size(), hint.constData(), &mSkeleton, &meshes,
+                                             &materialNames, &count);
     } else
       return;
   } else


### PR DESCRIPTION
Fixes #6210.

The crash was due to a dangling reference to a temporary string buffer (char *).