### PR TITLE
Fix unneeded regeneration of scene tree items

### DIFF
--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -95,8 +95,12 @@ WbTreeItem::WbTreeItem(WbField *field) {
 
   const WbMultipleValue *const multipleValue = static_cast<WbMultipleValue *>(value);
   // slots are executed in the order they have been connected
-  connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::emitChildNeedsDeletion);
-  connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::addChild);
+  if (mField->singleType() == WB_MF_NODE) {
+    connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::emitChildNeedsDeletion);
+    connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::addChild);
+  } else
+    // otherwise there is no need to recreate the item when the value changes
+    connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::propagateDataChange);
   connect(multipleValue, &WbMultipleValue::itemRemoved, this, &WbTreeItem::emitChildNeedsDeletion);
   connect(multipleValue, &WbMultipleValue::cleared, this, &WbTreeItem::emitDeleteAllChildren);
   connect(multipleValue, &WbMultipleValue::itemInserted, this, &WbTreeItem::addChild);

--- a/src/webots/scene_tree/WbTreeItem.cpp
+++ b/src/webots/scene_tree/WbTreeItem.cpp
@@ -95,7 +95,7 @@ WbTreeItem::WbTreeItem(WbField *field) {
 
   const WbMultipleValue *const multipleValue = static_cast<WbMultipleValue *>(value);
   // slots are executed in the order they have been connected
-  if (mField->singleType() == WB_MF_NODE) {
+  if (mField->type() == WB_MF_NODE) {
     connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::emitChildNeedsDeletion);
     connect(multipleValue, &WbMultipleValue::itemChanged, this, &WbTreeItem::addChild);
   } else


### PR DESCRIPTION
Issue introduced in #5950.
It is not needed to re-create the scene tree items if the changed field is not a node.
This will also avoid the selection change that it is automatically triggered when a new item is created.