### PR TITLE
Fix led crash

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -99,7 +99,7 @@ Released on ??
     - Fixed conversion of joints' axis in `pedal_racer.wbt` to FLU/ENU coordinate system ([#6115](https://github.com/cyberbotics/webots/pull/6115)).
     - Fixed a bug in ODE that caused minStop and maxStop limits to be violated in HingeJoints ([#6118](https://github.com/cyberbotics/webots/pull/6118)).
     - Fixed errors loading template PROTO if the system user name contains the `'` character ([#6131](https://github.com/cyberbotics/webots/pull/6131)).
-    - Fixed crash when deleting a [Group](group.md) or a [Pose](pose.md) in a [Led](led.md) or [Battery](battery.md) ([#6226](https://github.com/cyberbotics/webots/pull/6226)).
+    - Fixed crash when deleting a [Group](group.md) or a [Pose](pose.md) in a [Led](led.md) or [Charger](charger.md) ([#6226](https://github.com/cyberbotics/webots/pull/6226)).
   - Dependency Updates
     - Change the Windows version of SUMO to 1.13 to match the one used on Linux and macOS and avoid a potiental Log4J vulnerability ([#6010](https://github.com/cyberbotics/webots/pull/6010)).
     - Upgraded to Qt6.4.3 on Ubuntu ([#6065](https://github.com/cyberbotics/webots/pull/6065)) and macOS ([#6157](https://github.com/cyberbotics/webots/pull/6157)).

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -99,6 +99,7 @@ Released on ??
     - Fixed conversion of joints' axis in `pedal_racer.wbt` to FLU/ENU coordinate system ([#6115](https://github.com/cyberbotics/webots/pull/6115)).
     - Fixed a bug in ODE that caused minStop and maxStop limits to be violated in HingeJoints ([#6118](https://github.com/cyberbotics/webots/pull/6118)).
     - Fixed errors loading template PROTO if the system user name contains the `'` character ([#6131](https://github.com/cyberbotics/webots/pull/6131)).
+    - Fixed crash when deleting a [Group](group.md) or a [Pose](pose.md) in a [Led](led.md) or [Battery](battery.md) ([#6226](https://github.com/cyberbotics/webots/pull/6226)).
   - Dependency Updates
     - Change the Windows version of SUMO to 1.13 to match the one used on Linux and macOS and avoid a potiental Log4J vulnerability ([#6010](https://github.com/cyberbotics/webots/pull/6010)).
     - Upgraded to Qt6.4.3 on Ubuntu ([#6065](https://github.com/cyberbotics/webots/pull/6065)) and macOS ([#6157](https://github.com/cyberbotics/webots/pull/6157)).

--- a/src/webots/nodes/WbCharger.cpp
+++ b/src/webots/nodes/WbCharger.cpp
@@ -122,8 +122,10 @@ bool WbCharger::isAnyMaterialOrLightFound() const {
 
 void WbCharger::findMaterialsAndLights(const WbGroup *const g) {
   int size = g->children().size();
-  if (size < 1)
+  if (size < 1) {
+    clearMaterialsAndLights();
     return;
+  }
 
   if (g == this) {
     clearMaterialsAndLights();

--- a/src/webots/nodes/WbLed.cpp
+++ b/src/webots/nodes/WbLed.cpp
@@ -97,8 +97,10 @@ void WbLed::updateChildren() {
 
 void WbLed::findMaterialsAndLights(const WbGroup *group) {
   int size = group->children().size();
-  if (size < 1)
+  if (size < 1) {
+    clearMaterialsAndLights();
     return;
+  }
 
   if (group == this) {
     clearMaterialsAndLights();


### PR DESCRIPTION
**Description**
Fix #6213 

When deleting the group present in LED it was crashing because the appearances/lights lists of led was not reset.

This bug was also present in battery.