### PR TITLE
Fix double Lidar head export

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -101,6 +101,7 @@ Released on ??
     - Fixed a bug in ODE that caused minStop and maxStop limits to be violated in HingeJoints ([#6118](https://github.com/cyberbotics/webots/pull/6118)).
     - Fixed errors loading template PROTO if the system user name contains the `'` character ([#6131](https://github.com/cyberbotics/webots/pull/6131)).
     - Fixed crash when deleting a [Group](group.md) or a [Pose](pose.md) in a [Led](led.md) or [Charger](charger.md) ([#6226](https://github.com/cyberbotics/webots/pull/6226)).
+    - Fixed duplicate [Lidar](lidar.md) rotatingHead when exporting to URDF ([#6233](https://github.com/cyberbotics/webots/pull/6233)).
   - Dependency Updates
     - Change the Windows version of SUMO to 1.13 to match the one used on Linux and macOS and avoid a potiental Log4J vulnerability ([#6010](https://github.com/cyberbotics/webots/pull/6010)).
     - Upgraded to Qt6.4.3 on Ubuntu ([#6065](https://github.com/cyberbotics/webots/pull/6065)) and macOS ([#6157](https://github.com/cyberbotics/webots/pull/6157)).

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -239,7 +239,7 @@ void WbLidar::write(WbWriter &writer) const {
 
 void WbLidar::exportNodeSubNodes(WbWriter &writer) const {
   WbAbstractCamera::exportNodeSubNodes(writer);
-  if (writer.isWebots())
+  if (writer.isWebots() || writer.isUrdf())
     return;
 
   WbSolid *s = solidEndPoint();


### PR DESCRIPTION
As reported in https://github.com/cyberbotics/webots_ros2/pull/770, the Lidar head is written two times when exported to URDF. This PR limits the exports to subnodes for URDFs.