### PR TITLE
Fix bounding sphere updates

### DIFF
--- a/resources/web/wwi/nodes/utils/WbBoundingSphere.js
+++ b/resources/web/wwi/nodes/utils/WbBoundingSphere.js
@@ -43,9 +43,11 @@ export default class WbBoundingSphere {
 
     this.#subBoundingSpheres.add(subBoundingSphere);
     subBoundingSphere.parentBoundingSphere = this;
-    this.boundSpaceDirty = true;
-    this.parentCoordinatesDirty = true;
-    this.parentUpdateNotification();
+    if (!this.boundSpaceDirty) {
+      this.boundSpaceDirty = true;
+      this.parentCoordinatesDirty = true;
+      this.parentUpdateNotification();
+    }
   }
 
   centerInParentCoordinates() {

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -35,6 +35,7 @@
 #include "WbRobot.hpp"
 #include "WbSFNode.hpp"
 #include "WbSensor.hpp"
+#include "WbSimulationState.hpp"
 #include "WbStandardPaths.hpp"
 #include "WbUrl.hpp"
 #include "WbWorld.hpp"
@@ -124,6 +125,7 @@ void WbCamera::init() {
   mRecognitionRefreshRate = 0;
   mRecognizedObjects.clear();
   mRecognizedObjectsTexture = NULL;
+  mIsSubscribedToRayTracing = false;
   mSegmentationChanged = false;
   mSegmentationCamera = NULL;
   mSegmentationEnabled = false;
@@ -153,6 +155,9 @@ WbCamera::~WbCamera() {
 
   delete mSegmentationCamera;
   delete mSegmentationMemoryMappedFile;
+
+  if (mIsSubscribedToRayTracing)
+    WbSimulationState::instance()->unsubscribeToRayTracing();
 }
 
 void WbCamera::downloadAssets() {
@@ -982,6 +987,12 @@ void WbCamera::setup() {
   updateAmbientOcclusionRadius();
   updateBloomThreshold();
   connect(mNoiseMaskUrl, &WbSFString::changed, this, &WbCamera::updateNoiseMaskUrl);
+  
+  // make sure bounding sphere is updated when object's size and position changes
+  if (recognition()) {
+    mIsSubscribedToRayTracing = true;
+    WbSimulationState::instance()->subscribeToRayTracing();
+  }
 }
 
 bool WbCamera::isEnabled() const {
@@ -1034,6 +1045,16 @@ void WbCamera::updateRecognition() {
     mOverlay->deleteForegroundTexture(true);
     emit textureIdUpdated(mOverlay->foregroundTextureGLId(), FOREGROUND_TEXTURE);
     mRecognizedObjectsTexture = NULL;
+  }
+
+  // make sure bounding sphere is updated when object's size and position changes
+  const bool recognitionEnabled = recognitionNode != NULL;
+  if (recognitionEnabled != mIsSubscribedToRayTracing) {
+    mIsSubscribedToRayTracing = recognitionEnabled;
+    if (recognitionNode)
+      WbSimulationState::instance()->subscribeToRayTracing();
+    else
+      WbSimulationState::instance()->unsubscribeToRayTracing();
   }
 
   // clear mRecognizedObjects if Recognition node changed but not if `Recognition.segmentation` changed

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -987,7 +987,7 @@ void WbCamera::setup() {
   updateAmbientOcclusionRadius();
   updateBloomThreshold();
   connect(mNoiseMaskUrl, &WbSFString::changed, this, &WbCamera::updateNoiseMaskUrl);
-  
+
   // make sure bounding sphere is updated when object's size and position changes
   if (recognition()) {
     mIsSubscribedToRayTracing = true;

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -120,6 +120,7 @@ private:
   QList<WbRecognizedObject *> mRecognizedObjects;
   QList<WbRecognizedObject *> mInvalidRecognizedObjects;
   WrTexture *mRecognizedObjectsTexture;
+  bool mIsSubscribedToRayTracing;
   // smart camera segmentation
   void initializeSegmentationMemoryMappedFile();
   void createSegmentationCamera();

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -240,7 +240,7 @@ void WbSkin::applyToScale() {
   if (mBaseNode->areWrenObjectsInitialized())
     applyScaleToWren();
 
-  if (mBaseNode->boundingSphere() && !mBaseNode->isInBoundingObject() && WbSimulationState::instance()->isRayTracingEnabled())
+  if (WbSimulationState::instance()->isRayTracingEnabled() && mBaseNode->boundingSphere())
     mBaseNode->boundingSphere()->setOwnerSizeChanged();
 
   if (mTranslateRotateManipulator && mTranslateRotateManipulator->isAttached())

--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -55,7 +55,7 @@ void WbTransform::applyToScale() {
   if (mBaseNode->areWrenObjectsInitialized())
     applyScaleToWren();
 
-  if (mBaseNode->boundingSphere() && WbSimulationState::instance()->isRayTracingEnabled())
+  if (WbSimulationState::instance()->isRayTracingEnabled() && mBaseNode->boundingSphere())
     mBaseNode->boundingSphere()->setOwnerSizeChanged();
 
   if (mTranslateRotateManipulator && mTranslateRotateManipulator->isAttached())

--- a/src/webots/nodes/utils/WbBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.cpp
@@ -323,7 +323,7 @@ void WbBoundingSphere::parentUpdateNotification() const {
 
 void WbBoundingSphere::setOwnerMoved() {
   assert(mPoseOwner);
-  if (mParentBoundingSphere) {
+  if (mParentBoundingSphere && !mParentCoordinatesDirty) {
     mParentCoordinatesDirty = true;
     if (gUpdatesEnabled)
       parentUpdateNotification();
@@ -332,10 +332,12 @@ void WbBoundingSphere::setOwnerMoved() {
 
 void WbBoundingSphere::setOwnerSizeChanged() {
   assert(mGeomOwner || mSkinOwner || mPoseOwner);
-  mBoundSpaceDirty = true;
-  mParentCoordinatesDirty = true;
-  if (gUpdatesEnabled)
-    parentUpdateNotification();
+  if (!mBoundSpaceDirty) {
+    mBoundSpaceDirty = true;
+    mParentCoordinatesDirty = true;
+    if (gUpdatesEnabled)
+      parentUpdateNotification();
+  }
 }
 
 WbBoundingSphere::IntersectingShape WbBoundingSphere::computeIntersection(const WbRay &ray, double timeStep) {

--- a/src/webots/nodes/utils/WbBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.cpp
@@ -132,7 +132,7 @@ void WbBoundingSphere::set(const WbVector3 &center, const double radius) {
     return;
   mCenter = center;
   mRadius = radius;
-  if (!gRayTracingEnabled) {
+  if (!gRayTracingEnabled && !mBoundSpaceDirty) {
     mBoundSpaceDirty = true;
     mParentCoordinatesDirty = true;
     if (gUpdatesEnabled)
@@ -156,10 +156,12 @@ void WbBoundingSphere::addSubBoundingSphere(WbBoundingSphere *subBoundingSphere)
     return;
   mSubBoundingSpheres.append(subBoundingSphere);
   subBoundingSphere->setParentBoundingSphere(this);
-  mBoundSpaceDirty = true;
-  mParentCoordinatesDirty = true;
-  if (gUpdatesEnabled)
-    parentUpdateNotification();
+  if (!mBoundSpaceDirty) {
+    mBoundSpaceDirty = true;
+    mParentCoordinatesDirty = true;
+    if (gUpdatesEnabled)
+      parentUpdateNotification();
+  }
 }
 
 void WbBoundingSphere::removeSubBoundingSphere(WbBoundingSphere *boundingSphere) {
@@ -168,7 +170,7 @@ void WbBoundingSphere::removeSubBoundingSphere(WbBoundingSphere *boundingSphere)
   mSubBoundingSpheres.removeOne(boundingSphere);
   if (mSubBoundingSpheres.isEmpty())
     empty();
-  else {
+  else if (!mBoundSpaceDirty) {
     mBoundSpaceDirty = true;
     mParentCoordinatesDirty = true;
     if (gUpdatesEnabled)

--- a/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbVisualBoundingSphere.cpp
@@ -17,6 +17,7 @@
 #include "WbBaseNode.hpp"
 #include "WbBoundingSphere.hpp"
 #include "WbPerspective.hpp"
+#include "WbSimulationState.hpp"
 #include "WbSphere.hpp"
 #include "WbSysInfo.hpp"
 #include "WbWorld.hpp"
@@ -102,10 +103,13 @@ WbVisualBoundingSphere::WbVisualBoundingSphere() :
   mWrenSegmentationMaterial(NULL),
   mWrenMesh(NULL),
   mWrenRenderable(NULL) {
+  // make sure the bounding spheres are updates when node's position and size changes
+  WbSimulationState::instance()->subscribeToRayTracing();
 }
 
 WbVisualBoundingSphere::~WbVisualBoundingSphere() {
   deleteWrenObjects();
+  WbSimulationState::instance()->unsubscribeToRayTracing();
 }
 
 void WbVisualBoundingSphere::show(const WbBaseNode *node) {


### PR DESCRIPTION
Address part of #6063:
* [x] fix bounding sphere visualization by activating the bounding sphere updates when node position or size is changed
* [x] fix camera recognition functionality by activating the bounding sphere updates when node position or size is changed
* [x] restore performance optimization in bounding sphere checks (see https://github.com/cyberbotics/webots-dev/pull/7570)
* [x] improve performance by skipping parent notification if bound space is already dirty