### PR TITLE
Fixed scaled rotation matrix for Pose (and derived) nodes

### DIFF
--- a/src/webots/nodes/WbAbstractPose.hpp
+++ b/src/webots/nodes/WbAbstractPose.hpp
@@ -75,7 +75,13 @@ public:
   bool isTopPose() const;
 
   // 3x3 absolute rotation matrix
-  virtual WbMatrix3 rotationMatrix() const { return matrix().extracted3x3Matrix(); }
+  virtual WbMatrix3 rotationMatrix() const {
+    const WbMatrix4 &m = matrix();
+    const WbVector3 &s = m.scale();
+    WbMatrix3 rm = m.extracted3x3Matrix();
+    rm.scale(1.0 / s.x(), 1.0 / s.y(), 1.0 / s.z());
+    return rm;
+  }
 
   // position in 'world' coordinates
   WbVector3 position() const { return matrix().translation(); }

--- a/src/webots/nodes/WbTransform.cpp
+++ b/src/webots/nodes/WbTransform.cpp
@@ -127,14 +127,6 @@ const WbVector3 &WbTransform::absoluteScale() const {
   return mAbsoluteScale;
 }
 
-WbMatrix3 WbTransform::rotationMatrix() const {
-  const WbMatrix4 &m = matrix();
-  const WbVector3 &s = m.scale();
-  WbMatrix3 rm = m.extracted3x3Matrix();
-  rm.scale(1.0 / s.x(), 1.0 / s.y(), 1.0 / s.z());
-  return rm;
-}
-
 const WbMatrix4 &WbTransform::vrmlMatrix() const {
   if (mVrmlMatrixNeedUpdate) {
     mVrmlMatrix.fromVrml(translation(), rotation(), scale());

--- a/src/webots/nodes/WbTransform.hpp
+++ b/src/webots/nodes/WbTransform.hpp
@@ -57,7 +57,6 @@ public:
   mutable bool mAbsoluteScaleNeedUpdate;
 
   // 3x3 absolute rotation matrix
-  WbMatrix3 rotationMatrix() const override;
   const WbMatrix4 &vrmlMatrix() const override;
 
 protected:


### PR DESCRIPTION
After #5978, if the Pose (or derived) node has a scaled parent Transform then the `WbAbstractPose::rotationMatrix()` function returns the scaled 3x3 submatrix instead of the rotation matrix.

Even for pose, the extracted 3x3 matrix needs to be unscaled in order to return a valid rotation matrix.