### PR TITLE
Fix PROTO load when a context path contains backslash

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -1,5 +1,10 @@
 # Webots R2023 Change Log
 
+## Webots R2023b Revision 1
+Released on XXX XXth, 2023.
+  - Bug fixes
+    - Fixed errors loading template PROTO if the system user name, the project path, or the temporary directory path contains the `\` character ([#6288](https://github.com/cyberbotics/webots/pull/6288)).
+
 ## Webots R2023b
 Released on June 28th, 2023.
   - New Features

--- a/src/webots/core/WbTemplateEngine.cpp
+++ b/src/webots/core/WbTemplateEngine.cpp
@@ -137,6 +137,11 @@ const QString &WbTemplateEngine::closingToken() {
   return gClosingToken;
 }
 
+QString WbTemplateEngine::escapeString(const QString &string) {
+  QString escaped(string);
+  return escaped.replace("\\", "\\\\").replace("\n", "\\n").replace("'", "\\'").toUtf8();
+}
+
 bool WbTemplateEngine::generate(QHash<QString, QString> tags, const QString &logHeaderName, const QString &templateLanguage) {
   bool output;
 
@@ -340,11 +345,7 @@ bool WbTemplateEngine::generateLua(QHash<QString, QString> tags, const QString &
   tags["cpath"] = "package.cpath = package.cpath .. \";?.dylib\"";
 #endif
 
-  tags["templateContent"] = mTemplateContent;
-  tags["templateContent"] = tags["templateContent"].replace("\\", "\\\\");
-  tags["templateContent"] = tags["templateContent"].replace("\n", "\\n");
-  tags["templateContent"] = tags["templateContent"].replace("'", "\\'");
-  tags["templateContent"] = tags["templateContent"].toUtf8();
+  tags["templateContent"] = escapeString(mTemplateContent);
 
   // make sure these key are set
   if (!tags.contains("fields"))

--- a/src/webots/core/WbTemplateEngine.hpp
+++ b/src/webots/core/WbTemplateEngine.hpp
@@ -31,6 +31,7 @@ public:
 
   static void setOpeningToken(const QString &token);
   static void setClosingToken(const QString &token);
+  static QString escapeString(const QString &string);
 
   explicit WbTemplateEngine(const QString &templateContent);
   virtual ~WbTemplateEngine() {}

--- a/src/webots/vrml/WbProtoTemplateEngine.cpp
+++ b/src/webots/vrml/WbProtoTemplateEngine.cpp
@@ -38,11 +38,6 @@
 
 static QString gCoordinateSystem;
 
-static QString escapeString(const QString &string) {
-  QString escaped(string);
-  return escaped.replace("'", "\\'");
-}
-
 WbProtoTemplateEngine::WbProtoTemplateEngine(const QString &templateContent) : WbTemplateEngine(templateContent) {
 }
 


### PR DESCRIPTION
Fixes #6286:
backslash in paths passed to the template PROTO JS script are not correctly escaped producing invalid JS scrips that cannot load the PROTO models.