### PR TITLE
Fixed missing dependency of libController from version.txt

### DIFF
--- a/src/controller/c/Makefile
+++ b/src/controller/c/Makefile
@@ -172,6 +172,8 @@ $(TARGET): $(OBJECTS)
 	@chmod a-x $(TARGET)
 endif
 
+$(OBJDIR)/robot.o: $(WEBOTS_HOME_PATH)/resources/version.txt
+
 $(OBJDIR)/%.o:%.c
 	@echo "# compiling "$<
 	@$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) $< -o $@


### PR DESCRIPTION
Whenever [version.txt](https://github.com/cyberbotics/webots/blob/master/resources/version.txt) changes, [robot.c](https://github.com/cyberbotics/webots/blob/master/src/controller/c/robot.c) should be recompiled.
