### PR TITLE
Cleanup instanceof

### DIFF
--- a/resources/web/wwi/FloatingProtoParameterWindow.js
+++ b/resources/web/wwi/FloatingProtoParameterWindow.js
@@ -1,43 +1,14 @@
 import FloatingWindow from './FloatingWindow.js';
-import {VRML} from './protoVisualizer/vrml_type.js';
-import WbAccelerometer from './nodes/WbAccelerometer.js';
-import WbAltimeter from './nodes/WbAltimeter.js';
-import WbBallJoint from './nodes/WbBallJoint.js';
-import WbCamera from './nodes/WbCamera.js';
-import WbCharger from './nodes/WbCharger.js';
-import WbCompass from './nodes/WbCompass.js';
-import WbConnector from './nodes/WbConnector.js';
+import { VRML } from './protoVisualizer/vrml_type.js';
 import WbDevice from './nodes/WbDevice.js';
-import WbDisplay from './nodes/WbDisplay.js';
-import WbDistanceSensor from './nodes/WbDistanceSensor.js';
-import WbEmitter from './nodes/WbEmitter.js';
-import WbGps from './nodes/WbGps.js';
-import WbGyro from './nodes/WbGyro.js';
-import WbHingeJoint from './nodes/WbHingeJoint.js';
-import WbHinge2Joint from './nodes/WbHinge2Joint.js';
-import WbInertialUnit from './nodes/WbInertialUnit.js';
 import WbJoint from './nodes/WbJoint.js';
-import WbLed from './nodes/WbLed.js';
-import WbLidar from './nodes/WbLidar.js';
-import WbLinearMotor from './nodes/WbLinearMotor.js';
-import WbLightSensor from './nodes/WbLightSensor.js';
 import WbMotor from './nodes/WbMotor.js';
-import WbPen from './nodes/WbPen.js';
-import WbRadar from './nodes/WbRadar.js';
-import WbReceiver from './nodes/WbReceiver.js';
-import WbRotationalMotor from './nodes/WbRotationalMotor.js';
-import WbSpeaker from './nodes/WbSpeaker.js';
 import WbWorld from './nodes/WbWorld.js';
-import WbRangeFinder from './nodes/WbRangeFinder.js';
-import WbTouchSensor from './nodes/WbTouchSensor.js';
-import WbVacuumGripper from './nodes/WbVacuumGripper.js';
-import WbBrake from './nodes/WbBrake.js';
-import WbPositionSensor from './nodes/WbPositionSensor.js';
 import NodeSelectorWindow from './NodeSelectorWindow.js';
-import {SFNode, MFNode, vrmlFactory} from './protoVisualizer/Vrml.js';
+import { SFNode, MFNode, vrmlFactory } from './protoVisualizer/Vrml.js';
 import Node from './protoVisualizer/Node.js';
-import WbPropeller from './nodes/WbPropeller.js';
 import WbVector4 from './nodes/utils/WbVector4.js';
+import { WbNodeType } from './nodes/wb_node_type.js';
 
 export default class FloatingProtoParameterWindow extends FloatingWindow {
   #mfId;
@@ -1445,49 +1416,50 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
   }
 
   #sortDevice(device, div) {
-    if (device instanceof WbAccelerometer)
+    const nodeType = device.nodeType;
+    if (nodeType === WbNodeType.WB_NODE_ACCELEROMETER)
       this.devicesList.get('Accelerometer').push(div);
-    else if (device instanceof WbAltimeter)
+    else if (nodeType === WbNodeType.WB_NODE_ALTIMETER)
       this.devicesList.get('Altimeter').push(div);
-    else if (device instanceof WbCamera)
+    else if (nodeType === WbNodeType.WB_NODE_CAMERA)
       this.devicesList.get('Camera').push(div);
-    else if (device instanceof WbCharger)
+    else if (nodeType === WbNodeType.WB_NODE_CHARGER)
       this.devicesList.get('Charger').push(div);
-    else if (device instanceof WbCompass)
+    else if (nodeType === WbNodeType.WB_NODE_COMPASS)
       this.devicesList.get('Compass').push(div);
-    else if (device instanceof WbConnector)
+    else if (nodeType === WbNodeType.WB_NODE_CONNECTOR)
       this.devicesList.get('Connector').push(div);
-    else if (device instanceof WbDisplay)
+    else if (nodeType === WbNodeType.WB_NODE_DISPLAY)
       this.devicesList.get('Display').push(div);
-    else if (device instanceof WbDistanceSensor)
+    else if (nodeType === WbNodeType.WB_NODE_DISTANCE_SENSOR)
       this.devicesList.get('DistanceSensor').push(div);
-    else if (device instanceof WbEmitter)
+    else if (nodeType === WbNodeType.WB_NODE_EMITTER)
       this.devicesList.get('Emitter').push(div);
-    else if (device instanceof WbGps)
+    else if (nodeType === WbNodeType.WB_NODE_GPS)
       this.devicesList.get('Gps').push(div);
-    else if (device instanceof WbGyro)
+    else if (nodeType === WbNodeType.WB_NODE_GYRO)
       this.devicesList.get('Gyro').push(div);
-    else if (device instanceof WbInertialUnit)
+    else if (nodeType === WbNodeType.WB_NODE_INERTIAL_UNIT)
       this.devicesList.get('InertialUnit').push(div);
-    else if (device instanceof WbLed)
+    else if (nodeType === WbNodeType.WB_NODE_LED)
       this.devicesList.get('Led').push(div);
-    else if (device instanceof WbLidar)
+    else if (nodeType === WbNodeType.WB_NODE_LIDAR)
       this.devicesList.get('Lidar').push(div);
-    else if (device instanceof WbLightSensor)
+    else if (nodeType === WbNodeType.WB_NODE_LIGHT_SENSOR)
       this.devicesList.get('LightSensor').push(div);
-    else if (device instanceof WbPen)
+    else if (nodeType === WbNodeType.WB_NODE_PEN)
       this.devicesList.get('Pen').push(div);
-    else if (device instanceof WbRadar)
+    else if (nodeType === WbNodeType.WB_NODE_RADAR)
       this.devicesList.get('Radar').push(div);
-    else if (device instanceof WbRangeFinder)
+    else if (nodeType === WbNodeType.WB_NODE_RANGE_FINDER)
       this.devicesList.get('Rangefinder').push(div);
-    else if (device instanceof WbReceiver)
+    else if (nodeType === WbNodeType.WB_NODE_RECEIVER)
       this.devicesList.get('Receiver').push(div);
-    else if (device instanceof WbSpeaker)
+    else if (nodeType === WbNodeType.WB_NODE_SPEAKER)
       this.devicesList.get('Speaker').push(div);
-    else if (device instanceof WbTouchSensor)
+    else if (nodeType === WbNodeType.WB_NODE_TOUCH_SENSOR)
       this.devicesList.get('TouchSensor').push(div);
-    else if (device instanceof WbVacuumGripper)
+    else if (nodeType === WbNodeType.WB_NODE_VACUUM_GRIPPER)
       this.devicesList.get('VacuumGripper').push(div);
   }
 
@@ -1565,11 +1537,11 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
 
         const endPointName = joint.solidEndPoint() ? joint.solidEndPoint().name : numberOfJoint;
         let jointType;
-        if (joint instanceof WbBallJoint)
+        if (joint.nodeType === WbNodeType.WB_NODE_BALL_JOINT)
           jointType = 'BallJoint 1: ';
-        else if (joint instanceof WbHinge2Joint)
+        else if (joint.nodeType === WbNodeType.WB_NODE_HINGE_2_JOINT)
           jointType = 'Hinge2joint 1: ';
-        else if (joint instanceof WbHingeJoint)
+        else if (joint.nodeType === WbNodeType.WB_NODE_HINGE_JOINT)
           jointType = 'Hingejoint: ';
         else
           jointType = 'Sliderjoint: ';
@@ -1586,7 +1558,7 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
 
         this.joints.appendChild(div);
 
-        if (joint instanceof WbBallJoint) {
+        if (joint.nodeType === WbNodeType.WB_NODE_BALL_JOINT) {
           div = document.createElement('div');
           div.className = 'proto-joint';
 
@@ -1611,7 +1583,7 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
             this.#view.x3dScene.render();
           });
           this.joints.appendChild(div);
-        } else if (joint instanceof WbHinge2Joint) {
+        } else if (joint.nodeType === WbNodeType.WB_NODE_HINGE_2_JOINT) {
           div = document.createElement('div');
           div.className = 'proto-joint';
 
@@ -1626,7 +1598,7 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
           });
           this.joints.appendChild(div);
         }
-      } else if (joint instanceof WbPropeller) {
+      } else if (joint.nodeType === WbNodeType.WB_NODE_PROPELLER) {
         numberOfJoint++;
 
         let div = document.createElement('div');
@@ -1695,13 +1667,13 @@ export default class FloatingProtoParameterWindow extends FloatingWindow {
         this.#createGridFiller(grid, row);
 
         const deviceType = document.createElement('div');
-        if (devices[i] instanceof WbRotationalMotor)
+        if (devices[i].nodeType === WbNodeType.WB_NODE_ROTATIONAL_MOTOR)
           deviceType.innerHTML = 'RotationalMotor: ';
-        else if (devices[i] instanceof WbLinearMotor)
+        else if (devices[i].nodeType === WbNodeType.WB_NODE_LINEAR_MOTOR)
           deviceType.innerHTML = 'LinearMotor: ';
-        else if (devices[i] instanceof WbBrake)
+        else if (devices[i].nodeType === WbNodeType.WB_NODE_BRAKE)
           deviceType.innerHTML = 'Brake: ';
-        else if (devices[i] instanceof WbPositionSensor)
+        else if (devices[i].nodeType === WbNodeType.WB_NODE_POSITION_SENSOR)
           deviceType.innerHTML = 'PositionSensor:';
 
         deviceType.style.gridRow = row + ' / ' + row;

--- a/resources/web/wwi/Parser.js
+++ b/resources/web/wwi/Parser.js
@@ -80,6 +80,7 @@ import WbWorld from './nodes/WbWorld.js';
 import WbWrenPostProcessingEffects from './wren/WbWrenPostProcessingEffects.js';
 
 import { getAnId } from './nodes/utils/id_provider.js';
+import { WbNodeType } from './nodes/wb_node_type.js';
 
 import DefaultUrl from './DefaultUrl.js';
 import { webots } from './webots.js';
@@ -321,10 +322,10 @@ export default class Parser {
         // We are forced to check if the result correspond to the class we expect because of the case of a USE
         if (typeof result !== 'undefined' && result instanceof WbGeometry) {
           if (typeof parentNode !== 'undefined') {
-            if (parentNode instanceof WbShape) {
+            if (parentNode.nodeType === WbNodeType.WB_NODE_SHAPE) {
               parentNode.geometry?.delete();
               parentNode.geometry = result;
-            } else if (parentNode instanceof WbSolid || parentNode instanceof WbPose || parentNode instanceof WbGroup) {
+            } else if (parentNode instanceof WbGroup) {
               // Bounding object
               parentNode.boundingObject?.delete();
               if (parentNode instanceof WbSolid)
@@ -334,13 +335,13 @@ export default class Parser {
             }
           }
         } else if (node.tagName === 'PBRAppearance') {
-          if (typeof parentNode !== 'undefined' && parentNode instanceof WbShape) {
+          if (typeof parentNode !== 'undefined' && parentNode.nodeType === WbNodeType.WB_NODE_SHAPE) {
             parentNode.appearance?.delete();
             result = this.#parsePbrAppearance(node, id);
             parentNode.appearance = result;
           }
         } else if (node.tagName === 'Appearance') {
-          if (typeof parentNode !== 'undefined' && parentNode instanceof WbShape) {
+          if (typeof parentNode !== 'undefined' && parentNode.nodeType === WbNodeType.WB_NODE_SHAPE) {
             parentNode.appearance?.delete();
             result = this.#parseAppearance(node, id);
             parentNode.appearance = result;
@@ -348,7 +349,7 @@ export default class Parser {
         } else if (node.tagName === 'Material') {
           result = this.#parseMaterial(node, id);
           if (typeof result !== 'undefined') {
-            if (typeof parentNode !== 'undefined' && parentNode instanceof WbAppearance) {
+            if (typeof parentNode !== 'undefined' && parentNode.nodeType === WbNodeType.WB_NODE_APPEARANCE) {
               parentNode.material?.delete();
               parentNode.material = result;
             }
@@ -356,7 +357,7 @@ export default class Parser {
         } else if (node.tagName === 'ImageTexture') {
           result = this.#parseImageTexture(node, id);
           if (typeof result !== 'undefined') {
-            if (typeof parentNode !== 'undefined' && parentNode instanceof WbAppearance) {
+            if (typeof parentNode !== 'undefined' && parentNode.nodeType === WbNodeType.WB_NODE_APPEARANCE) {
               parentNode.texture?.delete();
               parentNode.texture = result;
             } else {
@@ -616,10 +617,11 @@ export default class Parser {
     if (typeof parentNode !== 'undefined') {
       useNode.parent = parentNode.id;
       const isBoundingObject = getNodeAttribute(node, 'role', undefined) === 'boundingObject';
-      if (isBoundingObject && (result instanceof WbShape || result instanceof WbGroup || result instanceof WbGeometry))
+      if (isBoundingObject && (result.nodeType === WbNodeType.WB_NODE_SHAPE || result instanceof WbGroup ||
+        result instanceof WbGeometry))
         parentNode.boundingObject = useNode;
-      else if (result instanceof WbShape || result instanceof WbGroup || result instanceof WbLight ||
-        result instanceof WbCadShape)
+      else if (result.nodeType === WbNodeType.WB_NODE_SHAPE || result instanceof WbGroup || result instanceof WbLight ||
+        result.nodeType === WbNodeType.WB_NODE_CAD_SHAPE)
         parentNode.children.push(useNode);
     }
 
@@ -766,7 +768,7 @@ export default class Parser {
         parentNode.geometryField = newNode;
       else if (isBoundingObject && parentNode instanceof WbSolid)
         parentNode.boundingObject = newNode;
-      else if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      else if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = newNode;
       else
         parentNode.children.push(newNode);
@@ -797,7 +799,7 @@ export default class Parser {
 
     if (typeof parentNode !== 'undefined') {
       newNode.parent = parentNode.id;
-      if (parentNode instanceof WbSlot)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT)
         parentNode.endPoint = newNode;
       else
         parentNode.children.push(newNode);
@@ -823,7 +825,7 @@ export default class Parser {
       group.parent = parentNode.id;
       if (isBoundingObject && parentNode instanceof WbSolid)
         parentNode.boundingObject = group;
-      else if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      else if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = group;
       else
         parentNode.children.push(group);
@@ -844,7 +846,7 @@ export default class Parser {
     this.#parseChildren(node, propeller);
 
     propeller.parent = parentNode.id;
-    if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+    if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
       parentNode.endPoint = propeller;
     else
       parentNode.children.push(propeller);
@@ -866,7 +868,7 @@ export default class Parser {
 
     if (typeof parentNode !== 'undefined') {
       slot.parent = parentNode.id;
-      if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = slot;
       else
         parentNode.children.push(slot);
@@ -894,7 +896,7 @@ export default class Parser {
 
     if (typeof parentNode !== 'undefined') {
       joint.parent = parentNode.id;
-      if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = joint;
       else
         parentNode.children.push(joint);
@@ -1024,7 +1026,7 @@ export default class Parser {
     if (typeof parentNode !== 'undefined') {
       if (isBoundingObject && parentNode instanceof WbSolid)
         parentNode.boundingObject = shape;
-      else if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      else if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = shape;
       else
         parentNode.children.push(shape);
@@ -1061,7 +1063,7 @@ export default class Parser {
 
     if (typeof parentNode !== 'undefined') {
       cadShape.parent = parentNode.id;
-      if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = cadShape;
       else
         parentNode.children.push(cadShape);
@@ -1111,7 +1113,7 @@ export default class Parser {
 
     if (typeof parentNode !== 'undefined' && typeof dirLight !== 'undefined') {
       dirLight.parent = parentNode.id;
-      if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = dirLight;
       else
         parentNode.children.push(dirLight);
@@ -1142,7 +1144,7 @@ export default class Parser {
       castShadows, parentNode);
 
     if (typeof parentNode !== 'undefined' && typeof pointLight !== 'undefined') {
-      if (parentNode instanceof WbSlot || parentNode instanceof WbJoint)
+      if (parentNode.nodeType === WbNodeType.WB_NODE_SLOT || parentNode instanceof WbJoint)
         parentNode.endPoint = pointLight;
       else
         parentNode.children.push(pointLight);

--- a/resources/web/wwi/WebotsView.js
+++ b/resources/web/wwi/WebotsView.js
@@ -5,9 +5,8 @@ import {webots} from './webots.js';
 import {changeGtaoLevel} from './nodes/wb_preferences.js';
 import WbWorld from './nodes/WbWorld.js';
 import WbDevice from './nodes/WbDevice.js';
-import WbShape from './nodes/WbShape.js';
-import WbSlot from './nodes/WbSlot.js';
 import WbVector3 from './nodes/utils/WbVector3.js';
+import {WbNodeType} from './nodes/wb_node_type.js';
 
 /* The following member variables can be set by the application:
 
@@ -402,8 +401,8 @@ export default class WebotsView extends HTMLElement {
         this.resize();
         this.toolbar.protoParameterWindowInitializeSizeAndPosition();
         const topProtoNode = WbWorld.instance.root.children[WbWorld.instance.root.children.length - 1];
-        if (topProtoNode instanceof WbDevice || topProtoNode instanceof WbSlot || topProtoNode instanceof WbShape ||
-          moveFloor === '1')
+        if (topProtoNode instanceof WbDevice || topProtoNode.nodeType === WbNodeType.WB_NODE_SLOT ||
+          topProtoNode.nodeType === WbNodeType.WB_NODE_SHAPE || moveFloor === '1')
           this.#repositionFloor(topProtoNode, WbWorld.instance.root.children[WbWorld.instance.root.children.length - 2]);
 
         WbWorld.instance.viewpoint.moveViewpointToObject(topProtoNode);

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -6,45 +6,15 @@ import { webots } from './webots.js';
 import WrenRenderer from './WrenRenderer.js';
 
 import WbAbstractCamera from './nodes/WbAbstractCamera.js';
-import WbBox from './nodes/WbBox.js';
-import WbCadShape from './nodes/WbCadShape.js';
-import WbCamera from './nodes/WbCamera.js';
-import WbCapsule from './nodes/WbCapsule.js';
-import WbColor from './nodes/WbColor.js';
-import WbCone from './nodes/WbCone.js';
-import WbCoordinate from './nodes/WbCoordinate.js';
-import WbCylinder from './nodes/WbCylinder.js';
-import WbDistanceSensor from './nodes/WbDistanceSensor.js';
-import WbElevationGrid from './nodes/WbElevationGrid.js';
-import WbFog from './nodes/WbFog.js';
-import WbImageTexture from './nodes/WbImageTexture.js';
-import WbIndexedFaceSet from './nodes/WbIndexedFaceSet.js';
-import WbIndexedLineSet from './nodes/WbIndexedLineSet.js';
-import WbLidar from './nodes/WbLidar.js';
 import WbLight from './nodes/WbLight.js';
-import WbMaterial from './nodes/WbMaterial.js';
-import WbMesh from './nodes/WbMesh.js';
-import WbPen from './nodes/WbPen.js';
-import WbPbrAppearance from './nodes/WbPbrAppearance.js';
-import WbPlane from './nodes/WbPlane.js';
-import WbPointLight from './nodes/WbPointLight.js';
 import WbPose from './nodes/WbPose.js';
-import WbRadar from './nodes/WbRadar.js';
-import WbSphere from './nodes/WbSphere.js';
-import WbTextureCoordinate from './nodes/WbTextureCoordinate.js';
-import WbTextureTransform from './nodes/WbTextureTransform.js';
-import WbTrackWheel from './nodes/WbTrackWheel.js';
 import WbWorld from './nodes/WbWorld.js';
 
 import WbVector2 from './nodes/utils/WbVector2.js';
 import WbVector3 from './nodes/utils/WbVector3.js';
-import WbNormal from './nodes/WbNormal.js';
-import WbSpotLight from './nodes/WbSpotLight.js';
 import WbDirectionalLight from './nodes/WbDirectionalLight.js';
-import WbRangeFinder from './nodes/WbRangeFinder.js';
-import WbConnector from './nodes/WbConnector.js';
-import WbPropeller from './nodes/WbPropeller.js';
 import { findUpperShape } from './nodes/utils/node_utilities.js';
+import { WbNodeType } from './nodes/wb_node_type.js';
 
 export default class X3dScene {
   #nextRenderingTime;
@@ -161,7 +131,7 @@ export default class X3dScene {
     const xmlhttp = new XMLHttpRequest();
     xmlhttp.open('GET', url, true);
     xmlhttp.overrideMimeType('plain/text');
-    xmlhttp.onreadystatechange = async () => {
+    xmlhttp.onreadystatechange = async() => {
       // Some browsers return HTTP Status 0 when using non-http protocol (for file://)
       if (xmlhttp.readyState === 4 && (xmlhttp.status === 200 || xmlhttp.status === 0)) {
         const parser = new Parser(prefix);
@@ -234,14 +204,14 @@ export default class X3dScene {
       if (key === 'translation') {
         if (object instanceof WbPose)
           object.translation = convertStringToVec3(update[key]);
-        else if (object instanceof WbTextureTransform)
+        else if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.translation = convertStringToVec2(update[key]);
       } else if (key === 'rotation') {
-        if (object instanceof WbTextureTransform)
+        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.rotation = parseFloat(update[key]);
         else {
           const quaternion = convertStringToQuaternion(update[key]);
-          if (object instanceof WbTrackWheel)
+          if (object.nodeType === WbNodeType.WB_NODE_TRACK_WHEEL)
             object.updateRotation(quaternion);
           else
             object.rotation = quaternion;
@@ -249,70 +219,71 @@ export default class X3dScene {
       } else if (key === 'scale') {
         if (object instanceof WbPose)
           object.scale = convertStringToVec3(update[key]);
-        else if (object instanceof WbTextureTransform)
+        else if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.scale = convertStringToVec2(update[key]);
       } else if (key === 'center') {
-        if (object instanceof WbTextureTransform)
+        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.center = convertStringToVec2(update[key]);
       } else if (key === 'castShadows') {
-        if (object instanceof WbLight || object instanceof WbCadShape)
+        if (object instanceof WbLight || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE ||
+          object.nodeType === WbNodeType.WB_NODE_SHAPE)
           object.castShadows = update[key].toLowerCase() === 'true';
       } else if (key === 'isPickable') {
-        if (object instanceof WbCadShape)
+        if (object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE || object.nodeType === WbNodeType.WB_NODE_SHAPE)
           object.isPickable = update[key].toLowerCase() === 'true';
       } else if (key === 'size') {
-        if (object instanceof WbBox || object instanceof WbPlane)
+        if (object.nodeType === WbNodeType.WB_NODE_BOX || object.nodeType === WbNodeType.WB_NODE_PLANE)
           object.size = convertStringToVec3(update[key]);
       } else if (key === 'radius') {
-        if (object instanceof WbCapsule || object instanceof WbSphere || object instanceof WbCylinder ||
-          object instanceof WbSpotLight || object instanceof WbPointLight)
+        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_SPHERE || object.nodeType === WbNodeType.WB_NODE_CYLINDER ||
+          object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.radius = parseFloat(update[key]);
       } else if (key === 'subdivision') {
-        if (object instanceof WbSphere || object instanceof WbCapsule || object instanceof WbCone ||
-          object instanceof WbCylinder)
+        if (object.nodeType === WbNodeType.WB_NODE_SPHERE || object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE ||
+          object.nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.subdivision = parseInt(update[key]);
       } else if (key === 'ico') {
-        if (object instanceof WbSphere)
+        if (object.nodeType === WbNodeType.WB_NODE_SPHERE)
           object.ico = update[key].toLowerCase() === 'true';
       } else if (key === 'height') {
-        if (object instanceof WbCapsule || object instanceof WbCone || object instanceof WbCylinder)
+        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.height = parseFloat(update[key]);
-        else if (object instanceof WbElevationGrid)
+        else if (object.nodeType === WbNodeType.WB_NODE_ELEVATION_GRID)
           // Filter is used to remove Nan elements
           object.height = convertStringToFloatArray(update[key]).filter(e => e);
         else if (object instanceof WbAbstractCamera)
           object.height = parseInt(update[key]);
       } else if (key === 'bottom') {
-        if (object instanceof WbCapsule || object instanceof WbCone || object instanceof WbCylinder)
+        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.bottom = update[key].toLowerCase() === 'true';
       } else if (key === 'top') {
-        if (object instanceof WbCapsule || object instanceof WbCylinder)
+        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.top = update[key].toLowerCase() === 'true';
       } else if (key === 'side') {
-        if (object instanceof WbCapsule || object instanceof WbCone || object instanceof WbCylinder)
+        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.side = update[key].toLowerCase() === 'true';
       } else if (key === 'bottomRadius') {
-        if (object instanceof WbCone)
+        if (object.nodeType === WbNodeType.WB_NODE_CONE)
           object.bottomRadius = parseFloat(update[key]);
       } else if (key === 'ccw') {
-        if (object instanceof WbMesh || object instanceof WbIndexedFaceSet || object instanceof WbCadShape)
+        if (object.nodeType === WbNodeType.WB_NODE_MESH || object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE)
           object.ccw = update[key].toLowerCase() === 'true';
       } else if (key === 'direction') {
-        if (object instanceof WbSpotLight || WbDirectionalLight)
+        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || WbDirectionalLight)
           object.direction = convertStringToVec3(update[key]);
       } else if (key === 'color') {
-        if (object instanceof WbLight || object instanceof WbFog)
+        if (object instanceof WbLight || object.nodeType === WbNodeType.WB_NODE_FOG)
           object.color = convertStringToVec3(update[key]);
-        else if (object instanceof WbColor)
+        else if (object.nodeType === WbNodeType.WB_NODE_COLOR)
           object.color = convertStringToVec3Array(update[key]);
       } else if (key === 'name') {
-        if (object instanceof WbMesh)
+        if (object.nodeType === WbNodeType.WB_NODE_MESH)
           object.name = update[key];
       } else if (key === 'materialIndex') {
-        if (object instanceof WbMesh)
+        if (object.nodeType === WbNodeType.WB_NODE_MESH)
           object.materialIndex = parseInt(update[key]);
       } else if (key === 'url') {
-        if (object instanceof WbMesh || object instanceof WbCadShape || object instanceof WbImageTexture) {
+        if (object.nodeType === WbNodeType.WB_NODE_MESH || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE || object.nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
           let urlString = update[key];
           if (urlString === '[]') {
             object.url = undefined;
@@ -323,33 +294,33 @@ export default class X3dScene {
           object.url = urlString.split('"').filter(element => { if (element !== ' ') return element; })[0];
         }
       } else if (key === 'point') {
-        if (object instanceof WbCoordinate)
+        if (object.nodeType === WbNodeType.WB_NODE_COORDINATE)
           object.point = convertStringToVec3Array(update[key]);
-        if (object instanceof WbTextureCoordinate)
+        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_COORDINATE)
           object.point = convertStringToVec2Array(update[key]);
       } else if (key === 'vector') {
-        if (object instanceof WbNormal)
+        if (object.nodeType === WbNodeType.WB_NODE_NORMAL)
           object.vector = convertStringToVec3Array(update[key]);
       } else if (key === 'coordIndex') {
-        if (object instanceof WbIndexedLineSet || object instanceof WbIndexedFaceSet)
+        if (object.nodeType === WbNodeType.WB_NODE_INDEXED_LINE_SET || object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET)
           object.coordIndex = update[key];
       } else if (key === 'attenuation') {
-        if (object instanceof WbSpotLight || object instanceof WbPointLight)
+        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.attenuation = convertStringToVec3(update[key]);
       } else if (key === 'location') {
-        if (object instanceof WbSpotLight || object instanceof WbPointLight)
+        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.location = convertStringToVec3(update[key]);
-      } else if (object instanceof WbFog) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_FOG) {
         if (key === 'visibilityRange')
           object.visibilityRange = parseFloat(update[key]);
         else if (key === 'fogType')
           object.fogType = update[key];
-      } else if (object instanceof WbSpotLight) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT) {
         if (key === 'beamWidth')
           object.beamWidth = parseFloat(update[key]);
         else if (key === 'cutOffAngle')
           object.cutOffAngle = parseFloat(update[key]);
-      } else if (object instanceof WbIndexedFaceSet) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET) {
         if (key === 'normalPerVertex')
           object.normalPerVertex = update[key].toLowerCase() === 'true';
         else if (key === 'normalIndex')
@@ -358,7 +329,7 @@ export default class X3dScene {
           object.texCoordIndex = update[key];
         else if (key === 'creaseAngle')
           object.creaseAngle = parseFloat(update[key]);
-      } else if (object instanceof WbElevationGrid) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_ELEVATION_GRID) {
         if (key === 'xDimension')
           object.xDimension = update[key];
         else if (key === 'xSpacing')
@@ -369,7 +340,7 @@ export default class X3dScene {
           object.ySpacing = update[key];
         else if (key === 'thickness')
           object.thickness = update[key];
-      } else if (object instanceof WbPbrAppearance || object instanceof WbMaterial) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_PBR_APPEARANCE || object.nodeType === WbNodeType.WB_NODE_MATERIAL) {
         if (key === 'baseColor')
           object.baseColor = convertStringToVec3(update[key]);
         else if (key === 'diffuseColor')
@@ -396,24 +367,24 @@ export default class X3dScene {
           object.shininess = parseFloat(update[key]);
         else if (key === 'specularColor')
           object.specularColor = convertStringToVec3(update[key]);
-      } else if (object instanceof WbImageTexture) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
         if (key === 'repeatS')
           object.repeatS = update[key].toLowerCase() === 'true';
         else if (key === 'repeatT')
           object.repeatT = update[key].toLowerCase() === 'true';
         else if (key === 'filtering')
           object.filtering = parseInt(update[key]);
-      } else if (object instanceof WbCamera) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_CAMERA) {
         if (key === 'far')
           object.far = parseFloat(update[key]);
         else if (key === 'near')
           object.near = parseFloat(update[key]);
-      } else if (object instanceof WbRangeFinder) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_RANGE_FINDER) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
           object.minRange = parseFloat(update[key]);
-      } else if (object instanceof WbLidar) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_LIDAR) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
@@ -426,7 +397,7 @@ export default class X3dScene {
           object.tiltAngle = parseFloat(update[key]);
         else if (key === 'verticalFieldOfView')
           object.verticalFieldOfView = parseFloat(update[key]);
-      } else if (object instanceof WbRadar) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_RADAR) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
@@ -435,10 +406,10 @@ export default class X3dScene {
           object.verticalFieldOfView = parseFloat(update[key]);
         else if (key === 'horizontalFieldOfView')
           object.horizontalFieldOfView = parseFloat(update[key]);
-      } else if (object instanceof WbPen) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_PEN) {
         if (key === 'write')
           object.write = update[key].toLowerCase() === 'true';
-      } else if (object instanceof WbDistanceSensor) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_DISTANCE_SENSOR) {
         if (key === 'numberOfRays')
           object.numberOfRays = parseInt(update[key]);
         else if (key === 'aperture')
@@ -457,7 +428,7 @@ export default class X3dScene {
           }
           object.lookupTable = lookupTable;
         }
-      } else if (object instanceof WbConnector) {
+      } else if (object.nodeType === WbNodeType.WB_NODE_CONNECTOR) {
         if (key === 'numberOfRotations')
           object.numberOfRotations = parseInt(update[key]);
       }
@@ -479,7 +450,7 @@ export default class X3dScene {
 
     if (typeof object.parent !== 'undefined') {
       const parent = WbWorld.instance.nodes.get(object.parent);
-      if (typeof parent !== 'undefined' && parent instanceof WbPropeller && parent.currentHelix !== object.id &&
+      if (typeof parent !== 'undefined' && parent.nodeType === WbNodeType.WB_NODE_PROPELLER && parent.currentHelix !== object.id &&
         WbWorld.instance.readyForUpdates)
         parent.switchHelix(object.id);
     }

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -201,17 +201,19 @@ export default class X3dScene {
       if (key === 'id')
         continue;
 
+      const nodeType = object.nodeType;
+
       if (key === 'translation') {
         if (object instanceof WbPose)
           object.translation = convertStringToVec3(update[key]);
-        else if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
+        else if (nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.translation = convertStringToVec2(update[key]);
       } else if (key === 'rotation') {
-        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
+        if (nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.rotation = parseFloat(update[key]);
         else {
           const quaternion = convertStringToQuaternion(update[key]);
-          if (object.nodeType === WbNodeType.WB_NODE_TRACK_WHEEL)
+          if (nodeType === WbNodeType.WB_NODE_TRACK_WHEEL)
             object.updateRotation(quaternion);
           else
             object.rotation = quaternion;
@@ -219,71 +221,76 @@ export default class X3dScene {
       } else if (key === 'scale') {
         if (object instanceof WbPose)
           object.scale = convertStringToVec3(update[key]);
-        else if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
+        else if (nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.scale = convertStringToVec2(update[key]);
       } else if (key === 'center') {
-        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
+        if (nodeType === WbNodeType.WB_NODE_TEXTURE_TRANSFORM)
           object.center = convertStringToVec2(update[key]);
       } else if (key === 'castShadows') {
-        if (object instanceof WbLight || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE ||
-          object.nodeType === WbNodeType.WB_NODE_SHAPE)
+        if (object instanceof WbLight || nodeType === WbNodeType.WB_NODE_CAD_SHAPE || nodeType === WbNodeType.WB_NODE_SHAPE)
           object.castShadows = update[key].toLowerCase() === 'true';
       } else if (key === 'isPickable') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE || object.nodeType === WbNodeType.WB_NODE_SHAPE)
+        if (nodeType === WbNodeType.WB_NODE_CAD_SHAPE || nodeType === WbNodeType.WB_NODE_SHAPE)
           object.isPickable = update[key].toLowerCase() === 'true';
       } else if (key === 'size') {
-        if (object.nodeType === WbNodeType.WB_NODE_BOX || object.nodeType === WbNodeType.WB_NODE_PLANE)
+        if (nodeType === WbNodeType.WB_NODE_BOX || nodeType === WbNodeType.WB_NODE_PLANE)
           object.size = convertStringToVec3(update[key]);
       } else if (key === 'radius') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_SPHERE || object.nodeType === WbNodeType.WB_NODE_CYLINDER ||
-          object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
+        if (nodeType === WbNodeType.WB_NODE_CAPSULE || nodeType === WbNodeType.WB_NODE_SPHERE ||
+          nodeType === WbNodeType.WB_NODE_CYLINDER || nodeType === WbNodeType.WB_NODE_SPOT_LIGHT ||
+          nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.radius = parseFloat(update[key]);
       } else if (key === 'subdivision') {
-        if (object.nodeType === WbNodeType.WB_NODE_SPHERE || object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE ||
-          object.nodeType === WbNodeType.WB_NODE_CYLINDER)
+        if (nodeType === WbNodeType.WB_NODE_SPHERE || nodeType === WbNodeType.WB_NODE_CAPSULE ||
+            nodeType === WbNodeType.WB_NODE_CONE || nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.subdivision = parseInt(update[key]);
       } else if (key === 'ico') {
-        if (object.nodeType === WbNodeType.WB_NODE_SPHERE)
+        if (nodeType === WbNodeType.WB_NODE_SPHERE)
           object.ico = update[key].toLowerCase() === 'true';
       } else if (key === 'height') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
+        if (nodeType === WbNodeType.WB_NODE_CAPSULE || nodeType === WbNodeType.WB_NODE_CONE ||
+          nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.height = parseFloat(update[key]);
-        else if (object.nodeType === WbNodeType.WB_NODE_ELEVATION_GRID)
+        else if (nodeType === WbNodeType.WB_NODE_ELEVATION_GRID)
           // Filter is used to remove Nan elements
           object.height = convertStringToFloatArray(update[key]).filter(e => e);
         else if (object instanceof WbAbstractCamera)
           object.height = parseInt(update[key]);
       } else if (key === 'bottom') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
+        if (nodeType === WbNodeType.WB_NODE_CAPSULE || nodeType === WbNodeType.WB_NODE_CONE ||
+          nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.bottom = update[key].toLowerCase() === 'true';
       } else if (key === 'top') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
+        if (nodeType === WbNodeType.WB_NODE_CAPSULE || nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.top = update[key].toLowerCase() === 'true';
       } else if (key === 'side') {
-        if (object.nodeType === WbNodeType.WB_NODE_CAPSULE || object.nodeType === WbNodeType.WB_NODE_CONE || object.nodeType === WbNodeType.WB_NODE_CYLINDER)
+        if (nodeType === WbNodeType.WB_NODE_CAPSULE || nodeType === WbNodeType.WB_NODE_CONE ||
+          nodeType === WbNodeType.WB_NODE_CYLINDER)
           object.side = update[key].toLowerCase() === 'true';
       } else if (key === 'bottomRadius') {
-        if (object.nodeType === WbNodeType.WB_NODE_CONE)
+        if (nodeType === WbNodeType.WB_NODE_CONE)
           object.bottomRadius = parseFloat(update[key]);
       } else if (key === 'ccw') {
-        if (object.nodeType === WbNodeType.WB_NODE_MESH || object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE)
+        if (nodeType === WbNodeType.WB_NODE_MESH || nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET ||
+          nodeType === WbNodeType.WB_NODE_CAD_SHAPE)
           object.ccw = update[key].toLowerCase() === 'true';
       } else if (key === 'direction') {
-        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || WbDirectionalLight)
+        if (nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || WbDirectionalLight)
           object.direction = convertStringToVec3(update[key]);
       } else if (key === 'color') {
-        if (object instanceof WbLight || object.nodeType === WbNodeType.WB_NODE_FOG)
+        if (object instanceof WbLight || nodeType === WbNodeType.WB_NODE_FOG)
           object.color = convertStringToVec3(update[key]);
-        else if (object.nodeType === WbNodeType.WB_NODE_COLOR)
+        else if (nodeType === WbNodeType.WB_NODE_COLOR)
           object.color = convertStringToVec3Array(update[key]);
       } else if (key === 'name') {
-        if (object.nodeType === WbNodeType.WB_NODE_MESH)
+        if (nodeType === WbNodeType.WB_NODE_MESH)
           object.name = update[key];
       } else if (key === 'materialIndex') {
-        if (object.nodeType === WbNodeType.WB_NODE_MESH)
+        if (nodeType === WbNodeType.WB_NODE_MESH)
           object.materialIndex = parseInt(update[key]);
       } else if (key === 'url') {
-        if (object.nodeType === WbNodeType.WB_NODE_MESH || object.nodeType === WbNodeType.WB_NODE_CAD_SHAPE || object.nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
+        if (nodeType === WbNodeType.WB_NODE_MESH || nodeType === WbNodeType.WB_NODE_CAD_SHAPE ||
+          nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
           let urlString = update[key];
           if (urlString === '[]') {
             object.url = undefined;
@@ -294,33 +301,33 @@ export default class X3dScene {
           object.url = urlString.split('"').filter(element => { if (element !== ' ') return element; })[0];
         }
       } else if (key === 'point') {
-        if (object.nodeType === WbNodeType.WB_NODE_COORDINATE)
+        if (nodeType === WbNodeType.WB_NODE_COORDINATE)
           object.point = convertStringToVec3Array(update[key]);
-        if (object.nodeType === WbNodeType.WB_NODE_TEXTURE_COORDINATE)
+        if (nodeType === WbNodeType.WB_NODE_TEXTURE_COORDINATE)
           object.point = convertStringToVec2Array(update[key]);
       } else if (key === 'vector') {
-        if (object.nodeType === WbNodeType.WB_NODE_NORMAL)
+        if (nodeType === WbNodeType.WB_NODE_NORMAL)
           object.vector = convertStringToVec3Array(update[key]);
       } else if (key === 'coordIndex') {
-        if (object.nodeType === WbNodeType.WB_NODE_INDEXED_LINE_SET || object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET)
+        if (nodeType === WbNodeType.WB_NODE_INDEXED_LINE_SET || nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET)
           object.coordIndex = update[key];
       } else if (key === 'attenuation') {
-        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
+        if (nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.attenuation = convertStringToVec3(update[key]);
       } else if (key === 'location') {
-        if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || object.nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
+        if (nodeType === WbNodeType.WB_NODE_SPOT_LIGHT || nodeType === WbNodeType.WB_NODE_POINT_LIGHT)
           object.location = convertStringToVec3(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_FOG) {
+      } else if (nodeType === WbNodeType.WB_NODE_FOG) {
         if (key === 'visibilityRange')
           object.visibilityRange = parseFloat(update[key]);
         else if (key === 'fogType')
           object.fogType = update[key];
-      } else if (object.nodeType === WbNodeType.WB_NODE_SPOT_LIGHT) {
+      } else if (nodeType === WbNodeType.WB_NODE_SPOT_LIGHT) {
         if (key === 'beamWidth')
           object.beamWidth = parseFloat(update[key]);
         else if (key === 'cutOffAngle')
           object.cutOffAngle = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET) {
+      } else if (nodeType === WbNodeType.WB_NODE_INDEXED_FACE_SET) {
         if (key === 'normalPerVertex')
           object.normalPerVertex = update[key].toLowerCase() === 'true';
         else if (key === 'normalIndex')
@@ -329,7 +336,7 @@ export default class X3dScene {
           object.texCoordIndex = update[key];
         else if (key === 'creaseAngle')
           object.creaseAngle = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_ELEVATION_GRID) {
+      } else if (nodeType === WbNodeType.WB_NODE_ELEVATION_GRID) {
         if (key === 'xDimension')
           object.xDimension = update[key];
         else if (key === 'xSpacing')
@@ -340,7 +347,7 @@ export default class X3dScene {
           object.ySpacing = update[key];
         else if (key === 'thickness')
           object.thickness = update[key];
-      } else if (object.nodeType === WbNodeType.WB_NODE_PBR_APPEARANCE || object.nodeType === WbNodeType.WB_NODE_MATERIAL) {
+      } else if (nodeType === WbNodeType.WB_NODE_PBR_APPEARANCE || nodeType === WbNodeType.WB_NODE_MATERIAL) {
         if (key === 'baseColor')
           object.baseColor = convertStringToVec3(update[key]);
         else if (key === 'diffuseColor')
@@ -367,24 +374,24 @@ export default class X3dScene {
           object.shininess = parseFloat(update[key]);
         else if (key === 'specularColor')
           object.specularColor = convertStringToVec3(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
+      } else if (nodeType === WbNodeType.WB_NODE_IMAGE_TEXTURE) {
         if (key === 'repeatS')
           object.repeatS = update[key].toLowerCase() === 'true';
         else if (key === 'repeatT')
           object.repeatT = update[key].toLowerCase() === 'true';
         else if (key === 'filtering')
           object.filtering = parseInt(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_CAMERA) {
+      } else if (nodeType === WbNodeType.WB_NODE_CAMERA) {
         if (key === 'far')
           object.far = parseFloat(update[key]);
         else if (key === 'near')
           object.near = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_RANGE_FINDER) {
+      } else if (nodeType === WbNodeType.WB_NODE_RANGE_FINDER) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
           object.minRange = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_LIDAR) {
+      } else if (nodeType === WbNodeType.WB_NODE_LIDAR) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
@@ -397,7 +404,7 @@ export default class X3dScene {
           object.tiltAngle = parseFloat(update[key]);
         else if (key === 'verticalFieldOfView')
           object.verticalFieldOfView = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_RADAR) {
+      } else if (nodeType === WbNodeType.WB_NODE_RADAR) {
         if (key === 'maxRange')
           object.maxRange = parseFloat(update[key]);
         else if (key === 'minRange')
@@ -406,10 +413,10 @@ export default class X3dScene {
           object.verticalFieldOfView = parseFloat(update[key]);
         else if (key === 'horizontalFieldOfView')
           object.horizontalFieldOfView = parseFloat(update[key]);
-      } else if (object.nodeType === WbNodeType.WB_NODE_PEN) {
+      } else if (nodeType === WbNodeType.WB_NODE_PEN) {
         if (key === 'write')
           object.write = update[key].toLowerCase() === 'true';
-      } else if (object.nodeType === WbNodeType.WB_NODE_DISTANCE_SENSOR) {
+      } else if (nodeType === WbNodeType.WB_NODE_DISTANCE_SENSOR) {
         if (key === 'numberOfRays')
           object.numberOfRays = parseInt(update[key]);
         else if (key === 'aperture')
@@ -428,7 +435,7 @@ export default class X3dScene {
           }
           object.lookupTable = lookupTable;
         }
-      } else if (object.nodeType === WbNodeType.WB_NODE_CONNECTOR) {
+      } else if (nodeType === WbNodeType.WB_NODE_CONNECTOR) {
         if (key === 'numberOfRotations')
           object.numberOfRotations = parseInt(update[key]);
       }

--- a/resources/web/wwi/X3dScene.js
+++ b/resources/web/wwi/X3dScene.js
@@ -457,8 +457,8 @@ export default class X3dScene {
 
     if (typeof object.parent !== 'undefined') {
       const parent = WbWorld.instance.nodes.get(object.parent);
-      if (typeof parent !== 'undefined' && parent.nodeType === WbNodeType.WB_NODE_PROPELLER && parent.currentHelix !== object.id &&
-        WbWorld.instance.readyForUpdates)
+      if (typeof parent !== 'undefined' && parent.nodeType === WbNodeType.WB_NODE_PROPELLER &&
+        parent.currentHelix !== object.id && WbWorld.instance.readyForUpdates)
         parent.switchHelix(object.id);
     }
   }

--- a/resources/web/wwi/nodes/WbBackground.js
+++ b/resources/web/wwi/nodes/WbBackground.js
@@ -1,6 +1,5 @@
 import {arrayXPointer, arrayXPointerFloat} from './utils/utils.js';
 import WbBaseNode from './WbBaseNode.js';
-import WbPbrAppearance from './WbPbrAppearance.js';
 import WbVector3 from './utils/WbVector3.js';
 import WbWorld from './WbWorld.js';
 import WbWrenShaders from '../wren/WbWrenShaders.js';
@@ -223,7 +222,7 @@ export default class WbBackground extends WbBaseNode {
 
   #updatePBRs() {
     WbWorld.instance.nodes.forEach((value, key, map) => {
-      if (value instanceof WbPbrAppearance && typeof value.parent !== 'undefined') {
+      if (value.nodeType === WbNodeType.WB_NODE_PBR_APPEARANCE && typeof value.parent !== 'undefined') {
         const parent = WbWorld.instance.nodes.get(value.parent);
         parent?.applyMaterialToGeometry();
       }

--- a/resources/web/wwi/nodes/WbBillboard.js
+++ b/resources/web/wwi/nodes/WbBillboard.js
@@ -54,7 +54,7 @@ export default class WbBillboard extends WbGroup {
 
   static isDescendantOfBillboard(node) {
     while (typeof node !== 'undefined') {
-      if (node instanceof WbBillboard)
+      if (node.nodeType === WbNodeType.WB_NODE_BILLBOARD)
         return true;
 
       node = WbWorld.instance.nodes.get(node.parent);

--- a/resources/web/wwi/nodes/WbCylinder.js
+++ b/resources/web/wwi/nodes/WbCylinder.js
@@ -161,7 +161,8 @@ export default class WbCylinder extends WbGeometry {
     this._computeWrenRenderable();
 
     const createOutlineMesh = this.isInBoundingObject();
-    this._wrenMesh = _wr_static_mesh_unit_cylinder_new(this.#subdivision, this.#side, this.#top, this.#bottom, createOutlineMesh);
+    this._wrenMesh = _wr_static_mesh_unit_cylinder_new(this.#subdivision, this.#side, this.#top, this.#bottom,
+      createOutlineMesh);
 
     if (createOutlineMesh)
       this.#updateLineScale();
@@ -217,6 +218,6 @@ export default class WbCylinder extends WbGeometry {
 
     const offset = _wr_config_get_line_scale() / WbGeometry.LINE_SCALE_FACTOR;
     _wr_transform_set_scale(this.wrenNode, _wrjs_array3(this.#radius * (1.0 + offset), this.#radius * (1.0 + offset),
-    this.#height * (1.0 + offset)));
+      this.#height * (1.0 + offset)));
   }
 }

--- a/resources/web/wwi/nodes/WbDevice.js
+++ b/resources/web/wwi/nodes/WbDevice.js
@@ -74,7 +74,8 @@ export default class WbDevice extends WbSolid {
     }
 
     // Axes (X & Z only)
-    const axesCoordinates = [[0, 0, 0, 0.1 * radiusScale, 0, 0], [0, 0, 0, 0, 0.1 * radiusScale, 0], [0, 0, 0, 0, 0, 0.1 * radiusScale]];
+    const axesCoordinates = [[0, 0, 0, 0.1 * radiusScale, 0, 0], [0, 0, 0, 0, 0.1 * radiusScale, 0],
+      [0, 0, 0, 0, 0, 0.1 * radiusScale]];
 
     for (let i = 0; i < 3; ++i) {
       const axesCoordinatesPointer = arrayXPointerFloat(axesCoordinates[i]);

--- a/resources/web/wwi/nodes/WbGroup.js
+++ b/resources/web/wwi/nodes/WbGroup.js
@@ -1,5 +1,4 @@
 import WbBaseNode from './WbBaseNode.js';
-import WbCadShape from './WbCadShape.js';
 import WbLight from './WbLight.js';
 import WbSolid from './WbSolid.js';
 import WbWorld from './WbWorld.js';
@@ -140,7 +139,7 @@ export default class WbGroup extends WbBaseNode {
 
   updateBoundingObjectVisibility() {
     this.children.forEach(child => {
-      if (!(child instanceof WbLight || child instanceof WbCadShape))
+      if (!(child instanceof WbLight || child.nodeType === WbNodeType.WB_NODE_CAD_SHAPE))
         child.updateBoundingObjectVisibility();
     });
   }

--- a/resources/web/wwi/nodes/WbImageTexture.js
+++ b/resources/web/wwi/nodes/WbImageTexture.js
@@ -1,7 +1,6 @@
 import {textureFiltering} from './wb_preferences.js';
 import {resetIfNotInRangeWithIncludedBounds} from './utils/WbFieldChecker.js';
 import ImageLoader from '../ImageLoader.js';
-import WbAppearance from './WbAppearance.js';
 import WbBaseNode from './WbBaseNode.js';
 import WbWorld from './WbWorld.js';
 import {WbNodeType} from './wb_node_type.js';
@@ -92,7 +91,7 @@ export default class WbImageTexture extends WbBaseNode {
     if (typeof this.parent !== 'undefined') {
       const parent = WbWorld.instance.nodes.get(this.parent);
       if (typeof parent !== 'undefined') {
-        if (parent instanceof WbAppearance)
+        if (parent.nodeType === WbNodeType.WB_NODE_APPEARANCE)
           parent.texture = undefined;
         else {
           switch (this.role) {

--- a/resources/web/wwi/nodes/WbJoint.js
+++ b/resources/web/wwi/nodes/WbJoint.js
@@ -1,7 +1,7 @@
 import WbBaseNode from './WbBaseNode.js';
-import WbSlot from './WbSlot.js';
 import WbSolid from './WbSolid.js';
 import WbWorld from './WbWorld.js';
+import {WbNodeType} from './wb_node_type.js';
 
 export default class WbJoint extends WbBaseNode {
   #endPoint;
@@ -91,7 +91,7 @@ export default class WbJoint extends WbBaseNode {
     if (typeof this.endPoint === 'undefined')
       return;
 
-    if (this.endPoint instanceof WbSlot) {
+    if (this.endPoint.nodeType === WbNodeType.WB_NODE_SLOT) {
       const childrenSlot = this.endPoint.slotEndPoint();
       return childrenSlot?.solidEndPoint();
     } else if (this.endPoint instanceof WbSolid)

--- a/resources/web/wwi/nodes/WbLed.js
+++ b/resources/web/wwi/nodes/WbLed.js
@@ -1,8 +1,6 @@
-import WbAppearance from './WbAppearance.js';
 import WbDevice from './WbDevice.js';
 import WbGroup from './WbGroup.js';
 import WbLight from './WbLight.js';
-import WbShape from './WbShape.js';
 import WbVector3 from './utils/WbVector3.js';
 import {clampValuesIfNeeded} from './utils/WbFieldChecker.js';
 import {WbNodeType} from './wb_node_type.js';
@@ -81,9 +79,9 @@ export default class WbLed extends WbDevice {
     }
 
     for (const child of group.children) {
-      if (child instanceof WbShape && typeof child.appearance !== 'undefined') {
+      if (child.nodeType === WbNodeType.WB_NODE_SHAPE && typeof child.appearance !== 'undefined') {
         const appearance = child.appearance;
-        if (appearance instanceof WbAppearance) {
+        if (appearance.nodeType === WbNodeType.WB_NODE_APPEARANCE) {
           const material = appearance.material;
           if (typeof material !== 'undefined')
             this.#materials.push(material);

--- a/resources/web/wwi/nodes/WbShape.js
+++ b/resources/web/wwi/nodes/WbShape.js
@@ -12,9 +12,9 @@ export default class WbShape extends WbBaseNode {
   #castShadows;
   #isInBoundingObject;
   #isPickable;
-  constructor(id, castShadow, isPickable, geometry, appearance) {
+  constructor(id, castShadows, isPickable, geometry, appearance) {
     super(id);
-    this.castShadow = castShadow;
+    this.#castShadows = castShadows;
     this.#isPickable = isPickable;
 
     this.#boundingObjectFirstTimeSearch = true;
@@ -57,7 +57,9 @@ export default class WbShape extends WbBaseNode {
   }
 
   set castShadows(newCastShadows) {
+    this.#castShadows = newCastShadows;
 
+    this.updateCastShadows();
   }
 
   get isPickable() {
@@ -65,7 +67,9 @@ export default class WbShape extends WbBaseNode {
   }
 
   set isPickable(newIsPickable) {
+    this.#isPickable = newIsPickable;
 
+    this.updateIsPickable();
   }
 
   applyMaterialToGeometry() {
@@ -89,7 +93,7 @@ export default class WbShape extends WbBaseNode {
         this.wrenMaterial = WbAppearance.fillWrenDefaultMaterial(this.wrenMaterial);
 
       if (!this.geometry.isInBoundingObject())
-        this.geometry.setWrenMaterial(this.wrenMaterial, this.castShadow);
+        this.geometry.setWrenMaterial(this.wrenMaterial, this.#castShadows);
     }
   }
 
@@ -112,7 +116,7 @@ export default class WbShape extends WbBaseNode {
     }
 
     this.useList.push(customID);
-    return new WbShape(customID, this.castShadow, this.#isPickable, geometry, appearance);
+    return new WbShape(customID, this.#castShadows, this.#isPickable, geometry, appearance);
   }
 
   createWrenObjects() {
@@ -184,7 +188,7 @@ export default class WbShape extends WbBaseNode {
     if (this.isInBoundingObject())
       return;
 
-    this.geometry?.computeCastShadows(this.castShadow);
+    this.geometry?.computeCastShadows(this.#castShadows);
   }
 
   updateIsPickable() {

--- a/resources/web/wwi/nodes/WbSlot.js
+++ b/resources/web/wwi/nodes/WbSlot.js
@@ -71,7 +71,7 @@ export default class WbSlot extends WbBaseNode {
   }
 
   slotEndPoint() {
-    if (typeof this.endPoint !== 'undefined' && this.endPoint instanceof WbSlot)
+    if (typeof this.endPoint !== 'undefined' && this.endPoint.nodeType === WbNodeType.WB_NODE_SLOT)
       return this.endPoint;
   }
 

--- a/resources/web/wwi/nodes/utils/utils.js
+++ b/resources/web/wwi/nodes/utils/utils.js
@@ -1,6 +1,5 @@
 import WbVector3 from './WbVector3.js';
 import WbVector4 from './WbVector4.js';
-import WbWorld from '../WbWorld.js';
 
 function array3Pointer(x, y, z) {
   const data = new Float32Array([x, y, z]);

--- a/src/webots/nodes/WbShape.cpp
+++ b/src/webots/nodes/WbShape.cpp
@@ -523,3 +523,10 @@ void WbShape::exportBoundingObjectToX3D(WbWriter &writer) const {
     writer << "</" + x3dName() + ">";
   }
 }
+
+QStringList WbShape::fieldsToSynchronizeWithX3D() const {
+  QStringList fields;
+  fields << "isPickable"
+         << "castShadows";
+  return fields;
+}

--- a/src/webots/nodes/WbShape.hpp
+++ b/src/webots/nodes/WbShape.hpp
@@ -78,6 +78,7 @@ public:
   // export
   bool exportNodeHeader(WbWriter &writer) const override;
   void exportBoundingObjectToX3D(WbWriter &writer) const override;
+  QStringList fieldsToSynchronizeWithX3D() const override;
 
 signals:
   void wrenMaterialChanged();


### PR DESCRIPTION
Replace `instanceof` by a check with `nodeType` when possible because it:
  - improves the performance
| Node | Instanceof | nodeType | 
| --- | --- | --- |
|Background| 0.06ms | 0.019 ms | 
|Shape| 0.27ms  | 0.077ms |
|Robot| 0.28ms | 0.09ms |
  - moreover using instanceof was the cause of a lot of imports and we had circular dependencies errors by the past.

The only reason to still use `instanceof`sometimes it to check for a node and its derived ones. For example, when checking
```if (node instanceof WbGroup)```it checks against group, but also, pose, transform, solid, and so on.

This PR also adds support for `castShadows` and `isPickable` in WbShape that were missing.