### PR TITLE
Fix assertion failure with Skin node

### DIFF
--- a/src/webots/nodes/utils/WbBoundingSphere.cpp
+++ b/src/webots/nodes/utils/WbBoundingSphere.cpp
@@ -324,7 +324,6 @@ void WbBoundingSphere::parentUpdateNotification() const {
 }
 
 void WbBoundingSphere::setOwnerMoved() {
-  assert(mPoseOwner);
   if (mParentBoundingSphere && !mParentCoordinatesDirty) {
     mParentCoordinatesDirty = true;
     if (gUpdatesEnabled)


### PR DESCRIPTION
Bounding sphere update could also be requested by the Skin node, so the assertion is wrong and results in a failure.
The assertion is not necessary and can be removed.

This issue occurs only when compiling in debug mode on not with the released versions of Webots.