### PR TITLE
Update ROSbot XL Bounding Object to Primitives

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -9,6 +9,7 @@ Released on XXX XXth, 2023.
   - Bug fixes
     - Fixed errors loading template PROTO if the system user name, the project path, or the temporary directory path contains the `\` character ([#6288](https://github.com/cyberbotics/webots/pull/6288)).
     - Fixed Webots and libController version comparison not to take revisions into account ([#6315](https://github.com/cyberbotics/webots/pull/6315)).
+    - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
 
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/projects/robots/husarion/rosbot_xl/protos/RosbotXl.proto
+++ b/projects/robots/husarion/rosbot_xl/protos/RosbotXl.proto
@@ -56,7 +56,7 @@ PROTO RosbotXl [
             USE SIDE_BODY_BOX
           ]
         }
-        DEF CENTER_BODY_COLLISiON Pose {
+        DEF CENTER_BODY_COLLISION Pose {
           translation -0.005 0 0.082
           children [
             Box {

--- a/projects/robots/husarion/rosbot_xl/protos/RosbotXl.proto
+++ b/projects/robots/husarion/rosbot_xl/protos/RosbotXl.proto
@@ -40,13 +40,43 @@ PROTO RosbotXl [
         -2.000608e-04 -9.754257e-04 -2.603326e-04
       ]
     }
-    boundingObject DEF body_collision Group {
+    boundingObject DEF BODY_COLLISION Group {
       children [
-        DEF MAIN_BODY_BOX Pose {
-          translation 0 0 0.048
+        DEF LEFT_BODY_COLLISION Pose {
+          translation -0.005 0.115 0.117
           children [
-            Mesh {
-              url "meshes/body_collision.stl"
+            DEF SIDE_BODY_BOX Box {
+              size 0.27 0.02 0.03
+            }
+          ]
+        }
+        DEF RIGHT_BODY_COLLISION Pose {
+          translation -0.005 -0.115 0.117
+          children [
+            USE SIDE_BODY_BOX
+          ]
+        }
+        DEF CENTER_BODY_COLLISiON Pose {
+          translation -0.005 0 0.082
+          children [
+            Box {
+              size 0.27 0.21 0.099
+            }
+          ]
+        }
+        DEF FRONT_BODY_COLLISION Pose {
+          translation 0.146 0 0.074
+          children [
+            Box {
+              size 0.032 0.21 0.069
+            }
+          ]
+        }
+        DEF BACK_BODY_COLLISION Pose {
+          translation -0.1536 0 0.082
+          children [
+            Box {
+              size 0.027 0.27 0.099
             }
           ]
         }


### PR DESCRIPTION
The ROSbot XL bounding object was made of a Mesh, which is not recommended. This PR replaces the Mesh by multiple Boxes.