### PR TITLE
FIX:Revert matlab batch option to nodesktop

### DIFF
--- a/projects/robots/robotis/darwin-op/controllers/symmetry_matlab/symmetry_matlab.m
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry_matlab/symmetry_matlab.m
@@ -2,7 +2,7 @@
 function symmetry_matlab
 
 % uncomment the next two lines if you want to use
-% MATLAB's desktop and interact with the controller
+% MATLAB's desktop and interact with the controller. Must disable the batch option in the preferences.
 %desktop;
 %keyboard;
 

--- a/projects/robots/softbank/nao/controllers/supervisor_matlab/supervisor_matlab.m
+++ b/projects/robots/softbank/nao/controllers/supervisor_matlab/supervisor_matlab.m
@@ -6,7 +6,7 @@
 function supervisor_matlab
 
 % uncomment the next two lines if you want to use
-% MATLAB's desktop to interact with this controller:
+% MATLAB's desktop to interact with this controller. Must disable the batch option in the preferences.
 %desktop;
 %keyboard;
 

--- a/projects/samples/howto/force_control/controllers/force_control_matlab/force_control_matlab.m
+++ b/projects/samples/howto/force_control/controllers/force_control_matlab/force_control_matlab.m
@@ -6,7 +6,7 @@
 function force_control_matlab
 
 % uncomment the next two lines if you want to use
-% MATLAB's desktop to interact with the controller:
+% MATLAB's desktop to interact with the controller. Must disable the batch option in the preferences.
 %desktop;
 %keyboard;
 

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -902,7 +902,7 @@ int main(int argc, char **argv) {
     char **new_argv = NULL;
     new_argv = add_single_argument(new_argv, &current_size, matlab_path);
     new_argv = add_single_argument(new_argv, &current_size, matlab_command);
-    new_argv = add_single_argument(new_argv, &current_size, "-nodisplay");
+    new_argv = add_single_argument(new_argv, &current_size, "-nodesktop");
     new_argv = add_single_argument(new_argv, &current_size, "-nosplash");
     new_argv = add_single_argument(new_argv, &current_size, "-r");
     new_argv = add_single_argument(new_argv, &current_size, "launcher");

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -902,7 +902,9 @@ int main(int argc, char **argv) {
     char **new_argv = NULL;
     new_argv = add_single_argument(new_argv, &current_size, matlab_path);
     new_argv = add_single_argument(new_argv, &current_size, matlab_command);
-    new_argv = add_single_argument(new_argv, &current_size, "-batch");
+    new_argv = add_single_argument(new_argv, &current_size, "-nodisplay");
+    new_argv = add_single_argument(new_argv, &current_size, "-nosplash");
+    new_argv = add_single_argument(new_argv, &current_size, "-r");
     new_argv = add_single_argument(new_argv, &current_size, "launcher");
     if (nb_controller_arguments)
       new_argv = add_controller_arguments(new_argv, argv, &current_size, true);

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -901,11 +901,18 @@ void WbController::startMatlab() {
     mCommand = mMatlabCommand;
 
   mArguments = WbLanguageTools::matlabArguments();
-  mArguments << "-sd" << WbStandardPaths::controllerLibPath() + "matlab"
-             << "-nosplash"
-             << "-nodesktop"
-             << "-r"
-             << "launcher";
+  mArguments << "-sd" << WbStandardPaths::controllerLibPath() + "matlab";
+  if (WbPreferences::instance()->value("General/useMatlabBatchMode").toBool()) 
+  {
+    mArguments << "-batch";
+  }
+  else
+  {
+    mArguments << "-nosplash"
+               << "-nodesktop"
+               << "-r";
+  }
+  mArguments << "launcher";
 }
 
 void WbController::startBotstudio() {

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -902,7 +902,7 @@ void WbController::startMatlab() {
 
   mArguments = WbLanguageTools::matlabArguments();
   mArguments << "-sd" << WbStandardPaths::controllerLibPath() + "matlab";
-  if (WbPreferences::instance()->value("General/useMatlabBatchMode").toBool()) 
+  if (WbPreferences::instance()->value("General/useMatlabBatchMode").toBool())
     mArguments << "-batch";
   else
     mArguments << "-nosplash"

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -903,9 +903,7 @@ void WbController::startMatlab() {
   mArguments = WbLanguageTools::matlabArguments();
   mArguments << "-sd" << WbStandardPaths::controllerLibPath() + "matlab";
   if (WbPreferences::instance()->value("General/useMatlabBatchMode").toBool()) 
-  {
     mArguments << "-batch";
-  }
   else
   {
     mArguments << "-nosplash"

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -902,7 +902,9 @@ void WbController::startMatlab() {
 
   mArguments = WbLanguageTools::matlabArguments();
   mArguments << "-sd" << WbStandardPaths::controllerLibPath() + "matlab"
-             << "-batch"
+             << "-nosplash"
+             << "-nodesktop"
+             << "-r"
              << "launcher";
 }
 

--- a/src/webots/control/WbController.cpp
+++ b/src/webots/control/WbController.cpp
@@ -905,11 +905,9 @@ void WbController::startMatlab() {
   if (WbPreferences::instance()->value("General/useMatlabBatchMode").toBool()) 
     mArguments << "-batch";
   else
-  {
     mArguments << "-nosplash"
                << "-nodesktop"
                << "-r";
-  }
   mArguments << "launcher";
 }
 

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -66,6 +66,7 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("General/language", "");
   setDefault("General/numberOfThreads", WbSysInfo::coreCount());
   setDefault("General/checkWebotsUpdateOnStartup", true);
+  setDefault("General/useMatlabBatchMode", true);
   setDefault("General/disableSaveWarning", false);
   setDefault("General/thumbnail", true);
   setDefault("Sound/mute", true);

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -93,6 +93,7 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
     mPythonCommand->setText(prefs->value("General/pythonCommand").toString());
   if (mMatlabCommand)
     mMatlabCommand->setText(prefs->value("General/matlabCommand").toString());
+  mUseMatlabBatchModeCheckBox->setChecked(prefs->value("General/useMatlabBatchMode").toBool());
   mExtraProjectPath->setText(prefs->value("General/extraProjectPath").toString());
   mTelemetryCheckBox->setChecked(prefs->value("General/telemetry").toBool());
   mCheckWebotsUpdateCheckBox->setChecked(prefs->value("General/checkWebotsUpdateOnStartup").toBool());
@@ -176,6 +177,7 @@ void WbPreferencesDialog::accept() {
     prefs->setValue("General/pythonCommand", mPythonCommand->text());
   if (mMatlabCommand)
     prefs->setValue("General/matlabCommand", mMatlabCommand->text());
+  prefs->setValue("General/useMatlabBatchMode", mUseMatlabBatchModeCheckBox->isChecked());
   prefs->setValue("General/extraProjectPath", mExtraProjectPath->text());
   prefs->setValue("General/telemetry", mTelemetryCheckBox->isChecked());
   prefs->setValue("General/checkWebotsUpdateOnStartup", mCheckWebotsUpdateCheckBox->isChecked());
@@ -402,6 +404,8 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   // row 8
   layout->addWidget(new QLabel(tr("MATLAB command:"), this), 8, 0);
   layout->addWidget(mMatlabCommand = new WbLineEdit(this), 8, 1);
+  mUseMatlabBatchModeCheckBox = new QCheckBox(tr("Batch mode"), this);
+  layout->addWidget(mUseMatlabBatchModeCheckBox, 8, 2);
 
   // row 9
   layout->addWidget(new QLabel(tr("Extra project path:"), this), 9, 0);

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -71,7 +71,8 @@ private:
   WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectPath, *mHttpProxyHostName, *mHttpProxyPort,
     *mHttpProxyUsername, *mHttpProxyPassword, *mUploadUrl, *mBrowserProgram;
   QCheckBox *mDisableSaveWarningCheckBox, *mThumnailCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox,
-    *mDisableShadowsCheckBox, *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox, *mNewBrowserWindow;
+    *mDisableShadowsCheckBox, *mDisableAntiAliasingCheckBox, *mHttpProxySocks5CheckBox, *mRenderingCheckBox, *mNewBrowserWindow,
+    *mUseMatlabBatchModeCheckBox;
   QSpinBox *mCacheSize;
   QListWidget *mAllowedIps;
   QLabel *mCacheSizeLabel;


### PR DESCRIPTION
**Description**
See issue #6362

**Related Issues**
This pull-request fixes issue #6362

**Tasks**
  - [x] Revert back to using option "-nodesktop" instead of "-batch" for matlab controller
  - [x] Test on Mac
  - [ ] Test on Linux
  - [ ] Test on Windows
  - [x] Add option in preferences to use batch mode since it seems faster

**Documentation**
If this pull-request mainly changes the code to make it compatible with the documentation again. Added remarks in the matlab examples files that are in this repository.

**Screenshots**
None

**Additional context**
None