### PR TITLE
Enable launching MATLAB desktop from the extern launcher

### DIFF
--- a/docs/guide/matlab.md
+++ b/docs/guide/matlab.md
@@ -36,7 +36,7 @@ while wb_robot_step(TIME_STEP) ~= -1
 end
 ```
 
-### Debugging using the MATLAB Desktop
+### Debugging Using the MATLAB Desktop
 
 For each controller written using MATLAB, Webots will start a new instance of MATLAB to act as an interpreter.
 In order to avoid cluttering the desktop with too many windows, Webots starts each instance of MATLAB in non-interactive mode.

--- a/docs/guide/matlab.md
+++ b/docs/guide/matlab.md
@@ -40,15 +40,17 @@ end
 
 For each controller written using MATLAB, Webots will start a new instance of MATLAB to act as an interpreter.
 In order to avoid cluttering the desktop with too many windows, Webots starts each instance of MATLAB in non-interactive mode.
-This starts MATLAB without the user interface and therefore it keeps the memory usage low, which is useful in particular for multi-robot experiments.
+This means that MATLAB starts without the user interface which keeps the memory usage low; this is particularly useful in multi-robot experiments.
+Any output to stdout (such as `disp` or `fprintf`) will also be redirected to the Webots console.
+
 If you would like to use the MATLAB desktop to interact with your controller, you will need to run it in `<extern>` mode with the appropriate additional argument. 
 You can read more about that [here](running-extern-robot-controllers.md).
+
+**Note**: This is equivalent to inserting the command `keyboard` in your controller code, but this is strongly discouraged since it will cause an error during non-interactive execution of the code.
 
 Running an external controller in interactive mode will automatically place a breakpoint at the first line of your controller. 
 Once MATLAB desktop has initialized, it will halt the execution of the controller and give control to the keyboard (`K>>` prompt).
 MATLAB also opens your controller m-file in its editor and indicates that the execution is stopped at the breakpoint.
-
-**Note**: This is equivalent to inserting the command `keyboard` in your controller code, but this is strongly discouraged since it will cause an error during non-interactive execution of the code.
 
 At this point, the controller m-file can be debugged interactively, i.e., it is possible to continue the execution step-by-step, set break points, watch variable, etc. 
 You can use the navigation buttons in the Editor Toolstrip such as Continue/Pause, Step, and Quit Debugging to control the execution.

--- a/docs/guide/matlab.md
+++ b/docs/guide/matlab.md
@@ -15,10 +15,6 @@ Here is a simple MATLAB controller example:
 ```MATLAB
 function simple_example
 
-% uncomment the next two lines to use the MATLAB desktop
-%desktop;
-%keyboard;
-
 TIME_STEP = 32;
 
 my_led = wb_robot_get_device('my_led');
@@ -40,41 +36,40 @@ while wb_robot_step(TIME_STEP) ~= -1
 end
 ```
 
-### Using the MATLAB Desktop
+### Debugging using the MATLAB Desktop
 
-In order to avoid cluttering the desktop with too many windows, Webots starts MATLAB with the *-nodesktop* option.
-The *-nodesktop* option starts MATLAB without user interface and therefore it keeps the memory usage low which is useful in particular for multi-robot experiments.
-If you would like to use the MATLAB desktop to interact with your controller you just need to add these two MATLAB commands somewhere at the beginning of your controller m-file:
+For each controller written using MATLAB, Webots will start a new instance of MATLAB to act as an interpreter.
+In order to avoid cluttering the desktop with too many windows, Webots starts each instance of MATLAB in non-interactive mode.
+This starts MATLAB without the user interface and therefore it keeps the memory usage low, which is useful in particular for multi-robot experiments.
+If you would like to use the MATLAB desktop to interact with your controller, you will need to run it in `<extern>` mode with the appropriate additional argument. 
+You can read more about that [here](running-extern-robot-controllers.md).
 
-```MATLAB
-desktop;
-keyboard;
-```
+Running an external controller in interactive mode will automatically place a breakpoint at the first line of your controller. 
+Once MATLAB desktop has initialized, it will halt the execution of the controller and give control to the keyboard (`K>>` prompt).
+MATLAB also opens your controller m-file in its editor and indicates that the execution is stopped at the breakpoint.
 
-The `desktop` command brings up the MATLAB desktop.
-The `keyboard` stops the execution of the controller and gives control to the keyboard (`K>>` prompt).
-Then MATLAB opens your controller m-file in its editor and indicates that the execution is stopped at the `keyboard` command.
-After that, the controller m-file can be debugged interactively, i.e., it is possible to continue the execution step-by-step, set break points, watch variable, etc.
-While debugging, the current values of the controller variables are shown in the MATLAB workspace.
-It is possible to *continue* the execution of the controller by typing `return` at the `K>>` prompt.
-Finally the execution of the controller can be terminated with <kbd>ctrl</kbd>-<kbd>C</kbd> key combination.
+**Note**: This is equivalent to inserting the command `keyboard` in your controller code, but this is strongly discouraged since it will cause an error during non-interactive execution of the code.
 
-Once the controller is terminated, the connection with Webots remains active.
+At this point, the controller m-file can be debugged interactively, i.e., it is possible to continue the execution step-by-step, set break points, watch variable, etc. 
+You can use the navigation buttons in the Editor Toolstrip such as Continue/Pause, Step, and Quit Debugging to control the execution.
+While running, the controller will run normally until it terminates or reaches another breakpoint.
+While paused, the current values of the controller variables are shown in the MATLAB workspace, and the Command Window becomes available.
+You can read more about debugging MATLAB code on the [MathWorks homepage](https://www.mathworks.com/help/matlab/matlab_prog/debugging-process-and-features.html).
+
+While paused (or after the controller has been terminated), the connection with Webots remains active.
 Therefore it becomes possible to issue Webots commands directly on the MATLAB prompt, for example you can interactively issue commands to query the sensors, etc.:
 
 ```MATLAB
->> wb_robot_step(1000);
->> wb_gps_get_values(gps)
+K>> wb_robot_step(1000);
+K>> wb_gps_get_values(gps)
 
 ans =
 
     0.0001    0.0030   -0.6425
->> |
 ```
 
-It is possible to use additional `keyboard` statements in various places in your ".m" controller.
-So each time MATLAB will run into a `keyboard` statement, it will return control to the `K>>` prompt where you will be able to debug interactively.
-
-At this point, it is also possible to restart the controller by calling its m-file from MATLAB prompt.
+The execution of the controller can be terminated with <kbd>Ctrl</kbd>+<kbd>C</kbd> key combination, or by quitting the debugger.
+However, since all controllers are functions, their Workspace (local variables) will be lost after termination.
+It is possible to re-run the controller by calling `launcher` from MATLAB prompt.
 Note that this will restart the controller only, not the whole simulation, so the current robot and motor positions will be preserved.
-If you want to restart the whole simulation you need to use the `Reload` button as usual.
+If you want to restart the whole simulation you need to use the `Reload` button in Webots as usual.

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -98,6 +98,10 @@ Concrete use cases are discussed in the [Setup](#setup) section.
   --robot-name=<robot-name>
     Target a specific robot by specifying its name in case multiple robots wait for an extern controller in the Webots instance.
 
+  --interactive
+    Launch MATLAB in interactive debugging mode.
+    See https://cyberbotics.com/doc/guide/matlab#using-the-matlab-desktop for more information.
+
   --matlab-path=<matlab-path>
     For MATLAB controllers, this option allows to specify the path to the executable of a specific MATLAB version.
     By default, the launcher checks in the default MATLAB installation folder.
@@ -171,7 +175,7 @@ It is recommended that you do not override this `WEBOTS_TMPDIR` environment vari
 
 Matlab controllers can also be started using the launcher.
 By default, the new instance of MATLAB will be running in non-interactive ("batch") mode. 
-However, by providing the `--matlab-desktop` option, this can be overridden, which will cause the full desktop user interface to run. 
+However, by providing the `--interactive` option, this can be overridden, which will cause the full desktop user interface to run. 
 See [this page](matlab.md) for more details on how to debug webots controllers using the MATLAB desktop.
 
 Regardless of mode, the launcher will look for the latest installed version of MATLAB in the following locations, depending on the OS:

--- a/docs/guide/running-extern-robot-controllers.md
+++ b/docs/guide/running-extern-robot-controllers.md
@@ -170,7 +170,11 @@ It is recommended that you do not override this `WEBOTS_TMPDIR` environment vari
 ### Running a MATLAB Extern Robot Controller
 
 Matlab controllers can also be started using the launcher.
-By default, the launcher will look for the latest installed version of MATLAB in the following locations, depending on the OS:
+By default, the new instance of MATLAB will be running in non-interactive ("batch") mode. 
+However, by providing the `--matlab-desktop` option, this can be overridden, which will cause the full desktop user interface to run. 
+See [this page](matlab.md) for more details on how to debug webots controllers using the MATLAB desktop.
+
+Regardless of mode, the launcher will look for the latest installed version of MATLAB in the following locations, depending on the OS:
 
 - **Windows**: C:\Program Files\MATLAB\R20XXx\bin\win64\MATLAB.exe
 - **Linux**: /usr/local/MATLAB/R20XXx/bin/matlab

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -5,6 +5,7 @@ Released on XXX XXth, 2023.
   - New Devices and Objects
     - Added a model of a silo and a field ditch ([#6289](https://github.com/cyberbotics/webots/pull/6289)).
   - Enhancements
+    - Enabled the launching of MATLAB desktop from the extern launcher ([#6366](https://github.com/cyberbotics/webots/pull/6366)). 
     - Improved overlays visible in Overlays menu by adding all the robots in the menu list ([#6297](https://github.com/cyberbotics/webots/pull/6297)).
   - Bug fixes
     - Fixed errors loading template PROTO if the system user name, the project path, or the temporary directory path contains the `\` character ([#6288](https://github.com/cyberbotics/webots/pull/6288)).

--- a/lib/controller/matlab/launcher.m
+++ b/lib/controller/matlab/launcher.m
@@ -181,9 +181,11 @@ try
   if ~isvarname(WEBOTS_CONTROLLER_NAME)
     newname = matlab.lang.makeValidName(WEBOTS_CONTROLLER_NAME);
     copyfile(append(WEBOTS_CONTROLLER_NAME, '.m'), append(newname, '.m'), 'f');
+    if desktop('-inuse'), dbstop('in', newname); end
     eval([newname, args]);
     delete(append(newname, '.m')); % delete temporary file
   else
+    if desktop('-inuse'), dbstop('in', WEBOTS_CONTROLLER_NAME); end
     eval([WEBOTS_CONTROLLER_NAME, args]);
   end
 

--- a/projects/robots/robotis/darwin-op/controllers/symmetry_matlab/symmetry_matlab.m
+++ b/projects/robots/robotis/darwin-op/controllers/symmetry_matlab/symmetry_matlab.m
@@ -1,11 +1,6 @@
 % Description: MATLAB controller example for Webots
 function symmetry_matlab
 
-% uncomment the next two lines if you want to use
-% MATLAB's desktop and interact with the controller
-%desktop;
-%keyboard;
-
 TIME_STEP = wb_robot_get_basic_time_step();
 
 right_shoulder_motor  = wb_robot_get_device('ShoulderR');

--- a/projects/robots/softbank/nao/controllers/supervisor_matlab/supervisor_matlab.m
+++ b/projects/robots/softbank/nao/controllers/supervisor_matlab/supervisor_matlab.m
@@ -5,11 +5,6 @@
 %               -MATLAB must be installed and the "matlab" command must be in the PATH environment variable
 function supervisor_matlab
 
-% uncomment the next two lines if you want to use
-% MATLAB's desktop to interact with this controller:
-%desktop;
-%keyboard;
-
 % controller time step
 TIME_STEP = 40;
 

--- a/projects/samples/howto/force_control/controllers/force_control_matlab/force_control_matlab.m
+++ b/projects/samples/howto/force_control/controllers/force_control_matlab/force_control_matlab.m
@@ -1,14 +1,8 @@
-%
 % Example of spring and dampers simulation implemented with force control
 % To try this example you need to change the Robot.controller field 
 % to "force_control_matlab" in the force_control.wbt example
-% 
-function force_control_matlab
 
-% uncomment the next two lines if you want to use
-% MATLAB's desktop to interact with the controller:
-%desktop;
-%keyboard;
+function force_control_matlab
 
 CONTROL_STEP = 4;
 SPRING_CONSTANT = 40;

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -234,8 +234,8 @@ static void print_options() {
     "connect.\n    1234 is used by default, as it is the default port for Webots.\n    This setting allows you to connect to a "
     "specific instance of Webots if\n    there are multiple instances running on the target machine.\n    The port of a Webots "
     "instance can be set at its launch.\n\n  --robot-name=<robot-name>\n    Target a specific robot by specifying its name in "
-    "case multiple robots wait\n    for an extern controller in the Webots instance.\n\n  --matlab-desktop\n    Launch the "
-    "full desktop version of MATLAB.\n    See https://cyberbotics.com/doc/guide/matlab#using-the-matlab-desktop for\n    more "
+    "case multiple robots wait\n    for an extern controller in the Webots instance.\n\n  --interactive\n    Launch MATLAB "
+    "in interactive debugging mode.\n    See https://cyberbotics.com/doc/guide/matlab#using-the-matlab-desktop for\n    more "
     "information.\n\n  --matlab-path=<matlab-path>\n    For MATLAB controllers, this option allows to specify the path to the "
     "\n    executable of a specific MATLAB version.\n    By default, the launcher checks in the default MATLAB installation "
     "folder.\n    See https://cyberbotics.com/doc/guide/running-extern-robot-controllers#running-a-matlab-extern-controller\n"
@@ -276,7 +276,7 @@ static bool parse_options(int nb_arguments, char **arguments) {
         const size_t robot_name_size = strlen(arguments[i] + 13) + 1;
         robot_name = malloc(robot_name_size);
         memcpy(robot_name, arguments[i] + 13, robot_name_size);
-      } else if (strncmp(arguments[i], "--matlab-desktop", 16) == 0) {
+      } else if (strncmp(arguments[i], "--interactive", 13) == 0) {
         const size_t matlab_args_size = snprintf(NULL, 0, "-nosplash -wait -r") + 1;
         matlab_args = malloc(matlab_args_size);
         sprintf(matlab_args, "-nosplash -wait -r");

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -277,9 +277,9 @@ static bool parse_options(int nb_arguments, char **arguments) {
         robot_name = malloc(robot_name_size);
         memcpy(robot_name, arguments[i] + 13, robot_name_size);
       } else if (strncmp(arguments[i], "--matlab-desktop", 16) == 0) {
-        const size_t matlab_args_size = snprintf(NULL, 0, "-nosplash -r") + 1;
+        const size_t matlab_args_size = snprintf(NULL, 0, "-nosplash -wait -r") + 1;
         matlab_args = malloc(matlab_args_size);
-        sprintf(matlab_args, "-nosplash -r");
+        sprintf(matlab_args, "-nosplash -wait -r");
       } else if (strncmp(arguments[i], "--matlab-path=", 14) == 0) {
         const size_t matlab_path_size = strlen(arguments[i] + 14) + 1;
         matlab_path = malloc(matlab_path_size);

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -186,7 +186,7 @@ static bool get_matlab_path() {
   DIR *directory = opendir(matlab_directory);
 #ifndef __APPLE__
   if (directory == NULL) {
-    fprintf(stderr, "No installation of Matlab available.\n");
+    fprintf(stderr, "No installation of MATLAB available.\n");
     return false;
   }
 #endif
@@ -204,7 +204,7 @@ static bool get_matlab_path() {
   }
   closedir(directory);
   if (!latest_version) {
-    fprintf(stderr, "No installation of Matlab available.\n");
+    fprintf(stderr, "No installation of MATLAB available.\n");
     return false;
   }
 
@@ -277,9 +277,15 @@ static bool parse_options(int nb_arguments, char **arguments) {
         robot_name = malloc(robot_name_size);
         memcpy(robot_name, arguments[i] + 13, robot_name_size);
       } else if (strncmp(arguments[i], "--interactive", 13) == 0) {
-        const size_t matlab_args_size = snprintf(NULL, 0, "-nosplash -wait -r") + 1;
+#ifdef _WIN32
+        const size_t matlab_args_size = snprintf(NULL, 0, "-wait -r") + 1;
         matlab_args = malloc(matlab_args_size);
-        sprintf(matlab_args, "-nosplash -wait -r");
+        sprintf(matlab_args, "-wait -r");
+#else
+        const size_t matlab_args_size = snprintf(NULL, 0, "-r") + 1;
+        matlab_args = malloc(matlab_args_size);
+        sprintf(matlab_args, "-r");
+#endif
       } else if (strncmp(arguments[i], "--matlab-path=", 14) == 0) {
         const size_t matlab_path_size = strlen(arguments[i] + 14) + 1;
         matlab_path = malloc(matlab_path_size);
@@ -357,9 +363,6 @@ static bool parse_options(int nb_arguments, char **arguments) {
                                      printf("\n");
   robot_name ? printf("Targeting robot '%s'.\n", robot_name) :
                printf("Targeting the only robot waiting for an extern controller.\n");
-
-  if (matlab_args)
-    printf("Running MATLAB in interactive mode...\n");
 
   free(protocol);
   free(ip_address);
@@ -901,6 +904,8 @@ int main(int argc, char **argv) {
       const size_t matlab_args_size = snprintf(NULL, 0, "-batch") + 1;
       matlab_args = malloc(matlab_args_size);
       sprintf(matlab_args, "-batch");
+    } else {
+      printf("Running MATLAB in interactive mode...\n");
     }
 
 #ifdef _WIN32

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -351,11 +351,15 @@ static bool parse_options(int nb_arguments, char **arguments) {
 
   // Show resulting target options to user
   const char *location = strncmp(protocol, "tcp", 3) == 0 ? "remote" : "local";
-  printf("\nThe started controller targets a %s instance (%s protocol) of Webots with port number %s. ", location, protocol, port);
-  strncmp(protocol, "tcp", 3) == 0 ? printf(" The IP address of the remote Webots instance is '%s'.\n\n", ip_address) :
-                                     printf("\n\n");
+  printf("\nThe started controller targets a %s instance (%s protocol) of Webots with port number %s.", location, protocol,
+         port);
+  strncmp(protocol, "tcp", 3) == 0 ? printf(" The IP address of the remote Webots instance is '%s'.\n", ip_address) :
+                                     printf("\n");
   robot_name ? printf("Targeting robot '%s'.\n", robot_name) :
                printf("Targeting the only robot waiting for an extern controller.\n");
+
+  if (matlab_args)
+    printf("Running MATLAB in interactive mode...\n");
 
   free(protocol);
   free(ip_address);

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -278,12 +278,10 @@ static bool parse_options(int nb_arguments, char **arguments) {
         memcpy(robot_name, arguments[i] + 13, robot_name_size);
       } else if (strncmp(arguments[i], "--interactive", 13) == 0) {
 #ifdef _WIN32
-        const size_t matlab_args_size = snprintf(NULL, 0, "-wait -r") + 1;
-        matlab_args = malloc(matlab_args_size);
+        matlab_args = malloc(strlen("-wait -r") + 1);
         sprintf(matlab_args, "-wait -r");
 #else
-        const size_t matlab_args_size = snprintf(NULL, 0, "-r") + 1;
-        matlab_args = malloc(matlab_args_size);
+        matlab_args = malloc(strlen("-r") + 1);
         sprintf(matlab_args, "-r");
 #endif
       } else if (strncmp(arguments[i], "--matlab-path=", 14) == 0) {
@@ -901,8 +899,7 @@ int main(int argc, char **argv) {
       return -1;
 
     if (!matlab_args) {
-      const size_t matlab_args_size = snprintf(NULL, 0, "-batch") + 1;
-      matlab_args = malloc(matlab_args_size);
+      matlab_args = malloc(strlen("-batch") + 1);
       sprintf(matlab_args, "-batch");
     } else {
       printf("Running MATLAB in interactive mode...\n");

--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -351,11 +351,11 @@ static bool parse_options(int nb_arguments, char **arguments) {
 
   // Show resulting target options to user
   const char *location = strncmp(protocol, "tcp", 3) == 0 ? "remote" : "local";
-  printf("The started controller targets a %s instance (%s protocol) of Webots with port number %s.", location, protocol, port);
-  strncmp(protocol, "tcp", 3) == 0 ? printf(" The IP address of the remote Webots instance is '%s'. ", ip_address) :
-                                     printf(" ");
-  robot_name ? printf("Targeting robot '%s'.\n\n", robot_name) :
-               printf("Targeting the only robot waiting for an extern controller.\n\n");
+  printf("\nThe started controller targets a %s instance (%s protocol) of Webots with port number %s. ", location, protocol, port);
+  strncmp(protocol, "tcp", 3) == 0 ? printf(" The IP address of the remote Webots instance is '%s'.\n\n", ip_address) :
+                                     printf("\n\n");
+  robot_name ? printf("Targeting robot '%s'.\n", robot_name) :
+               printf("Targeting the only robot waiting for an extern controller.\n");
 
   free(protocol);
   free(ip_address);


### PR DESCRIPTION
**Description**
This will add features as described in https://github.com/cyberbotics/webots/issues/6362#issuecomment-1695794195

**Related Issues**
This pull-request fixes issue https://github.com/cyberbotics/webots/issues/6362

**Tasks**
Add the list of tasks of this PR.
  - [x] Add the `--interactive` option to the webots-controller which will launch MATLAB in interactive (debug) mode.
  - [x] Remove references to deprecated commands in example files.
  - [x] Change the documentation to reflect the new workflow. 

**Documentation**
The following pages have been changed:
- https://cyberbotics.com/doc/guide/matlab#using-the-matlab-desktop
- https://cyberbotics.com/doc/guide/running-extern-robot-controllers
