### PR TITLE
Add ".app" suffix to default matlab path in webots-controller

### DIFF
--- a/src/controller/launcher/webots_controller.c
+++ b/src/controller/launcher/webots_controller.c
@@ -208,9 +208,9 @@ static bool get_matlab_path() {
   }
 
 #ifdef __APPLE__
-  const size_t matlab_path_size = snprintf(NULL, 0, "%s%s", matlab_directory, latest_version) + 1;
+  const size_t matlab_path_size = snprintf(NULL, 0, "%s%s.app", matlab_directory, latest_version) + 1;
   matlab_path = malloc(matlab_path_size);
-  sprintf(matlab_path, "%s%s", matlab_directory, latest_version);
+  sprintf(matlab_path, "%s%s.app", matlab_directory, latest_version);
 #else
   const size_t matlab_path_size = snprintf(NULL, 0, "%s%s%s", matlab_directory, latest_version, matlab_exec_suffix) + 1;
   matlab_path = malloc(matlab_path_size);


### PR DESCRIPTION
Couldn't help notice that in the docs (and in src/webots/control/WbController.cpp), the default matlab path has the suffix ".app" on macOS.

This is not present in src/controller/launcher/webots_controller.c.

This PR fixes this, and hopefully resolves #6387