### PR TITLE
Fix values returned by getEmitterDirection

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -13,7 +13,7 @@ Released on XXX XXth, 2023.
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).
     - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
-    - Fixed values returned by the `Receiver.getEmitterDirection` Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
+    - Fixed values returned by the [Receiver.getEmitterDirection](https://cyberbotics.com/doc/reference/receiver?tab-language=python#wb_receiver_get_emitter_direction) Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
 
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -13,6 +13,7 @@ Released on XXX XXth, 2023.
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).
     - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
+    - Fixed values returned by `getEmitterDirection` ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
 
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -13,7 +13,7 @@ Released on XXX XXth, 2023.
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).
     - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
-    - Fixed values returned by `getEmitterDirection` ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
+    - Fixed values returned by the `Receiver.getEmitterDirection` Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
 
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/lib/controller/python/controller/receiver.py
+++ b/lib/controller/python/controller/receiver.py
@@ -91,8 +91,8 @@ class Receiver(Sensor):
         return wb.wb_receiver_get_signal_strength(self._tag)
 
     @property
-    def emitter_direction(self):
-        return wb.wb_receiver_get_emitter_direction(self._tag)
+    def emitter_direction(self) -> List[float]:
+        return wb.wb_receiver_get_emitter_direction(self._tag)[:3]
 
     @property
     def channel(self) -> int:


### PR DESCRIPTION
**Description**
Fix returning 3D vector (list) instead of object. Fix based on `gps.py::getValues`

**Related Issues**
This pull-request fixes issue #6392 
