### PR TITLE
fixed mIsOmnidirectional in WbObjectDetection

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -13,6 +13,7 @@ Released on XXX XXth, 2023.
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).
     - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
+    - Fixed values returned by the [Receiver.getEmitterDirection](https://cyberbotics.com/doc/reference/receiver?tab-language=python#wb_receiver_get_emitter_direction) Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
 
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -14,7 +14,8 @@ Released on XXX XXth, 2023.
     - Replaced the [Mesh](mesh.md) bounding object of the ROSbot XL by [Boxes](box.md) ([#6326](https://github.com/cyberbotics/webots/pull/6326)).
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
     - Fixed values returned by the [Receiver.getEmitterDirection](https://cyberbotics.com/doc/reference/receiver?tab-language=python#wb_receiver_get_emitter_direction) Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
-
+    - Fixed recognition of omnidirectional cameras with fov > pi/2 in [WbObjectDetection] ([#6395] (https://github.com/cyberbotics/webots/pull/6396)).
+    
 ## Webots R2023b
 Released on June 28th, 2023.
   - New Features

--- a/lib/controller/python/controller/receiver.py
+++ b/lib/controller/python/controller/receiver.py
@@ -91,8 +91,8 @@ class Receiver(Sensor):
         return wb.wb_receiver_get_signal_strength(self._tag)
 
     @property
-    def emitter_direction(self):
-        return wb.wb_receiver_get_emitter_direction(self._tag)
+    def emitter_direction(self) -> List[float]:
+        return wb.wb_receiver_get_emitter_direction(self._tag)[:3]
 
     @property
     def channel(self) -> int:

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -37,7 +37,7 @@ WbObjectDetection::WbObjectDetection(WbSolid *device, WbSolid *object, const int
   mMaxRange(maxRange),
   mOdeGeomData(NULL),
   mHorizontalFieldOfView(horizontalFieldOfView),
-  mIsOmniDirectional(mHorizontalFieldOfView > M_PI / 2.0),
+  mIsOmniDirectional(mHorizontalFieldOfView > M_PI_2),
   mOcclusion(occlusion) {
   if (mOcclusion == ONE_RAY) {
     const WbVector3 devicePosition = mDevice->position();
@@ -420,7 +420,7 @@ bool WbObjectDetection::isWithinBounds(const WbAffinePlane *frustumPlanes, const
     }
 
     objectRelativePosition = deviceInverseRotation * (objectPosition - devicePosition);
-    if (!mIsOmniDirectional && mHorizontalFieldOfView <= M_PI_2) {
+    if (!mIsOmniDirectional) {
       // do not recompute the object size and position if partly outside in case of fovX > PI
       // (a more complete computation will be needed and currently it seems to work quite well as-is)
       objectSize.setY(objectSize.y() - outsidePart[RIGHT] - outsidePart[LEFT]);

--- a/src/webots/nodes/utils/WbObjectDetection.cpp
+++ b/src/webots/nodes/utils/WbObjectDetection.cpp
@@ -37,7 +37,7 @@ WbObjectDetection::WbObjectDetection(WbSolid *device, WbSolid *object, const int
   mMaxRange(maxRange),
   mOdeGeomData(NULL),
   mHorizontalFieldOfView(horizontalFieldOfView),
-  mIsOmniDirectional(mHorizontalFieldOfView > M_PI),
+  mIsOmniDirectional(mHorizontalFieldOfView > M_PI / 2.0),
   mOcclusion(occlusion) {
   if (mOcclusion == ONE_RAY) {
     const WbVector3 devicePosition = mDevice->position();

--- a/src/webots/nodes/utils/WbObjectDetection.hpp
+++ b/src/webots/nodes/utils/WbObjectDetection.hpp
@@ -98,7 +98,7 @@ private:
   QList<double> mRaysCollisionDepth;  // rays collision depth
   QList<dGeomID> mRayGeoms;           // rays that checks collision of this packet
   double mHorizontalFieldOfView;
-  bool mIsOmniDirectional;  // is sensor omnidirectional (horizontal FOV < PI/2)
+  bool mIsOmniDirectional;  // is sensor omnidirectional (horizontal FOV > PI/2)
   int mOcclusion;
 };
 


### PR DESCRIPTION
**Description**
Changes the calculation of mIsOmniDirectional to horizontalFov > pi / 2.

**Related Issues**
This pull-request fixes issue #6395

**Additional context**
Details on how the spherical projections were wrong before can be seen in #6395 
 
