### PR TITLE
Fix snap build

### DIFF
--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -30,6 +30,6 @@ script_full_path=$(dirname "$0")
 $script_full_path/linux_test_dependencies.sh --norecurse
 $script_full_path/linux_compilation_dependencies.sh
 
-if [[ ! $CI ]]; then
+if [[ -z "$CI" ]]; then
   $script_full_path/linux_web_viewer_dependencies.sh
 fi

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -30,6 +30,6 @@ script_full_path=$(dirname "$0")
 $script_full_path/linux_test_dependencies.sh --norecurse
 $script_full_path/linux_compilation_dependencies.sh
 
-if [[ -z "$CI" ]]; then
+if [[ -z "$SNAPCRAFT_PART_BUILD" ]]; then
   $script_full_path/linux_web_viewer_dependencies.sh
 fi

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -29,4 +29,7 @@ fi
 script_full_path=$(dirname "$0")
 $script_full_path/linux_test_dependencies.sh --norecurse
 $script_full_path/linux_compilation_dependencies.sh
-$script_full_path/linux_web_viewer_dependencies.sh
+
+if [[ ! $CI ]]; then
+  $script_full_path/linux_web_viewer_dependencies.sh
+fi

--- a/scripts/install/linux_optional_compilation_dependencies.sh
+++ b/scripts/install/linux_optional_compilation_dependencies.sh
@@ -30,6 +30,6 @@ script_full_path=$(dirname "$0")
 $script_full_path/linux_test_dependencies.sh --norecurse
 $script_full_path/linux_compilation_dependencies.sh
 
-if [[ -z "$SNAPCRAFT_PART_BUILD" ]]; then
+if [[ -z "$SNAP" ]]; then
   $script_full_path/linux_web_viewer_dependencies.sh
 fi


### PR DESCRIPTION
Do not install wrenJS dependencies when building the snap are they are not needed.