### PR TITLE
Fix the EvelationGrid height used for ODE

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -15,6 +15,7 @@ Released on XXX XXth, 2023.
     - Fixed a crash when [IndexedLineSet](indexedlineset.md) has `coord` but no `coordIndex` ([#6359](https://github.com/cyberbotics/webots/pull/6359)).
     - Fixed values returned by the [Receiver.getEmitterDirection](https://cyberbotics.com/doc/reference/receiver?tab-language=python#wb_receiver_get_emitter_direction) Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
     - Fixed recognition of omnidirectional cameras with fov > pi/2 in [WbObjectDetection] ([#6396](https://github.com/cyberbotics/webots/pull/6396)).
+    - Fixed [ElevationGrid](elevationgrid.md) collisions not matching the displayed when the x and y dimensions are different ([#6412](https://github.com/cyberbotics/webots/pull/6412))
     
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/src/webots/nodes/WbElevationGrid.cpp
+++ b/src/webots/nodes/WbElevationGrid.cpp
@@ -429,11 +429,11 @@ bool WbElevationGrid::setOdeHeightfieldData() {
   mHeight->copyItemsTo(mData, xdyd);
 
   // Inverse mData lines for ODE
-  for (int i = 0; i < xd / 2; i++) {  // integer division
-    for (int j = 0; j < yd; j++) {
-      double temp = mData[i * yd + j];
-      mData[i * yd + j] = mData[(xd - 1 - i) * yd + j];
-      mData[(xd - 1 - i) * yd + j] = temp;
+  for (int i = 0; i < yd / 2; i++) {  // integer division
+    for (int j = 0; j < xd; j++) {
+      double temp = mData[i * xd + j];
+      mData[i * xd + j] = mData[(yd - 1 - i) * xd + j];
+      mData[(yd - 1 - i) * xd + j] = temp;
     }
   }
 


### PR DESCRIPTION
**Description**

This pull-request fixes the issue with the collision of ElevationGrids not matching the displayed mesh.

**Related Issues**
This pull-request fixes issue #6363 and #4169 

**Screenshots**

Before the fix
![Screenshot from 2023-10-10 17-47-02](https://github.com/cyberbotics/webots/assets/12954392/e45725ac-2724-429c-9f75-8ee7e9bdf8c4)

https://github.com/cyberbotics/webots/assets/12954392/1a624ef2-cc6e-48b5-89ad-c8b9604af4fd

After the fix
![Screenshot from 2023-10-10 17-48-04](https://github.com/cyberbotics/webots/assets/12954392/3c4160fe-10dd-4d87-9a3b-ce8ffbac1a20)

https://github.com/cyberbotics/webots/assets/12954392/07e1406a-bbef-421a-a006-0eb542291ed7

**Additional context**

Test worlds ([archive](https://github.com/cyberbotics/webots/files/12859212/test_worlds.zip)) obtained and modified from #6363 and #4169 

