### PR TITLE
Fix missing points in lidar scan

### DIFF
--- a/resources/wren/shaders/merge_spherical.frag
+++ b/resources/wren/shaders/merge_spherical.frag
@@ -149,8 +149,7 @@ vec4 smooth_texture(sampler2D tex, vec2 p, int bias) {
 
 void main() {
   ivec2 texSize = textureSize(inputTextures[FRONT], 0);
-  ivec2 pixelCoord =
-    ivec2(round((texUv.x - 0.999 / texSize.x / 2) * texSize.x), round((texUv.y - 0.999 / texSize.y / 2) * texSize.y));
+  ivec2 pixelCoord = ivec2(round((texUv.x - 1 / texSize.x / 2) * texSize.x), round((texUv.y - 1 / texSize.y / 2) * texSize.y));
 
   vec3 coord3d;
 
@@ -182,8 +181,7 @@ void main() {
   float maxDot = dot(coord3d, orientations[0]);
   int face = FRONT;
   for (int i = 1; i < 6; ++i) {
-    float current_dot =
-      dot(vec3(coord3d.xy, coord3d.z * (pi_2 / min(fovY * fovYCorrectionCoefficient, pi_2))), orientations[i]);
+    float current_dot = dot(vec3(coord3d.xy, coord3d.z / tan(min(fovY, pi_2) / 2)), orientations[i]);
     if (maxDot < current_dot) {
       maxDot = current_dot;
       face = i;
@@ -197,7 +195,7 @@ void main() {
   else if (face == LEFT || face == RIGHT)
     absMax = abs(coord3d.y);
   else if (face == UP || face == DOWN)
-    absMax = abs(coord3d.z * (pi_2 / min(fovY * fovYCorrectionCoefficient, pi_2)));
+    absMax = abs(coord3d.z / tan(min(fovY, pi_2) / 2));
 
   vec3 normalizedCoord3d = coord3d;
   if (absMax > 0.0)
@@ -225,9 +223,9 @@ void main() {
 
   if (face != UP && face != DOWN) {
     if (fovX < pi_2)
-      coord.x *= pi_2 / fovX;
+      coord.x /= tan(fovX / 2);
     if (fovY < pi_2)
-      coord.y *= pi_2 / fovY * fovYCorrectionCoefficient;
+      coord.y /= tan(fovY / 2);
   }
 
   vec2 faceCoord = vec2(0.5 * (1.0 - coord.x), 0.5 * (1.0 - coord.y));

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -423,10 +423,10 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double cosPhi0 = cos(phi0);
   const double sinPhi0 = sin(phi0);
 
-  const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / (w - 1.0));
+  const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / w);
   const double cosdTheta = cos(dtheta);
   const double sindTheta = sin(dtheta);
-  const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta);
+  const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta + dtheta / 2);
   const double cosTheta0 = cos(theta0);
   const double sinTheta0 = sin(theta0);
 

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -194,10 +194,9 @@ void WbWrenCamera::setFieldOfView(float fov) {
       init();
     }
 
-    if (fov > M_PI_2) {  // maximum X field of view of the sub-camera is pi / 2
-      aspectRatio = aspectRatio * (M_PI_2 / fov);
-      fov = M_PI_2;
-    }
+    fov = fov > M_PI_2 ? M_PI_2 : fov;  // maximum X field of view of the sub-camera is pi / 2
+    aspectRatio = tan((mSphericalFieldOfViewX > M_PI_2 ? M_PI_2 : mSphericalFieldOfViewX) / 2) /
+                  tan((mSphericalFieldOfViewY > M_PI_2 ? M_PI_2 : mSphericalFieldOfViewY) / 2);
 
     fieldOfViewY = computeFieldOfViewY(fov, aspectRatio);
     if (fieldOfViewY > M_PI_2) {  // maximum Y field of view of the sub-camera is pi / 2
@@ -751,9 +750,7 @@ void WbWrenCamera::setupSphericalSubCameras() {
     mIsCameraActive[CAMERA_ORIENTATION_LEFT] = true;
     lateralCameraNumber += 2;
   }
-  //   if (mSphericalFieldOfViewY > 1.230959417) {  // 2.0*asin(1/sqrt(3)) // phi angle of the (Sqrt(3), Sqrt(3), Sqrt(3))
-  //   coordinate
-  if (true) {
+  if (mSphericalFieldOfViewY > 1.230959417) {  // 2.0*asin(1/sqrt(3)) // phi angle of the (Sqrt(3), Sqrt(3), Sqrt(3)) coordinate
     mIsCameraActive[CAMERA_ORIENTATION_UP] = true;
     mIsCameraActive[CAMERA_ORIENTATION_DOWN] = true;
     verticalCameraNumber += 2;
@@ -768,7 +765,7 @@ void WbWrenCamera::setupSphericalSubCameras() {
 
   if (verticalCameraNumber == 1) {
     // this coefficient is set to work even in the worse case (just before enabling top and bottom cameras)
-    mSphericalFovYCorrectionCoefficient = 1.27;
+    mSphericalFovYCorrectionCoefficient = 1.4;
     mSphericalFieldOfViewY *= mSphericalFovYCorrectionCoefficient;
   } else
     mSphericalFovYCorrectionCoefficient = 1.0;

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -751,7 +751,9 @@ void WbWrenCamera::setupSphericalSubCameras() {
     mIsCameraActive[CAMERA_ORIENTATION_LEFT] = true;
     lateralCameraNumber += 2;
   }
-  if (mSphericalFieldOfViewY > 1.230959417) {  // 2.0*asin(1/sqrt(3)) // phi angle of the (Sqrt(3), Sqrt(3), Sqrt(3)) coordinate
+  //   if (mSphericalFieldOfViewY > 1.230959417) {  // 2.0*asin(1/sqrt(3)) // phi angle of the (Sqrt(3), Sqrt(3), Sqrt(3))
+  //   coordinate
+  if (true) {
     mIsCameraActive[CAMERA_ORIENTATION_UP] = true;
     mIsCameraActive[CAMERA_ORIENTATION_DOWN] = true;
     verticalCameraNumber += 2;
@@ -883,17 +885,25 @@ void WbWrenCamera::setCamerasOrientations() {
 }
 
 void WbWrenCamera::setFovy(float fov) {
-  for (int i = 0; i < CAMERA_ORIENTATION_COUNT; ++i) {
+  for (int i = 0; i < CAMERA_ORIENTATION_COUNT - 2; ++i) {  // Skip the UP/DOWN camera
     if (mIsCameraActive[i])
       wr_camera_set_fovy(mCamera[i], fov);
   }
+  if (mIsCameraActive[CAMERA_ORIENTATION_UP])
+    wr_camera_set_fovy(mCamera[CAMERA_ORIENTATION_UP], M_PI - fov);
+  if (mIsCameraActive[CAMERA_ORIENTATION_DOWN])
+    wr_camera_set_fovy(mCamera[CAMERA_ORIENTATION_DOWN], M_PI - fov);
 }
 
 void WbWrenCamera::setAspectRatio(float aspectRatio) {
-  for (int i = 0; i < CAMERA_ORIENTATION_COUNT; ++i) {
+  for (int i = 0; i < CAMERA_ORIENTATION_COUNT - 2; ++i) {  // Skip the UP/DOWN camera
     if (mIsCameraActive[i])
       wr_camera_set_aspect_ratio(mCamera[i], aspectRatio);
   }
+  if (mIsCameraActive[CAMERA_ORIENTATION_UP])
+    wr_camera_set_aspect_ratio(mCamera[CAMERA_ORIENTATION_UP], 1.0);
+  if (mIsCameraActive[CAMERA_ORIENTATION_DOWN])
+    wr_camera_set_aspect_ratio(mCamera[CAMERA_ORIENTATION_DOWN], 1.0);
 }
 
 void WbWrenCamera::updatePostProcessingParameters(int index) {


### PR DESCRIPTION
**Description**

This pull request fixes the issue with missing points in lidar scan.

I was trying (and failing) to fix #5810 and came across this issue. For horizontal FOV higher than around 1 (depends on the vertical FOV), there are corners of points that are missing.

##### Missing points

Looking at `faceCoord` in [merge_spherical.frag](https://github.com/cyberbotics/webots/blob/master/resources/wren/shaders/merge_spherical.frag) I noticed that the values in the corners fall outside the [0, 1] range.
In black pixels where `faceCoord.y` is not within [0, 1]:
![Screenshot from 2023-10-21 16-56-19](https://github.com/cyberbotics/webots/assets/12954392/50fa7718-909a-4039-97f9-e2bd56e7fa4d)
Depth image:
![Screenshot from 2023-10-21 16-54-12](https://github.com/cyberbotics/webots/assets/12954392/ff950c06-03c4-4f16-89e7-ac461e74c706)

Looking at which face of the cube is used for each pixels:
![Screenshot from 2023-10-21 16-54-54](https://github.com/cyberbotics/webots/assets/12954392/c16dc4c7-2eca-4b92-bcca-eb816cb37b72)

As far as I understand the lidar depth is computed by merge_spherical.frag as a depth image using 6 images computed for each side of a cube. However, the 6 images form a flattened cube (depending on the vertical and horizontal FOV). Also, the shape of the camera used to render the top and bottom images was not square but had the same shape as the sides (leading to parts of space not being rendered).

For now I have forced the rendering of the UP and DOWN part of the cube and reworked the code that finds which face to use, leading to the correct face being found and the missing points being rendered.
![Screenshot from 2023-10-21 16-52-13](https://github.com/cyberbotics/webots/assets/12954392/6eee5d56-0e8e-46d9-add0-4b14c31ec17d)
![Screenshot from 2023-10-21 16-58-01](https://github.com/cyberbotics/webots/assets/12954392/6e8c5fde-ecb6-4362-8b0c-6fed4f7ec8f4)

##### Points forming small groups

The issue now is that these points look bad. They form small lines as in (#6344). I think it is because with the resolution used to render the cube multiple points will correspond to the same pixel of the cube (and therefore using the same depth value).

To fix this issue I used `texture` instead of `texelFetch` to get the pixel value with interpolation. This leads to a cleaner point cloud:
![Screenshot from 2023-10-21 17-40-46](https://github.com/cyberbotics/webots/assets/12954392/42bc5498-600c-499f-be17-66b63702153e)

Remaining issue
- the point at the edges of the cube can still look weird because the interpolation doesn't work on the edges
- the interpolation causes false points where there are discontinuities
![Screenshot from 2023-10-21 17-47-38](https://github.com/cyberbotics/webots/assets/12954392/408dde04-74e5-4cf0-b181-6d8926bfc2cf)
- forcing the render of the UP and DOWN part of the cube is not ideal. I think it would be better force the cube to be an actual cube (not flattened) in which case the existing condition should work. I haven't quite figured out how the rendering of the sides works. I the sides are rendered by considering the vertical FOV the missing corner should have started for any horizontal FOV.


**Related Issues**

This pull-request fixes issue #5809 and #6344.

**Additional context**

Test world: [lidar_cylinder_missing_points.zip](https://github.com/cyberbotics/webots/files/13061055/lidar_cylinder_missing_points.zip)  (modified from #5809)
