### PR TITLE
Avoid crashes and better warn when getting PROTO

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -8,7 +8,7 @@ Released on XXX XXth, 2023.
     - Enabled the launching of MATLAB desktop from the extern launcher ([#6366](https://github.com/cyberbotics/webots/pull/6366)). 
     - Improved overlays visible in Overlays menu by adding all the robots in the menu list ([#6297](https://github.com/cyberbotics/webots/pull/6297)).
   - Bug fixes
-    - Avoided crash and provided better warnings when attempting to access PROTO nodes in a wrong way from the supervisor API.
+    - Avoided crash and provided better warnings when attempting to access PROTO nodes in a wrong way from the supervisor API ([#6473](https://github.com/cyberbotics/webots/pull/6473)).
     - Fixed errors loading template PROTO if the system user name, the project path, or the temporary directory path contains the `\` character ([#6288](https://github.com/cyberbotics/webots/pull/6288)).
     - Fixed Webots and libController version comparison not to take revisions into account ([#6315](https://github.com/cyberbotics/webots/pull/6315)).
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).

--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -8,6 +8,7 @@ Released on XXX XXth, 2023.
     - Enabled the launching of MATLAB desktop from the extern launcher ([#6366](https://github.com/cyberbotics/webots/pull/6366)). 
     - Improved overlays visible in Overlays menu by adding all the robots in the menu list ([#6297](https://github.com/cyberbotics/webots/pull/6297)).
   - Bug fixes
+    - Avoided crash and provided better warnings when attempting to access PROTO nodes in a wrong way from the supervisor API.
     - Fixed errors loading template PROTO if the system user name, the project path, or the temporary directory path contains the `\` character ([#6288](https://github.com/cyberbotics/webots/pull/6288)).
     - Fixed Webots and libController version comparison not to take revisions into account ([#6315](https://github.com/cyberbotics/webots/pull/6315)).
     - Fixed translation, rotation and scale displayed in the Position tab of the Node viewer in the scene tree ([#6309](https://github.com/cyberbotics/webots/pull/6309)).

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -503,7 +503,15 @@ WbNode *WbSupervisorUtilities::getProtoParameterNodeInstance(int nodeId, const Q
     mRobot->warn(tr("%1: node not found.").arg(functionName));
     return NULL;
   }
-  return static_cast<WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
+  WbBaseNode *proto = static_cast<WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
+  if (!proto)
+  {
+    if (node->modelName() != node->nodeModelName())
+        mRobot->warn(tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
+      else
+        mRobot->warn(tr("Cannot get the PROTO instance for node '%1'.").arg(node->usefulName()));
+  }
+  return proto;
 }
 
 void WbSupervisorUtilities::changeSimulationMode(int newMode) {
@@ -594,7 +602,8 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       stream >> nodeId;
       const QString &stateName = readString(stream);
       WbNode *const node = getProtoParameterNodeInstance(nodeId, "wb_supervisor_node_load_state()");
-      node->reset(stateName);
+      if (node)
+        node->reset(stateName);
       return;
     }
     case C_SUPERVISOR_NODE_SAVE_STATE: {
@@ -602,7 +611,8 @@ void WbSupervisorUtilities::handleMessage(QDataStream &stream) {
       stream >> nodeId;
       const QString &stateName = readString(stream);
       WbNode *const node = getProtoParameterNodeInstance(nodeId, "wb_supervisor_node_save_state()");
-      node->save(stateName);
+      if (node)
+        node->save(stateName);
       return;
     }
     case C_SUPERVISOR_NODE_SET_JOINT_POSITION: {

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -506,7 +506,8 @@ WbNode *WbSupervisorUtilities::getProtoParameterNodeInstance(int nodeId, const Q
   WbBaseNode *proto = static_cast<WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
   if (!proto) {
     if (node->modelName() != node->nodeModelName())
-        mRobot->warn(tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
+        mRobot->warn(
+          tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
       else
         mRobot->warn(tr("Cannot get the PROTO instance for node '%1'.").arg(node->usefulName()));
   }

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -506,10 +506,10 @@ WbNode *WbSupervisorUtilities::getProtoParameterNodeInstance(int nodeId, const Q
   WbBaseNode *proto = static_cast<WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
   if (!proto) {
     if (node->modelName() != node->nodeModelName())
-        mRobot->warn(
-          tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
-      else
-        mRobot->warn(tr("Cannot get the PROTO instance for node '%1'.").arg(node->usefulName()));
+      mRobot->warn(
+        tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
+    else
+      mRobot->warn(tr("Cannot get the PROTO instance for node '%1'.").arg(node->usefulName()));
   }
   return proto;
 }

--- a/src/webots/nodes/utils/WbSupervisorUtilities.cpp
+++ b/src/webots/nodes/utils/WbSupervisorUtilities.cpp
@@ -504,8 +504,7 @@ WbNode *WbSupervisorUtilities::getProtoParameterNodeInstance(int nodeId, const Q
     return NULL;
   }
   WbBaseNode *proto = static_cast<WbBaseNode *>(node)->getFirstFinalizedProtoInstance();
-  if (!proto)
-  {
+  if (!proto) {
     if (node->modelName() != node->nodeModelName())
         mRobot->warn(tr("Cannot get the PROTO instance for node '%1' (derived from '%2').").arg(node->usefulName(), node->nodeModelName()));
       else


### PR DESCRIPTION
Avoid crashes and better warn when getting the PROTO in `WbSupervisorUtilities::getProtoParameterNodeInstance()`.

**Description**
I discovered the bug when we used a cache to save nodes in Python. When calling `getPose()` or `getPosition()` we got an error message that `wb_supervisor_node_get_position() can exclusively be used with Pose (or derived)`. Now, the error message is `Cannot get the PROTO instance for node `LED` (type LED).` plus the old message. This helped me fixing the bug in our code.

**Related Issues**
None

**Tasks**
Add the list of tasks of this PR.
  - [ ] Translate the strings

**Documentation**
No documentation change

**Additional context**
We probably save the result of `getMFNode()` in Python too soon because the pointed object is not a valid node later in our code (maybe the pointer changes when changing the DEF?).
