### PR TITLE
Fix jnilibs flags

### DIFF
--- a/docs/reference/changelog-r2023.md
+++ b/docs/reference/changelog-r2023.md
@@ -18,6 +18,8 @@ Released on XXX XXth, 2023.
     - Fixed values returned by the [Receiver.getEmitterDirection](https://cyberbotics.com/doc/reference/receiver?tab-language=python#wb_receiver_get_emitter_direction) Python method ([#6394](https://github.com/cyberbotics/webots/pull/6394)).
     - Fixed recognition of omnidirectional cameras with fov > pi/2 in [WbObjectDetection] ([#6396](https://github.com/cyberbotics/webots/pull/6396)).
     - Fixed [ElevationGrid](elevationgrid.md) collisions not matching the displayed when the x and y dimensions are different ([#6412](https://github.com/cyberbotics/webots/pull/6412))
+    - Fixed JNILIB_FLAGS relative reference for Java controllers ([#5181](https://github.com/cyberbotics/webots/issues/5181))
+
     
 ## Webots R2023b
 Released on June 28th, 2023.

--- a/src/controller/java/Makefile
+++ b/src/controller/java/Makefile
@@ -113,7 +113,7 @@ CFLAGS1               = -isysroot $(MACOSX_SDK_PATH) -mmacosx-version-min=$(MACO
 PLATFORM_INCLUDE      = -I"$(MACOSX_SDK_PATH)/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers"
 TARGET                = $(WEBOTS_CONTROLLER_LIB_PATH)/java/lib$(LIBNAME).jnilib
 CFLAGS2               = -c -Wall -isysroot $(MACOSX_SDK_PATH) -mmacosx-version-min=$(MACOSX_MIN_SDK_VERSION) -Wno-unused-function
-JNILIB_FLAGS          = -dynamiclib -install_name @rpath/Contents/lib/controller/java/libJavaController.jnilib -Wl,-rpath,@loader_path/../../..
+JNILIB_FLAGS          = -dynamiclib -install_name @rpath/Contents/lib/controller/java/libJavaController.jnilib -Wl,-rpath,@loader_path/../../../..
 JAVA_INCLUDES         = -I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/darwin"
 LIBCONTROLLER         = $(WEBOTS_CONTROLLER_LIB_PATH)/libController.dylib
 LIBCPPCONTROLLER      = $(WEBOTS_CONTROLLER_LIB_PATH)/libCppController.dylib


### PR DESCRIPTION
**Description**
Ensure that libController.dylib can be found on MacOS by fixing the relative path in JNILIB_FLAGS.

**Related Issues**
This pull-request fixes issue #5181

**Tasks**
  - [X] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2023.md)
  - [ ] Test whether this also fixes the issue when running with other JVM/JDKs


