### PR TITLE
remove position from crazyflie proto

### DIFF
--- a/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto
+++ b/projects/robots/bitcraze/crazyflie/protos/Crazyflie.proto
@@ -29,7 +29,6 @@ PROTO Crazyflie [
     synchronization IS synchronization
     name IS name
     model "Bitcraze's Crazyflie"
-    translation 0 0 0.015
     children [
       DEF BODY Pose {
         translation 0 0 -0.015


### PR DESCRIPTION

**Description**
This simple change to the crazyflie proto should fix the bug where upon reset the crazyflie goes back to 0.0 position


**Related Issues**
This pull-request fixes issue #6467 

**Tasks**
N/A

**Documentation**
N/A

**Screenshots**
N/A

**Additional context**
N/A