### PR TITLE
build with ros in Ubuntu 22.04/23.04 

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -6,9 +6,10 @@ on:
   schedule:
     - cron:  '0 23 * * *'
   push:
-    tags:
-      - nightly_*
-      - R20*
+  #  tags:
+  #    - nightly_*
+  #    - R20*
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -68,6 +68,7 @@ jobs:
         export PATH=$JAVA_HOME/bin:$PATH
         export LIBGL_ALWAYS_SOFTWARE=true
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
+        source /opt/ros/$ROS_DISTRO/setup.bash || true
         xvfb-run --auto-servernum make distrib -j4
     - name: Create/Update GitHub release
       if: ${{ matrix.os == 'ubuntu-20.04' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -1,10 +1,8 @@
 name: Linux build (develop)
 
 on:
-  push:
   schedule:
     - cron:  '0 23 * * *'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -1,8 +1,10 @@
 name: Linux build (develop)
 
 on:
+  push:
   schedule:
     - cron:  '0 23 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/nothings/stb.git
 [submodule "resources/webots_ros"]
 	path = resources/webots_ros
-	url = https://github.com/cyberbotics/webots_ros
+	url = https://github.com/lucasw/webots_ros

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -64,17 +64,12 @@ include/services/%.h: $(WEBOTS_HOME_PATH)/resources/webots_ros/srv/%.srv include
 	@echo "# generating service header" $(notdir $<)
 	$(SILENT)$(PYTHON_COMMAND) headersFromSRV.py $<
 
-ifeq ($(ROS_PATH),noetic)
+ifeq ($(ROS_DISTRO),noetic)
  INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include -isystem /opt/ros/$(ROS_DISTRO)/include
-else
- INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
-endif
-
-# include ros libraries
-
-ifeq ($(ROS_PATH),noetic)
+ # include ros libraries
  LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
 else
+ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
  LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system
 endif
 

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -35,17 +35,16 @@ ifeq ($(OSTYPE),linux)
  CFLAGS = -std=c++11
 endif
 
+
 PYTHON_COMMAND ?= python3
-ifeq (, $(ROS_DISTRO))
-release debug profile clean:
-	@$(ECHO) "# \033[0;33mROS not installed or 'ROS_DISTRO' not defined\033[0m"
-else
 ifeq (2, $(ROS_VERSION))
 release debug profile clean:
-	@$(ECHO) "# \033[0;33mROS_DISTRO should not be a ROS2 distribution\033[0m"
+	@$(ECHO) "# \033[0;33mROS_VERSION should not be a ROS2 distribution\033[0m"
 else
 CXX_SOURCES = $(wildcard *.cpp)
-CXX_SOURCES += $(wildcard highlevel/*.cpp)
+# neither of these work with ros_control
+# CXX_SOURCES += highlevel/RosControl.cpp
+# CXX_SOURCES += highlevel/WebotsHW.cpp
 
 ifeq ($(OSTYPE),windows)
  ros.exe: $(CXX_SOURCES:.cxx=.d)
@@ -65,11 +64,11 @@ include/services/%.h: $(WEBOTS_HOME_PATH)/resources/webots_ros/srv/%.srv include
 	@echo "# generating service header" $(notdir $<)
 	$(SILENT)$(PYTHON_COMMAND) headersFromSRV.py $<
 
-INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include -isystem /opt/ros/$(ROS_DISTRO)/include
+INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)
@@ -97,5 +96,4 @@ FILES_TO_REMOVE += include/webots_ros include/messages include/services headersG
 ### Do not modify: this includes Webots global Makefile.include
 
 include $(WEBOTS_HOME_PATH)/resources/Makefile.include
-endif
 endif

--- a/projects/default/controllers/ros/Makefile
+++ b/projects/default/controllers/ros/Makefile
@@ -64,11 +64,20 @@ include/services/%.h: $(WEBOTS_HOME_PATH)/resources/webots_ros/srv/%.srv include
 	@echo "# generating service header" $(notdir $<)
 	$(SILENT)$(PYTHON_COMMAND) headersFromSRV.py $<
 
-INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
+ifeq ($(ROS_PATH),noetic)
+ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include -isystem /opt/ros/$(ROS_DISTRO)/include
+else
+ INCLUDE = -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
+endif
 
 # include ros libraries
 
-LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system
+ifeq ($(ROS_PATH),noetic)
+ LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+else
+ LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system
+endif
+
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/default/controllers/ros/Ros.cpp
+++ b/projects/default/controllers/ros/Ros.cpp
@@ -45,7 +45,7 @@
 #include "RosSupervisor.hpp"
 #include "RosTouchSensor.hpp"
 #include "RosVacuumGripper.hpp"
-#include "highlevel/RosControl.hpp"
+// #include "highlevel/RosControl.hpp"
 
 #include <webots/Node.hpp>
 #include <webots/Supervisor.hpp>
@@ -54,7 +54,7 @@
 
 #include <algorithm>
 #include <ctime>
-#include "ros/master.h"
+#include <ros/master.h>
 #include "std_msgs/String.h"
 
 // IP resolution includes
@@ -80,11 +80,11 @@ Ros::Ros() :
   mIsSynchronized(false),
   mUseWebotsSimTime(false),
   mAutoPublish(false),
-  mUseRosControl(false),
+  // mUseRosControl(false),
   mRosNameSpace(""),
   mRobotDescriptionPrefix(""),
-  mSetRobotDescription(false),
-  mRosControl(NULL) {
+  mSetRobotDescription(false) {
+  //mRosControl(NULL) {
 }
 
 Ros::~Ros() {
@@ -109,7 +109,7 @@ Ros::~Ros() {
 
   ros::shutdown();
   delete mRobot;
-  delete mRosControl;
+  // delete mRosControl;
   for (unsigned int i = 0; i < mDeviceList.size(); i++)
     delete mDeviceList[i];
   delete mRosJoystick;
@@ -148,7 +148,8 @@ void Ros::launchRos(int argc, char **argv) {
     else if (strcmp(argv[i], "--use-sim-time") == 0)
       mUseWebotsSimTime = true;
     else if (strcmp(argv[i], "--use-ros-control") == 0)
-      mUseRosControl = true;
+      ROS_ERROR("no ros control in this version");
+    //   mUseRosControl = true;
     else if (strcmp(argv[i], "--auto-publish") == 0)
       mAutoPublish = true;
     else if (std::string(argv[i]).rfind("--robot-description") == 0) {
@@ -477,8 +478,8 @@ void Ros::run(int argc, char **argv) {
   if (mSetRobotDescription)
     mNodeHandle->setParam("robot_description", mRobot->getUrdf(mRobotDescriptionPrefix));
 
-  if (mUseRosControl)
-    mRosControl = new highlevel::RosControl(mRobot, mNodeHandle);
+  // if (mUseRosControl)
+  //   mRosControl = new highlevel::RosControl(mRobot, mNodeHandle);
 
   while (!mEnd && ros::ok()) {
     if (!ros::master::check()) {
@@ -486,8 +487,8 @@ void Ros::run(int argc, char **argv) {
       mEnd = true;
     }
 
-    if (mRosControl)
-      mRosControl->read();
+    // if (mRosControl)
+    //   mRosControl->read();
 
     publishClockIfNeeded();
     for (unsigned int i = 0; i < mSensorList.size(); i++)
@@ -502,8 +503,8 @@ void Ros::run(int argc, char **argv) {
     } else if (step(mRobot->getBasicTimeStep()) == -1)
       mEnd = true;
 
-    if (mRosControl)
-      mRosControl->write();
+    // if (mRosControl)
+    //   mRosControl->write();
     if (!mIsSynchronized)
       mStep++;
   }

--- a/projects/default/controllers/ros/Ros.hpp
+++ b/projects/default/controllers/ros/Ros.hpp
@@ -30,7 +30,8 @@
 #include <webots_ros/robot_set_mode.h>
 #include <webots_ros/robot_wait_for_user_input_event.h>
 
-#include <highlevel/RosControl.hpp>
+// temp disable until controller_manager.h is in Ubuntu Debian ros
+// #include <highlevel/RosControl.hpp>
 
 using namespace webots;
 
@@ -122,11 +123,11 @@ private:
   bool mIsSynchronized;
   bool mUseWebotsSimTime;
   bool mAutoPublish;
-  bool mUseRosControl;
+  // bool mUseRosControl;
   std::string mRosNameSpace;
   std::string mRobotDescriptionPrefix;
   bool mSetRobotDescription;
-  highlevel::RosControl *mRosControl;
+  // highlevel::RosControl *mRosControl;
 };
 
 #endif  // ROS_HPP

--- a/projects/default/controllers/ros/include/templateHeader.h
+++ b/projects/default/controllers/ros/include/templateHeader.h
@@ -17,7 +17,7 @@
 #ifndef WEBOTS_ROS_MESSAGE_%SERVICE_NAME%_H
 #define WEBOTS_ROS_MESSAGE_%SERVICE_NAME%_H
 
-#include "ros/service_traits.h"
+#include <ros/service_traits.h>
 
 #include "%service_name%Request.h"
 #include "%service_name%Response.h"

--- a/projects/default/controllers/ros/include/templateRequest.h
+++ b/projects/default/controllers/ros/include/templateRequest.h
@@ -21,10 +21,10 @@
 #include <vector>
 #include <map>
 
-#include "ros/types.h"
-#include "ros/serialization.h"
-#include "ros/builtin_message_traits.h"
-#include "ros/message_operations.h"
+#include <ros/types.h>
+#include <ros/serialization.h>
+#include <ros/builtin_message_traits.h>
+#include <ros/message_operations.h>
 
 %addedheaders%
 

--- a/projects/default/controllers/ros/include/templateResponse.h
+++ b/projects/default/controllers/ros/include/templateResponse.h
@@ -21,10 +21,10 @@
 #include <vector>
 #include <map>
 
-#include "ros/types.h"
-#include "ros/serialization.h"
-#include "ros/builtin_message_traits.h"
-#include "ros/message_operations.h"
+#include <ros/types.h>
+#include <ros/serialization.h>
+#include <ros/builtin_message_traits.h>
+#include <ros/message_operations.h>
 
 %addedheaders%
 

--- a/projects/vehicles/controllers/ros_automobile/Makefile
+++ b/projects/vehicles/controllers/ros_automobile/Makefile
@@ -41,12 +41,17 @@ else
  ros_automobile: $(CXX_SOURCES:.cxx=.d)
 endif
 
-INCLUDE = -I$(WEBOTS_HOME_PATH)/projects/default/controllers/ros -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
+ifeq ($(ROS_DISTRO),noetic)
+ INCLUDE = -I$(WEBOTS_HOME_PATH)/projects/default/controllers/ros -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include -isystem /opt/ros/$(ROS_DISTRO)/include
+ # include ros libraries
+ LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+else
+ INCLUDE = -I$(WEBOTS_HOME_PATH)/projects/default/controllers/ros -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
+ LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system  # -lcontroller_manager
+endif
+
 LIBRARIES += -lCppDriver -lCppCar -ldriver -lcar
 
-# include ros libraries
-
-LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system  # -lcontroller_manager
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)

--- a/projects/vehicles/controllers/ros_automobile/Makefile
+++ b/projects/vehicles/controllers/ros_automobile/Makefile
@@ -24,21 +24,16 @@ WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 include $(WEBOTS_HOME_PATH)/resources/Makefile.os.include
 
 ifeq ($(OSTYPE),linux)
- CFLAGS = -std=c++11
+ CFLAGS = -std=c++17
 endif
 
-PYTHON_COMMAND ?= python3
-ifeq (, $(ROS_DISTRO))
-release debug profile clean:
-	@$(ECHO) "# \033[0;33mROS not installed or 'ROS_DISTRO' not defined\033[0m"
-else
 ifeq (2, $(ROS_VERSION))
 release debug profile clean:
-	@$(ECHO) "# \033[0;33mROS_DISTRO should not be a ROS2 distribution\033[0m"
+	@$(ECHO) "# \033[0;33mROS_VERSION should not be a ROS2 distribution\033[0m"
 else
 CXX_SOURCES = $(wildcard *.cpp)
 CXX_SOURCES += $(wildcard $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/Ros*.cpp)
-CXX_SOURCES += $(wildcard $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/highlevel/*.cpp)
+# CXX_SOURCES += $(wildcard $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/highlevel/*.cpp)
 
 ifeq ($(OSTYPE),windows)
  ros_automobile.exe: $(CXX_SOURCES:.cxx=.d)
@@ -46,12 +41,12 @@ else
  ros_automobile: $(CXX_SOURCES:.cxx=.d)
 endif
 
-INCLUDE = -I$(WEBOTS_HOME_PATH)/projects/default/controllers/ros -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include -isystem /opt/ros/$(ROS_DISTRO)/include
+INCLUDE = -I$(WEBOTS_HOME_PATH)/projects/default/controllers/ros -isystem $(WEBOTS_HOME_PATH)/projects/default/controllers/ros/include
 LIBRARIES += -lCppDriver -lCppCar -ldriver -lcar
 
 # include ros libraries
 
-LIBRARIES += -L/opt/ros/$(ROS_DISTRO)/lib -Wl,-rpath-link=/opt/ros/$(ROS_DISTRO)/lib -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lcontroller_manager -lboost_system
+LIBRARIES += -W -lxmlrpcpp -lcpp_common -lrosconsole_backend_interface -lroscpp -lrosconsole -lrosconsole_log4cxx -lroscpp_serialization -lrostime -lboost_system  # -lcontroller_manager
 ifeq ($(OSTYPE),windows)
  LIBRARIES += -lws2_32
  ifeq ($(MAKECMDGOALS),debug)
@@ -75,5 +70,4 @@ CFLAGS += -std=c++11
 endif
 
 include $(WEBOTS_HOME_PATH)/resources/Makefile.include
-endif
 endif

--- a/scripts/install/linux_test_dependencies.sh
+++ b/scripts/install/linux_test_dependencies.sh
@@ -22,8 +22,14 @@ if [[ $@ != *"--exclude-ros"* ]]; then
          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
          apt update -qq
          apt install -y ros-$ROS_DISTRO-ros-base ros-$ROS_DISTRO-sensor-msgs ros-$ROS_DISTRO-tf ros-$ROS_DISTRO-ros-controllers ros-$ROS_DISTRO-controller-manager ros-$ROS_DISTRO-ros-control ros-$ROS_DISTRO-class-loader ros-$ROS_DISTRO-roslib liburdfdom-tools
+         apt install -y ros-$ROS_DISTRO-*msgs
          apt install -y python3-rosdep
-  elif [[ $UBUNTU_VERSION != "22.04" ]]; then
+  elif [[ $UBUNTU_VERSION == "22.04" ]]; then
+         echo "Adding ROS dependencies"
+         apt update -qq
+         apt install -y ros-*
+         apt install -y *-msgs-dev
+  else
          echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."
   fi
 fi


### PR DESCRIPTION
**Description**

This builds and runs in Ubuntu 23.04, and probably also in 22.04 (it builds in CI).  It loses some functionality in the process which is why this is just a draft, maybe it can be useful for anyone else want to use webots and ros in 22.04 or later.

**Tasks**
Add the list of tasks of this PR.
  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2023.md)
  - [ ] Update the documentation (if needed)

**Additional context**

The packages available in Ubuntu from Debian with apt install ros-* (as opposed to install ros-noetic* in 20.04 with the build farm configured) are almost enough to make all of the webots ros code build, except controller manager and moveit aren't there so I've had to disable the code depending on those- a conditionally building them would be preferable of course.

There are a lot of commits trying to get the github action for 20.04 to build, once it works most of those could be squashed down to clean it up- the 22.04 ci does seem to be passing and is building the ros code (earlier it was skipping over it).
