### PR TITLE
Update generate_proto_list.py

### DIFF
--- a/scripts/packaging/generate_proto_list.py
+++ b/scripts/packaging/generate_proto_list.py
@@ -44,7 +44,7 @@ class ProtoInfo:
         self.needs_robot_ancestor = False
 
         # store file contents to avoid reading it multiple times
-        with open(self.path, 'r') as file:
+        with open(self.path, 'r', encoding='utf-8') as file:
             self.contents = file.read()
             # remove IndexedFaceSet related fields since they significantly slow down the subsequent regex
             self.contents = re.sub(r'point\s+\[[^\]]+\]', '', self.contents)


### PR DESCRIPTION
In Chinese Windows System，”open“ will  generate error: 

generating resources/proto-list.xml from PROTO files with prefix "webots://"
Traceback (most recent call last):
  File "E:/msys64/home/AAA/webots/scripts/packaging/generate_proto_list.py", line 241, in <module>
    generate_proto_list(tag)
  File "E:/msys64/home/AAA/webots/scripts/packaging/generate_proto_list.py", line 143, in generate_proto_list
    info = ProtoInfo(str(asset), asset.stem)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:/msys64/home/AAA/webots/scripts/packaging/generate_proto_list.py", line 48, in __init__
    self.contents = file.read()
                    ^^^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 547: illegal multibyte sequence
make: *** [Makefile:128: webots_dependencies] Error 1
make: *** Waiting for unfinished jobs.... 

