### PR TITLE
Fix missing pi offset after merge of #6417

### DIFF
--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -428,7 +428,7 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double cosdTheta = cos(dtheta);
   const double sindTheta = sin(dtheta);
   const double theta0 =
-    mIsActuallyRotating ? (minWidth * dtheta) - M_PI : (actualFieldOfView() / 2 + minWidth * dtheta + dtheta / 2);
+    mIsActuallyRotating ? minWidth * dtheta - M_PI : actualFieldOfView() / 2 + minWidth * dtheta + dtheta / 2;
   const double cosTheta0 = cos(theta0);
   const double sinTheta0 = sin(theta0);
 

--- a/src/webots/nodes/WbLidar.cpp
+++ b/src/webots/nodes/WbLidar.cpp
@@ -427,7 +427,8 @@ void WbLidar::updatePointCloud(int minWidth, int maxWidth) {
   const double dtheta = mIsActuallyRotating ? (-2 * M_PI / (double)resolution) : (-actualFieldOfView() / w);
   const double cosdTheta = cos(dtheta);
   const double sindTheta = sin(dtheta);
-  const double theta0 = mIsActuallyRotating ? (minWidth * dtheta) : (actualFieldOfView() / 2 + minWidth * dtheta + dtheta / 2);
+  const double theta0 =
+    mIsActuallyRotating ? (minWidth * dtheta) - M_PI : (actualFieldOfView() / 2 + minWidth * dtheta + dtheta / 2);
   const double cosTheta0 = cos(theta0);
   const double sinTheta0 = sin(theta0);
 


### PR DESCRIPTION
**Description**

Rotating lidars produced points rotate by 180 degrees.

On develop, #6324 introduced changes to the rotating lidar to produce lidar images ranging from -M_PI to +M_PI instead of 0 to 2*M_PI. On master, #6417 fixed a few issues with the point cloud computation for some FOVs. Both change modified the way `theta0` is computed (one for rotating lidar and the other for fixed lidar). The changes made by #6324 were lost when #6417 was merged.

**Related Issues**

This bug was first identified in #6505