### PR TITLE
Fixed Windows compilation on the CI worker

### DIFF
--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #ifdef _WIN32
-#include <windows.h>
 #include <dwmapi.h>
+#include <windows.h>
 #include <QtGui/QWindow>
 #endif
 

--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef _WIN32
+#include <windows.h>
+#include <dwmapi.h>
+#include <QtGui/QWindow>
+#endif
+
 #include "WbGuiApplication.hpp"
 
 #include "WbApplication.hpp"
@@ -492,10 +498,6 @@ void WbGuiApplication::loadInitialWorld() {
 }
 
 #ifdef _WIN32
-#include <Windows.h>
-#include <dwmapi.h>
-#include <QtGui/QWindow>
-
 static bool windowsDarkMode = false;
 
 enum PreferredAppMode { Default, AllowDark, ForceDark, ForceLight, Max };

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -40,6 +40,10 @@
 
 #include <QtCore/QDataStream>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #define SHIFT(value, shift) (((value) >> (shift)) & 0xFF)
 
 class WbDisplayImage {


### PR DESCRIPTION
Fixes compilation error in the CI:
```
nodes/WbDisplay.cpp: In member function 'void WbDisplay::drawText(const char*, int, int)':
nodes/WbDisplay.cpp:718:27: error: 'CP_UTF8' was not declared in this scope
  718 |   l = MultiByteToWideChar(CP_UTF8, 0, txt, -1, text, l + 1) - 1;
      |                           ^~~~~~~
nodes/WbDisplay.cpp:718:7: error: 'MultiByteToWideChar' was not declared in this scope
  718 |   l = MultiByteToWideChar(CP_UTF8, 0, txt, -1, text, l + 1) - 1;
      |       ^~~~~~~~~~~~~~~~~~~
```
