### PR TITLE
Add libssl to MSys2 Windows Distribution

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -9,5 +9,5 @@ Released on December **th, 2023.
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
   - Bug Fixes
-    - Fixed error message on Windows when `libssl-3-x64.dll` was added to `PATH` ([#6553]((https://github.com/cyberbotics/webots/pull/6553)).
+    - Fixed error message on Windows when `libssl-3-x64.dll` was added to `PATH` ([#6553](https://github.com/cyberbotics/webots/pull/6553)).
 

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -8,3 +8,6 @@ Released on December **th, 2023.
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
+  - Bug Fixes
+    - Fixed error message on Windows when `libssl-3-x64.dll` was added to `PATH` ([#6553]((https://github.com/cyberbotics/webots/pull/6553)).
+

--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -18,6 +18,7 @@
 /mingw64/bin/libpcre2-8-0.dll
 /mingw64/bin/libpcre2-16-0.dll
 /mingw64/bin/libpng16-16.dll
+/mingw64/bin/libssl-3-x64.dll
 /mingw64/bin/Qt6Core.dll
 /mingw64/bin/Qt6Gui.dll
 /mingw64/bin/Qt6Network.dll


### PR DESCRIPTION
**Description**
Adds libssl to the packaged msys2 distribution in order to prevent Webots from looking for it in other msys2 installs.

**Related Issues**
This pull-request fixes issue #6503.

**Tasks**
  - [x] Fix "entry point `BIO_err_is_non_fatal` error message"
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2023.md)
