### PR TITLE
Update PR template to Refer to 2024 Changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ This pull-request fixes issue #
 
 **Tasks**
 Add the list of tasks of this PR.
-  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2023.md)
+  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
   - [ ] Update the documentation (if needed)
   - [ ] Task 1
   - [ ] Task 2


### PR DESCRIPTION
**Description**
Given that (I assume) new PRs are going to be released as part of R2024, they should be recorded in the 2024 changelog. This PR updates the default changelog link in the PR template to refer to [`changelog-r2024.md`](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md).

**Tasks**
  - [x] Update PR template changelog link
