### PR TITLE
Fix getPose() returning arrays of length 3 in Java.

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -10,4 +10,4 @@ Released on December **th, 2023.
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
   - Bug Fixes
     - Fixed error message on Windows when `libssl-3-x64.dll` was added to `PATH` ([#6553](https://github.com/cyberbotics/webots/pull/6553)).
-    - Fixed length of arrays returned by `getPose()` in Java ([#6328](https://github.com/cyberbotics/webots/pull/6556)).
+    - Fixed length of arrays returned by `getPose()` in Java ([#6556](https://github.com/cyberbotics/webots/pull/6556)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -9,4 +9,4 @@ Released on December **th, 2023.
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
   - Bug fixes
-    - Fixed length of arrays returned by `getPose()` in Java ([#6328](https://github.com/cyberbotics/webots/pull/6555)).
+    - Fixed length of arrays returned by `getPose()` in Java ([#6328](https://github.com/cyberbotics/webots/pull/6556)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -8,3 +8,5 @@ Released on December **th, 2023.
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
+  - Bug fixes
+    - Fixed length of arrays returned by `getPose()` in Java ([#6328](https://github.com/cyberbotics/webots/pull/6555)).

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -83,10 +83,10 @@ using namespace std;
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 6);
   else if (test == "getOrientation" || test == "virtualRealityHeadsetGetOrientation")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 9);
+  else if (test == "getPose")
+    $result = SWIG_JavaArrayOutDouble(jenv, $1, 16);
   else if (test != "getLookupTable")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 3);
-  else if (test != "getPose")
-    $result = SWIG_JavaArrayOutDouble(jenv, $1, 16);
 }
 %apply double[] {double *};
 


### PR DESCRIPTION
**Description**
getPose() in Java was returning arrays of length 3 instead of 16.

**Related Issues**
This pull-request fixes issue #

**Tasks**
Add the list of tasks of this PR.
  - [ x ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
