### PR TITLE
[Controller API (Java)] Fix Length of Arrays Returned by `CameraRecognitionObject.getColors()`

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -11,3 +11,5 @@ Released on December **th, 2023.
   - Bug Fixes
     - Fixed error message on Windows when `libssl-3-x64.dll` was added to `PATH` ([#6553](https://github.com/cyberbotics/webots/pull/6553)).
     - Fixed length of arrays returned by `getPose()` in Java ([#6556](https://github.com/cyberbotics/webots/pull/6556)).
+    - Fixed length of arrays returned by `CameraRecognitionObject.getColors()` in Java ([#6564](https://github.com/cyberbotics/webots/pull/6564))
+    

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -230,7 +230,7 @@ namespace webots {
   }
   const double *getColor(int index) const {
     const double *colors = $self->colors;
-    return colors[index];
+    return &colors[3*index];
   }
 };
 

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -85,6 +85,8 @@ using namespace std;
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 9);
   else if (test == "getPose")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 16);
+  else if (test == "getColor")
+    $result = SWIG_JavaArrayOutDouble(jenv, $1, 3);
   else if (test != "getLookupTable")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 3);
 }
@@ -207,6 +209,7 @@ namespace webots {
 %javamethodmodifiers position_on_image "private"
 %javamethodmodifiers size_on_image "private"
 %javamethodmodifiers number_of_colors "private"
+%javamethodmodifiers colors "private"
 
 %typemap(out) int [] {
   $result = SWIG_JavaArrayOutInt(jenv, $1, 2);
@@ -224,6 +227,10 @@ namespace webots {
   }
   int getNumberOfColors() const {
     return $self->number_of_colors;
+  }
+  const double *getColor(int index) const {
+    const double *colors = $self->colors;
+    return colors[index];
   }
 };
 

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -85,12 +85,14 @@ using namespace std;
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 9);
   else if (test == "getPose")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 16);
-  else if (test == "getColor")
-    $result = SWIG_JavaArrayOutDouble(jenv, $1, 3);
-  else if (test != "getLookupTable")
+  else if (test != "colors" && test != "getLookupTable")
     $result = SWIG_JavaArrayOutDouble(jenv, $1, 3);
 }
 %apply double[] {double *};
+
+%typemap(out) double *colors {
+  $result = SWIG_JavaArrayOutDouble(jenv, (double *) $1, arg1->number_of_colors*3);
+}
 
 %typemap(out) const double *getLookupTable {
   $result = SWIG_JavaArrayOutDouble(jenv, (double *) $1, arg1->getLookupTableSize()*3);
@@ -209,7 +211,6 @@ namespace webots {
 %javamethodmodifiers position_on_image "private"
 %javamethodmodifiers size_on_image "private"
 %javamethodmodifiers number_of_colors "private"
-%javamethodmodifiers colors "private"
 
 %typemap(out) int [] {
   $result = SWIG_JavaArrayOutInt(jenv, $1, 2);
@@ -227,10 +228,6 @@ namespace webots {
   }
   int getNumberOfColors() const {
     return $self->number_of_colors;
-  }
-  const double *getColor(int index) const {
-    const double *colors = $self->colors;
-    return &colors[3*index];
   }
 };
 


### PR DESCRIPTION
**Description**
`CameraRecognitionObject.getColors()` is supposed to return an array of length `3*CameraRecognitionObject.getNumberOfColors()`. At the moment, the returned array is truncated to always have a length of `3`. Thus, only the first color can be retrieved. This PR updates the API so that an array of the correct length is returned.

**Tasks**
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
