### PR TITLE
Canged code to convert compass readings into a bearing

### DIFF
--- a/docs/reference/compass.md
+++ b/docs/reference/compass.md
@@ -179,7 +179,7 @@ Now if the [Compass](#compass) node is in *upright* position, meaning that its z
 double get_bearing_in_degrees() {
   const double *north = wb_compass_get_values(tag);
   double rad = atan2(north[1], north[0]);
-  double bearing = (rad - 1.5708) / M_PI * 180.0;
+  double bearing = (rad / M_PI) * 180.0;
   if (bearing < 0.0)
     bearing = bearing + 360.0;
   return bearing;


### PR DESCRIPTION
Changed example code to convert compass readings into a bearing since it produced an angle using the x-axis as north rather than the y-axis as explained in the description above it.

**Description**
The example code in the compass page of the documentation for computing the bearing in degrees from compass readings produces the incorrect output or it is misleading given the description above it. This is caused by the function adjusting the produced angle to consider the positive x-axis as the north direction rather than the positive y-axis as described in the description above the example code in the documentation.

**Related Issues**
None.

**Tasks**
No tasks.

**Documentation**
Original documentation: https://cyberbotics.com/doc/reference/compass?version=R2023b
Also present in the main branch documentation: https://cyberbotics.com/doc/reference/compass?version=master

**Screenshots**
None.

**Additional context**
I noticed this after using this function in a project and later having issues understanding why my headings where wrong.
