### PR TITLE
Fix #6578 `Device`s with Duplicate Names Cause Unexpected Behavior

### DIFF
--- a/docs/reference/robot.md
+++ b/docs/reference/robot.md
@@ -766,11 +766,12 @@ WbDeviceTag wb_robot_get_device(const char *name);
 namespace webots {
   class Robot {
     Accelerometer *getAccelerometer(const std::string &name);
-    Altimeter *getAltimeter(const std::string &name);    
+    Altimeter *getAltimeter(const std::string &name);
     Brake *getBrake(const std::string &name);
     Camera *getCamera(const std::string &name);
     Compass *getCompass(const std::string &name);
     Connector *getConnector(const std::string &name);
+    Device *getDevice(const std::string &name);
     Display *getDisplay(const std::string &name);
     DistanceSensor *getDistanceSensor(const std::string &name);
     Emitter *getEmitter(const std::string &name);
@@ -826,6 +827,7 @@ public class Robot {
   public Camera getCamera(String name);
   public Compass getCompass(String name);
   public Connector getConnector(String name);
+  public Device getDevice(String name);
   public Display getDisplay(String name);
   public DistanceSensor getDistanceSensor(String name);
   public Emitter getEmitter(String name);
@@ -874,7 +876,7 @@ Devices are available through their services.
 
 *get a unique identifier to a device*
 
-The `wb_robot_get_device` function (available in C, Python and MATLAB) returns a unique identifier for a device corresponding to a specified `name`.
+The `wb_robot_get_device` function returns a unique identifier for a device corresponding to a specified `name`.
 For example, if a robot contains a [DistanceSensor](distancesensor.md) node whose `name` field is "ds1", the function will return the unique identifier of that device.
 This `WbDeviceTag` identifier will be used subsequently for enabling, sending commands to, or reading data from this device.
 If the specified device is not found, the function returns 0 in C and MATLAB or `None` in Python.
@@ -884,6 +886,8 @@ These functions return a reference to an object corresponding to a specified `na
 Depending on the called function, this object can be an instance of a `Device` subclass.
 For example, if a robot contains a [DistanceSensor](distancesensor.md) node whose `name` field is "ds1", the function `getDistanceSensor` will return a reference to a [DistanceSensor](distancesensor.md) object.
 If the specified device is not found, the function returns `NULL` in C++ or `null` in Java.
+
+Note that if any two devices share the same name, `wb_robot_get_device` will return the first one it finds. In order to distinguish between devices with the same name, users should consider iterating over a robot's devices using `wb_robot_get_device_by_index` and `wb_robot_get_number_of_devices`.
 
 ---
 

--- a/include/controller/cpp/webots/Accelerometer.hpp
+++ b/include/controller/cpp/webots/Accelerometer.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Accelerometer : public Device {
   public:
     explicit Accelerometer(const std::string &name) : Device(name) {}  // Use Robot::getAccelerometer() instead
+    explicit Accelerometer(WbDeviceTag tag) : Device(tag) {}
     virtual ~Accelerometer() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Altimeter.hpp
+++ b/include/controller/cpp/webots/Altimeter.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Altimeter : public Device {
   public:
     explicit Altimeter(const std::string &name) : Device(name) {}  // Use Robot::getAltimeter instead
+    explicit Altimeter(WbDeviceTag tag) : Device(tag) {}
     virtual ~Altimeter() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Brake.hpp
+++ b/include/controller/cpp/webots/Brake.hpp
@@ -31,6 +31,11 @@ namespace webots {
       motor(NULL),
       positionSensor(NULL) {}  // Use Robot::getBrake() instead
     virtual ~Brake() {}
+    explicit Brake(WbDeviceTag tag) :
+      Device(tag),
+      motor(NULL),
+      positionSensor(NULL) {}
+    virtual ~Brake() {}
     Type getType() const;
     void setDampingConstant(double dampingConstant) const;
 

--- a/include/controller/cpp/webots/Brake.hpp
+++ b/include/controller/cpp/webots/Brake.hpp
@@ -30,7 +30,6 @@ namespace webots {
       Device(name),
       motor(NULL),
       positionSensor(NULL) {}  // Use Robot::getBrake() instead
-    virtual ~Brake() {}
     explicit Brake(WbDeviceTag tag) :
       Device(tag),
       motor(NULL),

--- a/include/controller/cpp/webots/Camera.hpp
+++ b/include/controller/cpp/webots/Camera.hpp
@@ -24,6 +24,7 @@ namespace webots {
   class Camera : public Device {
   public:
     explicit Camera(const std::string &name) : Device(name) {}  // Use Robot::getCamera() instead
+    explicit Camera(WbDeviceTag tag) : Device(tag) {}
     virtual ~Camera() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Compass.hpp
+++ b/include/controller/cpp/webots/Compass.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Compass : public Device {
   public:
     explicit Compass(const std::string &name) : Device(name) {}  // Use Robot::getCompass() instead
+    explicit Compass(WbDeviceTag tag) : Device(tag) {}
     virtual ~Compass() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Connector.hpp
+++ b/include/controller/cpp/webots/Connector.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Connector : public Device {
   public:
     explicit Connector(const std::string &name) : Device(name) {}  // Use Robot::getConnector() instead
+    explicit Connector(WbDeviceTag tag) : Device(tag) {}
     virtual ~Connector() {}
     virtual void enablePresence(int samplingPeriod);
     virtual void disablePresence();

--- a/include/controller/cpp/webots/Device.hpp
+++ b/include/controller/cpp/webots/Device.hpp
@@ -32,6 +32,7 @@ namespace webots {
 
   protected:
     explicit Device(const std::string &name);
+    explicit Device(WbDeviceTag tag);
 
   private:
     WbDeviceTag tag;

--- a/include/controller/cpp/webots/Display.hpp
+++ b/include/controller/cpp/webots/Display.hpp
@@ -24,6 +24,7 @@ namespace webots {
   public:
     enum { RGB = 3, RGBA, ARGB, BGRA, ABGR };
     explicit Display(const std::string &name) : Device(name) {}  // Use Robot::getDisplay() instead
+    explicit Display(WbDeviceTag tag) : Device(tag) {}
     virtual ~Display() {}
     int getWidth() const;
     int getHeight() const;

--- a/include/controller/cpp/webots/DistanceSensor.hpp
+++ b/include/controller/cpp/webots/DistanceSensor.hpp
@@ -23,6 +23,7 @@ namespace webots {
     typedef enum { GENERIC = 0, INFRA_RED, SONAR, LASER } Type;
 
     explicit DistanceSensor(const std::string &name) : Device(name) {}  // Use Robot::getDistanceSensor() instead
+    explicit DistanceSensor(WbDeviceTag tag) : Device(tag) {}
     virtual ~DistanceSensor() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Emitter.hpp
+++ b/include/controller/cpp/webots/Emitter.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Emitter : public Device {
   public:
     explicit Emitter(const std::string &name) : Device(name) {}  // Use Robot::getEmitter() instead
+    explicit Emitter(WbDeviceTag tag) : Device(tag) {}
     virtual ~Emitter() {}
     enum { CHANNEL_BROADCAST = -1 };
     virtual int send(const void *data, int size);

--- a/include/controller/cpp/webots/GPS.hpp
+++ b/include/controller/cpp/webots/GPS.hpp
@@ -23,6 +23,7 @@ namespace webots {
     typedef enum { LOCAL = 0, WGS84 } CoordinateSystem;
 
     explicit GPS(const std::string &name) : Device(name) {}  // Use Robot::getGPS() instead
+    explicit GPS(WbDeviceTag tag) : Device(tag) {}
     virtual ~GPS() {}
 
     virtual void enable(int samplingPeriod);

--- a/include/controller/cpp/webots/Gyro.hpp
+++ b/include/controller/cpp/webots/Gyro.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Gyro : public Device {
   public:
     explicit Gyro(const std::string &name) : Device(name) {}  // Use Robot::getGyro() instead
+    explicit Gyro(WbDeviceTag tag) : Device(tag) {}
     virtual ~Gyro() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/InertialUnit.hpp
+++ b/include/controller/cpp/webots/InertialUnit.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class InertialUnit : public Device {
   public:
     explicit InertialUnit(const std::string &name) : Device(name) {}  // Use Robot::getInertialUnit() instead
+    explicit InertialUnit(WbDeviceTag tag) : Device(tag) {}
     virtual ~InertialUnit() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/LED.hpp
+++ b/include/controller/cpp/webots/LED.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class LED : public Device {
   public:
     explicit LED(const std::string &name) : Device(name) {}  // Use Robot::getLED() instead
+    explicit LED(WbDeviceTag tag) : Device(tag) {}
     virtual ~LED() {}
     virtual void set(int value);
     int get() const;

--- a/include/controller/cpp/webots/Lidar.hpp
+++ b/include/controller/cpp/webots/Lidar.hpp
@@ -24,6 +24,7 @@ namespace webots {
   class Lidar : public Device {
   public:
     explicit Lidar(const std::string &name) : Device(name) {}  // Use Robot::getLidar() instead
+    explicit Lidar(WbDeviceTag tag) : Device(tag) {}
     virtual ~Lidar() {}
     virtual void enable(int samplingPeriod);
     void enablePointCloud();

--- a/include/controller/cpp/webots/LightSensor.hpp
+++ b/include/controller/cpp/webots/LightSensor.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class LightSensor : public Device {
   public:
     explicit LightSensor(const std::string &name) : Device(name) {}  // Use Robot::getLightSensor() instead
+    explicit LightSensor(WbDeviceTag tag) : Device(tag) {}
     virtual ~LightSensor() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Motor.hpp
+++ b/include/controller/cpp/webots/Motor.hpp
@@ -31,6 +31,10 @@ namespace webots {
       Device(name),
       brake(NULL),
       positionSensor(NULL) {}  // Use Robot::getMotor() instead
+    explicit Motor(WbDeviceTag tag) :
+      Device(tag),
+      brake(NULL),
+      positionSensor(NULL) {}
     virtual ~Motor() {}
 
     virtual void setPosition(double position);

--- a/include/controller/cpp/webots/Pen.hpp
+++ b/include/controller/cpp/webots/Pen.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Pen : public Device {
   public:
     explicit Pen(const std::string &name) : Device(name) {}  // Use Robot::getPen() instead
+    explicit Pen(WbDeviceTag tag) : Device(tag) {}
     virtual ~Pen() {}
     virtual void write(bool write);
     virtual void setInkColor(int color, double density);

--- a/include/controller/cpp/webots/PositionSensor.hpp
+++ b/include/controller/cpp/webots/PositionSensor.hpp
@@ -29,6 +29,10 @@ namespace webots {
       Device(name),
       brake(NULL),
       motor(NULL) {}  // Use Robot::getPositionSensor() instead
+    explicit PositionSensor(WbDeviceTag tag) :
+      Device(tag),
+      brake(NULL),
+      motor(NULL) {}
     virtual ~PositionSensor() {}
     virtual void enable(int samplingPeriod);  // milliseconds
     virtual void disable();

--- a/include/controller/cpp/webots/Radar.hpp
+++ b/include/controller/cpp/webots/Radar.hpp
@@ -24,6 +24,7 @@ namespace webots {
   class Radar : public Device {
   public:
     explicit Radar(const std::string &name) : Device(name) {}  // Use Robot::getRadar() instead
+    explicit Radar(WbDeviceTag tag) : Device(tag) {}
     virtual ~Radar() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/RangeFinder.hpp
+++ b/include/controller/cpp/webots/RangeFinder.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class RangeFinder : public Device {
   public:
     explicit RangeFinder(const std::string &name) : Device(name) {}  // Use Robot::getRangeFinder() instead
+    explicit RangeFinder(WbDeviceTag tag) : Device(tag) {}
     virtual ~RangeFinder() {}
     virtual void enable(int samplingPeriod);
     virtual void disable();

--- a/include/controller/cpp/webots/Receiver.hpp
+++ b/include/controller/cpp/webots/Receiver.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Receiver : public Device {
   public:
     explicit Receiver(const std::string &name) : Device(name) {}  // Use Robot::getReceiver() instead
+    explicit Receiver(WbDeviceTag tag) : Device(tag) {}
     virtual ~Receiver() {}
     enum { CHANNEL_BROADCAST = -1 };
     virtual void enable(int samplingPeriod);

--- a/include/controller/cpp/webots/Robot.hpp
+++ b/include/controller/cpp/webots/Robot.hpp
@@ -141,31 +141,31 @@ namespace webots {
 
   protected:
     static Robot *cInstance;
-    virtual Accelerometer *createAccelerometer(const std::string &name) const;
-    virtual Altimeter *createAltimeter(const std::string &name) const;
-    virtual Brake *createBrake(const std::string &name) const;
-    virtual Camera *createCamera(const std::string &name) const;
-    virtual Compass *createCompass(const std::string &name) const;
-    virtual Connector *createConnector(const std::string &name) const;
-    virtual Display *createDisplay(const std::string &name) const;
-    virtual DistanceSensor *createDistanceSensor(const std::string &name) const;
-    virtual Emitter *createEmitter(const std::string &name) const;
-    virtual GPS *createGPS(const std::string &name) const;
-    virtual Gyro *createGyro(const std::string &name) const;
-    virtual InertialUnit *createInertialUnit(const std::string &name) const;
-    virtual LED *createLED(const std::string &name) const;
-    virtual Lidar *createLidar(const std::string &name) const;
-    virtual LightSensor *createLightSensor(const std::string &name) const;
-    virtual Motor *createMotor(const std::string &name) const;
-    virtual Pen *createPen(const std::string &name) const;
-    virtual PositionSensor *createPositionSensor(const std::string &name) const;
-    virtual Radar *createRadar(const std::string &name) const;
-    virtual RangeFinder *createRangeFinder(const std::string &name) const;
-    virtual Receiver *createReceiver(const std::string &name) const;
-    virtual Skin *createSkin(const std::string &name) const;
-    virtual Speaker *createSpeaker(const std::string &name) const;
-    virtual TouchSensor *createTouchSensor(const std::string &name) const;
-    virtual VacuumGripper *createVacuumGripper(const std::string &name) const;
+    virtual Accelerometer *createAccelerometer(WbDeviceTag tag) const;
+    virtual Altimeter *createAltimeter(WbDeviceTag tag) const;
+    virtual Brake *createBrake(WbDeviceTag tag) const;
+    virtual Camera *createCamera(WbDeviceTag tag) const;
+    virtual Compass *createCompass(WbDeviceTag tag) const;
+    virtual Connector *createConnector(WbDeviceTag tag) const;
+    virtual Display *createDisplay(WbDeviceTag tag) const;
+    virtual DistanceSensor *createDistanceSensor(WbDeviceTag tag) const;
+    virtual Emitter *createEmitter(WbDeviceTag tag) const;
+    virtual GPS *createGPS(WbDeviceTag tag) const;
+    virtual Gyro *createGyro(WbDeviceTag tag) const;
+    virtual InertialUnit *createInertialUnit(WbDeviceTag tag) const;
+    virtual LED *createLED(WbDeviceTag tag) const;
+    virtual Lidar *createLidar(WbDeviceTag tag) const;
+    virtual LightSensor *createLightSensor(WbDeviceTag tag) const;
+    virtual Motor *createMotor(WbDeviceTag tag) const;
+    virtual Pen *createPen(WbDeviceTag tag) const;
+    virtual PositionSensor *createPositionSensor(WbDeviceTag tag) const;
+    virtual Radar *createRadar(WbDeviceTag tag) const;
+    virtual RangeFinder *createRangeFinder(WbDeviceTag tag) const;
+    virtual Receiver *createReceiver(WbDeviceTag tag) const;
+    virtual Skin *createSkin(WbDeviceTag tag) const;
+    virtual Speaker *createSpeaker(WbDeviceTag tag) const;
+    virtual TouchSensor *createTouchSensor(WbDeviceTag tag) const;
+    virtual VacuumGripper *createVacuumGripper(WbDeviceTag tag) const;
 
   private:
     Keyboard *mKeyboard;

--- a/include/controller/cpp/webots/Robot.hpp
+++ b/include/controller/cpp/webots/Robot.hpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <vector>
 
+#include "../../c/webots/types.h"
+
 namespace webots {
   class Accelerometer;
   class Altimeter;

--- a/include/controller/cpp/webots/Skin.hpp
+++ b/include/controller/cpp/webots/Skin.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Skin : public Device {
   public:
     explicit Skin(const std::string &name) : Device(name) {}
+    explicit Skin(WbDeviceTag tag) : Device(tag) {}
     virtual ~Skin() {}
     void setBoneOrientation(int index, const double orientation[4], bool absolute);
     void setBonePosition(int index, const double position[3], bool absolute);

--- a/include/controller/cpp/webots/Speaker.hpp
+++ b/include/controller/cpp/webots/Speaker.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class Speaker : public Device {
   public:
     explicit Speaker(const std::string &name) : Device(name) {}  // Use Robot::getSpeaker() instead
+    explicit Speaker(WbDeviceTag tag) : Device(tag) {}
     virtual ~Speaker() {}
     static void playSound(Speaker *left, Speaker *right, const std::string &sound, double volume, double pitch, double balance,
                           bool loop);

--- a/include/controller/cpp/webots/TouchSensor.hpp
+++ b/include/controller/cpp/webots/TouchSensor.hpp
@@ -23,6 +23,7 @@ namespace webots {
     typedef enum { BUMPER = 0, FORCE, FORCE3D } Type;
 
     explicit TouchSensor(const std::string &name) : Device(name) {}  // Use Robot::getTouchSensor() instead
+    explicit TouchSensor(WbDeviceTag tag) : Device(tag) {}
     virtual ~TouchSensor() {}
 
     virtual void enable(int samplingPeriod);

--- a/include/controller/cpp/webots/VacuumGripper.hpp
+++ b/include/controller/cpp/webots/VacuumGripper.hpp
@@ -21,6 +21,7 @@ namespace webots {
   class VacuumGripper : public Device {
   public:
     explicit VacuumGripper(const std::string &name) : Device(name) {}  // Use Robot::getVacuumGripper() instead
+    explicit VacuumGripper(WbDeviceTag tag) : Device(tag) {}
     virtual ~VacuumGripper() {}
     virtual void enablePresence(int samplingPeriod);
     virtual void disablePresence();

--- a/lib/controller/python/controller/robot.py
+++ b/lib/controller/python/controller/robot.py
@@ -136,7 +136,7 @@ class Robot:
             if type == Node.ACCELEROMETER:
                 self.devices[name] = Accelerometer(tag)
             elif type == Node.ALTIMETER:
-                self.devices[name] = Altimeter(name)
+                self.devices[name] = Altimeter(tag)
             elif type == Node.BRAKE:
                 self.devices[name] = Brake(tag)
             elif type == Node.CAMERA:

--- a/src/controller/cpp/Device.cpp
+++ b/src/controller/cpp/Device.cpp
@@ -26,6 +26,10 @@ Device::Device(const string &deviceName) : name(deviceName) {
   tag = wb_robot_get_device(name.c_str());
 }
 
+Device::Device(WbDeviceTag deviceTag) : tag(deviceTag) {
+  name = wb_device_get_name(deviceTag);
+}
+
 int Device::getNodeType() const {
   return wb_device_get_node_type(tag);
 }

--- a/src/controller/cpp/Robot.cpp
+++ b/src/controller/cpp/Robot.cpp
@@ -199,8 +199,8 @@ Accelerometer *Robot::getAccelerometer(const string &name) {
   return dynamic_cast<Accelerometer *>(getOrCreateDevice(tag));
 }
 
-Accelerometer *Robot::createAccelerometer(const string &name) const {
-  return new Accelerometer(name);
+Accelerometer *Robot::createAccelerometer(WbDeviceTag tag) const {
+  return new Accelerometer(tag);
 }
 
 Altimeter *Robot::getAltimeter(const string &name) {
@@ -210,8 +210,8 @@ Altimeter *Robot::getAltimeter(const string &name) {
   return dynamic_cast<Altimeter *>(getOrCreateDevice(tag));
 }
 
-Altimeter *Robot::createAltimeter(const string &name) const {
-  return new Altimeter(name);
+Altimeter *Robot::createAltimeter(WbDeviceTag tag) const {
+  return new Altimeter(tag);
 }
 
 Brake *Robot::getBrake(const string &name) {
@@ -221,8 +221,8 @@ Brake *Robot::getBrake(const string &name) {
   return dynamic_cast<Brake *>(getOrCreateDevice(tag));
 }
 
-Brake *Robot::createBrake(const string &name) const {
-  return new Brake(name);
+Brake *Robot::createBrake(WbDeviceTag tag) const {
+  return new Brake(tag);
 }
 
 Camera *Robot::getCamera(const string &name) {
@@ -232,8 +232,8 @@ Camera *Robot::getCamera(const string &name) {
   return dynamic_cast<Camera *>(getOrCreateDevice(tag));
 }
 
-Camera *Robot::createCamera(const string &name) const {
-  return new Camera(name);
+Camera *Robot::createCamera(WbDeviceTag tag) const {
+  return new Camera(tag);
 }
 
 Compass *Robot::getCompass(const string &name) {
@@ -243,8 +243,8 @@ Compass *Robot::getCompass(const string &name) {
   return dynamic_cast<Compass *>(getOrCreateDevice(tag));
 }
 
-Compass *Robot::createCompass(const string &name) const {
-  return new Compass(name);
+Compass *Robot::createCompass(WbDeviceTag tag) const {
+  return new Compass(tag);
 }
 
 Connector *Robot::getConnector(const string &name) {
@@ -254,8 +254,8 @@ Connector *Robot::getConnector(const string &name) {
   return dynamic_cast<Connector *>(getOrCreateDevice(tag));
 }
 
-Connector *Robot::createConnector(const string &name) const {
-  return new Connector(name);
+Connector *Robot::createConnector(WbDeviceTag tag) const {
+  return new Connector(tag);
 }
 
 Display *Robot::getDisplay(const string &name) {
@@ -265,8 +265,8 @@ Display *Robot::getDisplay(const string &name) {
   return dynamic_cast<Display *>(getOrCreateDevice(tag));
 }
 
-Display *Robot::createDisplay(const string &name) const {
-  return new Display(name);
+Display *Robot::createDisplay(WbDeviceTag tag) const {
+  return new Display(tag);
 }
 
 DistanceSensor *Robot::getDistanceSensor(const string &name) {
@@ -276,8 +276,8 @@ DistanceSensor *Robot::getDistanceSensor(const string &name) {
   return dynamic_cast<DistanceSensor *>(getOrCreateDevice(tag));
 }
 
-DistanceSensor *Robot::createDistanceSensor(const string &name) const {
-  return new DistanceSensor(name);
+DistanceSensor *Robot::createDistanceSensor(WbDeviceTag tag) const {
+  return new DistanceSensor(tag);
 }
 
 Emitter *Robot::getEmitter(const string &name) {
@@ -287,8 +287,8 @@ Emitter *Robot::getEmitter(const string &name) {
   return dynamic_cast<Emitter *>(getOrCreateDevice(tag));
 }
 
-Emitter *Robot::createEmitter(const string &name) const {
-  return new Emitter(name);
+Emitter *Robot::createEmitter(WbDeviceTag tag) const {
+  return new Emitter(tag);
 }
 
 GPS *Robot::getGPS(const string &name) {
@@ -298,8 +298,8 @@ GPS *Robot::getGPS(const string &name) {
   return dynamic_cast<GPS *>(getOrCreateDevice(tag));
 }
 
-GPS *Robot::createGPS(const string &name) const {
-  return new GPS(name);
+GPS *Robot::createGPS(WbDeviceTag tag) const {
+  return new GPS(tag);
 }
 
 Gyro *Robot::getGyro(const string &name) {
@@ -309,8 +309,8 @@ Gyro *Robot::getGyro(const string &name) {
   return dynamic_cast<Gyro *>(getOrCreateDevice(tag));
 }
 
-Gyro *Robot::createGyro(const string &name) const {
-  return new Gyro(name);
+Gyro *Robot::createGyro(WbDeviceTag tag) const {
+  return new Gyro(tag);
 }
 
 InertialUnit *Robot::getInertialUnit(const string &name) {
@@ -320,8 +320,8 @@ InertialUnit *Robot::getInertialUnit(const string &name) {
   return dynamic_cast<InertialUnit *>(getOrCreateDevice(tag));
 }
 
-InertialUnit *Robot::createInertialUnit(const string &name) const {
-  return new InertialUnit(name);
+InertialUnit *Robot::createInertialUnit(WbDeviceTag tag) const {
+  return new InertialUnit(tag);
 }
 
 LED *Robot::getLED(const string &name) {
@@ -331,8 +331,8 @@ LED *Robot::getLED(const string &name) {
   return dynamic_cast<LED *>(getOrCreateDevice(tag));
 }
 
-LED *Robot::createLED(const string &name) const {
-  return new LED(name);
+LED *Robot::createLED(WbDeviceTag tag) const {
+  return new LED(tag);
 }
 
 Lidar *Robot::getLidar(const string &name) {
@@ -342,8 +342,8 @@ Lidar *Robot::getLidar(const string &name) {
   return dynamic_cast<Lidar *>(getOrCreateDevice(tag));
 }
 
-Lidar *Robot::createLidar(const string &name) const {
-  return new Lidar(name);
+Lidar *Robot::createLidar(WbDeviceTag tag) const {
+  return new Lidar(tag);
 }
 
 LightSensor *Robot::getLightSensor(const string &name) {
@@ -353,8 +353,8 @@ LightSensor *Robot::getLightSensor(const string &name) {
   return dynamic_cast<LightSensor *>(getOrCreateDevice(tag));
 }
 
-LightSensor *Robot::createLightSensor(const string &name) const {
-  return new LightSensor(name);
+LightSensor *Robot::createLightSensor(WbDeviceTag tag) const {
+  return new LightSensor(tag);
 }
 
 Motor *Robot::getMotor(const string &name) {
@@ -364,8 +364,8 @@ Motor *Robot::getMotor(const string &name) {
   return dynamic_cast<Motor *>(getOrCreateDevice(tag));
 }
 
-Motor *Robot::createMotor(const string &name) const {
-  return new Motor(name);
+Motor *Robot::createMotor(WbDeviceTag tag) const {
+  return new Motor(tag);
 }
 
 Pen *Robot::getPen(const string &name) {
@@ -375,8 +375,8 @@ Pen *Robot::getPen(const string &name) {
   return dynamic_cast<Pen *>(getOrCreateDevice(tag));
 }
 
-Pen *Robot::createPen(const string &name) const {
-  return new Pen(name);
+Pen *Robot::createPen(WbDeviceTag tag) const {
+  return new Pen(tag);
 }
 
 PositionSensor *Robot::getPositionSensor(const string &name) {
@@ -386,8 +386,8 @@ PositionSensor *Robot::getPositionSensor(const string &name) {
   return dynamic_cast<PositionSensor *>(getOrCreateDevice(tag));
 }
 
-PositionSensor *Robot::createPositionSensor(const string &name) const {
-  return new PositionSensor(name);
+PositionSensor *Robot::createPositionSensor(WbDeviceTag tag) const {
+  return new PositionSensor(tag);
 }
 
 Radar *Robot::getRadar(const string &name) {
@@ -397,8 +397,8 @@ Radar *Robot::getRadar(const string &name) {
   return dynamic_cast<Radar *>(getOrCreateDevice(tag));
 }
 
-Radar *Robot::createRadar(const string &name) const {
-  return new Radar(name);
+Radar *Robot::createRadar(WbDeviceTag tag) const {
+  return new Radar(tag);
 }
 
 RangeFinder *Robot::getRangeFinder(const string &name) {
@@ -408,8 +408,8 @@ RangeFinder *Robot::getRangeFinder(const string &name) {
   return dynamic_cast<RangeFinder *>(getOrCreateDevice(tag));
 }
 
-RangeFinder *Robot::createRangeFinder(const string &name) const {
-  return new RangeFinder(name);
+RangeFinder *Robot::createRangeFinder(WbDeviceTag tag) const {
+  return new RangeFinder(tag);
 }
 
 Receiver *Robot::getReceiver(const string &name) {
@@ -419,8 +419,8 @@ Receiver *Robot::getReceiver(const string &name) {
   return dynamic_cast<Receiver *>(getOrCreateDevice(tag));
 }
 
-Receiver *Robot::createReceiver(const string &name) const {
-  return new Receiver(name);
+Receiver *Robot::createReceiver(WbDeviceTag tag) const {
+  return new Receiver(tag);
 }
 
 Skin *Robot::getSkin(const string &name) {
@@ -430,8 +430,8 @@ Skin *Robot::getSkin(const string &name) {
   return dynamic_cast<Skin *>(getOrCreateDevice(tag));
 }
 
-Skin *Robot::createSkin(const string &name) const {
-  return new Skin(name);
+Skin *Robot::createSkin(WbDeviceTag tag) const {
+  return new Skin(tag);
 }
 
 Speaker *Robot::getSpeaker(const string &name) {
@@ -441,8 +441,8 @@ Speaker *Robot::getSpeaker(const string &name) {
   return dynamic_cast<Speaker *>(getOrCreateDevice(tag));
 }
 
-Speaker *Robot::createSpeaker(const string &name) const {
-  return new Speaker(name);
+Speaker *Robot::createSpeaker(WbDeviceTag tag) const {
+  return new Speaker(tag);
 }
 
 TouchSensor *Robot::getTouchSensor(const string &name) {
@@ -452,8 +452,8 @@ TouchSensor *Robot::getTouchSensor(const string &name) {
   return dynamic_cast<TouchSensor *>(getOrCreateDevice(tag));
 }
 
-TouchSensor *Robot::createTouchSensor(const string &name) const {
-  return new TouchSensor(name);
+TouchSensor *Robot::createTouchSensor(WbDeviceTag tag) const {
+  return new TouchSensor(tag);
 }
 
 VacuumGripper *Robot::getVacuumGripper(const string &name) {
@@ -463,8 +463,8 @@ VacuumGripper *Robot::getVacuumGripper(const string &name) {
   return dynamic_cast<VacuumGripper *>(getOrCreateDevice(tag));
 }
 
-VacuumGripper *Robot::createVacuumGripper(const string &name) const {
-  return new VacuumGripper(name);
+VacuumGripper *Robot::createVacuumGripper(WbDeviceTag tag) const {
+  return new VacuumGripper(tag);
 }
 
 Device *Robot::getDeviceFromTag(int tag) {
@@ -495,84 +495,83 @@ Device *Robot::getOrCreateDevice(int tag) {
   deviceList[0] = NULL;
   for (int i = 0; i < count; i++) {
     WbDeviceTag otherTag = wb_robot_get_device_by_index(i);
-    const char *name = wb_device_get_name(otherTag);
     assert(otherTag <= count);
     switch (wb_device_get_node_type(otherTag)) {
       case WB_NODE_ACCELEROMETER:
-        deviceList[otherTag] = createAccelerometer(name);
+        deviceList[otherTag] = createAccelerometer(otherTag);
         break;
       case WB_NODE_ALTIMETER:
-        deviceList[otherTag] = createAltimeter(name);
+        deviceList[otherTag] = createAltimeter(otherTag);
         break;
       case WB_NODE_BRAKE:
-        deviceList[otherTag] = createBrake(name);
+        deviceList[otherTag] = createBrake(otherTag);
         break;
       case WB_NODE_CAMERA:
-        deviceList[otherTag] = createCamera(name);
+        deviceList[otherTag] = createCamera(otherTag);
         break;
       case WB_NODE_COMPASS:
-        deviceList[otherTag] = createCompass(name);
+        deviceList[otherTag] = createCompass(otherTag);
         break;
       case WB_NODE_CONNECTOR:
-        deviceList[otherTag] = createConnector(name);
+        deviceList[otherTag] = createConnector(otherTag);
         break;
       case WB_NODE_DISPLAY:
-        deviceList[otherTag] = createDisplay(name);
+        deviceList[otherTag] = createDisplay(otherTag);
         break;
       case WB_NODE_DISTANCE_SENSOR:
-        deviceList[otherTag] = createDistanceSensor(name);
+        deviceList[otherTag] = createDistanceSensor(otherTag);
         break;
       case WB_NODE_EMITTER:
-        deviceList[otherTag] = createEmitter(name);
+        deviceList[otherTag] = createEmitter(otherTag);
         break;
       case WB_NODE_GPS:
-        deviceList[otherTag] = createGPS(name);
+        deviceList[otherTag] = createGPS(otherTag);
         break;
       case WB_NODE_GYRO:
-        deviceList[otherTag] = createGyro(name);
+        deviceList[otherTag] = createGyro(otherTag);
         break;
       case WB_NODE_INERTIAL_UNIT:
-        deviceList[otherTag] = createInertialUnit(name);
+        deviceList[otherTag] = createInertialUnit(otherTag);
         break;
       case WB_NODE_LED:
-        deviceList[otherTag] = createLED(name);
+        deviceList[otherTag] = createLED(otherTag);
         break;
       case WB_NODE_LIDAR:
-        deviceList[otherTag] = createLidar(name);
+        deviceList[otherTag] = createLidar(otherTag);
         break;
       case WB_NODE_LIGHT_SENSOR:
-        deviceList[otherTag] = createLightSensor(name);
+        deviceList[otherTag] = createLightSensor(otherTag);
         break;
       case WB_NODE_LINEAR_MOTOR:
       case WB_NODE_ROTATIONAL_MOTOR:
-        deviceList[otherTag] = createMotor(name);
+        deviceList[otherTag] = createMotor(otherTag);
         break;
       case WB_NODE_PEN:
-        deviceList[otherTag] = createPen(name);
+        deviceList[otherTag] = createPen(otherTag);
         break;
       case WB_NODE_POSITION_SENSOR:
-        deviceList[otherTag] = createPositionSensor(name);
+        deviceList[otherTag] = createPositionSensor(otherTag);
         break;
       case WB_NODE_RADAR:
-        deviceList[otherTag] = createRadar(name);
+        deviceList[otherTag] = createRadar(otherTag);
         break;
       case WB_NODE_RANGE_FINDER:
-        deviceList[otherTag] = createRangeFinder(name);
+        deviceList[otherTag] = createRangeFinder(otherTag);
         break;
       case WB_NODE_RECEIVER:
-        deviceList[otherTag] = createReceiver(name);
+        deviceList[otherTag] = createReceiver(otherTag);
         break;
       case WB_NODE_SKIN:
-        deviceList[otherTag] = createSkin(name);
+        deviceList[otherTag] = createSkin(otherTag);
         break;
       case WB_NODE_SPEAKER:
-        deviceList[otherTag] = createSpeaker(name);
+        deviceList[otherTag] = createSpeaker(otherTag);
         break;
       case WB_NODE_TOUCH_SENSOR:
-        deviceList[otherTag] = createTouchSensor(name);
+        deviceList[otherTag] = createTouchSensor(otherTag);
         break;
       case WB_NODE_VACUUM_GRIPPER:
-        deviceList[otherTag] = createVacuumGripper(name);
+        deviceList[otherTag] = createVacuumGripper(otherTag);
         break;
       default:
         deviceList[otherTag] = NULL;

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -118,6 +118,9 @@ using namespace std;
 //handling std::string
 %include "std_string.i"
 
+//handling WbDeviceTag
+%include <webots/types.h>
+
 //----------------------------------------------------------------------------------------------
 //  ANSI Support
 //----------------------------------------------------------------------------------------------
@@ -878,8 +881,8 @@ namespace webots {
   private Keyboard keyboard = new Keyboard();
   private Mouse mouse = new Mouse();
 
-  protected Accelerometer createAccelerometer(String name) {
-    return new Accelerometer(name);
+  protected Accelerometer createAccelerometer(int tag) {
+    return new Accelerometer(tag);
   }
 
   public Accelerometer getAccelerometer(String name) {
@@ -889,8 +892,8 @@ namespace webots {
     return (Accelerometer)getOrCreateDevice(tag);
   }
 
-  protected Altimeter createAltimeter(String name) {
-    return new Altimeter(name);
+  protected Altimeter createAltimeter(int tag) {
+    return new Altimeter(tag);
   }
 
   public Altimeter getAltimeter(String name) {
@@ -900,8 +903,8 @@ namespace webots {
     return (Altimeter)getOrCreateDevice(tag);
   }
 
-  protected Brake createBrake(String name) {
-    return new Brake(name);
+  protected Brake createBrake(int tag) {
+    return new Brake(tag);
   }
 
   public Brake getBrake(String name) {
@@ -911,8 +914,8 @@ namespace webots {
     return (Brake)getOrCreateDevice(tag);
   }
 
-  protected Camera createCamera(String name) {
-    return new Camera(name);
+  protected Camera createCamera(int tag) {
+    return new Camera(tag);
   }
 
   public Camera getCamera(String name) {
@@ -922,8 +925,8 @@ namespace webots {
     return (Camera)getOrCreateDevice(tag);
   }
 
-  protected Compass createCompass(String name) {
-    return new Compass(name);
+  protected Compass createCompass(int tag) {
+    return new Compass(tag);
   }
 
   public Compass getCompass(String name) {
@@ -933,8 +936,8 @@ namespace webots {
     return (Compass)getOrCreateDevice(tag);
   }
 
-  protected Connector createConnector(String name) {
-    return new Connector(name);
+  protected Connector createConnector(int tag) {
+    return new Connector(tag);
   }
 
   public Connector getConnector(String name) {
@@ -944,8 +947,8 @@ namespace webots {
     return (Connector)getOrCreateDevice(tag);
   }
 
-  protected Display createDisplay(String name) {
-    return new Display(name);
+  protected Display createDisplay(int tag) {
+    return new Display(tag);
   }
 
   public Display getDisplay(String name) {
@@ -955,8 +958,8 @@ namespace webots {
     return (Display)getOrCreateDevice(tag);
   }
 
-  protected DistanceSensor createDistanceSensor(String name) {
-    return new DistanceSensor(name);
+  protected DistanceSensor createDistanceSensor(int tag) {
+    return new DistanceSensor(tag);
   }
 
   public DistanceSensor getDistanceSensor(String name) {
@@ -966,8 +969,8 @@ namespace webots {
     return (DistanceSensor)getOrCreateDevice(tag);
   }
 
-  protected Emitter createEmitter(String name) {
-    return new Emitter(name);
+  protected Emitter createEmitter(int tag) {
+    return new Emitter(tag);
   }
 
   public Emitter getEmitter(String name) {
@@ -977,8 +980,8 @@ namespace webots {
     return (Emitter)getOrCreateDevice(tag);
   }
 
-  protected GPS createGPS(String name) {
-    return new GPS(name);
+  protected GPS createGPS(int tag) {
+    return new GPS(tag);
   }
 
   public GPS getGPS(String name) {
@@ -988,8 +991,8 @@ namespace webots {
     return (GPS)getOrCreateDevice(tag);
   }
 
-  protected Gyro createGyro(String name) {
-    return new Gyro(name);
+  protected Gyro createGyro(int tag) {
+    return new Gyro(tag);
   }
 
   public Gyro getGyro(String name) {
@@ -999,8 +1002,8 @@ namespace webots {
     return (Gyro)getOrCreateDevice(tag);
   }
 
-  protected InertialUnit createInertialUnit(String name) {
-    return new InertialUnit(name);
+  protected InertialUnit createInertialUnit(int tag) {
+    return new InertialUnit(tag);
   }
 
   public InertialUnit getInertialUnit(String name) {
@@ -1018,8 +1021,8 @@ namespace webots {
     return keyboard;
   }
 
-  protected LED createLED(String name) {
-    return new LED(name);
+  protected LED createLED(int tag) {
+    return new LED(tag);
   }
 
   public LED getLED(String name) {
@@ -1029,8 +1032,8 @@ namespace webots {
     return (LED)getOrCreateDevice(tag);
   }
 
-  protected Lidar createLidar(String name) {
-    return new Lidar(name);
+  protected Lidar createLidar(int tag) {
+    return new Lidar(tag);
   }
 
   public Lidar getLidar(String name) {
@@ -1040,8 +1043,8 @@ namespace webots {
     return (Lidar)getOrCreateDevice(tag);
   }
 
-  protected LightSensor createLightSensor(String name) {
-    return new LightSensor(name);
+  protected LightSensor createLightSensor(int tag) {
+    return new LightSensor(tag);
   }
 
   public LightSensor getLightSensor(String name) {
@@ -1051,8 +1054,8 @@ namespace webots {
     return (LightSensor)getOrCreateDevice(tag);
   }
 
-  protected Motor createMotor(String name) {
-    return new Motor(name);
+  protected Motor createMotor(int tag) {
+    return new Motor(tag);
   }
 
   public Motor getMotor(String name) {
@@ -1066,8 +1069,8 @@ namespace webots {
     return mouse;
   }
 
-  protected Pen createPen(String name) {
-    return new Pen(name);
+  protected Pen createPen(int tag) {
+    return new Pen(tag);
   }
 
   public Pen getPen(String name) {
@@ -1077,8 +1080,8 @@ namespace webots {
     return (Pen)getOrCreateDevice(tag);
   }
 
-  protected PositionSensor createPositionSensor(String name) {
-    return new PositionSensor(name);
+  protected PositionSensor createPositionSensor(int tag) {
+    return new PositionSensor(tag);
   }
 
   public PositionSensor getPositionSensor(String name) {
@@ -1088,8 +1091,8 @@ namespace webots {
     return (PositionSensor)getOrCreateDevice(tag);
   }
 
-  protected Radar createRadar(String name) {
-    return new Radar(name);
+  protected Radar createRadar(int tag) {
+    return new Radar(tag);
   }
 
   public Radar getRadar(String name) {
@@ -1099,8 +1102,8 @@ namespace webots {
     return (Radar)getOrCreateDevice(tag);
   }
 
-  protected RangeFinder createRangeFinder(String name) {
-    return new RangeFinder(name);
+  protected RangeFinder createRangeFinder(int tag) {
+    return new RangeFinder(tag);
   }
 
   public RangeFinder getRangeFinder(String name) {
@@ -1110,8 +1113,8 @@ namespace webots {
     return (RangeFinder)getOrCreateDevice(tag);
   }
 
-  protected Receiver createReceiver(String name) {
-    return new Receiver(name);
+  protected Receiver createReceiver(int tag) {
+    return new Receiver(tag);
   }
 
   public Receiver getReceiver(String name) {
@@ -1121,8 +1124,8 @@ namespace webots {
     return (Receiver)getOrCreateDevice(tag);
   }
 
-  protected Skin createSkin(String name) {
-    return new Skin(name);
+  protected Skin createSkin(int tag) {
+    return new Skin(tag);
   }
 
   public Skin getSkin(String name) {
@@ -1132,8 +1135,8 @@ namespace webots {
     return (Skin)getOrCreateDevice(tag);
   }
 
-  protected Speaker createSpeaker(String name) {
-    return new Speaker(name);
+  protected Speaker createSpeaker(int tag) {
+    return new Speaker(tag);
   }
 
   public Speaker getSpeaker(String name) {
@@ -1143,8 +1146,8 @@ namespace webots {
     return (Speaker)getOrCreateDevice(tag);
   }
 
-  protected TouchSensor createTouchSensor(String name) {
-    return new TouchSensor(name);
+  protected TouchSensor createTouchSensor(int tag) {
+    return new TouchSensor(tag);
   }
 
   public TouchSensor getTouchSensor(String name) {
@@ -1154,8 +1157,8 @@ namespace webots {
     return (TouchSensor)getOrCreateDevice(tag);
   }
 
-  protected VacuumGripper createVacuumGripper(String name) {
-    return new VacuumGripper(name);
+  protected VacuumGripper createVacuumGripper(int tag) {
+    return new VacuumGripper(tag);
   }
 
   public VacuumGripper getVacuumGripper(String name) {
@@ -1191,34 +1194,33 @@ namespace webots {
     devices = new Device[count + 1];
     for (int i = 0; i < count; i++) {
       int otherTag = getDeviceTagFromIndex(i);
-      String name = getDeviceNameFromTag(otherTag);
       switch(getDeviceTypeFromTag(otherTag)) {
-        case Node.ACCELEROMETER:    devices[otherTag] = createAccelerometer(name); break;
-        case Node.ALTIMETER:        devices[otherTag] = createAltimeter(name); break;
-        case Node.BRAKE:            devices[otherTag] = createBrake(name); break;
-        case Node.CAMERA:           devices[otherTag] = createCamera(name); break;
-        case Node.COMPASS:          devices[otherTag] = createCompass(name); break;
-        case Node.CONNECTOR:        devices[otherTag] = createConnector(name); break;
-        case Node.DISPLAY:          devices[otherTag] = createDisplay(name); break;
-        case Node.DISTANCE_SENSOR:  devices[otherTag] = createDistanceSensor(name); break;
-        case Node.EMITTER:          devices[otherTag] = createEmitter(name); break;
-        case Node.GPS:              devices[otherTag] = createGPS(name); break;
-        case Node.GYRO:             devices[otherTag] = createGyro(name); break;
-        case Node.INERTIAL_UNIT:    devices[otherTag] = createInertialUnit(name); break;
-        case Node.LED:              devices[otherTag] = createLED(name); break;
-        case Node.LIDAR:            devices[otherTag] = createLidar(name); break;
-        case Node.LIGHT_SENSOR:     devices[otherTag] = createLightSensor(name); break;
+        case Node.ACCELEROMETER:    devices[otherTag] = createAccelerometer(otherTag); break;
+        case Node.ALTIMETER:        devices[otherTag] = createAltimeter(otherTag); break;
+        case Node.BRAKE:            devices[otherTag] = createBrake(otherTag); break;
+        case Node.CAMERA:           devices[otherTag] = createCamera(otherTag); break;
+        case Node.COMPASS:          devices[otherTag] = createCompass(otherTag); break;
+        case Node.CONNECTOR:        devices[otherTag] = createConnector(otherTag); break;
+        case Node.DISPLAY:          devices[otherTag] = createDisplay(otherTag); break;
+        case Node.DISTANCE_SENSOR:  devices[otherTag] = createDistanceSensor(otherTag); break;
+        case Node.EMITTER:          devices[otherTag] = createEmitter(otherTag); break;
+        case Node.GPS:              devices[otherTag] = createGPS(otherTag); break;
+        case Node.GYRO:             devices[otherTag] = createGyro(otherTag); break;
+        case Node.INERTIAL_UNIT:    devices[otherTag] = createInertialUnit(otherTag); break;
+        case Node.LED:              devices[otherTag] = createLED(otherTag); break;
+        case Node.LIDAR:            devices[otherTag] = createLidar(otherTag); break;
+        case Node.LIGHT_SENSOR:     devices[otherTag] = createLightSensor(otherTag); break;
         case Node.LINEAR_MOTOR:
-        case Node.ROTATIONAL_MOTOR: devices[otherTag] = createMotor(name); break;
-        case Node.PEN:              devices[otherTag] = createPen(name); break;
-        case Node.POSITION_SENSOR:  devices[otherTag] = createPositionSensor(name); break;
-        case Node.RADAR:            devices[otherTag] = createRadar(name); break;
-        case Node.RANGE_FINDER:     devices[otherTag] = createRangeFinder(name); break;
-        case Node.RECEIVER:         devices[otherTag] = createReceiver(name); break;
-        case Node.SKIN:             devices[otherTag] = createSkin(name); break;
-        case Node.SPEAKER:          devices[otherTag] = createSpeaker(name); break;
-        case Node.TOUCH_SENSOR:     devices[otherTag] = createTouchSensor(name); break;
-        case Node.VACUUM_GRIPPER:   devices[otherTag] = createVacuumGripper(name); break;
+        case Node.ROTATIONAL_MOTOR: devices[otherTag] = createMotor(otherTag); break;
+        case Node.PEN:              devices[otherTag] = createPen(otherTag); break;
+        case Node.POSITION_SENSOR:  devices[otherTag] = createPositionSensor(otherTag); break;
+        case Node.RADAR:            devices[otherTag] = createRadar(otherTag); break;
+        case Node.RANGE_FINDER:     devices[otherTag] = createRangeFinder(otherTag); break;
+        case Node.RECEIVER:         devices[otherTag] = createReceiver(otherTag); break;
+        case Node.SKIN:             devices[otherTag] = createSkin(otherTag); break;
+        case Node.SPEAKER:          devices[otherTag] = createSpeaker(otherTag); break;
+        case Node.TOUCH_SENSOR:     devices[otherTag] = createTouchSensor(otherTag); break;
+        case Node.VACUUM_GRIPPER:   devices[otherTag] = createVacuumGripper(otherTag); break;
         default:                    devices[otherTag] = null; break;
       }
     }

--- a/src/controller/java/controller.i
+++ b/src/controller/java/controller.i
@@ -839,6 +839,7 @@ namespace webots {
 %ignore webots::Robot::getCamera(const std::string &name);
 %ignore webots::Robot::getCompass(const std::string &name);
 %ignore webots::Robot::getConnector(const std::string &name);
+%ignore webots::Robot::getDevice(const std::string &name);
 %ignore webots::Robot::getDisplay(const std::string &name);
 %ignore webots::Robot::getDistanceSensor(const std::string &name);
 %ignore webots::Robot::getEmitter(const std::string &name);
@@ -945,6 +946,11 @@ namespace webots {
     if (!Device.hasType(tag, Node.CONNECTOR))
       return null;
     return (Connector)getOrCreateDevice(tag);
+  }
+
+  public Device getDevice(String name) {
+    int tag = getDeviceTagFromName(name);
+    return getOrCreateDevice(tag);
   }
 
   protected Display createDisplay(int tag) {

--- a/tests/lib/TestUtils.hpp
+++ b/tests/lib/TestUtils.hpp
@@ -49,8 +49,18 @@ public:
     exit(EXIT_SUCCESS);
   }
 
+  void assertIntNotEqual(int value, int not_expected, const std::string &errorMessage) {
+    if (value == not_expected)
+      sendErrorAndExit(errorMessage);
+  }
+
   void assertPointerNotNull(void *ptr, const std::string &errorMessage) {
     if (ptr == NULL)
+      sendErrorAndExit(errorMessage);
+  }
+
+  void assertStringEquals(std::string &value, std::string &expected, const std::string &errorMessage) {
+    if (value != expected)
       sendErrorAndExit(errorMessage);
   }
 

--- a/tests/other_api/controllers/cpp_device_with_same_name/.gitignore
+++ b/tests/other_api/controllers/cpp_device_with_same_name/.gitignore
@@ -1,0 +1,1 @@
+/cpp_import_device

--- a/tests/other_api/controllers/cpp_device_with_same_name/.gitignore
+++ b/tests/other_api/controllers/cpp_device_with_same_name/.gitignore
@@ -1,1 +1,1 @@
-/cpp_import_device
+/cpp_device_with_same_name

--- a/tests/other_api/controllers/cpp_device_with_same_name/Makefile
+++ b/tests/other_api/controllers/cpp_device_with_same_name/Makefile
@@ -1,0 +1,72 @@
+# Copyright 1996-2023 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Generic Makefile.include for Webots controllers, physics plugins, robot
+### window libraries, remote control libraries and other libraries
+### to be used with GNU make
+###
+### Platforms: Windows, macOS, Linux
+### Languages: C, C++
+###
+### Authors: Olivier Michel, Yvan Bourquin, Fabien Rohrer
+###          Edmund Ronald, Sergei Poskriakov
+###
+###-----------------------------------------------------------------------------
+###
+### This file is meant to be included from the Makefile files located in the
+### Webots projects subdirectories. It is possible to set a number of variables
+### to customize the build process, i.e., add source files, compilation flags,
+### include paths, libraries, etc. These variables should be set in your local
+### Makefile just before including this Makefile.include. This Makefile.include
+### should never be modified.
+###
+### Here is a description of the variables you may set in your local Makefile:
+###
+### ---- C Sources ----
+### if your program uses several C source files:
+### C_SOURCES = my_plugin.c my_clever_algo.c my_graphics.c
+###
+### ---- C++ Sources ----
+### if your program uses several C++ source files:
+### CXX_SOURCES = my_plugin.cc my_clever_algo.cpp my_graphics.c++
+###
+### ---- Compilation options ----
+### if special compilation flags are necessary:
+### CFLAGS = -Wno-unused-result
+###
+### ---- Linked libraries ----
+### if your program needs additional libraries:
+### INCLUDE = -I"/my_library_path/include"
+### LIBRARIES = -L"/path/to/my/library" -lmy_library -lmy_other_library
+###
+### ---- Linking options ----
+### if special linking flags are needed:
+### LFLAGS = -s
+###
+### ---- Webots included libraries ----
+### if you want to use the Webots C API in your C++ controller program:
+### USE_C_API = true
+###
+### ---- Debug mode ----
+### if you want to display the gcc command line for compilation and link, as
+### well as the rm command details used for cleaning:
+### VERBOSE = 1
+###
+###-----------------------------------------------------------------------------
+
+### Do not modify: this includes Webots global Makefile.include
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/tests/other_api/controllers/cpp_device_with_same_name/cpp_device_with_same_name.cpp
+++ b/tests/other_api/controllers/cpp_device_with_same_name/cpp_device_with_same_name.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
   TestUtils ts(robot, argv[0]);
 
   int deviceTag1 = robot->getDeviceTagFromIndex(0);
-  int deviceTag2 = robot->getDeviceTagFromIndex(0);
+  int deviceTag2 = robot->getDeviceTagFromIndex(1);
   Accelerometer *device1 = dynamic_cast<Accelerometer *>(robot->getDeviceFromTag(deviceTag1));
   Accelerometer *device2 = dynamic_cast<Accelerometer *>(robot->getDeviceFromTag(deviceTag2));
 

--- a/tests/other_api/controllers/cpp_device_with_same_name/cpp_device_with_same_name.cpp
+++ b/tests/other_api/controllers/cpp_device_with_same_name/cpp_device_with_same_name.cpp
@@ -1,0 +1,22 @@
+#include <webots/Accelerometer.hpp>
+#include <webots/Robot.hpp>
+
+#include "../../../lib/TestUtils.hpp"
+
+using namespace webots;
+
+int main(int argc, char **argv) {
+  Robot *robot = new Robot();
+  TestUtils ts(robot, argv[0]);
+
+  int deviceTag1 = robot->getDeviceTagFromIndex(0);
+  int deviceTag2 = robot->getDeviceTagFromIndex(0);
+  Accelerometer *device1 = dynamic_cast<Accelerometer *>(robot->getDeviceFromTag(deviceTag1));
+  Accelerometer *device2 = dynamic_cast<Accelerometer *>(robot->getDeviceFromTag(deviceTag2));
+
+  ts.assertPointerNotNull(device1, "Accelerometer 1 not found.");
+  ts.assertPointerNotNull(device2, "Accelerometer 2 not found.");
+  ts.assertIntNotEqual(device1->getTag(), device2->getTag(), "Accelerometer 1 and 2 are the same device.");
+
+  ts.sendSuccess();
+}

--- a/tests/other_api/worlds/cpp_device_with_same_name.wbt
+++ b/tests/other_api/worlds/cpp_device_with_same_name.wbt
@@ -1,0 +1,35 @@
+#VRML_SIM R2024a utf8
+
+EXTERNPROTO "webots://tests/default/protos/TestSuiteEmitter.proto"
+EXTERNPROTO "webots://tests/default/protos/TestSuiteSupervisor.proto"
+
+WorldInfo {
+  coordinateSystem "NUE"
+}
+Viewpoint {
+  orientation 0.7470290283624516 0.646616024550071 0.15438700586161153 5.42889
+  position -1.2077 1.6424 1.96945
+}
+Background {
+  skyColor [
+    0.4 0.7 1
+  ]
+}
+DirectionalLight {
+  ambientIntensity 1
+  direction -0.33 -1 -0.5
+  castShadows TRUE
+}
+Robot {
+  children [
+    Accelerometer {
+      name "accel"
+    }
+    Accelerometer {
+      name "accel"
+    }
+  ]
+  controller "cpp_device_with_same_name"
+}
+TestSuiteSupervisor {
+}

--- a/tests/other_api/worlds/cpp_device_with_same_name.wbt
+++ b/tests/other_api/worlds/cpp_device_with_same_name.wbt
@@ -28,6 +28,8 @@ Robot {
     Accelerometer {
       name "accel"
     }
+    TestSuiteEmitter {
+    }
   ]
   controller "cpp_device_with_same_name"
 }


### PR DESCRIPTION
**Description**
Updates the controller api to create devices using their device tags instead of their names.

**Related Issues**
This pull-request fixes issue #6578.

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix the bug in the C++ controller API
  - [x] Propagate necessary changes to other language APIs
  - [x] Update the documentation
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)

**Documentation**
[Robot.md](https://cyberbotics.com/doc/reference/robot?version=DeepBlueRobotics:fix-devices-with-duplicate-names-cause-unexpected-behavior#wb_robot_get_device).
