### PR TITLE
Remote assets per URL

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -15,3 +15,4 @@ Released on December **th, 2023.
     - Fixed length of arrays returned by `getPose()` in Java ([#6556](https://github.com/cyberbotics/webots/pull/6556)).
     - Fixed length of arrays returned by `CameraRecognitionObject.getColors()` in Java ([#6564](https://github.com/cyberbotics/webots/pull/6564)).
     - Fixed handling of device objects with the same name in the controller API ([#6579](https://github.com/cyberbotics/webots/pull/6579)).
+    - Fixed handling of remote assets from unofficial sources ([#6585](https://github.com/cyberbotics/webots/pull/6585)).

--- a/src/webots/vrml/WbProtoManager.cpp
+++ b/src/webots/vrml/WbProtoManager.cpp
@@ -171,9 +171,11 @@ WbProtoModel *WbProtoManager::findModel(const QString &modelName, const QString 
 
   // a PROTO declaration is provided, enforce it
   QString modelPath;  // how the PROTO is referenced
-  if (WbUrl::isWeb(protoDeclaration) && WbNetwork::instance()->isCachedWithMapUpdate(modelPath))
-    modelPath = protoDeclaration;
-  else if (WbUrl::isLocalUrl(protoDeclaration) || QDir::isRelativePath(protoDeclaration)) {
+  if (WbUrl::isWeb(protoDeclaration)) {
+    // The PROTO is a remote asset, check if it's already cached
+    if (WbNetwork::instance()->isCachedWithMapUpdate(protoDeclaration))
+      modelPath = protoDeclaration;
+  } else if (WbUrl::isLocalUrl(protoDeclaration) || QDir::isRelativePath(protoDeclaration)) {
     // two possibitilies arise if the declaration is local (webots://)
     // 1. the parent PROTO is in the cache (all its references are always 'webots://'): it may happen if a PROTO references
     // another PROTO (both being cached)


### PR DESCRIPTION
**Description**
Remote assets do no require any inferring mechanisms from the parent files. This is only valid for local files. Remote asset was being treated as local.

**Related Issues**
This pull-request fixes issue #6571 

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
  - [x] Fix handling of remote assets from unofficial sources.

**Additional Information**
`WbNetwork::instance()->isCachedWithMapUpdate(modelPath)`  in line 174 did nothing, as `modelPath` was empty. This was changed to check `WbNetwork::instance()->isCachedWithMapUpdate(protoDeclaration)`, which makes more sense here.