### PR TITLE
Fix windows nightly build

### DIFF
--- a/scripts/packaging/files_msys64.txt
+++ b/scripts/packaging/files_msys64.txt
@@ -33,7 +33,6 @@
 /mingw64/share/qt6/plugins/imageformats/qjpeg.dll
 /mingw64/bin/libjpeg-8.dll
 /mingw64/share/qt6/plugins/platforms/qwindows.dll
-/mingw64/share/qt6/plugins/styles/qwindowsvistastyle.dll
 /mingw64/share/qt6/plugins/tls/qcertonlybackend.dll
 /mingw64/share/qt6/plugins/tls/qopensslbackend.dll
 /mingw64/share/qt6/plugins/tls/qschannelbackend.dll

--- a/scripts/packaging/windows_distro.py
+++ b/scripts/packaging/windows_distro.py
@@ -205,7 +205,9 @@ class WindowsWebotsPackage(WebotsPackage):
         else:
             INNO_SETUP_HOME = "/C/Program Files (x86)/Inno Setup 6"
         print('creating webots_setup.exe (takes long)\n')
-        subprocess.run([INNO_SETUP_HOME + '/iscc', '-Q', 'webots.iss'])
+        subprocess.run(
+            [INNO_SETUP_HOME + "/iscc", "-Q", "webots.iss"]
+        ).check_returncode()
 
         print('Done.')
 

--- a/scripts/packaging/windows_distro.py
+++ b/scripts/packaging/windows_distro.py
@@ -206,7 +206,7 @@ class WindowsWebotsPackage(WebotsPackage):
             INNO_SETUP_HOME = "/C/Program Files (x86)/Inno Setup 6"
         print('creating webots_setup.exe (takes long)\n')
         subprocess.run(
-            [INNO_SETUP_HOME + "/iscc", "-Q", "webots.iss"]
+            [INNO_SETUP_HOME + '/iscc', '-Q', 'webots.iss']
         ).check_returncode()
 
         print('Done.')

--- a/src/webots/maths/WbMathsUtilities.cpp
+++ b/src/webots/maths/WbMathsUtilities.cpp
@@ -107,7 +107,11 @@ int WbMathsUtilities::convexHull(const QVector<WbVector2> &points, QVector<int> 
       iMin = i;
   }
 
+  // Ignore false positive warning produced by some versions of GCC.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
   QVector<int> index(size);
+#pragma GCC diagnostic pop
   for (i = 0; i < size; ++i)
     index[i] = i;
 

--- a/src/webots/maths/WbMathsUtilities.cpp
+++ b/src/webots/maths/WbMathsUtilities.cpp
@@ -109,7 +109,9 @@ int WbMathsUtilities::convexHull(const QVector<WbVector2> &points, QVector<int> 
 
   // Ignore false positive warning produced by some versions of GCC.
 #pragma GCC diagnostic push
+#if __GNUC__ >= 7
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   QVector<int> index(size);
 #pragma GCC diagnostic pop
   for (i = 0; i < size; ++i)


### PR DESCRIPTION
**Description**
Fix the the nightly build not containing a version for Windows. It was silently [failing because it couldn't find a file](https://github.com/cyberbotics/webots/actions/runs/10102776931/job/27938991208#step:8:4207) that does not seem to be included in the mingw qt6 packages. Removing that file from the list of files to include seems to have fixed the problem. I did a basic test of the resulting setup file on my local Windows 11 machine and it seemed to start up and run a world without any issues.

This PR also ensures that any similar failures in the future will not be silent (ie they will cause the CI to fail).
