### PR TITLE
Remove references to unused custom uniforms.

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -14,3 +14,4 @@ Released on December **th, 2023.
     - Fixed length of arrays returned by `getPose()` in Java ([#6556](https://github.com/cyberbotics/webots/pull/6556)).
     - Fixed length of arrays returned by `CameraRecognitionObject.getColors()` in Java ([#6564](https://github.com/cyberbotics/webots/pull/6564)).
     - Fixed handling of device objects with the same name in the controller API ([#6579](https://github.com/cyberbotics/webots/pull/6579)).
+    - Fixed crashes (with some graphics cards) caused by references to unused GLSL uniforms ([#6587](https://github.com/cyberbotics/webots/pull/6587)).

--- a/resources/wren/shaders/merge_spherical.frag
+++ b/resources/wren/shaders/merge_spherical.frag
@@ -23,8 +23,6 @@ out vec4 fragColor;
 
 uniform bool rangeCamera;
 uniform bool cylindrical;
-uniform int subCamerasResolutionX;
-uniform int subCamerasResolutionY;
 
 uniform float maxRange;
 uniform float minRange;

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -979,14 +979,6 @@ void WbWrenCamera::applySphericalPostProcessingEffect() {
                                              WR_SHADER_PROGRAM_UNIFORM_TYPE_BOOL,
                                              reinterpret_cast<const char *>(&isCylindrical));
 
-  wr_shader_program_set_custom_uniform_value(WbWrenShaders::mergeSphericalShader(), "subCamerasResolutionX",
-                                             WR_SHADER_PROGRAM_UNIFORM_TYPE_INT,
-                                             reinterpret_cast<const char *>(&mSubCamerasResolutionX));
-
-  wr_shader_program_set_custom_uniform_value(WbWrenShaders::mergeSphericalShader(), "subCamerasResolutionY",
-                                             WR_SHADER_PROGRAM_UNIFORM_TYPE_INT,
-                                             reinterpret_cast<const char *>(&mSubCamerasResolutionY));
-
   wr_shader_program_set_custom_uniform_value(WbWrenShaders::mergeSphericalShader(), "minRange",
                                              WR_SHADER_PROGRAM_UNIFORM_TYPE_FLOAT, reinterpret_cast<const char *>(&mMinRange));
 

--- a/src/webots/wren/WbWrenShaders.cpp
+++ b/src/webots/wren/WbWrenShaders.cpp
@@ -735,16 +735,11 @@ WrShaderProgram *WbWrenShaders::mergeSphericalShader() {
     wr_shader_program_use_uniform(gShaders[SHADER_MERGE_SPHERICAL], WR_GLSL_LAYOUT_UNIFORM_TEXTURE4);
     wr_shader_program_use_uniform(gShaders[SHADER_MERGE_SPHERICAL], WR_GLSL_LAYOUT_UNIFORM_TEXTURE5);
 
-    const int defaultInt = 0;
     const bool defaultBool = false;
     wr_shader_program_create_custom_uniform(gShaders[SHADER_MERGE_SPHERICAL], "rangeCamera",
                                             WR_SHADER_PROGRAM_UNIFORM_TYPE_BOOL, reinterpret_cast<const char *>(&defaultBool));
     wr_shader_program_create_custom_uniform(gShaders[SHADER_MERGE_SPHERICAL], "cylindrical",
                                             WR_SHADER_PROGRAM_UNIFORM_TYPE_BOOL, reinterpret_cast<const char *>(&defaultBool));
-    wr_shader_program_create_custom_uniform(gShaders[SHADER_MERGE_SPHERICAL], "subCamerasResolutionX",
-                                            WR_SHADER_PROGRAM_UNIFORM_TYPE_INT, reinterpret_cast<const char *>(&defaultInt));
-    wr_shader_program_create_custom_uniform(gShaders[SHADER_MERGE_SPHERICAL], "subCamerasResolutionY",
-                                            WR_SHADER_PROGRAM_UNIFORM_TYPE_INT, reinterpret_cast<const char *>(&defaultInt));
 
     const float defaultFloat = 0.0f;
     wr_shader_program_create_custom_uniform(gShaders[SHADER_MERGE_SPHERICAL], "minRange", WR_SHADER_PROGRAM_UNIFORM_TYPE_FLOAT,


### PR DESCRIPTION
**Description**
Some graphics cards/drivers do not allow uniforms that are unused because they are optimized away by the GLSL compiler. The uniforms "subCamerasResolutionX" and "subCamerasResolutionY" were present in merge_spherical.frag but were never used. As a result, when trying to call to glGetUniformLocation() would return -1 for those names, crashing webots.

**Tasks**
Add the list of tasks of this PR.
  - [X] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
