### PR TITLE
Allow non-nightly builds on weekends.

### DIFF
--- a/scripts/packaging/publish_release.py
+++ b/scripts/packaging/publish_release.py
@@ -47,9 +47,6 @@ now = datetime.datetime.now()
 if now.hour <= 5:
     # Publish nightly build with previous day date even if it completes in the morning
     now = now - datetime.timedelta(hours=6)
-if now.weekday() >= 5:
-    print('Skipping nightly build for Saturday and Sunday.')
-    sys.exit(0)
 
 warningMessage = '\nIt might be unstable, for a stable version of Webots, please use the [latest official release]' \
                  '(https://github.com/cyberbotics/webots/releases/latest).'
@@ -67,6 +64,10 @@ else:
     branchLink = '[%s](https://github.com/%s/blob/%s/docs/reference/changelog-r%d.md)' \
                  % (branchName, options.repo, options.commit, now.year)
     message = 'This is a nightly build of Webots from the following branch(es):\n  - %s\n%s' % (branchLink, warningMessage)
+
+if now.weekday() >= 5 and tagName.startswith("nightly_"):
+    print("Skipping nightly build for Saturday and Sunday.")
+    sys.exit(0)
 
 for release in repo.get_releases():
     match = re.match(r'Webots Nightly Build \((\d*)-(\d*)-(\d*)\)', release.title, re.MULTILINE)


### PR DESCRIPTION
**Description**

This allows for major releases, hot fixes, and one-off snapshots of branches to happen on weekends. It's particularly useful where a project that uses Webots has a CI workflow that needs to download a version of webots with unmerged fixes for testing (potentially across multiple platforms). Without this change, that project's development may be delayed waiting for the next official nightly that contains the fixes. With this fix, the developer can push a tag starting with "R20" (e.g. "R2024a_MyFork_YYYY_MM_DD") to a branch on their unofficial fork of Webots and use the generated release in their unofficial fork until the the branch is merged into the official master.

