### PR TITLE
[CI] Install Swig on Mac

### DIFF
--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -42,10 +42,9 @@ jobs:
          fetch-depth: 15
     - name: Install Webots Compilation Dependencies
       run: |
-        # wget and cmake are already installed
+        # swig wget and cmake are already installed
         pip install setuptools
         npm install -g appdmg
-        brew install swig
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -42,9 +42,10 @@ jobs:
          fetch-depth: 15
     - name: Install Webots Compilation Dependencies
       run: |
-        # swig wget and cmake are already installed
+        # wget and cmake are already installed
         pip install setuptools
         npm install -g appdmg
+        brew install swig
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -38,10 +38,9 @@ jobs:
          ref: develop
     - name: Install Webots Compilation Dependencies
       run: |
-        # wget and cmake are already installed
+        # swig wget and cmake are already installed
         pip install setuptools
         npm install -g appdmg
-        brew install swig
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -38,9 +38,10 @@ jobs:
          ref: develop
     - name: Install Webots Compilation Dependencies
       run: |
-        # swig wget and cmake are already installed
+        # wget and cmake are already installed
         pip install setuptools
         npm install -g appdmg
+        brew install swig
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python scripts/packaging/set_commit_and_date_in_version.py $(git log -1 --format='%H')


### PR DESCRIPTION
**Description**
GitHub no longer includes swig by default on the macos 14 runner. Thus, as a result of #6580, builds made on mac with the current ci do not include the java controller api ([example](https://github.com/cyberbotics/webots/actions/runs/10135426969/job/28022815297#step:5:3077)). This PR installs swig, fixing the problem. I've also verified that [the other dependencies mentioned in the workflow](https://github.com/DeepBlueRobotics/webots/blob/d0b12071b400633dd83fb649de31d8bfae5c7233/.github/workflows/test_suite_mac.yml#L45) are still installed by default.

Once I verify that this does, in fact, solve the bug, I'll mark this PR as ready for review.