### PR TITLE
6592 invalid sound path results in crash

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -16,3 +16,4 @@ Released on December **th, 2023.
     - Fixed handling of device objects with the same name in the controller API ([#6579](https://github.com/cyberbotics/webots/pull/6579)).
     - Fixed crashes (with some graphics cards) caused by references to unused GLSL uniforms ([#6587](https://github.com/cyberbotics/webots/pull/6587)).
     - Fixed `Brake`s added to the second axis of a `Hinge2Joint` being applied to the non-transformed axis ([#6584](https://github.com/cyberbotics/webots/pull/6584)).
+    - Fixed invalid absolute sound file path resulted in crash ([#6593](https://github.com/cyberbotics/webots/pull/6593))

--- a/src/webots/nodes/WbSpeaker.cpp
+++ b/src/webots/nodes/WbSpeaker.cpp
@@ -205,7 +205,7 @@ void WbSpeaker::playSound(const char *file, double volume, double pitch, double 
   if (!mSoundSourcesMap.contains(key)) {  // this sound was never played
     QString path;
     // check if the path is absolute
-    if (QDir::isAbsolutePath(filename))
+    if (QDir::isAbsolutePath(filename) && QFile::exists(filename))
       path = filename;
     // check if the path is relative to the controller
     if (path.isEmpty() && QFile::exists(mControllerDir + filename))

--- a/src/webots/sound/WbWaveFile.cpp
+++ b/src/webots/sound/WbWaveFile.cpp
@@ -138,13 +138,13 @@ void WbWaveFile::loadConvertedFile(int side) {
     }
 
     if (riffChunkRead == false)
-      throw("Corrupted WAVE file: RIFF chunk not found");
+      throw(QObject::tr("Corrupted WAVE file: RIFF chunk not found"));
 
     if (formatChunkRead == false)
-      throw("Corrupted WAVE file: format chunk not found");
+      throw(QObject::tr("Corrupted WAVE file: format chunk not found"));
 
     if (dataChunkRead == false)
-      throw("Corrupted WAVE file: data chunk not found");
+      throw(QObject::tr("Corrupted WAVE file: data chunk not found"));
 
   } catch (const QString &e) {
     // clean up


### PR DESCRIPTION
**Description**
Using the Speaker to play a WAV file: using an absolute path that does not exist result in Webots crashing.
- `QObject` was expected on the `catch` block of `WbSoundEngine.cpp:246`, but a `char*` was returned.
- Existance of file with absolute path was not checked.

**Related Issues**
This pull-request fixes issue #6592 

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
  - [x] Fix Webots crash on invalid absolute path.