### PR TITLE
Fix macos CI being slow.

### DIFF
--- a/src/webots/sound/WbSoundEngine.cpp
+++ b/src/webots/sound/WbSoundEngine.cpp
@@ -49,6 +49,7 @@
 #include <ode/ode.h>
 
 #include <cassert>
+#include <cstring>
 
 static WbWorld *gWorld = NULL;
 static bool gOpenAL = false;
@@ -93,7 +94,7 @@ static void init() {
   WbLog::toggle(stderr);  // we want to disable stderr to avoid warnings in the console
   try {
     const ALCchar *defaultDeviceName = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
-    if (defaultDeviceName == NULL)
+    if (defaultDeviceName == NULL || !strcmp(defaultDeviceName, "Null Audio Device"))
       throw QObject::tr("Cannot find OpenAL default device");
     gDefaultDevice = alcOpenDevice(defaultDeviceName);
     if (gDefaultDevice == NULL)

--- a/src/webots/sound/WbSoundEngine.cpp
+++ b/src/webots/sound/WbSoundEngine.cpp
@@ -94,7 +94,7 @@ static void init() {
   WbLog::toggle(stderr);  // we want to disable stderr to avoid warnings in the console
   try {
     const ALCchar *defaultDeviceName = alcGetString(NULL, ALC_DEFAULT_DEVICE_SPECIFIER);
-    if (defaultDeviceName == NULL || !strcmp(defaultDeviceName, "Null Audio Device"))
+    if (defaultDeviceName == NULL || strcmp(defaultDeviceName, "Null Audio Device") == 0)
       throw QObject::tr("Cannot find OpenAL default device");
     gDefaultDevice = alcOpenDevice(defaultDeviceName);
     if (gDefaultDevice == NULL)


### PR DESCRIPTION
**Description**

Treat the "Null Audio Device" returned by Apple's OpenAL during CI the same as NULL so we don't attempt to open it. Attempting to open it was causing the code to hang for 6.5 minutes.

