### PR TITLE
Only Try To Delete Old Temp Directories if Root Temp Directory Exists

### DIFF
--- a/src/webots/core/WbStandardPaths.cpp
+++ b/src/webots/core/WbStandardPaths.cpp
@@ -244,17 +244,17 @@ bool WbStandardPaths::webotsTmpPathCreate(const int id) {
 #endif
   // cleanup old and unused tmp directories
   QDir directory(cWebotsTmpPath);
-  if (!directory.cdUp())
-    assert(false);
-  const QStringList &webotsTmp = directory.entryList(QStringList() << "webots-*", QDir::Dirs | QDir::Writable);
-  foreach (const QString &dirname, webotsTmp) {
-    const QString fullName(directory.absolutePath() + "/" + dirname);
-    const QFileInfo fileInfo(fullName + "/live.txt");
-    const QDateTime &lastModified = fileInfo.fileTime(QFileDevice::FileModificationTime);
-    const qint64 diff = lastModified.secsTo(QDateTime::currentDateTime());
-    if (diff > 3600) {  // if the live.txt file was not modified for more than one hour, delete the tmp folder
-      QDir d(fullName);
-      d.removeRecursively();
+  if (directory.cdUp()) {
+    const QStringList &webotsTmp = directory.entryList(QStringList() << "webots-*", QDir::Dirs | QDir::Writable);
+    foreach (const QString &dirname, webotsTmp) {
+      const QString fullName(directory.absolutePath() + "/" + dirname);
+      const QFileInfo fileInfo(fullName + "/live.txt");
+      const QDateTime &lastModified = fileInfo.fileTime(QFileDevice::FileModificationTime);
+      const qint64 diff = lastModified.secsTo(QDateTime::currentDateTime());
+      if (diff > 3600) {  // if the live.txt file was not modified for more than one hour, delete the tmp folder
+        QDir d(fullName);
+        d.removeRecursively();
+      }
     }
   }
 


### PR DESCRIPTION
**Description**
Currently, if run in debug mode and the base path for the temp directory doesn't exist (default: `/tmp/webots/<username>/`), Webots crashes with an assertion failure. (In a release build, the assertion doesn't exist and [I'm guessing] `directory.entryList` returns an empty list, so nothing happens.) This PR updates the code so that if the base path does not exist, Webots does not try to find and delete temporary files within it.