### PR TITLE
Mostly MacOS-related fixes

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -26,3 +26,4 @@ Released on December **th, 2023.
     - Fixed CA certificates needed by `test_suite.py` missing in Windows development environment ([#6628](https://github.com/cyberbotics/webots/pull/6628)).
     - Fixed to use a version of Qt that is still supported ([#6623](https://github.com/cyberbotics/webots/pull/6623)).
     - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
+    - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -25,4 +25,4 @@ Released on December **th, 2023.
     - Made `supervisor_export_image` work even if using the `--minimize --no-rendering` options ([#6622](https://github.com/cyberbotics/webots/pull/6622)).
     - Fixed CA certificates needed by `test_suite.py` missing in Windows development environment ([#6628](https://github.com/cyberbotics/webots/pull/6628)).
     - Fixed to use a version of Qt that is still supported ([#6623](https://github.com/cyberbotics/webots/pull/6623)).
-    - Fixed connection errors when using long robot names in some environments ([#6638](https://github.com/cyberbotics/webots/pull/6638)).
+    - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -25,3 +25,4 @@ Released on December **th, 2023.
     - Made `supervisor_export_image` work even if using the `--minimize --no-rendering` options ([#6622](https://github.com/cyberbotics/webots/pull/6622)).
     - Fixed CA certificates needed by `test_suite.py` missing in Windows development environment ([#6628](https://github.com/cyberbotics/webots/pull/6628)).
     - Fixed to use a version of Qt that is still supported ([#6623](https://github.com/cyberbotics/webots/pull/6623)).
+    - Fixed connection errors when using long robot names in some environments ([#6638](https://github.com/cyberbotics/webots/pull/6638)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -27,3 +27,4 @@ Released on December **th, 2023.
     - Fixed to use a version of Qt that is still supported ([#6623](https://github.com/cyberbotics/webots/pull/6623)).
     - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
+    - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).

--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
@@ -384,7 +384,8 @@ void Serial::updatePorts() {
     printf("IOServiceMatching failed.\n");
 
   CFDictionarySetValue(classesToMatch, CFSTR(kIOSerialBSDTypeKey), CFSTR(kIOSerialBSDRS232Type));
-  kernResult = IOServiceGetMatchingServices(kIOMainPortDefault, classesToMatch, &serialPortIterator);
+  // NULL is equivalent to kIOMainPortDefault or kIOMasterPortDefault but works across SDK versions
+  kernResult = IOServiceGetMatchingServices((mach_port_t)NULL, classesToMatch, &serialPortIterator);
   if (kernResult != KERN_SUCCESS)
     printf("IOServiceGetMatchingServices failed: %d\n", kernResult);
   io_object_t service;

--- a/scripts/install/qt_mac_installer.sh
+++ b/scripts/install/qt_mac_installer.sh
@@ -9,11 +9,12 @@ if [[ -z "${WEBOTS_HOME}" ]]; then
 fi
 
 QT_VERSION=6.5.3
-PYTHON_USER_BASE=`python3 -m site --user-base`
-export PATH="${PATH}:${PYTHON_USER_BASE}/bin"
-python3 -m pip install --user --upgrade pip
-python3 -m pip install --user --no-input aqtinstall
+python3 -m venv ~/python_env_for_aqt
+source ~/python_env_for_aqt/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install --no-input aqtinstall
 aqt install-qt --outputdir $HOME/Qt mac desktop ${QT_VERSION} clang_64 -m qtwebsockets
+rm -rf ~/python_env_for_aqt
 
 # prepare Webots
 cd $WEBOTS_HOME

--- a/scripts/install/qt_mac_installer.sh
+++ b/scripts/install/qt_mac_installer.sh
@@ -9,7 +9,10 @@ if [[ -z "${WEBOTS_HOME}" ]]; then
 fi
 
 QT_VERSION=6.5.3
-pip install --no-input aqtinstall
+PYTHON_USER_BASE=`python3 -m site --user-base`
+export PATH="${PATH}:${PYTHON_USER_BASE}/bin"
+python3 -m pip install --user --upgrade pip
+python3 -m pip install --user --no-input aqtinstall
 aqt install-qt --outputdir $HOME/Qt mac desktop ${QT_VERSION} clang_64 -m qtwebsockets
 
 # prepare Webots

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1475,10 +1475,9 @@ int wb_robot_init() {  // API initialization
         retry -= 5;
         fprintf(stderr, "%s, pending until loading is done...\n", error_message);
       } else if (socket_filename) {
-        fprintf(
-          stderr,
-          "The specified robot (at %s) is not in the list of robots with <extern> controllers, retrying for another %d seconds...\n",
-          socket_filename, 50 - retry);
+        fprintf(stderr,
+                "The specified robot (at %s) is not in the list of robots with <extern> controllers, retrying for another %d seconds...\n",
+                socket_filename, 50 - retry);
         free(socket_filename);
       } else
         fprintf(stderr, "%s, retrying for another %d seconds...\n", error_message, 50 - retry);

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1088,10 +1088,10 @@ static char *encode_robot_name(const char *robot_name) {
   char *encoded_name = percent_encode(robot_name);
   int length = strlen(encoded_name);
   // the robot name is used to connect to the libController and in this process there are indirect
-  // limitations such as QLocalServer only accepting strings up to 91 characters long for server names 
+  // limitations such as QLocalServer only accepting strings up to 91 characters long for server names
   // on some platforms.
   // Since the server name also contains the tmp path and that includes the user's username and,
-  // in the case of a Snap, the user's home directory, we need to limit the length of the encoded 
+  // in the case of a Snap, the user's home directory, we need to limit the length of the encoded
   // robot name based on the tmp path. If it is longer than that, then we compute a hashed version
   // of the name and use as much of it as we can. If that would be less than 4 chars, we try to use
   // 4 chars and hope we are on a platform where QLocalServer accepts longer names. 4 chars makes the

--- a/src/controller/c/robot.c
+++ b/src/controller/c/robot.c
@@ -1477,7 +1477,8 @@ int wb_robot_init() {  // API initialization
         fprintf(stderr, "%s, pending until loading is done...\n", error_message);
       } else if (socket_filename) {
         fprintf(stderr,
-                "The specified robot (at %s) is not in the list of robots with <extern> controllers, retrying for another %d seconds...\n",
+                "The specified robot (at %s) is not in the list of robots with <extern> controllers, retrying for another %d "
+                "seconds...\n",
                 socket_filename, 50 - retry);
         free(socket_filename);
       } else

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -303,7 +303,7 @@ void WbRenderingDeviceWindow::renderNow() {
 
   if (!mContext) {
     mContext = new QOpenGLContext(this);
-    mContext->setFormat(requestedFormat());
+    mContext->setFormat(cMainOpenGLContext->format());
     mContext->setShareContext(cMainOpenGLContext);
     mContext->create();
   }

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -59,8 +59,8 @@
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
 
-#include <limits>
 #include <algorithm>
+#include <limits>
 
 static QHash<int, int> createSpecialKeys() {
   QHash<int, int> map;
@@ -1096,10 +1096,10 @@ void WbRobot::dispatchAnswer(WbDataStream &stream, bool includeDevices) {
 QString WbRobot::encodedName() const {
   QString encodedName = QUrl::toPercentEncoding(name());
   // the robot name is used to connect to the libController and in this process there are indirect
-  // limitations such as QLocalServer only accepting strings up to 91 characters long for server names 
+  // limitations such as QLocalServer only accepting strings up to 91 characters long for server names
   // on some platforms.
   // Since the server name also contains the tmp path and that includes the user's username and,
-  // in the case of a Snap, the user's home directory, we need to limit the length of the encoded 
+  // in the case of a Snap, the user's home directory, we need to limit the length of the encoded
   // robot name based on the tmp path. If it is longer than that, then we compute a hashed version
   // of the name and use as much of it as we can. If that would be less than 4 chars, we try to use
   // 4 chars and hope we are on a platform where QLocalServer accepts longer names. 4 chars makes the

--- a/src/webots/nodes/WbRobot.cpp
+++ b/src/webots/nodes/WbRobot.cpp
@@ -60,6 +60,7 @@
 #include <QtCore/QUrl>
 
 #include <limits>
+#include <algorithm>
 
 static QHash<int, int> createSpecialKeys() {
   QHash<int, int> map;
@@ -1093,12 +1094,25 @@ void WbRobot::dispatchAnswer(WbDataStream &stream, bool includeDevices) {
 }
 
 QString WbRobot::encodedName() const {
-  const QString encodedName = QUrl::toPercentEncoding(name());
+  QString encodedName = QUrl::toPercentEncoding(name());
   // the robot name is used to connect to the libController and in this process there are indirect
-  // limitations such as QLocalServer only accepting strings up to 106 characters for server names,
-  // for these reasons if the robot name is bigger than an arbitrary length, a hashed version is used instead
-  if (encodedName.length() > 70)  // note: this threshold should be the same as in robot.c
-    return QString(QCryptographicHash::hash(encodedName.toUtf8(), QCryptographicHash::Sha1).toHex());
+  // limitations such as QLocalServer only accepting strings up to 91 characters long for server names 
+  // on some platforms.
+  // Since the server name also contains the tmp path and that includes the user's username and,
+  // in the case of a Snap, the user's home directory, we need to limit the length of the encoded 
+  // robot name based on the tmp path. If it is longer than that, then we compute a hashed version
+  // of the name and use as much of it as we can. If that would be less than 4 chars, we try to use
+  // 4 chars and hope we are on a platform where QLocalServer accepts longer names. 4 chars makes the
+  // chance of a name collision 1/65536.
+  // Note: It is critical that the same logic is used in robot.c
+  const QString &tmpPath = WbStandardPaths::webotsTmpPath();
+  qsizetype maxNameLength = std::max((qsizetype)4, 91 - (tmpPath.length() + (qsizetype)strlen("ipc//extern")));
+  // Round down to the next multiple of 2 because it makes the code in robot.c easier.
+  maxNameLength = maxNameLength / 2 * 2;
+  if (encodedName.length() > maxNameLength) {
+    encodedName = QString(QCryptographicHash::hash(encodedName.toUtf8(), QCryptographicHash::Sha1).toHex());
+    encodedName.truncate(maxNameLength);
+  }
   return encodedName;
 }
 

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -666,7 +666,7 @@ void WbWrenCamera::cleanup() {
   WrTextureRtt *renderingTexture = wr_frame_buffer_get_output_texture(mResultFrameBuffer, 0);
   wr_texture_delete(WR_TEXTURE(renderingTexture));
   // For some reason, deleting the outputTexture when cleaning the world causes crash on macos when closing the app.
-#ifndef __APPLE__  
+#ifndef __APPLE__
   WrTextureRtt *outputTexture = wr_frame_buffer_get_output_texture(mResultFrameBuffer, 1);
   wr_texture_delete(WR_TEXTURE(outputTexture));
 #endif

--- a/src/webots/wren/WbWrenCamera.cpp
+++ b/src/webots/wren/WbWrenCamera.cpp
@@ -664,10 +664,13 @@ void WbWrenCamera::cleanup() {
   }
 
   WrTextureRtt *renderingTexture = wr_frame_buffer_get_output_texture(mResultFrameBuffer, 0);
-  WrTextureRtt *outputTexture = wr_frame_buffer_get_output_texture(mResultFrameBuffer, 1);
-  wr_frame_buffer_delete(mResultFrameBuffer);
   wr_texture_delete(WR_TEXTURE(renderingTexture));
+  // For some reason, deleting the outputTexture when cleaning the world causes crash on macos when closing the app.
+#ifndef __APPLE__  
+  WrTextureRtt *outputTexture = wr_frame_buffer_get_output_texture(mResultFrameBuffer, 1);
   wr_texture_delete(WR_TEXTURE(outputTexture));
+#endif
+  wr_frame_buffer_delete(mResultFrameBuffer);
 
   wr_texture_delete(WR_TEXTURE(mNoiseMaskTexture));
   mNoiseMaskTexture = NULL;

--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -60,7 +60,8 @@ int main(int argc, char **argv) {
       break;
     usleep(100000);  // sleep for 100 ms
   };
-  ts_assert_int_not_equal(file_size, 0, "check_urdf command is missing");
+  ts_assert_int_not_equal(file_size, 0, "check_urdf command is missing. "
+    "Install with 'apt install liburdfdom-tools' on Ubuntu or 'brew install urdfdom' on MacOS.");
   if ((urdf_check_status >> 8) != 127 && file_size > 0) {
     // `check_urdf` command is available
     // Verify output from `check_urdf`

--- a/tests/api/controllers/robot_urdf/robot_urdf.c
+++ b/tests/api/controllers/robot_urdf/robot_urdf.c
@@ -60,8 +60,9 @@ int main(int argc, char **argv) {
       break;
     usleep(100000);  // sleep for 100 ms
   };
-  ts_assert_int_not_equal(file_size, 0, "check_urdf command is missing. "
-    "Install with 'apt install liburdfdom-tools' on Ubuntu or 'brew install urdfdom' on MacOS.");
+  ts_assert_int_not_equal(file_size, 0,
+                          "check_urdf command is missing. "
+                          "Install with 'apt install liburdfdom-tools' on Ubuntu or 'brew install urdfdom' on MacOS.");
   if ((urdf_check_status >> 8) != 127 && file_size > 0) {
     // `check_urdf` command is available
     // Verify output from `check_urdf`

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -350,20 +350,20 @@ backgroundWebots = subprocess.Popen([webotsFullPath, "--mode=pause", "--no-rende
                                     webotsEmptyWorldPath], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 atexit.register(subprocess.Popen.terminate, self=backgroundWebots)
 # Wait until we can actually connect to it, trying 10 times.
-with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-    retries = 0
-    error = None
-    while retries < 10:
-        try:
+retries = 0
+error = None
+while retries < 10:
+    try:
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             sock.settimeout(1)
             sock.connect(("127.0.0.1", 1234))
             break
-        except socket.error as e:
-            error = e
-            retries += 1
-            time.sleep(1)
-    if retries == 10:
-        raise error
+    except socket.error as e:
+        error = e
+        retries += 1
+        time.sleep(1)
+if retries == 10:
+    raise error
 
 for groupName in testGroups:
     if groupName == 'cache':


### PR DESCRIPTION
**Description**

These are changes I needed to run make and test_suite.py on my MacOS laptop as a regular user without it crashing.

At least one test (`supervisor_export_image`) still fails for me on MacOS but at least the test suite now runs without crashing.

Notable user-visible changes:

 - Fixed connection errors when using long robot names in some environments (issue #5452). This is not MacOS specific but is more likely to occur on a Mac because it's max socket path length is shorter than on Linux.
 - Fixed crash on MacOS when quitting under some circumstances. One reproducible case was quitting after running `check_saved_hidden_parameters.wbt`.
 - Fixed error when putting displays and cameras in separate windows on MacOS (e.g. with the `mirror.wbt` test). This was caused by using different formats for the different windows.

There are also some minor changes that are not user-visible:

- Use `(mach_port_t)NULL` because it is equivalent to kIOMainPortDefault or kIOMasterPortDefault but works across SDK versions.
- Run `aqt` in a python virtual env.
- Make `test_suite.py` use a new socket for each retry.



