### PR TITLE
Fix bugs (introduced in PR #6622) when grabbing/recording with devicePixelRatio != 1.

### DIFF
--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -346,7 +346,7 @@ void WbVideoRecorder::stopRecording(bool canceled) {
 void WbVideoRecorder::writeSnapshot(unsigned char *frame) {
   QString fileName = nextFileName();
   FrameWriterThread *thread =
-    new FrameWriterThread(frame, fileName, mVideoResolution * mScreenPixelRatio, mScreenPixelRatio, mVideoQuality);
+    new FrameWriterThread(frame, fileName, mVideoResolution, 1, mVideoQuality);
   connect(thread, &QThread::finished, this, &WbVideoRecorder::terminateSnapshotWrite);
   thread->start();
 }
@@ -481,7 +481,7 @@ void WbVideoRecorder::createMpeg() {
     // bitrate range between 4 and 24000000
     // cast into 'long long int' is mandatory on 32-bit machine
     long long int bitrate = (long long int)mVideoQuality * mMovieFPS * mVideoResolution.width() * mVideoResolution.height() /
-                            256 / (mScreenPixelRatio * mScreenPixelRatio);
+                            256;
 
     QTextStream stream(&ffmpegScript);
 #ifndef _WIN32

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -345,8 +345,7 @@ void WbVideoRecorder::stopRecording(bool canceled) {
 
 void WbVideoRecorder::writeSnapshot(unsigned char *frame) {
   QString fileName = nextFileName();
-  FrameWriterThread *thread =
-    new FrameWriterThread(frame, fileName, mVideoResolution, 1, mVideoQuality);
+  FrameWriterThread *thread = new FrameWriterThread(frame, fileName, mVideoResolution, 1, mVideoQuality);
   connect(thread, &QThread::finished, this, &WbVideoRecorder::terminateSnapshotWrite);
   thread->start();
 }
@@ -480,8 +479,8 @@ void WbVideoRecorder::createMpeg() {
   if (ffmpegScript.open(QIODevice::WriteOnly)) {
     // bitrate range between 4 and 24000000
     // cast into 'long long int' is mandatory on 32-bit machine
-    long long int bitrate = (long long int)mVideoQuality * mMovieFPS * mVideoResolution.width() * mVideoResolution.height() /
-                            256;
+    long long int bitrate =
+      (long long int)mVideoQuality * mMovieFPS * mVideoResolution.width() * mVideoResolution.height() / 256;
 
     QTextStream stream(&ffmpegScript);
 #ifndef _WIN32

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -327,9 +327,8 @@ QImage WbWrenWindow::grabWindowBufferNow() {
 void WbWrenWindow::initVideoPBO() {
   WbWrenOpenGlContext::makeWrenCurrent();
 
-  const int ratio = (int)devicePixelRatio();
-  mVideoWidth = width() * ratio;
-  mVideoHeight = height() * ratio;
+  mVideoWidth = width();
+  mVideoHeight = height();
   const int size = 4 * mVideoWidth * mVideoHeight;
   wr_scene_init_frame_capture(wr_scene_get_instance(), PBO_COUNT, mVideoPBOIds, size);
   mVideoPBOIndex = -1;

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -313,12 +313,11 @@ QImage WbWrenWindow::grabWindowBufferNow() {
     mSnapshotBufferHeight = destinationHeight;
     mSnapshotBuffer = new unsigned char[4 * destinationWidth * destinationHeight];
   }
-  const qreal ratio = devicePixelRatio();
-  const int sourceWidth = destinationWidth * ratio;
-  const int sourceHeight = destinationHeight * ratio;
+  const int sourceWidth = destinationWidth;
+  const int sourceHeight = destinationHeight;
   unsigned char *temp = new unsigned char[4 * sourceWidth * sourceHeight];
   readPixels(sourceWidth, sourceHeight, GL_BGRA, temp);
-  flipAndScaleDownImageBuffer(temp, mSnapshotBuffer, sourceWidth, sourceHeight, ratio);
+  flipAndScaleDownImageBuffer(temp, mSnapshotBuffer, sourceWidth, sourceHeight, 1.0);
   delete[] temp;
   WbWrenOpenGlContext::doneWren();
 


### PR DESCRIPTION
**Description**

PR #6622 causes grabs to come from an offscreen fbo instead of the default framebuffer. The latter can be scaled (e.g. on a MacOS Retina display) and the code was still compensating for that, resulting in screen grabs where the screen's image was only in the top left quadrant of the resulting screenshot. There was a similar problem with video recording. This PR addresses both.
