### PR TITLE
Fix-use-supported-version-of-lua

### DIFF
--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -8,7 +8,6 @@ DEPENDENCIES_URL = https://cyberbotics.com/files/repository/dependencies/linux64
 
 QT_VERSION = 6.5.3
 QT_PACKAGE = webots-qt-$(QT_VERSION)-linux64-release.tar.bz2
-OPENAL_PACKAGE = openal-linux64-1.16.0.tar.bz2
 OIS_PACKAGE = libOIS.1.4.tar.bz2
 ASSIMP_PACKAGE = libassimp-5.2.3.tar.bz2
 PICO_PACKAGE = libpico.tar.bz2
@@ -58,22 +57,13 @@ $(WEBOTS_DEPENDENCY_PATH)/$(QT_PACKAGE):
 
 
 open-al-clean:
-	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/openal $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)* $(WEBOTS_HOME_LIB)/libopenal.so*
+	@rm -rf $(WEBOTS_HOME_LIB)/libopenal.so*
 
 open-al: $(WEBOTS_HOME_LIB)/libopenal.so
 
-$(WEBOTS_HOME_LIB)/libopenal.so: $(WEBOTS_DEPENDENCY_PATH)/openal
-	@cp -a $(WEBOTS_DEPENDENCY_PATH)/openal/build/libopenal.so* $(WEBOTS_HOME_LIB)/
-
-$(WEBOTS_DEPENDENCY_PATH)/openal:
-	@echo "# downloading $(OPENAL_PACKAGE)"
-	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
-	@wget -qq $(DEPENDENCIES_URL)/$(OPENAL_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	@if [ "$$(md5sum $(OPENAL_PACKAGE) | awk '{print $$1;}')" != "6c7c9a77dec67f42c51d0f035a94a090" ]; then echo "MD5 checksum failed for $(OPENAL_PACKAGE)"; exit 1; fi
-	@echo "# uncompressing $(OPENAL_PACKAGE)"
-	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
-	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(OPENAL_PACKAGE)
-
+.LIBPATTERNS = lib%.so lib%.so.1 lib%.a
+$(WEBOTS_HOME_LIB)/libopenal.so: -lopenal
+	@cp -a $<* $(WEBOTS_HOME_LIB)/
 
 ois-clean:
 	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE) $(WEBOTS_HOME_LIB)/libOIS* $(WEBOTS_HOME)/include/libOIS

--- a/dependencies/Makefile.linux
+++ b/dependencies/Makefile.linux
@@ -11,7 +11,8 @@ QT_PACKAGE = webots-qt-$(QT_VERSION)-linux64-release.tar.bz2
 OIS_PACKAGE = libOIS.1.4.tar.bz2
 ASSIMP_PACKAGE = libassimp-5.2.3.tar.bz2
 PICO_PACKAGE = libpico.tar.bz2
-LUA_PACKAGE = lua-5.2.3.tar.gz
+LUA_VERSION=5.4.7
+LUA_PACKAGE = lua-$(LUA_VERSION).tar.gz
 OPENSSL_VERSION=3.0.14
 OPENSSL_SRC_PACKAGE=openssl-$(OPENSSL_VERSION).tar.gz
 
@@ -114,22 +115,22 @@ $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE):
 	@touch $(WEBOTS_DEPENDENCY_PATH)/$(PICO_PACKAGE)
 
 lua-clean:
-	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
+	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION) $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
-lua: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a
+lua: $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)/src/liblua.a
 
-$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
+$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION):
 	@echo "# downloading $(LUA_PACKAGE)"
 	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 	@wget -qq https://www.lua.org/ftp/$(LUA_PACKAGE) -P $(WEBOTS_DEPENDENCY_PATH)
-	@if [ "$$(md5sum $(LUA_PACKAGE) | awk '{print $$1;}')" != "dc7f94ec6ff15c985d2d6ad0f1b35654" ]; then echo "MD5 checksum failed for $(LUA_PACKAGE)"; exit 1; fi
+	@if [ "$$(sha256sum $(LUA_PACKAGE) | awk '{print $$1;}')" != "9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30" ]; then echo "SHA256 checksum failed for $(LUA_PACKAGE)"; exit 1; fi
 	@echo "# uncompressing $(LUA_PACKAGE)"
 	@tar xfm $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE) -C $(WEBOTS_DEPENDENCY_PATH)
 	@rm -f $(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)
 
-$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3
+$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)/src/liblua.a: $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)
 	@echo "# compiling lua"
-	+@make --silent -C $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3 linux 2> /dev/null
+	+@make --silent -C $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION) linux 2> /dev/null
 
 open-ssl-clean:
 	@rm -rf $(WEBOTS_DEPENDENCY_PATH)/$(OPENSSL_SRC_PACKAGE) $(WEBOTS_DEPENDENCY_PATH)/openssl-$(OPENSSL_VERSION) $(WEBOTS_DEPENDENCY_PATH)/openssl-3.0 $(WEBOTS_HOME_LIB)/libcrypto.so* $(WEBOTS_HOME_LIB)/libssl.so*

--- a/dependencies/Makefile.windows
+++ b/dependencies/Makefile.windows
@@ -7,7 +7,12 @@ DEPENDENCIES_URL = https://cyberbotics.com/files/repository/dependencies/windows
 
 ASSIMP_PACKAGE = assimp-5.2.3.zip
 OPEN_VR_PACKAGE = openvr-1.0.7.zip
-LUA_PACKAGE = lua-5.2.3.tar.gz
+LUA_MAJOR_VERSION=5
+LUA_MINOR_VERSION=4
+LUA_RELEASE=7
+LUA_VERSION=$(LUA_MAJOR).$(LUA_MINOR).$(LUA_RELEASE)
+LUA_DLL=lua$(LUA_MAJOR)$(LUA_MINOR).dll
+LUA_PACKAGE = lua-$(LUA_VERSION).tar.gz
 OIS_PACKAGE = libOIS.zip
 PICO_PACKAGE = libpico-1.0.zip
 LUA_GD_PACKAGE = lua-gd-windows.zip
@@ -100,16 +105,16 @@ $(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7:
 	@touch "$(WEBOTS_DEPENDENCY_PATH)/openvr-1.0.7"
 
 lua-clean:
-	@rm -rf $(TARGET_PATH)/lua52.dll "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3"
+	@rm -rf $(TARGET_PATH)/$(LUA_DLL) "$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)"
 
-lua: $(TARGET_PATH)/lua52.dll
+lua: $(TARGET_PATH)/$(LUA_DLL)
 
-$(TARGET_PATH)/lua52.dll: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll
+$(TARGET_PATH)/$(LUA_DLL): $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)/src/$(LUA_DLL)
 	@echo "# copying lua dll"
 	@mkdir -p $(TARGET_PATH)
-	@cp "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll" "$(TARGET_PATH)/"
+	@cp "$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)/src/$(LUA_DLL)" "$(TARGET_PATH)/"
 
-$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
+$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION):
 	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
 	@echo "# downloading $(LUA_PACKAGE)"
 	@wget -qq "https://www.lua.org/ftp/$(LUA_PACKAGE)" -P "$(WEBOTS_DEPENDENCY_PATH)"
@@ -118,10 +123,10 @@ $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3:
 	@cd "$(WEBOTS_DEPENDENCY_PATH)"; tar xfm $(LUA_PACKAGE) -C "$(WEBOTS_DEPENDENCY_PATH)"
 	@rm -f "$(WEBOTS_DEPENDENCY_PATH)/$(LUA_PACKAGE)"
 
-$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/lua52.dll: $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3
-	@sed -i '/AR= ar rcu/c\AR= ar rc' lua-5.2.3/src/Makefile
+$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)/src/$(LUA_DLL): $(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)
+	@sed -i '/AR= ar rcu/c\AR= ar rc' lua-$(LUA_VERSION)/src/Makefile
 	@echo "# compiling lua"
-	+@make --silent -C "$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3" mingw
+	+@make --silent -C "$(WEBOTS_DEPENDENCY_PATH)/lua-$(LUA_VERSION)" mingw
 
 ois-clean:
 	@rm -rf "$(WEBOTS_DEPENDENCY_PATH)/$(OIS_PACKAGE)" $(TARGET_PATH)/OIS.dll $(TARGET_PATH)/XInput9_1_0.dll "$(WEBOTS_HOME_PATH)/include/libOIS"

--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -12,7 +12,7 @@ fi
 
 alias apt='apt --option="APT::Acquire::Retries=3"'
 apt update
-apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage3 libfreetype6-dev libxml2-dev libboost-dev libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 wget zip unzip python3 python3-pip
+apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage3 libfreetype6-dev libxml2-dev libboost-dev libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 wget zip unzip python3 python3-pip libopenal-dev
 
 UBUNTU_VERSION=$(lsb_release -rs)
 if [[ $UBUNTU_VERSION == "20.04" ]]; then

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -44,7 +44,7 @@ WB_CONTROL_INCLUDE       = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) -Icore -Ieng
 WB_NODES_INCLUDE         = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) $(QT_GUI_INCLUDE) $(ODE_INCLUDE) $(CONTROLLER_INCLUDE) $(OIS_INCLUDE) $(FREETYPE_INCLUDE) $(WREN_INCLUDE) $(STB_INCLUDE) $(ASSIMP_INCLUDE) -Iapp -Icore -isystem external/siphash -Imaths -Inodes -Inodes/utils -Iode -Iplugins -Isound -Iutil -Ivrml
 WB_APP_INCLUDE           = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) $(ODE_INCLUDE) $(WREN_INCLUDE) -Icontrol -Icore -Ieditor -Iengine -Imaths -Inodes -Inodes/utils -Iplugins -Iscene_tree -Ivrml
 WB_SCENE_TREE_INCLUDE    = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) $(ASSIMP_INCLUDE) -isystem external/siphash -Iapp -Icore -Ieditor -Imaths -Inodes -Inodes/utils -Iode -Iuser_commands -Ivrml -Iwidgets
-WB_SOUND_INCLUDE         = $(QT_CORE_INCLUDE) $(QT_XML_INCLUDE) $(ODE_INCLUDE) $(OPENAL_INCLUDE) $(PICO_INCLUDE) -Icore -Imaths -Inodes -Inodes/utils -Isound -Ivrml
+WB_SOUND_INCLUDE         = $(QT_CORE_INCLUDE) $(QT_XML_INCLUDE) $(ODE_INCLUDE) $(PICO_INCLUDE) -Icore -Imaths -Inodes -Inodes/utils -Isound -Ivrml
 WB_GUI_INCLUDE           = $(QT_CORE_INCLUDE) $(QT_NETWORK_INCLUDE) $(QT_WEBSOCKETS_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) $(QT_OPENGL_INCLUDE) $(QT_OPENGL_WIDGETS_INCLUDE) $(ODE_INCLUDE) $(WREN_INCLUDE) -Iapp -Icontrol -Icore -Iwidgets -Ieditor -Iengine -isystem external/siphash -Imaths -Inodes -Inodes/utils -Iplugins -Iscene_tree -Isound -Iuser_commands -Iutil -Ivrml
 WB_RENDER_INCLUDE        = $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_OPENGL_INCLUDE) $(QT_WIDGETS_INCLUDE) $(WREN_INCLUDE) -isystem external/siphash
 
@@ -104,7 +104,6 @@ CFLAGS += -Wno-deprecated-register
 
 else ifeq ($(OSTYPE),linux)
 LIB_WREN           = ../wren/libwren.a ../glad/libglad.a
-OPENAL_INCLUDE     = -I$(WEBOTS_DEPENDENCY_PATH)/openal/include
 ASSIMP_INCLUDE     = -I$(WEBOTS_PATH)/include/libassimp/include
 QT_CORE_INCLUDE    = -isystem $(WEBOTS_PATH)/include/qt/QtCore
 QT_GUI_INCLUDE     = -isystem $(WEBOTS_PATH)/include/qt/QtGui
@@ -182,7 +181,7 @@ CONTROLLER_INCLUDE = -I$(WEBOTS_PATH)/include/controller/c
 ODE_INCLUDE        = -Iode -isystem $(WEBOTS_PATH)/include/ode
 QT_CORE_INCLUDE   += -I$(OBJDIR)
 WREN_INCLUDE      += -Iwren
-INCLUDE            = $(ALL_INCLUDE) $(CONTROLLER_INCLUDE) $(ODE_INCLUDE) $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) $(QT_PRINT_SUPPORT_INCLUDE) $(QT_OPENGL_INCLUDE) $(QT_NETWORK_INCLUDE) $(LUA_INCLUDE) $(OIS_INCLUDE) $(OPENAL_INCLUDE) $(PICO_INCLUDE) $(WREN_INCLUDE) $(FREETYPE_INCLUDE) $(STB_INCLUDE) $(ASSIMP_INCLUDE)
+INCLUDE            = $(ALL_INCLUDE) $(CONTROLLER_INCLUDE) $(ODE_INCLUDE) $(QT_CORE_INCLUDE) $(QT_GUI_INCLUDE) $(QT_WIDGETS_INCLUDE) $(QT_PRINT_SUPPORT_INCLUDE) $(QT_OPENGL_INCLUDE) $(QT_NETWORK_INCLUDE) $(LUA_INCLUDE) $(OIS_INCLUDE) $(PICO_INCLUDE) $(WREN_INCLUDE) $(FREETYPE_INCLUDE) $(STB_INCLUDE) $(ASSIMP_INCLUDE)
 
 ifeq ($(MAKECMDGOALS),debug)
 CFLAGS += -ggdb

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -154,7 +154,7 @@ CFLAGS                    = -isystem /mingw64/lib/libzip/include
 CXXFLAGS                  = -std=c++11 -D_USE_MATH_DEFINES
 MOC                       = /mingw64/share/qt6/bin/moc
 MOC_FLAGS                += -D_WIN32
-LIBS                     += $(LIB_WREN) -L$(TARGET_PATH) -L/mingw64/bin -L/mingw64/lib -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lode -lopenal -lopengl32 -liphlpapi -ld3d9 -lgdi32 -lglu32 -lOIS -ldinput8 -ldxguid -lole32 -lsapi -loleaut32 -luuid -lpico -llua52 -lfreetype-6 -lopenvr_api -lassimp-5
+LIBS                     += $(LIB_WREN) -L$(TARGET_PATH) -L/mingw64/bin -L/mingw64/lib -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lode -lopenal -lopengl32 -liphlpapi -ld3d9 -lgdi32 -lglu32 -lOIS -ldinput8 -ldxguid -lole32 -lsapi -loleaut32 -luuid -lpico -llua54 -lfreetype-6 -lopenvr_api -lassimp-5
 LD_FLAGS                  = -Wl,--enable-auto-import
 EXTRA_CMD                 = cp launcher/webots-bin.exe.config $(TARGET_PATH)/
 FILES_TO_REMOVE           = $(TARGET_PATH)/webots-bin.exe.config

--- a/src/webots/Makefile
+++ b/src/webots/Makefile
@@ -58,7 +58,7 @@ HOSTTYPE ?= $(shell uname -m)
 %:: s.%
 %:: SCCS/s.%
 
-LUA_INCLUDE = -I$(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src
+LUA_INCLUDE = -I$(WEBOTS_DEPENDENCY_PATH)/lua-5.4.7/src
 OIS_INCLUDE = -isystem $(WEBOTS_PATH)/include/libOIS
 PICO_INCLUDE = -I$(WEBOTS_PATH)/include/libpico
 WREN_INCLUDE = -I$(WEBOTS_PATH)/include
@@ -120,7 +120,7 @@ TARGET             = $(WEBOTS_PATH)/bin/webots-bin
 CFLAGS             = -fPIC
 CXXFLAGS           = -std=c++11
 MOC                = $(WEBOTS_PATH)/bin/qt/moc
-LIBS              += $(WEBOTS_DEPENDENCY_PATH)/lua-5.2.3/src/liblua.a $(LIB_WREN) -Wl,-rpath $(WEBOTS_LIB_PATH) -L$(WEBOTS_LIB_PATH) -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lopenal -lGL -lGLU -ldl -lOIS -lpico -lfreetype -lassimp -lrt
+LIBS              += $(WEBOTS_DEPENDENCY_PATH)/lua-5.4.7/src/liblua.a $(LIB_WREN) -Wl,-rpath $(WEBOTS_LIB_PATH) -L$(WEBOTS_LIB_PATH) -lQt6Core -lQt6Network -lQt6Gui -lQt6OpenGL -lQt6OpenGLWidgets -lQt6WebSockets -lQt6Widgets -lQt6PrintSupport -lQt6Qml -lQt6Xml -lopenal -lGL -lGLU -ldl -lOIS -lpico -lfreetype -lassimp -lrt
 LD_FLAGS           = -rdynamic
 EXTRA_CMD          = cp launcher/webots-linux.sh $(WEBOTS_PATH)/webots && chmod 755 $(WEBOTS_PATH)/webots
 FILES_TO_REMOVE    = $(WEBOTS_PATH)/webots


### PR DESCRIPTION
**Description**
Use Lua 5.4.7 because 5.2.3 is no longer supported.

**Related Issues**

This PR includes PR  #6640.

**Tasks**
Add the list of tasks of this PR.
  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)

