### PR TITLE
Fix-mirror-crash-under-wayland

### DIFF
--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -303,7 +303,7 @@ void WbRenderingDeviceWindow::renderNow() {
 
   if (!mContext) {
     mContext = new QOpenGLContext(this);
-    mContext->setFormat(cMainOpenGLContext->format());
+    mContext->setFormat(format());
     mContext->setShareContext(cMainOpenGLContext);
     mContext->create();
   }

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -112,9 +112,8 @@ WbRenderingDeviceWindow::WbRenderingDeviceWindow(WbRenderingDevice *device) :
   mUpdateRequested(true),
   mShowOverlayOnClose(true) {
   setSurfaceType(QWindow::OpenGLSurface);
-  QSurfaceFormat surfaceFormat = format();
-  surfaceFormat.setMajorVersion(3);
-  surfaceFormat.setMinorVersion(3);
+  assert(cMainOpenGLContext);
+  QSurfaceFormat surfaceFormat = cMainOpenGLContext->format();
   setFormat(surfaceFormat);
 
   mAbstractCamera = dynamic_cast<WbAbstractCamera *>(mDevice);
@@ -303,7 +302,7 @@ void WbRenderingDeviceWindow::renderNow() {
 
   if (!mContext) {
     mContext = new QOpenGLContext(this);
-    mContext->setFormat(format());
+    mContext->setFormat(cMainOpenGLContext->format());
     mContext->setShareContext(cMainOpenGLContext);
     mContext->create();
   }


### PR DESCRIPTION
**Description**
Fixes bug introduced by PR #6635 which forced the format of the *context* for a rendering device window to be the same as the format of the main opengl context.  This resulted in the context not being usable with  rendering device windows created under wayland. This PR fixes that by requesting that the format of the *window" to be the same as the main opengl context.


