### PR TITLE
Fix failure of supervisor_start_stop_movie introduced by PR #6623.

### DIFF
--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -459,7 +459,7 @@ QString WbVideoRecorder::nextFileName() {
 
 void WbVideoRecorder::createMpeg() {
 #ifdef __linux__
-  static const QString ffmpeg("ffmpeg");
+  static const QString ffmpeg("LD_LIBRARY_PATH=\"$WEBOTS_ORIG_LD_LIBRARY_PATH\" ffmpeg");
   static const QString percentageChar = "%";
   mScriptPath = "ffmpeg_script.sh";
 #elif defined(__APPLE__)

--- a/src/webots/gui/WbVideoRecorder.cpp
+++ b/src/webots/gui/WbVideoRecorder.cpp
@@ -459,7 +459,7 @@ QString WbVideoRecorder::nextFileName() {
 
 void WbVideoRecorder::createMpeg() {
 #ifdef __linux__
-  static const QString ffmpeg("LD_LIBRARY_PATH=\"$WEBOTS_ORIG_LD_LIBRARY_PATH\" ffmpeg");
+  static const QString ffmpeg("LD_LIBRARY_PATH=\"$WEBOTS_ORIGINAL_LD_LIBRARY_PATH\" ffmpeg");
   static const QString percentageChar = "%";
   mScriptPath = "ffmpeg_script.sh";
 #elif defined(__APPLE__)

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -69,6 +69,7 @@ export TMPDIR=$WEBOTS_TMPDIR
 export WEBOTS_TMPDIR=$WEBOTS_TMPDIR
 
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
+export WEBOTS_ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$webots_home/lib/webots":$LD_LIBRARY_PATH
 
 # Fix for i3 window manager not working with Qt6

--- a/src/webots/launcher/webots-linux.sh
+++ b/src/webots/launcher/webots-linux.sh
@@ -69,7 +69,7 @@ export TMPDIR=$WEBOTS_TMPDIR
 export WEBOTS_TMPDIR=$WEBOTS_TMPDIR
 
 # add the "lib" directory into LD_LIBRARY_PATH as the first entry
-export WEBOTS_ORIG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+export WEBOTS_ORIGINAL_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$webots_home/lib/webots":$LD_LIBRARY_PATH
 
 # Fix for i3 window manager not working with Qt6


### PR DESCRIPTION
If the system ffmpeg links (possibly indirectly) to a different openssl than what we bundle, ffmpeg will fail to start. This fixes that by restoring the original LD_LIBRARY_PATH while running ffmpeg.

