### PR TITLE
Fix Crash When `wb_supervisor_field_get_name` is Called With NULL

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -28,3 +28,4 @@ Released on December **th, 2023.
     - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
+    - Fixed crash when `wb_supervisor_field_get_name` is called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647))

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -28,4 +28,4 @@ Released on December **th, 2023.
     - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
-    - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647))
+    - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -28,4 +28,4 @@ Released on December **th, 2023.
     - Fixed connection errors when using long robot names in some environments ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
-    - Fixed crash when `wb_supervisor_field_get_name` is called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647))
+    - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647))

--- a/src/controller/c/supervisor.c
+++ b/src/controller/c/supervisor.c
@@ -2831,6 +2831,9 @@ const double *wb_supervisor_virtual_reality_headset_get_orientation() {
 }
 
 const char *wb_supervisor_field_get_name(WbFieldRef field) {
+  if (!check_field(field, __FUNCTION__, WB_NO_FIELD, false, NULL, false, false))
+    return "";
+
   return field->name;
 }
 

--- a/tests/api/controllers/supervisor_field/supervisor_field.c
+++ b/tests/api/controllers/supervisor_field/supervisor_field.c
@@ -25,6 +25,11 @@ int main(int argc, char **argv) {
   int i;
   double d;
 
+  ts_assert_string_equal(wb_supervisor_field_get_name(NULL), "", "wb_supervisor_field_get_name(NULL) should return the empty string");
+  ts_assert_int_equal(wb_supervisor_field_get_type(NULL), 0, "wb_supervisor_field_get_type(NULL) should return 0");
+  ts_assert_string_equal(wb_supervisor_field_get_type_name(NULL), "", "wb_supervisor_field_get_type_name(NULL) should return the empty string");
+  ts_assert_int_equal(wb_supervisor_field_get_count(NULL), -1, "wb_supervisor_field_get_count(NULL) should return -1");
+
   root = wb_supervisor_node_get_root();
   ts_assert_pointer_not_null(root, "Root node is not found");
 

--- a/tests/api/controllers/supervisor_field/supervisor_field.c
+++ b/tests/api/controllers/supervisor_field/supervisor_field.c
@@ -25,9 +25,11 @@ int main(int argc, char **argv) {
   int i;
   double d;
 
-  ts_assert_string_equal(wb_supervisor_field_get_name(NULL), "", "wb_supervisor_field_get_name(NULL) should return the empty string");
+  ts_assert_string_equal(wb_supervisor_field_get_name(NULL), "",
+                         "wb_supervisor_field_get_name(NULL) should return the empty string");
   ts_assert_int_equal(wb_supervisor_field_get_type(NULL), 0, "wb_supervisor_field_get_type(NULL) should return 0");
-  ts_assert_string_equal(wb_supervisor_field_get_type_name(NULL), "", "wb_supervisor_field_get_type_name(NULL) should return the empty string");
+  ts_assert_string_equal(wb_supervisor_field_get_type_name(NULL), "",
+                         "wb_supervisor_field_get_type_name(NULL) should return the empty string");
   ts_assert_int_equal(wb_supervisor_field_get_count(NULL), -1, "wb_supervisor_field_get_count(NULL) should return -1");
 
   root = wb_supervisor_node_get_root();


### PR DESCRIPTION
**Description**
Currently, calling `wb_supervisor_field_get_name(NULL)` crashes the supervisor. This PR fixes that and adds a test for the new behavior.
