### PR TITLE
Fix crash when using muscles and animatedGeometry in sequential worlds.

### DIFF
--- a/src/webots/nodes/utils/WbWorld.cpp
+++ b/src/webots/nodes/utils/WbWorld.cpp
@@ -57,6 +57,7 @@
 #include "WbWorldInfo.hpp"
 #include "WbWrenOpenGlContext.hpp"
 #include "WbWrenRenderingContext.hpp"
+#include "WbWrenVertexArrayFrameListener.hpp"
 #include "WbWriter.hpp"
 
 #include <wren/scene.h>
@@ -92,6 +93,7 @@ WbWorld::WbWorld(WbTokenizer *tokenizer) :
   mIsLoading(true),
   mIsCleaning(false),
   mIsVideoRecording(false) {
+  WbWrenVertexArrayFrameListener::resetLastUpdateTime();
   gInstance = this;
   WbNode::setInstantiateMode(true);
   WbNode::setGlobalParentNode(NULL);

--- a/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.cpp
+++ b/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.cpp
@@ -21,9 +21,13 @@
 #include <wren/scene.h>
 
 WbWrenVertexArrayFrameListener *WbWrenVertexArrayFrameListener::cInstance = NULL;
+static double lastUpdateTime = -1.0;
+
+void WbWrenVertexArrayFrameListener::resetLastUpdateTime() {
+  lastUpdateTime = -1.0;
+}
 
 static void processEvent() {
-  static double lastUpdateTime = -1.0;
   const double currentTime = WbSimulationState::instance()->time();
   if (currentTime == lastUpdateTime)
     return;

--- a/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.hpp
+++ b/src/webots/nodes/utils/WbWrenVertexArrayFrameListener.hpp
@@ -24,6 +24,7 @@ class WbWrenVertexArrayFrameListener {
 public:
   static WbWrenVertexArrayFrameListener *instance();
   static void clear();
+  static void resetLastUpdateTime();
 
   void subscribeTrack(WbTrack *track);
   void unsubscribeTrack(WbTrack *track);

--- a/tests/api/controllers/track_animated_geometry_muscles/.gitignore
+++ b/tests/api/controllers/track_animated_geometry_muscles/.gitignore
@@ -1,0 +1,1 @@
+/track_animated_geometry_muscles

--- a/tests/api/controllers/track_animated_geometry_muscles/Makefile
+++ b/tests/api/controllers/track_animated_geometry_muscles/Makefile
@@ -1,0 +1,25 @@
+# Copyright 1996-2023 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Webots Makefile system 
+#
+# You may add some variable definitions hereafter to customize the build process
+# See documentation in $(WEBOTS_HOME_PATH)/resources/Makefile.include
+
+
+# Do not modify the following: this includes Webots global Makefile.include
+null :=
+space := $(null) $(null)
+WEBOTS_HOME_PATH?=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
+include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/tests/api/controllers/track_animated_geometry_muscles/track_animated_geometry_muscles.c
+++ b/tests/api/controllers/track_animated_geometry_muscles/track_animated_geometry_muscles.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <webots/brake.h>
+#include <webots/motor.h>
+#include <webots/position_sensor.h>
+#include <webots/robot.h>
+#include <webots/supervisor.h>
+
+#include "../../../lib/ts_assertion.h"
+#include "../../../lib/ts_utils.h"
+
+#define TIME_STEP 32
+
+int main(int argc, char **argv) {
+  ts_setup(argv[0]);
+  wb_robot_step(TIME_STEP);
+  // Test that a world with a Muscle node will load. See issue #6659.
+  wb_supervisor_world_load("../../worlds/supervisor_set_hinge_position_dynamic.wbt");
+
+  ts_send_success();
+  return EXIT_SUCCESS;
+}

--- a/tests/api/worlds/track_animated_geometry_muscles.wbt
+++ b/tests/api/worlds/track_animated_geometry_muscles.wbt
@@ -1,0 +1,27 @@
+#VRML_SIM R2024a utf8
+
+EXTERNPROTO "webots://tests/default/protos/TestSuiteEmitter.proto"
+EXTERNPROTO "webots://tests/default/protos/TestSuiteSupervisor.proto"
+
+WorldInfo {
+}
+Viewpoint {
+}
+Background {
+}
+Robot {
+  children [
+    Track {
+      children [
+        TrackWheel {
+        }
+      ]
+      animatedGeometry Shape {
+      }
+    }
+  ]
+  controller "track_animated_geometry_muscles"
+  supervisor TRUE
+}
+TestSuiteSupervisor {
+}


### PR DESCRIPTION
**Description**

The issue was that `WbWrenVertexArrayFrameListener` thought that the frame had already been handled because it had been handled in the previous world.

**Related Issues**
This pull-request fixes issue #6659

**Tasks**

No changelog update because the issue did not exist in R2023a.


