### PR TITLE
Ensure that test_suite.py only tries to build controllers which have Makefiles.

### DIFF
--- a/tests/api/controllers/Makefile
+++ b/tests/api/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/cache/controllers/Makefile
+++ b/tests/cache/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/other_api/controllers/Makefile
+++ b/tests/other_api/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/parser/controllers/Makefile
+++ b/tests/parser/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/physics/controllers/Makefile
+++ b/tests/physics/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/protos/controllers/Makefile
+++ b/tests/protos/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean

--- a/tests/rendering/controllers/Makefile
+++ b/tests/rendering/controllers/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DIRECTORIES=$(subst test_suite_supervisor,,$(subst Makefile,,$(shell ls)))
+DIRECTORIES=$(dir $(wildcard */Makefile))
 TARGETS = $(DIRECTORIES:=.Makefile)
 
 .PHONY: release debug profile clean


### PR DESCRIPTION
**Description**

Switching between master and develop branches can result in controller directories sticking around that only contain the results of a build on the previous branch. test_suite.py was trying (and failing) to run make in those directories.


