### PR TITLE
Fix bug where the wrong y coord was used for one corner of the box drawn to represent a box-plane collision.

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -29,3 +29,4 @@ Released on December **th, 2023.
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).
+    - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6669](https://github.com/cyberbotics/webots/pull/6669)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -29,4 +29,4 @@ Released on December **th, 2023.
     - Fixed crash on macos when closing Webots under some circumstances ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).
-    - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6669](https://github.com/cyberbotics/webots/pull/6669)).
+    - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6677](https://github.com/cyberbotics/webots/pull/6677)).

--- a/src/webots/app/WbContactPointsRepresentation.cpp
+++ b/src/webots/app/WbContactPointsRepresentation.cpp
@@ -184,9 +184,9 @@ void WbContactPointsRepresentation::updateRendering() {
                   odeContacts[cg0 + 3].contactGeom().pos[2]);
         addVertex(mContactMesh, index++, odeContacts[cg0 + 3].contactGeom().pos[0], odeContacts[cg0 + 3].contactGeom().pos[1],
                   odeContacts[cg0 + 3].contactGeom().pos[2]);
-        addVertex(mContactMesh, index++, odeContacts[cg0 + 2].contactGeom().pos[0], odeContacts[cg0 + 1].contactGeom().pos[1],
+        addVertex(mContactMesh, index++, odeContacts[cg0 + 2].contactGeom().pos[0], odeContacts[cg0 + 2].contactGeom().pos[1],
                   odeContacts[cg0 + 2].contactGeom().pos[2]);
-        addVertex(mContactMesh, index++, odeContacts[cg0 + 2].contactGeom().pos[0], odeContacts[cg0 + 1].contactGeom().pos[1],
+        addVertex(mContactMesh, index++, odeContacts[cg0 + 2].contactGeom().pos[0], odeContacts[cg0 + 2].contactGeom().pos[1],
                   odeContacts[cg0 + 2].contactGeom().pos[2]);
         addVertex(mContactMesh, index++, odeContacts[cg0].contactGeom().pos[0], odeContacts[cg0].contactGeom().pos[1],
                   odeContacts[cg0].contactGeom().pos[2]);


### PR DESCRIPTION
**Description**
Fix bug where the wrong y coord was used for one corner of the box drawn to represent a box-plane collision.

**Tasks**
  - [X] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)
