### PR TITLE
Show box-plane contact point normals when showing contact points.

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -17,7 +17,7 @@ Released on December **th, 2023.
     - Removed support for Lua as a PROTO scripting language ([#6642](https://github.com/cyberbotics/webots/pull/6642)).
   - Enhancements
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
-    - Show box-plane contact point normals when showing contact points ([#6670](https://github.com/cyberbotics/webots/pull/6670)).
+    - Show box-plane contact point normals when showing contact points ([#6678](https://github.com/cyberbotics/webots/pull/6678)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
   - Bug Fixes

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -17,6 +17,7 @@ Released on December **th, 2023.
     - Removed support for Lua as a PROTO scripting language ([#6642](https://github.com/cyberbotics/webots/pull/6642)).
   - Enhancements
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
+    - Show box-plane contact point normals when showing contact points ([#6670](https://github.com/cyberbotics/webots/pull/6670)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).
   - Bug Fixes

--- a/src/webots/app/WbContactPointsRepresentation.cpp
+++ b/src/webots/app/WbContactPointsRepresentation.cpp
@@ -145,8 +145,6 @@ void WbContactPointsRepresentation::updateRendering() {
   const double L = 0.2 * world->worldInfo()->lineScale();
   for (int i = 0; i < contactSize; ++i) {
     const dContactGeom &cg = odeContacts[i].contactGeom();
-    if (boxVersusPlane(cg.g1, cg.g2))
-      continue;
     const dReal H[3] = {cg.normal[0] * L, cg.normal[1] * L, cg.normal[2] * L};
     const dReal *const pos = cg.pos;
     addVertex(mContactMesh, index++, pos[0] - H[0], pos[1] - H[1], pos[2] - H[2]);


### PR DESCRIPTION
**Description**
Show box-plane contact point normals when showing contact points. This had been intentionally prevented, but it isn't clear why. I found it confusing that these were missing when I enabled showing contact points.

**Tasks**
Add the list of tasks of this PR.
  - [X] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)

