### PR TITLE
Fix Bounding Box Initialization when a Geometry is Inserted into a Shape

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -30,3 +30,4 @@ Released on December **th, 2023.
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).
     - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6677](https://github.com/cyberbotics/webots/pull/6677)).
+    - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).

--- a/src/webots/nodes/WbGeometry.cpp
+++ b/src/webots/nodes/WbGeometry.cpp
@@ -466,7 +466,7 @@ void WbGeometry::setOdeMass(const dMass *mass) {
 }
 
 void WbGeometry::setOdeData(dGeomID geom, WbMatter *matterAncestor) {
-  assert(geom && matterAncestor);
+  assert(geom && geom != mOdeGeom && matterAncestor);
 
   if (!areOdeObjectsCreated())
     createOdeObjects();

--- a/src/webots/nodes/WbMatter.cpp
+++ b/src/webots/nodes/WbMatter.cpp
@@ -377,7 +377,7 @@ void WbMatter::createOdeGeomFromInsertedShapeItem() {
     if (eg)
       connect(eg, &WbElevationGrid::validElevationGridInserted, shape, &WbShape::geometryInShapeInserted, Qt::UniqueConnection);
 
-    insertedGeom = createOdeGeomFromGeometry(upperSpace(), geometry);
+    insertedGeom = createOdeGeomFromGeometry(upperSpace(), geometry, false);
     if (insertedGeom == NULL) {
       assert(ifs || eg);
       return;

--- a/src/webots/nodes/WbMatter.cpp
+++ b/src/webots/nodes/WbMatter.cpp
@@ -279,6 +279,8 @@ dGeomID WbMatter::createOdeGeomFromGeometry(dSpaceID space, WbGeometry *geometry
   dGeomID geom = geometry->createOdeGeom(space);
 
   if (geom && setOdeData) {
+    // Stores a pointer to the ODE geometry into the WbGeometry node & sets the WbGeometry node and its WbMatter parent node as
+    // reference data
     geometry->setOdeData(geom, this);
     connect(geometry, &WbGeometry::boundingGeometryRemoved, this, &WbMatter::removeBoundingGeometry, Qt::UniqueConnection);
   }
@@ -333,16 +335,7 @@ dGeomID WbMatter::createOdeGeomFromPose(dSpaceID space, WbPose *pose) {
   if (eg)  // TODO: rename slot?
     connect(eg, &WbElevationGrid::validElevationGridInserted, pose, &WbPose::geometryInPoseInserted, Qt::UniqueConnection);
 
-  dGeomID geom = createOdeGeomFromGeometry(space, geometry, false);
-  if (geom == NULL)
-    return NULL;
-
-  // Stores a pointer to the ODE geometry into the WbGeometry node & sets the WbGeometry node and its WbMatter parent node as
-  // reference data
-  geometry->setOdeData(geom, this);
-  connect(geometry, &WbGeometry::boundingGeometryRemoved, this, &WbMatter::removeBoundingGeometry, Qt::UniqueConnection);
-
-  return geom;
+  return createOdeGeomFromGeometry(space, geometry);
 }
 
 void WbMatter::createOdeGeomFromInsertedPoseItem() {
@@ -377,15 +370,12 @@ void WbMatter::createOdeGeomFromInsertedShapeItem() {
     if (eg)
       connect(eg, &WbElevationGrid::validElevationGridInserted, shape, &WbShape::geometryInShapeInserted, Qt::UniqueConnection);
 
-    insertedGeom = createOdeGeomFromGeometry(upperSpace(), geometry, false);
+    insertedGeom = createOdeGeomFromGeometry(upperSpace(), geometry);
     if (insertedGeom == NULL) {
       assert(ifs || eg);
       return;
     }
-    // Stores a pointer to the ODE geometry into the WbGeometry node & sets the WbGeometry node and its WbMatter parent node as
-    // reference data
-    geometry->setOdeData(insertedGeom, this);
-    connect(geometry, &WbGeometry::boundingGeometryRemoved, this, &WbMatter::removeBoundingGeometry, Qt::UniqueConnection);
+
     setGeomMatter(insertedGeom, geometry);
   }
 


### PR DESCRIPTION
**Description**
Currently, when `WbMatter` creates an ode geometry from a newly inserted `WbGeometry` in a `Shape` node, `WbGeometry::setOdeData` is called twice by `WbMatter::createOdeGeomFromInsertedShapeItem` (once directly and once through the call to `WbMatter::createOdeGeomFromGeometry`). Because `setOdeData` destroys its old geometry, this has the effect of setting the geometry to an invalid pointer. This PR removes one of these calls so that the geometry is only set once. Additionally, the assumption that `geom != mOdeGeom` in `WbGeometry::setOdeData` is now included in an assertion, so future similar problems should be easier to identify.

I also did a small bit of deduplication in e254766. Those changes can be reviewed independently. If they are determined to be out of scope for this PR, that commit can be safely reverted without affecting the rest of the PR.

**Related Issues**
This pull-request fixes issue #6675.

**Tasks**
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)