### PR TITLE
Fix Worlds Test on Forked Repositories

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -175,9 +175,6 @@ jobs:
       with:
         name: build-ubuntu-20.04
         path: artifact
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v7.0.7
     - name: Extract Webots and Cache
       run: |
         tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
@@ -188,14 +185,20 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
+    - name: Download Scripts
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/install/linux_runtime_dependencies.sh
+          tests/test_worlds.py
+        sparse-checkout-cone-mode: false
     - name: Update World, Check Warnings and Validate Cache
       run: |
-        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
+        sudo bash scripts/install/linux_runtime_dependencies.sh
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
         export WEBOTS_HOME=$PWD/artifact/webots
-        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
-        xvfb-run --auto-servernum python3 test_worlds.py
+        xvfb-run --auto-servernum python3 tests/test_worlds.py
         if [[ "$(diff -qr artifact/ untouched-artifact/ | wc -l)" -ne "0" ]]; then echo Some world and/or wbproj files are not up to date: "$(diff -qr artifact/ untouched-artifact/)"; exit 1; fi
   delete-artifacts:
     needs: [build, test-suite, test-ros, test-worlds]

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -9,7 +9,6 @@ on:
     tags:
       - nightly_*
       - R20*
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - nightly_*
       - R20*
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -190,11 +191,11 @@ jobs:
         python-version: 3.9
     - name: Update World, Check Warnings and Validate Cache
       run: |
-        wget https://raw.githubusercontent.com/cyberbotics/webots/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
+        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
         export WEBOTS_HOME=$PWD/artifact/webots
-        wget https://raw.githubusercontent.com/cyberbotics/webots/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
+        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
         xvfb-run --auto-servernum python3 test_worlds.py
         if [[ "$(diff -qr artifact/ untouched-artifact/ | wc -l)" -ne "0" ]]; then echo Some world and/or wbproj files are not up to date: "$(diff -qr artifact/ untouched-artifact/)"; exit 1; fi
   delete-artifacts:

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -170,6 +170,13 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test worlds') || github.event_name == 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
+    - name: Download Scripts
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/install/linux_runtime_dependencies.sh
+          tests/test_worlds.py
+        sparse-checkout-cone-mode: false
     - name: Download Artifacts
       uses: actions/download-artifact@v4.1.7
       with:
@@ -190,14 +197,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Download Scripts
-      uses: actions/checkout@v4
-      with:
-        clean: false
-        sparse-checkout: |
-          scripts/install/linux_runtime_dependencies.sh
-          tests/test_worlds.py
-        sparse-checkout-cone-mode: false
     - run: |
         ls -l artifact
         echo $PWD

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -175,12 +175,14 @@ jobs:
       with:
         name: build-ubuntu-20.04
         path: artifact
+    - run: ls -l artifact
     - name: Extract Webots and Cache
       run: |
         tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
         cp -R artifact/ untouched-artifact/
         mkdir -p ~/.cache/Cyberbotics/Webots/
         unzip -q artifact/assets-*.zip -d ~/.cache/Cyberbotics/Webots/assets
+    - run: ls -l artifact
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -182,25 +182,16 @@ jobs:
       with:
         name: build-ubuntu-20.04
         path: artifact
-    - run: ls -l artifact
     - name: Extract Webots and Cache
       run: |
         tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
         cp -R artifact/ untouched-artifact/
         mkdir -p ~/.cache/Cyberbotics/Webots/
         unzip -q artifact/assets-*.zip -d ~/.cache/Cyberbotics/Webots/assets
-    - run: |
-        ls -l artifact
-        echo $PWD
-        ls -l /home/runner/work/webots/webots/artifact/webots
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - run: |
-        ls -l artifact
-        echo $PWD
-        ls -l /home/runner/work/webots/webots/artifact/webots
     - name: Update World, Check Warnings and Validate Cache
       run: |
         sudo bash scripts/install/linux_runtime_dependencies.sh

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -193,6 +193,7 @@ jobs:
     - name: Download Scripts
       uses: actions/checkout@v4
       with:
+        clean: false
         sparse-checkout: |
           scripts/install/linux_runtime_dependencies.sh
           tests/test_worlds.py

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -182,7 +182,10 @@ jobs:
         cp -R artifact/ untouched-artifact/
         mkdir -p ~/.cache/Cyberbotics/Webots/
         unzip -q artifact/assets-*.zip -d ~/.cache/Cyberbotics/Webots/assets
-    - run: ls -l artifact
+    - run: |
+        ls -l artifact
+        echo $PWD
+        ls -l /home/runner/work/webots/webots/artifact/webots
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -197,6 +197,10 @@ jobs:
           scripts/install/linux_runtime_dependencies.sh
           tests/test_worlds.py
         sparse-checkout-cone-mode: false
+    - run: |
+        ls -l artifact
+        echo $PWD
+        ls -l /home/runner/work/webots/webots/artifact/webots
     - name: Update World, Check Warnings and Validate Cache
       run: |
         sudo bash scripts/install/linux_runtime_dependencies.sh

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -183,11 +183,11 @@ jobs:
         python-version: 3.9
     - name: Update World, Check Warnings and Validate Cache
       run: |
-        wget https://raw.githubusercontent.com/cyberbotics/webots/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
+        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
         export WEBOTS_HOME=$PWD/artifact/webots
-        sudo apt install -y wget && wget https://raw.githubusercontent.com/cyberbotics/webots/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
+        sudo apt install -y wget && wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
         xvfb-run --auto-servernum python3 test_worlds.py
         if [[ "$(diff -qr artifact/ untouched-artifact/ | wc -l)" -ne "0" ]]; then echo Some world and/or wbproj files are not up to date: "$(diff -qr artifact/ untouched-artifact/)"; exit 1; fi
   delete-artifacts:

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -168,9 +168,6 @@ jobs:
       with:
         name: build-ubuntu-20.04
         path: artifact
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v7.0.7
     - name: Extract Webots and Cache
       run: |
         tar xjf artifact/webots-*-x86-64*.tar.bz2 -C artifact
@@ -181,14 +178,20 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Download Scripts
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/install/linux_runtime_dependencies.sh
+          tests/test_worlds.py
+        sparse-checkout-cone-mode: false
     - name: Update World, Check Warnings and Validate Cache
       run: |
-        wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/scripts/install/linux_runtime_dependencies.sh && sudo bash linux_runtime_dependencies.sh
+        sudo bash scripts/install/linux_runtime_dependencies.sh
         export LIBGL_ALWAYS_SOFTWARE=true
         export WEBOTS_DISABLE_SAVE_SCREEN_PERSPECTIVE_ON_CLOSE=true
         export WEBOTS_HOME=$PWD/artifact/webots
-        sudo apt install -y wget && wget https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.branch-name.outputs.current_branch }}/tests/test_worlds.py
-        xvfb-run --auto-servernum python3 test_worlds.py
+        xvfb-run --auto-servernum python3 tests/test_worlds.py
         if [[ "$(diff -qr artifact/ untouched-artifact/ | wc -l)" -ne "0" ]]; then echo Some world and/or wbproj files are not up to date: "$(diff -qr artifact/ untouched-artifact/)"; exit 1; fi
   delete-artifacts:
     needs: [build, test-suite, test-ros, test-worlds]

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -163,6 +163,13 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test worlds') || github.event_name == 'schedule' }}
     runs-on: ubuntu-20.04
     steps:
+    - name: Download Scripts
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/install/linux_runtime_dependencies.sh
+          tests/test_worlds.py
+        sparse-checkout-cone-mode: false
     - name: Download Artifacts
       uses: actions/download-artifact@v4.1.7
       with:
@@ -178,14 +185,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Download Scripts
-      uses: actions/checkout@v4
-      with:
-        clean: false
-        sparse-checkout: |
-          scripts/install/linux_runtime_dependencies.sh
-          tests/test_worlds.py
-        sparse-checkout-cone-mode: false
     - name: Update World, Check Warnings and Validate Cache
       run: |
         sudo bash scripts/install/linux_runtime_dependencies.sh

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -181,6 +181,7 @@ jobs:
     - name: Download Scripts
       uses: actions/checkout@v4
       with:
+        clean: false
         sparse-checkout: |
           scripts/install/linux_runtime_dependencies.sh
           tests/test_worlds.py

--- a/tests/test_worlds.py
+++ b/tests/test_worlds.py
@@ -69,7 +69,6 @@ class TestWorldsWarnings(unittest.TestCase):
                 self.webotsFullPath = os.path.join('..', webotsBinary)
             if not os.path.isfile(self.webotsFullPath):
                 print('Error: ' + webotsBinary + ' binary not found')
-                print(f'WEBOTS_HOME: {os.listdir(WEBOTS_HOME)}')
                 sys.exit(1)
             self.webotsFullPath = os.path.normpath(self.webotsFullPath)
 

--- a/tests/test_worlds.py
+++ b/tests/test_worlds.py
@@ -69,6 +69,7 @@ class TestWorldsWarnings(unittest.TestCase):
                 self.webotsFullPath = os.path.join('..', webotsBinary)
             if not os.path.isfile(self.webotsFullPath):
                 print('Error: ' + webotsBinary + ' binary not found')
+                print(f'WEBOTS_HOME: {WEBOTS_HOME}')
                 sys.exit(1)
             self.webotsFullPath = os.path.normpath(self.webotsFullPath)
 

--- a/tests/test_worlds.py
+++ b/tests/test_worlds.py
@@ -69,7 +69,7 @@ class TestWorldsWarnings(unittest.TestCase):
                 self.webotsFullPath = os.path.join('..', webotsBinary)
             if not os.path.isfile(self.webotsFullPath):
                 print('Error: ' + webotsBinary + ' binary not found')
-                print(f'WEBOTS_HOME: {WEBOTS_HOME}')
+                print(f'WEBOTS_HOME: {os.listdir(WEBOTS_HOME)}')
                 sys.exit(1)
             self.webotsFullPath = os.path.normpath(self.webotsFullPath)
 


### PR DESCRIPTION
**Description**
Currently, the `test-worlds` job in the Linux CI workflow explicitly refers to the `cyberbotics/Webots` repository when attempting to download the necessary scripts. This causes the workflow to fail when run on a fork. This PR updates the job to use a sparse checkout to retrieve the files, which is repo-agnostic.
