### PR TITLE
Fix bug in Python "example.wbt" world

### DIFF
--- a/lib/controller/python/controller/field.py
+++ b/lib/controller/python/controller/field.py
@@ -63,7 +63,7 @@ class Field:
     wb.wb_supervisor_virtual_reality_headset_get_orientation = ctypes.POINTER(ctypes.c_double)
 
     def __init__(self, ref: ctypes.c_void_p):
-        self._ref = ref
+        self._ref = ctypes.c_void_p(ref)
         if self._ref:
             self.type = wb.wb_supervisor_field_get_type(self._ref)
         else:

--- a/projects/languages/python/controllers/driver/driver.py
+++ b/projects/languages/python/controllers/driver/driver.py
@@ -29,7 +29,7 @@ class Driver (Supervisor):
     translation = [x, y, 0]
 
     def __init__(self):
-        super(Driver, self).__init__()
+        super(Driver, self).__init__() # First commit
         self.emitter = self.getDevice('emitter')
         robot = self.getFromDef('ROBOT1')
         self.translationField = robot.getField('translation')

--- a/projects/languages/python/controllers/driver/driver.py
+++ b/projects/languages/python/controllers/driver/driver.py
@@ -29,7 +29,7 @@ class Driver (Supervisor):
     translation = [x, y, 0]
 
     def __init__(self):
-        super(Driver, self).__init__() # First commit
+        super(Driver, self).__init__()
         self.emitter = self.getDevice('emitter')
         robot = self.getFromDef('ROBOT1')
         self.translationField = robot.getField('translation')


### PR DESCRIPTION
**Description**
When running the simulation this error message appears: _Error: wb_supervisor_field_get_type() called with invalid 'field' argument._

**Related Issues**
Fixes #6707

**Tasks**
  - [x] Establish where the error comes from
  - [x] Fix the error

**Additional Information**
I suspect that the bug is related to PR #6613.
https://github.com/cyberbotics/webots/blob/37f0c144eb311a598e5f99345021060aad04fca4/src/controller/c/supervisor.c#L1398-L1422
The _check_field_ failed, meaning the field reference (_WbFieldRef_) was not found in the _field_list_. 
That means that the _field_list_ is not updated correctly, or the field reference _f_ was not properly retreived from _wb_supervisor_field_get_type_ method.