### PR TITLE
Fix rollers rotating angle In "omni_wheels.wbt" sample world

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -30,6 +30,6 @@ Released on December **th, 2023.
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).
     - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6677](https://github.com/cyberbotics/webots/pull/6677)).
-    - Fixed bug where the rotation axis of the omni wheel rollers was incorrect ([6710](https://github.com/cyberbotics/webots/pull/6710)).
+    - Fixed bug where the rotation axis of the omni wheel rollers were incorrect ([6710](https://github.com/cyberbotics/webots/pull/6710)).
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -30,5 +30,6 @@ Released on December **th, 2023.
     - Fixed error on macos when when putting displays and cameras in separate windows ([#6635](https://github.com/cyberbotics/webots/pull/6635)).
     - Fixed crash when `wb_supervisor_field_get_name` was called with NULL ([#6647](https://github.com/cyberbotics/webots/pull/6647)).
     - Fixed bug where the wrong y coordinate was used for one corner of the box drawn to represent a box-plane collision ([#6677](https://github.com/cyberbotics/webots/pull/6677)).
+    - Fixed bug where the rotation axis of the omni wheel rollers was incorrect ([6710](https://github.com/cyberbotics/webots/pull/6710)).
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).

--- a/projects/samples/howto/omni_wheels/worlds/omni_wheels.wbt
+++ b/projects/samples/howto/omni_wheels/worlds/omni_wheels.wbt
@@ -43,6 +43,7 @@ DEF OMNI_WHEELS Robot {
             children [
               DEF sr1 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 0.05
                 }
                 endPoint Solid {
@@ -100,6 +101,7 @@ DEF OMNI_WHEELS Robot {
               }
               DEF sr3 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 -0.05
                 }
                 endPoint Solid {
@@ -306,6 +308,7 @@ DEF OMNI_WHEELS Robot {
             children [
               DEF sr1 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 0.05
                 }
                 endPoint Solid {
@@ -343,6 +346,7 @@ DEF OMNI_WHEELS Robot {
               }
               DEF sr3 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 -0.05
                 }
                 endPoint Solid {
@@ -502,6 +506,7 @@ DEF OMNI_WHEELS Robot {
             children [
               DEF sr1 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 0.05
                 }
                 endPoint Solid {
@@ -539,6 +544,7 @@ DEF OMNI_WHEELS Robot {
               }
               DEF sr3 HingeJoint {
                 jointParameters HingeJointParameters {
+                  axis 0 1 0
                   anchor -0.02 0 -0.05
                 }
                 endPoint Solid {


### PR DESCRIPTION
**Description**
Omni wheeled robot in webots sample project is having issue with the rollers rotation.
The rollers are rotating around wrong axis.

**Related Issues**
Fixes #6616 

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix the rotating angle of the rollers
  - [x] Update changelog

**Screenshots**
Rotating axis of the rollers before the modification:
![before](https://github.com/user-attachments/assets/3a28acbd-5fd3-46a7-b828-064b1828e3d3)

Rotating axis of the rollers after the modification:
![after](https://github.com/user-attachments/assets/f5e077c0-c0df-488a-97ec-5099f92d6975)

**Additional context**
After the fix, the rollers of all three omni wheels are rotating as expected.
