### PR TITLE
Add styles for webots classic, dusk and dark mode

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -15,6 +15,7 @@ Released on December **th, 2023.
       - Added the ability to query the field in the scene tree that corresponds to a proto internal field.
       - Fixed the method signature of `wb_supervisor_node_get_number_of_fields` in MATLAB.
     - Removed support for Lua as a PROTO scripting language ([#6642](https://github.com/cyberbotics/webots/pull/6642)).
+    - Adapt QtToolTip text box for every Webots mode ([#6711](https://github.com/cyberbotics/webots/pull/6711)).
   - Enhancements
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
     - Show box-plane contact point normals when showing contact points ([#6678](https://github.com/cyberbotics/webots/pull/6678)).
@@ -45,3 +46,4 @@ Released on December **th, 2023.
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).
     - Fixed handling of remote assets from unofficial sources ([#6585](https://github.com/cyberbotics/webots/pull/6585)).
+    - Fixed the QtToolTip bug, where the text in the text box is not being displayed ([#6711](https://github.com/cyberbotics/webots/pull/6711)).

--- a/resources/webots_classic.qss
+++ b/resources/webots_classic.qss
@@ -932,3 +932,12 @@ QProgressBar::chunk {
   background: #308cc6;
   border-radius: 3px;
 }
+
+QToolTip {
+  background-color: #f5f5f5;
+  color: #000;
+  border: 1px solid #ccc;
+  padding: 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}

--- a/resources/webots_dusk.qss
+++ b/resources/webots_dusk.qss
@@ -932,3 +932,13 @@ QProgressBar::chunk {
   background: #61e2a8;
   border-radius: 3px;
 }
+
+QToolTip {
+  background-color: #33333f;
+  color: #fff;
+  border: 1px solid #41f4c1;
+  padding: 4px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: Arial, sans-serif;
+}

--- a/resources/webots_night.qss
+++ b/resources/webots_night.qss
@@ -932,3 +932,12 @@ QProgressBar::chunk {
   background: #9b93ff;
   border-radius: 3px;
 }
+
+QToolTip {
+  background-color: #22222a;
+  color: #fff;
+  border: 1px solid #a98dff;
+  padding: 4px;
+  border-radius: 4px;
+  font-size: 12px;
+}


### PR DESCRIPTION
**Description**
Adapt the QtToolTip by adding styles for Webots classic, dusk and dark mode.

**Related Issues**
Fixes #6709

**Tasks**
Add the list of tasks of this PR.
  - [x] Fix QtToolTip issue
  - [x] Adapt styles for Webots modes
  - [x] Update changelog

**Screenshots**
Old theme for all modes:
![old_theme](https://github.com/user-attachments/assets/6c08aaee-50ef-45fd-819e-071a3de7e8d3)
New theme for classic mode:
![classic_theme](https://github.com/user-attachments/assets/652ebebd-37bd-4d67-8a6b-99468f4db07e)
New theme for dusk mode:
![dusk_theme](https://github.com/user-attachments/assets/75184659-36cc-46a0-a603-d61924c2c5c3)
New theme for night mode:
![night_theme](https://github.com/user-attachments/assets/ae375a38-aa46-4027-b9c7-67024cb17013)

**Additional context**
Since the old theme looked outdated, I decided to adapt the QtToolTip for every theme for better user experience.
