### PR TITLE
Fix `WbField::isParameter` for Unconnected Fields

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -33,3 +33,4 @@ Released on December **th, 2023.
     - Fixed bug where the rotation axis of the omni wheel rollers were incorrect ([6710](https://github.com/cyberbotics/webots/pull/6710)).
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).
+    - Fixed a bug preventing nodes from being inserted into unconnected proto fields ([#6735](https://github.com/cyberbotics/webots/pull/6735)).

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -131,8 +131,7 @@ bool WbTemplateManager::nodeNeedsToSubscribe(WbNode *node) {
 void WbTemplateManager::recursiveFieldSubscribeToRegenerateNode(WbNode *node, bool subscribedNode, bool subscribedDescendant) {
   if (subscribedNode || subscribedDescendant) {
     if (node->isProtoInstance())
-      connect(node, &WbNode::parameterChanged, this, &WbTemplateManager::regenerateNodeFromField,
-              Qt::UniqueConnection);
+      connect(node, &WbNode::parameterChanged, this, &WbTemplateManager::regenerateNodeFromField, Qt::UniqueConnection);
     else
       connect(node, &WbNode::fieldChanged, this, &WbTemplateManager::regenerateNodeFromField, Qt::UniqueConnection);
   }

--- a/src/webots/nodes/utils/WbTemplateManager.cpp
+++ b/src/webots/nodes/utils/WbTemplateManager.cpp
@@ -131,10 +131,10 @@ bool WbTemplateManager::nodeNeedsToSubscribe(WbNode *node) {
 void WbTemplateManager::recursiveFieldSubscribeToRegenerateNode(WbNode *node, bool subscribedNode, bool subscribedDescendant) {
   if (subscribedNode || subscribedDescendant) {
     if (node->isProtoInstance())
-      connect(node, &WbNode::parameterChanged, this, &WbTemplateManager::regenerateNodeFromParameterChange,
+      connect(node, &WbNode::parameterChanged, this, &WbTemplateManager::regenerateNodeFromField,
               Qt::UniqueConnection);
     else
-      connect(node, &WbNode::fieldChanged, this, &WbTemplateManager::regenerateNodeFromFieldChange, Qt::UniqueConnection);
+      connect(node, &WbNode::fieldChanged, this, &WbTemplateManager::regenerateNodeFromField, Qt::UniqueConnection);
   }
 
   // if PROTO node:
@@ -177,25 +177,15 @@ void WbTemplateManager::recursiveFieldSubscribeToRegenerateNode(WbNode *node, bo
   }
 }
 
-void WbTemplateManager::regenerateNodeFromFieldChange(WbField *field) {
-  // retrieve the right node
-  WbNode *templateNode = dynamic_cast<WbNode *>(sender());
-  assert(templateNode);
-  if (templateNode)
-    regenerateNodeFromField(templateNode, field, false);
-}
-
-void WbTemplateManager::regenerateNodeFromParameterChange(WbField *field) {
-  // retrieve the right node
-  WbNode *templateNode = dynamic_cast<WbNode *>(sender());
-  assert(templateNode);
-  if (templateNode)
-    regenerateNodeFromField(templateNode, field, true);
-}
-
 // intermediate function to determine which node should be updated
 // Note: The security is probably overkill there, but its also safer for the first versions of the template mechanism
-void WbTemplateManager::regenerateNodeFromField(WbNode *templateNode, WbField *field, bool isParameter) {
+void WbTemplateManager::regenerateNodeFromField(WbField *field) {
+  // retrieve the right node
+  WbNode *templateNode = dynamic_cast<WbNode *>(sender());
+  assert(templateNode);
+  if (!templateNode)
+    return;
+
   // 1. retrieve upper template node where the modification appeared in a template regenerator field
   WbNode *upperTemplateNode = WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(field, templateNode);
 
@@ -203,7 +193,7 @@ void WbTemplateManager::regenerateNodeFromField(WbNode *templateNode, WbField *f
     return;
 
   // 2. check it's not a parameter managed by ODE
-  if (!isParameter && dynamic_cast<const WbSolid *>(templateNode) &&
+  if (!field->isParameter() && dynamic_cast<const WbSolid *>(templateNode) &&
       ((field->name() == "translation" && field->type() == WB_SF_VEC3F) ||
        (field->name() == "rotation" && field->type() == WB_SF_ROTATION) ||
        (field->name() == "position" && field->type() == WB_SF_FLOAT)))

--- a/src/webots/nodes/utils/WbTemplateManager.hpp
+++ b/src/webots/nodes/utils/WbTemplateManager.hpp
@@ -52,8 +52,7 @@ signals:
 
 private slots:
   void unsubscribe(QObject *node);
-  void regenerateNodeFromFieldChange(WbField *field);
-  void regenerateNodeFromParameterChange(WbField *field);
+  void regenerateNodeFromField(WbField *field);
   void regenerateNode(WbNode *node, bool restarted = false);
   void nodeNeedRegeneration();
 
@@ -67,7 +66,6 @@ private:
 
   bool nodeNeedsToSubscribe(WbNode *node);
   void recursiveFieldSubscribeToRegenerateNode(WbNode *node, bool subscribedNode, bool subscribedDescendant);
-  void regenerateNodeFromField(WbNode *templateNode, WbField *field, bool isParameter);
 
   QList<WbNode *> mTemplates;
   QSet<const WbNode *> mNodesSubscribedForRegeneration;

--- a/src/webots/scene_tree/WbAddNodeDialog.cpp
+++ b/src/webots/scene_tree/WbAddNodeDialog.cpp
@@ -450,7 +450,7 @@ void WbAddNodeDialog::buildTree() {
     static const QString INVALID_FOR_INSERTION_IN_BOUNDING_OBJECT("N");
 
     const WbField *const actualField =
-      (mField->isParameter() && !mField->alias().isEmpty()) ? mField->internalFields().at(0) : mField;
+      (!mField->internalFields().isEmpty() && !mField->alias().isEmpty()) ? mField->internalFields().at(0) : mField;
     bool boInfo = actualField->name() == "boundingObject";
     if (!boInfo)
       boInfo = nodeUse & WbNode::BOUNDING_OBJECT_USE;

--- a/src/webots/scene_tree/WbExtendedStringEditor.cpp
+++ b/src/webots/scene_tree/WbExtendedStringEditor.cpp
@@ -453,7 +453,7 @@ void WbExtendedStringEditor::edit(bool copyOriginalValue) {
 
   if (copyOriginalValue) {
     const WbField *effectiveField = field();
-    if (effectiveField->isParameter())
+    if (!effectiveField->internalFields().isEmpty())
       effectiveField = effectiveField->internalFields().at(0);
 
     mStringType = fieldNameToStringType(effectiveField->name(), effectiveField->parentNode());

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -104,6 +104,12 @@ bool WbField::isDeprecated() const {
   return mModel->isDeprecated();
 }
 
+// Because of unconnected fields, the only way to definitively check if a field is a parameter is to check its parent node
+// If that is not possible, fallback to the old behavior (See #6604 and #<PR PENDING>)
+bool isParameter() const {
+  return parentNode() ? parentNode()->isProtoInstance() : !mInternalFields.isEmpty();
+}
+
 void WbField::readValue(WbTokenizer *tokenizer, const QString &worldPath) {
   if (mWasRead)
     tokenizer->reportError(tr("Duplicate field value: '%1'").arg(name()));

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -106,7 +106,7 @@ bool WbField::isDeprecated() const {
 
 // Because of unconnected fields, the only way to definitively check if a field is a parameter is to check its parent node
 // If that is not possible, fallback to the old behavior (See #6604 and #<PR PENDING>)
-bool isParameter() const {
+bool WbField::isParameter() const {
   return parentNode() ? parentNode()->isProtoInstance() : !mInternalFields.isEmpty();
 }
 

--- a/src/webots/vrml/WbField.cpp
+++ b/src/webots/vrml/WbField.cpp
@@ -105,7 +105,7 @@ bool WbField::isDeprecated() const {
 }
 
 // Because of unconnected fields, the only way to definitively check if a field is a parameter is to check its parent node
-// If that is not possible, fallback to the old behavior (See #6604 and #<PR PENDING>)
+// If that is not possible, fallback to the old behavior (See #6604 and #6735)
 bool WbField::isParameter() const {
   return parentNode() ? parentNode()->isProtoInstance() : !mInternalFields.isEmpty();
 }

--- a/src/webots/vrml/WbField.hpp
+++ b/src/webots/vrml/WbField.hpp
@@ -69,9 +69,7 @@ public:
   void redirectTo(WbField *parameter, bool skipCopy = false);
   WbField *parameter() const { return mParameter; }
   const QList<WbField *> &internalFields() const { return mInternalFields; }
-  // Because of unconnected fields, the only way to definitively check if a field is a parameter is to check its parent node
-  // If that is not possible, fallback to the old behavior (See #6604 and #<PR PENDING>)
-  bool isParameter() const { return parentNode() ? parentNode()->isProtoInstance() : !mInternalFields.isEmpty(); }
+  bool isParameter() const;
 
   void clearInternalFields() { mInternalFields.clear(); }
 

--- a/src/webots/vrml/WbField.hpp
+++ b/src/webots/vrml/WbField.hpp
@@ -69,7 +69,9 @@ public:
   void redirectTo(WbField *parameter, bool skipCopy = false);
   WbField *parameter() const { return mParameter; }
   const QList<WbField *> &internalFields() const { return mInternalFields; }
-  bool isParameter() const { return mInternalFields.size() != 0; }
+  // Because of unconnected fields, the only way to definitively check if a field is a parameter is to check its parent node
+  // If that is not possible, fallback to the old behavior (See #6604 and #<PR PENDING>)
+  bool isParameter() const { return parentNode() ? parentNode()->isProtoInstance() : !mInternalFields.isEmpty(); }
 
   void clearInternalFields() { mInternalFields.clear(); }
 


### PR DESCRIPTION
**Description**
Updates `WbField::isParameter()` so that it returns true even on `unconnectedFields` (which have no internal fields). This fixes the linked issue.

Some parts of the codebase previously assumed that `field->isParameter() => !field->internalFields().isEmpty()`. Given that that is no longer the case, those sections have been updated to perform that check explicitly. Additionally, `WbTemplateManager::regenerateNodeFromFieldChange` and `WbTemplateManager::regenerateNodeFromParameterChange` appeared to be workarounds to call `WbTemplateManager::regenerateNodeFromField` given that there was no way to directly tell if a field was a parameter, so I updated `regenerateNodeFromField` to make use of `WbField::isParameter` and deleted the other two.

**Related Issues**
This pull-request fixes issue #6604.

**Tasks**
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2024.md)