### PR TITLE
Restore Support for Ubuntu 20.04 in Dependency Installation Scripts

### DIFF
--- a/scripts/install/linux_compilation_dependencies.sh
+++ b/scripts/install/linux_compilation_dependencies.sh
@@ -15,7 +15,9 @@ apt update
 apt install --yes git lsb-release cmake swig libglu1-mesa-dev libglib2.0-dev libfreeimage3 libfreetype6-dev libxml2-dev libboost-dev libssh-gcrypt-dev libzip-dev libreadline-dev pbzip2 wget zip unzip python3 python3-pip libopenal-dev
 
 UBUNTU_VERSION=$(lsb_release -rs)
-if [[ $UBUNTU_VERSION == "22.04" || $UBUNTU_VERSION == "24.04" ]]; then
+if [[ $UBUNTU_VERSION == "20.04" ]]; then
+       apt install --yes libzip5 perl libtext-template-perl
+elif [[ $UBUNTU_VERSION == "22.04" || $UBUNTU_VERSION == "24.04" ]]; then
        apt install --yes libzip4 openssl
 else
        echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."

--- a/scripts/install/linux_runtime_dependencies.sh
+++ b/scripts/install/linux_runtime_dependencies.sh
@@ -18,7 +18,7 @@ if [[ -z "$DISPLAY" ]]; then
 fi
 
 UBUNTU_VERSION=$(lsb_release -rs)
-if [[ $UBUNTU_VERSION == "22.04" || $UBUNTU_VERSION == "24.04" ]]; then
+if [[ $UBUNTU_VERSION == "20.04" || $UBUNTU_VERSION == "22.04" || $UBUNTU_VERSION == "24.04" ]]; then
        apt install --yes ffmpeg
 else
        echo "Unsupported Linux version: dependencies may not be completely installed. Only the two latest Ubuntu LTS are supported."


### PR DESCRIPTION
**Description**
#6719 removed support for Ubuntu 20.04 in some of the setup scripts. However, because the master branch is still built against 20.04 (iirc only develop has been fully updated for 24.04), this is causing CI failures. IMO, this removal should only target develop and not master. However, given that the other changes from that PR are necessary to fix the Windows and develop builds, it does not make sense to fully revert #6719.

This PR reverts enough to fix the master CI and retains support for 24.04. Given that develop no longer supports 20.04, after this is synchronized, another PR should be opened to fully revert this PR (#6736) *on develop only*. (This can be done by either me or another contributor/maintainer.)
