### PR TITLE
Pin empy Version in Ros CI Test

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         export WEBOTS_HOME=$PWD/artifact/webots
         export ROS_DISTRO=${{ matrix.ROS_DISTRO }}
-        python -m pip install rospkg catkin_pkg empy defusedxml netifaces
+        python -m pip install rospkg catkin_pkg empy==3.3.4 defusedxml netifaces
         Xvfb :99 &
         export DISPLAY=:99
         ./tests/ros.sh


### PR DESCRIPTION
**Description**
Pins the empy version in the ros CI to 3.3.4 (as suggested [here](https://stackoverflow.com/a/77656642/22362115)) to fix the ros CI failure.
