### PR TITLE
Fix Crash When Loading an Invalid Background HDR Image

### DIFF
--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -34,4 +34,4 @@ Released on December **th, 2023.
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).
     - Fixed a bug preventing nodes from being inserted into unconnected proto fields ([#6735](https://github.com/cyberbotics/webots/pull/6735)).
-    - Fixed crash when an invalid HDR image was set as a world background ([#6744](httpsjson://github.com/cyberbotics/webots/pull/6744)).
+    - Fixed crash when an invalid HDR image was set as a world background ([#6744](https://github.com/cyberbotics/webots/pull/6744)).

--- a/docs/reference/changelog-r2024.md
+++ b/docs/reference/changelog-r2024.md
@@ -34,3 +34,4 @@ Released on December **th, 2023.
     - Fixed a bug where Webots would crash if a geometry was inserted into a `Shape` node used a bounding box ([#6691](https://github.com/cyberbotics/webots/pull/6691)).
     - Removed the old `wb_supervisor_field_import_sf_node` and `wb_supervisor_field_import_mf_node` functions from the list of editor autocomplete suggestions ([#6701](https://github.com/cyberbotics/webots/pull/6701)).
     - Fixed a bug preventing nodes from being inserted into unconnected proto fields ([#6735](https://github.com/cyberbotics/webots/pull/6735)).
+    - Fixed crash when an invalid HDR image was set as a world background ([#6744](httpsjson://github.com/cyberbotics/webots/pull/6744)).

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -540,6 +540,11 @@ bool WbBackground::loadIrradianceTexture(int i) {
   float *data = stbi_loadf_from_memory(reinterpret_cast<const unsigned char *>(content.constData()), content.size(),
                                        &mIrradianceWidth, &mIrradianceHeight, &components, 0);
 
+  if (data == NULL) {
+    warn(tr("Cannot load HDR texture '%1': %2.").arg(url).arg(stbi_failure_reason()));
+    return false;
+  }
+
   const int rotate = gCoordinateSystemRotate(i);
   // FIXME: this texture rotation should be performed by OpenGL or in the shader to get a better performance
   if (rotate != 0) {

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -541,7 +541,7 @@ bool WbBackground::loadIrradianceTexture(int i) {
                                        &mIrradianceWidth, &mIrradianceHeight, &components, 0);
 
   if (data == NULL) {
-    warn(tr("Cannot load HDR texture '%1': %2.").arg(url).arg(stbi_failure_reason()));
+    warn(tr("Failed to load HDR texture '%1': %2.").arg(url).arg(stbi_failure_reason()));
     return false;
   }
 


### PR DESCRIPTION
**Description**
Currently, if an invalid HDR image is loaded by `WbBackground`, the input data is read as `NULL`, causing a segfault. This PR adds a statement to check for that condition and print an error message which contains the cause from `stb_image`.