### PR TITLE
Decouple MATLAB Functions Test from `Controller.def`

### DIFF
--- a/include/controller/c/webots/supervisor.h
+++ b/include/controller/c/webots/supervisor.h
@@ -227,7 +227,7 @@ bool wb_supervisor_save_world(const char *filename) WB_DEPRECATED;  // please us
 // deprecated since Webots 8.6.0, please use wb_supervisor_field_remove_mf() instead
 void wb_supervisor_field_remove_mf_node(WbFieldRef field, int position) WB_DEPRECATED;
 
-// deprecated since Webots 8.0.0, pleaae use wb_supervisor_simulation_reset_physics() instead
+// deprecated since Webots 8.0.0, please use wb_supervisor_simulation_reset_physics() instead
 void wb_supervisor_simulation_physics_reset() WB_DEPRECATED;
 
 // deprecated since Webots 8.4.0 please use wb_supervisor_movie_is_ready and wb_supervisor_movie_failed

--- a/include/controller/c/webots/supervisor.h
+++ b/include/controller/c/webots/supervisor.h
@@ -224,10 +224,10 @@ void wb_supervisor_simulation_revert() WB_DEPRECATED;               // please us
 void wb_supervisor_load_world(const char *filename) WB_DEPRECATED;  // please use wb_supervisor_world_load() instead
 bool wb_supervisor_save_world(const char *filename) WB_DEPRECATED;  // please use wb_supervisor_world_save() instead
 
-// deprecated since Webots 8.6.0, plesae use wb_supervisor_field_remove_mf_item() instead
+// deprecated since Webots 8.6.0, please use wb_supervisor_field_remove_mf() instead
 void wb_supervisor_field_remove_mf_node(WbFieldRef field, int position) WB_DEPRECATED;
 
-// deprecated since Webots 8.0.0, plesae use wb_supervisor_simulation_reset_physics() instead
+// deprecated since Webots 8.0.0, pleaae use wb_supervisor_simulation_reset_physics() instead
 void wb_supervisor_simulation_physics_reset() WB_DEPRECATED;
 
 // deprecated since Webots 8.4.0 please use wb_supervisor_movie_is_ready and wb_supervisor_movie_failed

--- a/tests/sources/test_matlab_functions.py
+++ b/tests/sources/test_matlab_functions.py
@@ -79,7 +79,7 @@ class TestMatlabFunctions(unittest.TestCase):
                 *glob.glob(os.path.join(WEBOTS_HOME, 'include', 'controller', 'c', 'webots', 'utils', '*.h'))
                 ], capture_output=True, text=True)
             if symbolSearch.returncode != 0:
-                self.fail(f'Failed to generate function list:\n{symbolSearch.stdout}')
+                self.fail(f'Failed to generate function list:\n{symbolSearch.stdout}\n{symbolSearch.stderr}')
 
             for line in symbolSearch.stdout.splitlines():
                 if not any(re.match(f'^{skippedLine}$', line) for skippedLine in skippedLines) and line not in self.functions:

--- a/tests/sources/test_matlab_functions.py
+++ b/tests/sources/test_matlab_functions.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test that all the required Matlab functions are defined."""
+"""Test that all the required MATLAB functions are defined."""
 import unittest
 import glob
 import os
@@ -28,7 +28,7 @@ import mgenerate  # noqa: E402
 
 
 class TestMatlabFunctions(unittest.TestCase):
-    """Unit test for checking that all the required Matlab functions are defined."""
+    """Unit test for checking that all the required MATLAB functions are defined."""
 
     def setUp(self):
         if sys.version_info[0] >= 3:
@@ -40,12 +40,12 @@ class TestMatlabFunctions(unittest.TestCase):
                 '.*_H',  # Header Guards
                 '.*_',  # Some comments use the ..._* pattern to refer to a group of functions ;
                         # grep will filter the *, but no function should end with _
-                'wb_camera_image_get_.*',  # The Matlab API exposes the image data as a multidimensional array,
+                'wb_camera_image_get_.*',  # The MATLAB API exposes the image data as a multidimensional array,
                                            # so these functions are not needed
                 'wb_(microphone|radio)_.*',  # Experimental Node Types
                 'wb_remote_control_.*', 'wbr_.*',  # Remote Control Plugin
                 'wb_robot_.*',  # Many robot functions are used internally by the C API (e.x. wb_robot_mutex_*)
-                '.*_lookup_table_size',  # Matlab lets you get the size of an array, so these functions are not needed
+                '.*_lookup_table_size',  # MATLAB lets you get the size of an array, so these functions are not needed
                 'wbu_string_.*',  # String manipulation functions are not needed
 
                 # Specific Functions
@@ -56,7 +56,7 @@ class TestMatlabFunctions(unittest.TestCase):
                 'WB_MATLAB_LOADLIBRARY',
                 'WB_USING_C(PP)?_API',
 
-                # These functions are used internally by the Matlab API
+                # These functions are used internally by the MATLAB API
                 'wb_camera_recognition_get_object',
                 'wb_lidar_get_point',
                 'wb_mouse_get_state_pointer',

--- a/tests/sources/test_matlab_functions.py
+++ b/tests/sources/test_matlab_functions.py
@@ -16,8 +16,12 @@
 
 """Test that all the required Matlab functions are defined."""
 import unittest
+import glob
 import os
+import re
+import subprocess
 import sys
+
 WEBOTS_HOME = os.path.normpath(os.environ['WEBOTS_HOME'])
 sys.path.append(os.path.join(WEBOTS_HOME, 'src', 'controller', 'matlab'))
 import mgenerate  # noqa: E402
@@ -30,38 +34,68 @@ class TestMatlabFunctions(unittest.TestCase):
         if sys.version_info[0] >= 3:
             mgenerate.UPDATE = False
             mgenerate.main()
-            """Get all the required function."""
+            """Get all the required functions."""
             skippedLines = [
-                'wbr',
-                'microphone',
-                'remote_control',
-                'robot',
-                'wb_device_get_type',
-                'wb_node_get_name',
-                'wbu_string',
-                'lookup_table_size',
-                'EXPORTS'
+                # Patterns
+                '.*_H',  # Header Guards
+                '.*_',  # Some comments use the ..._* pattern to refer to a group of functions ;
+                        # grep will filter the *, but no function should end with _
+                'wb_camera_image_get_.*',  # The Matlab API exposes the image data as a multidimensional array,
+                                           # so these functions are not needed
+                'wb_(microphone|radio)_.*',  # Experimental Node Types
+                'wb_remote_control_.*', 'wbr_.*',  # Remote Control Plugin
+                'wb_robot_.*',  # Many robot functions are used internally by the C API (e.x. wb_robot_mutex_*)
+                '.*_lookup_table_size',  # Matlab lets you get the size of an array, so these functions are not needed
+                'wbu_string_.*',  # String manipulation functions are not needed
+
+                # Specific Functions
+
+                # Non-Function Macros
+                'WB_ALLOW_MIXING_C_AND_CPP_API',
+                'WB_DEPRECATED',
+                'WB_MATLAB_LOADLIBRARY',
+                'WB_USING_C(PP)?_API',
+
+                # These functions are used internally by the Matlab API
+                'wb_camera_recognition_get_object',
+                'wb_lidar_get_point',
+                'wb_mouse_get_state_pointer',
+                'wb_radar_get_target',
+
+                'wb_device_get_type',  # Deprecated since 8.0.0
+                'wb_node_get_name',  # C API Only
+
+                # Not Yet Implemented
+                'wbu_system_tmpdir',
+                'wbu_system_webots_instance_path',
             ]
             self.functions = []
-            filename = os.path.join(WEBOTS_HOME, 'src', 'controller', 'c', 'Controller.def')
-            self.assertTrue(
-                os.path.isfile(filename),
-                msg='Missing "%s" file.' % filename
-            )
-            with open(filename) as file:
-                for line in file:
-                    if not any(skippedLine in line for skippedLine in skippedLines) and not line[3:].isupper():
-                        self.functions.append(line.replace('\n', ''))
+
+            symbolSearch = subprocess.run([
+                # Search for webots definitions
+                'grep', '-Ehio', r'\bwb_\w+\b',
+                # In the controller headers
+                *glob.glob(os.path.join(WEBOTS_HOME, 'include', 'controller', 'c', 'webots', '*.h')),
+                *glob.glob(os.path.join(WEBOTS_HOME, 'include', 'controller', 'c', 'webots', 'utils', '*.h'))
+                ], capture_output=True, text=True)
+            if symbolSearch.returncode != 0:
+                self.fail(f'Failed to generate function list:\n{symbolSearch.stdout}')
+
+            for line in symbolSearch.stdout.splitlines():
+                if not any(re.match(f'^{skippedLine}$', line) for skippedLine in skippedLines) and line not in self.functions:
+                    self.functions.append(line)
 
     @unittest.skipIf(sys.version_info[0] < 3, "not supported by Python 2.7")
     def test_matlab_function_exists(self):
         """Test that the function file exists."""
-        for function in self.functions:
-            filename = os.path.join(WEBOTS_HOME, 'lib', 'controller', 'matlab', function + '.m')
-            self.assertTrue(
-                os.path.isfile(filename),
-                msg='Missing "%s" file.' % filename
-            )
+        expectedFiles = (os.path.join(WEBOTS_HOME, 'lib', 'controller', 'matlab', function + '.m')
+                         for function in self.functions)
+        missingFiles = [file for file in expectedFiles if not os.path.isfile(file)]
+
+        self.assertTrue(
+            not missingFiles,
+            msg='Missing files: %s' % ', '.join(missingFiles)
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description**
This PR is a breakoff of #6740 containing just the changes to the MATLAB sources test. It updates the test to search for functions in the exposed header files rather than relying on the `Controller.def` file. This means that it can catch new functions whether or not the contributor remembers to place them in the def file.

The previous test also excluded constants from its search. I see no reason to do this, so I removed that restriction. I've created and attached a diff of the functions the test searches for before and after this change. Viewing it reveals that, with the exception of the aforementioned constants, there is no difference between the functions checked by the two versions.

Keep in mind that in order to achieve this, I had to update the function exclusion list. I think that all of these exclusions make sense (and I've added comments to that effect). The two exceptions are `wbu_system_tmpdir` and `wbu_system_webots_instance_path`. My guess is that these should be included in the MATLAB API and were just never added to `Controller.def`, but if there's another reason these should be excluded, let me know. IMO, adding them is out of scope for this PR and should be addressed separately. (Addressed in #6756)

The `supervisor.h` changes are to remove the `wb_supervisor_field_remove_mf_item` reference, which is a non-existent function that the grep search was picking up.

[matlab_functions_diff.txt](https://github.com/user-attachments/files/18324741/matlab_functions_diff.txt) (GitHub won't let me upload a `.diff`)