### PR TITLE
Fix `test-suite` Label on Linux

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -38,7 +38,7 @@ jobs:
         export LIBGL_ALWAYS_SOFTWARE=true
         xvfb-run --auto-servernum make webots_target -j4
   build:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test worlds') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test suite') || contains(github.event.pull_request.labels.*.name, 'test worlds') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description**
#6697 accidently deleted the directive to run the Linux build job when the `test-suite` label is applied to a PR. This PR restores that condition.