### PR TITLE
Bump `geekyeggo/delete-artifact` to v5

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -169,6 +169,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -161,6 +161,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -107,6 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -101,6 +101,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -164,6 +164,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -98,6 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}


### PR DESCRIPTION
**Description**
The CI is currently failing because `geekyeggo/delete-artifact` is unable to list artifacts correctly. My guess is that this is because `v4` artifacts support wasn't introduced until v4 of the action. (Although I'm not sure why this didn't occur when #6654 was originally merged.)

This PR bumps the action version to v5, which should fix this issue.