### PR TITLE
Build `webots-controller` for both x86 and arm on MacOS

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -1,5 +1,9 @@
 # Webots R2025 Change Log
 
+## Webots R2025b
+  - Bug Fixes
+    - Fixed a bug preventing the `webots-controller` executable from running on arm-based mac devices ([#6806](https://github.com/cyberbotics/webots/pull/6806)).
+
 ## Webots R2025a
 Released on January 31st, 2025.
   - New Features
@@ -24,7 +28,7 @@ Released on January 31st, 2025.
     - Improved the image range of the rotating [Lidar](lidar.md) ([#6324](https://github.com/cyberbotics/webots/pull/6324)).
     - Show box-plane contact point normals when showing contact points ([#6678](https://github.com/cyberbotics/webots/pull/6678)).
     - Improved the speed and accuracy of box-plane collisions ([#6688](https://github.com/cyberbotics/webots/pull/6688)).
-    - Enabled the launching of MATLAB desktop from the extern launcher ([#6366](https://github.com/cyberbotics/webots/pull/6366)). 
+    - Enabled the launching of MATLAB desktop from the extern launcher ([#6366](https://github.com/cyberbotics/webots/pull/6366)).
     - Improved overlays visible in Overlays menu by adding all the robots in the menu list ([#6297](https://github.com/cyberbotics/webots/pull/6297)).
   - Cleanup
     - Removed deprecated `windowPosition`, `pixelSize` fields of [Display](display.md) node ([#6327](https://github.com/cyberbotics/webots/pull/6327)).

--- a/src/controller/launcher/Makefile
+++ b/src/controller/launcher/Makefile
@@ -50,11 +50,11 @@ $(CONTROLLER_LAUNCHER): $(OBJDIR)/x86_64/webots-controller $(OBJDIR)/arm64/webot
 
 $(OBJDIR)/x86_64/webots-controller: webots_controller.c
 	@echo "# compiling " $@ "(x64_64)"
-	@$(CXX) $(CFLAGS) -target x86_64-apple-macos12 webots_controller.c -o $@
+	@gcc $(CFLAGS) -target x86_64-apple-macos12 webots_controller.c -o $@
 
 $(OBJDIR)/arm64/webots-controller: webots_controller.c
 	@echo "# compiling " $@ "(arm64)"
-	@$(CXX) $(CFLAGS) -target arm64-apple-macos12 webots_controller.c -o $@
+	@gcc $(CFLAGS) -target arm64-apple-macos12 webots_controller.c -o $@
 
 else
 

--- a/src/controller/launcher/Makefile
+++ b/src/controller/launcher/Makefile
@@ -43,6 +43,9 @@ release debug profile: $(CONTROLLER_LAUNCHER)
 
 ifeq ($(OSTYPE),darwin)
 
+OBJDIR = build/$(MAKECMDGOALS)
+BUILD_PATH_SETUP := $(shell mkdir -p $(OBJDIR)/x86_64 $(OBJDIR)/arm64)
+
 $(CONTROLLER_LAUNCHER): $(OBJDIR)/x86_64/webots-controller $(OBJDIR)/arm64/webots-controller
 	@echo "# creating fat " $(notdir $@)
 	@lipo -create -output $@ $(OBJDIR)/x86_64/webots-controller $(OBJDIR)/arm64/webots-controller

--- a/src/controller/launcher/Makefile
+++ b/src/controller/launcher/Makefile
@@ -41,8 +41,27 @@ endif
 
 release debug profile: $(CONTROLLER_LAUNCHER)
 
+ifeq ($(OSTYPE),darwin)
+
+$(CONTROLLER_LAUNCHER): $(OBJDIR)/x86_64/webots-controller $(OBJDIR)/arm64/webots-controller
+	@echo "# creating fat " $(notdir $@)
+	@lipo -create -output $@ $(OBJDIR)/x86_64/webots-controller $(OBJDIR)/arm64/webots-controller
+	@codesign -s - $@
+
+$(OBJDIR)/x86_64/webots-controller: webots_controller.c
+	@echo "# compiling " $@ "(x64_64)"
+	@$(CXX) $(CFLAGS) -target x86_64-apple-macos12 webots_controller.c -o $@
+
+$(OBJDIR)/arm64/webots-controller: webots_controller.c
+	@echo "# compiling " $@ "(arm64)"
+	@$(CXX) $(CFLAGS) -target arm64-apple-macos12 webots_controller.c -o $@
+
+else
+
 $(CONTROLLER_LAUNCHER): webots_controller.c
 	@echo "# compiling" $<
 	@gcc $(CFLAGS) webots_controller.c -o $@
+
+endif
 
 FILES_TO_REMOVE += $(CONTROLLER_LAUNCHER)


### PR DESCRIPTION
**Description**
Currently the `webots-controller` executable is only built with the default cxx options, meaning that on macos, it only contains code for the platform it was built on. This PR updates the relevant `Makefile` to use the same approach as the rest of Webots to generate object code for both platforms.

**Related Issues**
This pull-request fixes issue #6805 

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)
