### PR TITLE
Backport #6787

### DIFF
--- a/.github/workflows/test_suite_linux.yml
+++ b/.github/workflows/test_suite_linux.yml
@@ -169,6 +169,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_linux_develop.yml
+++ b/.github/workflows/test_suite_linux_develop.yml
@@ -161,6 +161,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_mac.yml
+++ b/.github/workflows/test_suite_mac.yml
@@ -107,6 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_mac_develop.yml
+++ b/.github/workflows/test_suite_mac_develop.yml
@@ -101,6 +101,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -164,6 +164,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -98,6 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts
-      uses: geekyeggo/delete-artifact@v1
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: build-${{ matrix.os }}


### PR DESCRIPTION
**Description**
#6787 was merged into master, however, this means that it never made its way into `released`, so PRs targeting that branch will still fail (e.x. #6818). This PR backports that patch so that PRs targeting `released` will be able to pass CI.