### PR TITLE
Upgrade workflows to windows-2022

### DIFF
--- a/.github/workflows/test_suite_windows.yml
+++ b/.github/workflows/test_suite_windows.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test webots build') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: msys2/setup-msys2@v2
@@ -46,7 +46,7 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test suite') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: msys2/setup-msys2@v2
@@ -98,7 +98,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test suite') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
     if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'test distribution') && !contains(github.event.pull_request.labels.*.name, 'test webots build') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts

--- a/.github/workflows/test_suite_windows_develop.yml
+++ b/.github/workflows/test_suite_windows_develop.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test webots build') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: msys2/setup-msys2@v2
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test distribution') || contains(github.event.pull_request.labels.*.name, 'test suite') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: msys2/setup-msys2@v2
@@ -94,7 +94,7 @@ jobs:
     if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'test distribution') && !contains(github.event.pull_request.labels.*.name, 'test webots build') }}
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
     runs-on: ubuntu-latest
     steps:
     - name: Delete artifacts


### PR DESCRIPTION
The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

- June 3 13:00-21:00 UTC
- June 10 13:00-21:00 UTC
- June 17 13:00-21:00 UTC
- June 24 13:00-21:00 UTC

# What we need to do

Jobs using the windows-2019 YAML workflow label should be updated to windows-2022, windows-2025 or windows-latest.