### PR TITLE
Fix Checking of Reload/Reset Selection in WbBuildEditor

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -4,6 +4,7 @@
   - Bug Fixes
     - Fixed a bug preventing the `webots-controller` executable from running on arm-based mac devices ([#6806](https://github.com/cyberbotics/webots/pull/6806)).
     - Fixed a bug causing Webots to crash when multiple sounds were used with a [Speaker](speaker.md) node ([#6843](https://github.com/cyberbotics/webots/pull/6843)).
+    - Fixed a bug causing the "Reload/Reset" buttons in the controller recompilation popup to not work on Windows ([#6844](https://github.com/cyberbotics/webots/pull/6844)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -269,13 +269,13 @@ void WbBuildEditor::reloadMessageBoxIfNeeded() {
       if (WbMessageBox::enabled()) {
         QMessageBox messageBox(QMessageBox::Question, tr("Compilation successful"),
                                tr("Do you want to reset or reload the world?"), QMessageBox::Cancel, this);
-        QPushButton *reloadButton = messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
+        const QPushButton *reloadButton = messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
         QPushButton *resetButton = messageBox.addButton(tr("Reset"), QMessageBox::AcceptRole);
         messageBox.setDefaultButton(resetButton);
 
         messageBox.exec();
 
-        QAbstractButton *clickedButton = messageBox.clickedButton();
+        const QAbstractButton *clickedButton = messageBox.clickedButton();
         if (clickedButton == reloadButton)
           emit reloadRequested();
         else if (clickedButton == resetButton)

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -269,13 +269,13 @@ void WbBuildEditor::reloadMessageBoxIfNeeded() {
       if (WbMessageBox::enabled()) {
         QMessageBox messageBox(QMessageBox::Question, tr("Compilation successful"),
                                tr("Do you want to reset or reload the world?"), QMessageBox::Cancel, this);
-        QPushButton* reloadButton = messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
-        QPushButton* resetButton = messageBox.addButton(tr("Reset"), QMessageBox::AcceptRole);
+        QPushButton *reloadButton = messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
+        QPushButton *resetButton = messageBox.addButton(tr("Reset"), QMessageBox::AcceptRole);
         messageBox.setDefaultButton(resetButton);
 
         messageBox.exec();
 
-        QAbstractButton* clickedButton = messageBox.clickedButton();
+        QAbstractButton *clickedButton = messageBox.clickedButton();
         if (clickedButton == reloadButton)
           emit reloadRequested();
         else if (clickedButton == resetButton)

--- a/src/webots/editor/WbBuildEditor.cpp
+++ b/src/webots/editor/WbBuildEditor.cpp
@@ -28,6 +28,7 @@
 #include "../../../include/controller/c/webots/utils/ansi_codes.h"
 
 #include <QtGui/QAction>
+#include <QtWidgets/QPushButton>
 #include <QtWidgets/QToolBar>
 #include <QtWidgets/QToolButton>
 
@@ -268,12 +269,16 @@ void WbBuildEditor::reloadMessageBoxIfNeeded() {
       if (WbMessageBox::enabled()) {
         QMessageBox messageBox(QMessageBox::Question, tr("Compilation successful"),
                                tr("Do you want to reset or reload the world?"), QMessageBox::Cancel, this);
-        messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
-        messageBox.setDefaultButton(messageBox.addButton(tr("Reset"), QMessageBox::AcceptRole));
-        const int ret = messageBox.exec();
-        if (ret == 0)
+        QPushButton* reloadButton = messageBox.addButton(tr("Reload"), QMessageBox::AcceptRole);
+        QPushButton* resetButton = messageBox.addButton(tr("Reset"), QMessageBox::AcceptRole);
+        messageBox.setDefaultButton(resetButton);
+
+        messageBox.exec();
+
+        QAbstractButton* clickedButton = messageBox.clickedButton();
+        if (clickedButton == reloadButton)
           emit reloadRequested();
-        else if (ret == 1)
+        else if (clickedButton == resetButton)
           emit resetRequested();
       }
     } else


### PR DESCRIPTION
**Description**
`QMessageBox::exec()` returns an opaque value when used with custom buttons [[1]](https://doc.qt.io/qt-6/qmessagebox.html#exec). However, `WbBuildEditor` was treating this result as an indication of the user's selection. This lead to implementation-dependent behavior, causing the "Reload" and "Reset" buttons to work on Linux but do nothing on Windows.

This PR updates the relevant code to use `QMessageBox::clickedButton()`, which has predictable behavior on both platforms.

I did a quick scan for similar issues throughout the codebase and didn't find any.

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)
