### PR TITLE
Use `QImage::flipped` instead of `QImage::mirrored` in `WbWrenTextureOverlay` on Windows

### DIFF
--- a/src/webots/wren/WbWrenTextureOverlay.cpp
+++ b/src/webots/wren/WbWrenTextureOverlay.cpp
@@ -272,7 +272,15 @@ WrTexture2d *WbWrenTextureOverlay::createIconTexture(QString filePath) {
     return imageTexture;
 
   QImageReader imageReader(filePath);
-  QImage image = imageReader.read().mirrored(false, true);  // account for inverted Y axis in OpenGL
+  QImage image = imageReader.read();
+
+  // account for inverted Y axis in OpenGL
+#ifdef _WIN32  // Windows builds against a newer version of Qt, which deprecates `mirrored`
+  image = image.flipped(Qt::Vertical);
+#else
+  image = image.mirrored(false, true);
+#endif
+
   const bool isTranslucent = image.pixelFormat().alphaUsage() == QPixelFormat::UsesAlpha;
 
   imageTexture = wr_texture_2d_new();


### PR DESCRIPTION
**Description**
`QImage::mirrored` is deprecated in newer Qt versions. Windows always builds against the latest version of Qt, while Linux and Mac versions are pinned. Thus, recent CI runs are failing on Windows. This PR updates the relevant code to use the new function `QImage::flipped`.

Unfortunately, this new function is not available in older versions of Qt, so two separate code paths are necessary until Qt is bumped on the other platforms.