### PR TITLE
Rework Resource Handling in Node Exports

### DIFF
--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -720,3 +720,12 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
     }
   }
 }
+
+QStringList WbBackground::customExportedFields() const {
+  QStringList fields;
+  for (int i = 0; i < 6; ++i) {
+    fields << gUrlNames(i);
+    fields << gIrradianceUrlNames(i);
+  }
+  return fields;
+}

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -691,17 +691,8 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
         continue;
 
       WbField urlFieldCopy(*findField(gUrlNames(i), true));
-      const QString &imagePath = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i]->item(0));
-      if (WbUrl::isLocalUrl(imagePath))
-        backgroundFileNames[i] = WbUrl::computeLocalAssetUrl(imagePath, writer.isW3d());
-      else if (WbUrl::isWeb(imagePath))
-        backgroundFileNames[i] = imagePath;
-      else {
-        if (writer.isWritingToFile())
-          backgroundFileNames[i] = WbUrl::exportResource(this, imagePath, imagePath, writer.relativeTexturesPath(), writer);
-        else
-          backgroundFileNames[i] = WbUrl::expressRelativeToWorld(imagePath);
-      }
+      const QString &resolvedURL = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i], 0);
+      backgroundFileNames[i] = exportResource(mUrlFields[i]->item(0), resolvedURL, writer.relativeTexturesPath(), writer);
     }
 
     QString irradianceFileNames[6];
@@ -709,18 +700,9 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
       if (mIrradianceUrlFields[i]->size() == 0)
         continue;
 
-      const QString &irradiancePath = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i]->item(0));
-      if (WbUrl::isLocalUrl(irradiancePath))
-        irradianceFileNames[i] = WbUrl::computeLocalAssetUrl(irradiancePath, writer.isW3d());
-      else if (WbUrl::isWeb(irradiancePath))
-        irradianceFileNames[i] = irradiancePath;
-      else {
-        if (writer.isWritingToFile())
-          irradianceFileNames[i] =
-            WbUrl::exportResource(this, irradiancePath, irradiancePath, writer.relativeTexturesPath(), writer);
-        else
-          irradianceFileNames[i] = WbUrl::expressRelativeToWorld(irradiancePath);
-      }
+      const QString &resolvedURL = WbUrl::computePath(this, gIrradianceUrlNames(i), mIrradianceUrlFields[i], 0);
+      irradianceFileNames[i] = exportResource(mIrradianceUrlFields[i]->item(0), resolvedURL,
+                                              writer.relativeTexturesPath(), writer);
     }
 
     writer << " ";

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -708,15 +708,10 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
       if (!irradianceFileNames[i].isEmpty())
         writer << gIrradianceUrlNames(i) << "='\"" << irradianceFileNames[i] << "\"' ";
     }
-  } else if (writer.isProto()) {
+  } else {
     for (int i = 0; i < 6; ++i) {
       exportMFResourceField(gUrlNames(i), mUrlFields[i], writer.relativeTexturesPath(), writer);
       exportMFResourceField(gIrradianceUrlNames(i), mIrradianceUrlFields[i], writer.relativeTexturesPath(), writer);
-    }
-  } else {
-    for (int i = 0; i < 6; ++i) {
-      findField(gUrlNames(i), true)->write(writer);
-      findField(gIrradianceUrlNames(i), true)->write(writer);
     }
   }
 }

--- a/src/webots/nodes/WbBackground.cpp
+++ b/src/webots/nodes/WbBackground.cpp
@@ -679,10 +679,7 @@ WbRgb WbBackground::skyColor() const {
 }
 
 void WbBackground::exportNodeFields(WbWriter &writer) const {
-  if (writer.isWebots()) {
-    WbBaseNode::exportNodeFields(writer);
-    return;
-  }
+  WbBaseNode::exportNodeFields(writer);
 
   if (writer.isW3d()) {
     QString backgroundFileNames[6];
@@ -690,7 +687,6 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
       if (mUrlFields[i]->size() == 0)
         continue;
 
-      WbField urlFieldCopy(*findField(gUrlNames(i), true));
       const QString &resolvedURL = WbUrl::computePath(this, gUrlNames(i), mUrlFields[i], 0);
       backgroundFileNames[i] = exportResource(mUrlFields[i]->item(0), resolvedURL, writer.relativeTexturesPath(), writer);
     }
@@ -712,7 +708,15 @@ void WbBackground::exportNodeFields(WbWriter &writer) const {
       if (!irradianceFileNames[i].isEmpty())
         writer << gIrradianceUrlNames(i) << "='\"" << irradianceFileNames[i] << "\"' ";
     }
+  } else if (writer.isProto()) {
+    for (int i = 0; i < 6; ++i) {
+      exportMFResourceField(gUrlNames(i), mUrlFields[i], writer.relativeTexturesPath(), writer);
+      exportMFResourceField(gIrradianceUrlNames(i), mIrradianceUrlFields[i], writer.relativeTexturesPath(), writer);
+    }
+  } else {
+    for (int i = 0; i < 6; ++i) {
+      findField(gUrlNames(i), true)->write(writer);
+      findField(gIrradianceUrlNames(i), true)->write(writer);
+    }
   }
-
-  WbBaseNode::exportNodeFields(writer);
 }

--- a/src/webots/nodes/WbBackground.hpp
+++ b/src/webots/nodes/WbBackground.hpp
@@ -59,6 +59,7 @@ signals:
 
 protected:
   void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
 
 private:
   static QList<WbBackground *> cBackgroundList;

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -603,6 +603,12 @@ void WbCadShape::exportNodeFields(WbWriter &writer) const {
   urlFieldCopy.write(writer);
 }
 
+QStringList WbCadShape::customExportedFields() const {
+  QStringList fields;
+  fields << "url";
+  return fields;
+}
+
 QString WbCadShape::cadPath() const {
   return WbUrl::computePath(this, "url", mUrl, 0);
 }

--- a/src/webots/nodes/WbCadShape.cpp
+++ b/src/webots/nodes/WbCadShape.cpp
@@ -568,13 +568,15 @@ const WbVector3 WbCadShape::absoluteScale() const {
 }
 
 void WbCadShape::exportNodeFields(WbWriter &writer) const {
-  if (!(writer.isW3d() || writer.isProto()))
-    return;
-
   WbBaseNode::exportNodeFields(writer);
 
   if (mUrl->size() == 0)
     return;
+
+  if (!(writer.isW3d() || writer.isProto())) {
+    findField("url", true)->write(writer);
+    return;
+  }
 
   // export model
   WbField urlFieldCopy(*findField("url", true));

--- a/src/webots/nodes/WbCadShape.hpp
+++ b/src/webots/nodes/WbCadShape.hpp
@@ -56,6 +56,7 @@ public:
 
 protected:
   void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
   WbBoundingSphere *boundingSphere() const override { return mBoundingSphere; }
   void recomputeBoundingSphere() const;
 

--- a/src/webots/nodes/WbCamera.cpp
+++ b/src/webots/nodes/WbCamera.cpp
@@ -1017,6 +1017,18 @@ WbVector3 WbCamera::urdfRotation(const WbMatrix3 &rotationMatrix) const {
   return eulerRotation;
 }
 
+void WbCamera::exportNodeFields(WbWriter &writer) const {
+  WbAbstractCamera::exportNodeFields(writer);
+
+  exportSFResourceField("noiseMaskUrl", mNoiseMaskUrl, writer.relativeMeshesPath(), writer);
+}
+
+QStringList WbCamera::customExportedFields() const {
+  QStringList fields;
+  fields << "noiseMaskUrl";
+  return fields;
+}
+
 /////////////////////
 //  Update methods //
 /////////////////////

--- a/src/webots/nodes/WbCamera.hpp
+++ b/src/webots/nodes/WbCamera.hpp
@@ -67,6 +67,8 @@ protected:
   void setup() override;
   void render() override;
   bool needToRender() const override;
+  void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
 
 private:
   WbSFNode *mFocus;

--- a/src/webots/nodes/WbContactProperties.cpp
+++ b/src/webots/nodes/WbContactProperties.cpp
@@ -121,6 +121,20 @@ void WbContactProperties::postFinalize() {
   connect(mMaxContactJoints, &WbSFInt::changed, this, &WbContactProperties::updateMaxContactJoints);
 }
 
+void WbContactProperties::exportNodeFields(WbWriter &writer) const {
+  WbBaseNode::exportNodeFields(writer);
+
+  exportSFResourceField(gUrlNames[0], mBumpSound, writer.relativeSoundsPath(), writer);
+  exportSFResourceField(gUrlNames[1], mRollSound, writer.relativeSoundsPath(), writer);
+  exportSFResourceField(gUrlNames[2], mSlideSound, writer.relativeSoundsPath(), writer);
+}
+
+QStringList WbContactProperties::customExportedFields() const {
+  QStringList fields;
+  fields << "url";
+  return fields;
+}
+
 void WbContactProperties::updateCoulombFriction() {
   const int nbElements = mCoulombFriction->size();
   if (nbElements < 1 || nbElements > 4) {

--- a/src/webots/nodes/WbContactProperties.hpp
+++ b/src/webots/nodes/WbContactProperties.hpp
@@ -64,6 +64,10 @@ signals:
   void valuesChanged();
   void needToEnableBodies();
 
+protected:
+  void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
+
 private:
   // user accessible fields
   WbSFString *mMaterial1;

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -531,18 +531,9 @@ void WbImageTexture::exportNodeFields(WbWriter &writer) const {
   // export to ./textures folder relative to writer path
   WbField urlFieldCopy(*findField("url", true));
   for (int i = 0; i < mUrl->size(); ++i) {
-    QString completeUrl = WbUrl::computePath(this, "url", mUrl, i);
+    const QString &resolvedURL = WbUrl::computePath(this, "url", mUrl, i);
     WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
-    if (WbUrl::isLocalUrl(completeUrl))
-      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl, writer.isW3d()));
-    else if (WbUrl::isWeb(completeUrl))
-      urlFieldValue->setItem(i, completeUrl);
-    else {
-      if (writer.isWritingToFile())
-        urlFieldValue->setItem(i, WbUrl::exportTexture(this, mUrl, i, writer));
-      else
-        urlFieldValue->setItem(i, WbUrl::expressRelativeToWorld(completeUrl));
-    }
+    urlFieldValue->setItem(i, exportResource(mUrl->item(i), resolvedURL, writer.relativeTexturesPath(), writer));
   }
 
   urlFieldCopy.write(writer);
@@ -560,7 +551,7 @@ void WbImageTexture::exportShallowNode(const WbWriter &writer) const {
   // note: the texture of the shallow nodes needs to be exported only if the URL is locally defined but not of type
   // 'webots://' since this case would be converted to a remote one that targets the current branch
   if (!WbUrl::isWeb(mUrl->item(0)) && !WbUrl::isLocalUrl(mUrl->item(0)) && !WbWorld::isW3dStreaming())
-    WbUrl::exportTexture(this, mUrl, 0, writer);
+    WbUrl::exportResource(this, mUrl->item(0), WbUrl::computePath(this, "url", mUrl, 0), writer.relativeTexturesPath(), writer);
 }
 
 QStringList WbImageTexture::fieldsToSynchronizeWithW3d() const {

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -528,15 +528,7 @@ bool WbImageTexture::exportNodeHeader(WbWriter &writer) const {
 void WbImageTexture::exportNodeFields(WbWriter &writer) const {
   WbBaseNode::exportNodeFields(writer);
 
-  // export to ./textures folder relative to writer path
-  WbField urlFieldCopy(*findField("url", true));
-  for (int i = 0; i < mUrl->size(); ++i) {
-    const QString &resolvedURL = WbUrl::computePath(this, "url", mUrl, i);
-    WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
-    urlFieldValue->setItem(i, exportResource(mUrl->item(i), resolvedURL, writer.relativeTexturesPath(), writer));
-  }
-
-  urlFieldCopy.write(writer);
+  exportMFResourceField("url", mUrl, writer.relativeTexturesPath(), writer);
 
   if (writer.isW3d()) {
     if (!mRole.isEmpty())

--- a/src/webots/nodes/WbImageTexture.cpp
+++ b/src/webots/nodes/WbImageTexture.cpp
@@ -536,6 +536,12 @@ void WbImageTexture::exportNodeFields(WbWriter &writer) const {
   }
 }
 
+QStringList WbImageTexture::customExportedFields() const {
+  QStringList fields;
+  fields << "url";
+  return fields;
+}
+
 void WbImageTexture::exportShallowNode(const WbWriter &writer) const {
   if (!writer.isW3d() || mUrl->size() == 0)
     return;

--- a/src/webots/nodes/WbImageTexture.hpp
+++ b/src/webots/nodes/WbImageTexture.hpp
@@ -80,6 +80,7 @@ signals:
 protected:
   bool exportNodeHeader(WbWriter &writer) const override;
   void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
 
 private:
   // user accessible fields

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -409,18 +409,9 @@ void WbMesh::exportNodeFields(WbWriter &writer) const {
 
   WbField urlFieldCopy(*findField("url", true));
   for (int i = 0; i < mUrl->size(); ++i) {
-    const QString &completeUrl = WbUrl::computePath(this, "url", mUrl, i);
+    const QString &resolvedURL = WbUrl::computePath(this, "url", mUrl, i);
     WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
-    if (WbUrl::isLocalUrl(completeUrl))
-      urlFieldValue->setItem(i, WbUrl::computeLocalAssetUrl(completeUrl, writer.isW3d()));
-    else if (WbUrl::isWeb(completeUrl))
-      urlFieldValue->setItem(i, completeUrl);
-    else {
-      if (writer.isWritingToFile())
-        urlFieldValue->setItem(i, WbUrl::exportMesh(this, mUrl, i, writer));
-      else
-        urlFieldValue->setItem(i, WbUrl::expressRelativeToWorld(completeUrl));
-    }
+    urlFieldValue->setItem(i, exportResource(mUrl->item(i), resolvedURL, writer.relativeMeshesPath(), writer));
   }
 
   urlFieldCopy.write(writer);

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -404,17 +404,7 @@ void WbMesh::exportNodeFields(WbWriter &writer) const {
   if (!(writer.isW3d() || writer.isProto()))
     return;
 
-  if (mUrl->size() == 0)
-    return;
-
-  WbField urlFieldCopy(*findField("url", true));
-  for (int i = 0; i < mUrl->size(); ++i) {
-    const QString &resolvedURL = WbUrl::computePath(this, "url", mUrl, i);
-    WbMFString *urlFieldValue = dynamic_cast<WbMFString *>(urlFieldCopy.value());
-    urlFieldValue->setItem(i, exportResource(mUrl->item(i), resolvedURL, writer.relativeMeshesPath(), writer));
-  }
-
-  urlFieldCopy.write(writer);
+  exportMFResourceField("url", mUrl, writer.relativeMeshesPath(), writer);
 
   WbGeometry::exportNodeFields(writer);
 }

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -401,12 +401,9 @@ void WbMesh::updateMaterialIndex() {
 }
 
 void WbMesh::exportNodeFields(WbWriter &writer) const {
-  if (!(writer.isW3d() || writer.isProto()))
-    return;
+  WbGeometry::exportNodeFields(writer);
 
   exportMFResourceField("url", mUrl, writer.relativeMeshesPath(), writer);
-
-  WbGeometry::exportNodeFields(writer);
 }
 
 QStringList WbMesh::fieldsToSynchronizeWithW3d() const {

--- a/src/webots/nodes/WbMesh.cpp
+++ b/src/webots/nodes/WbMesh.cpp
@@ -406,6 +406,12 @@ void WbMesh::exportNodeFields(WbWriter &writer) const {
   exportMFResourceField("url", mUrl, writer.relativeMeshesPath(), writer);
 }
 
+QStringList WbMesh::customExportedFields() const {
+  QStringList fields;
+  fields << "url";
+  return fields;
+}
+
 QStringList WbMesh::fieldsToSynchronizeWithW3d() const {
   QStringList fields;
   fields << "url"

--- a/src/webots/nodes/WbMesh.hpp
+++ b/src/webots/nodes/WbMesh.hpp
@@ -48,6 +48,7 @@ public:
 
 protected:
   void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
 
 private:
   // user accessible fields

--- a/src/webots/nodes/WbMotor.cpp
+++ b/src/webots/nodes/WbMotor.cpp
@@ -853,3 +853,15 @@ QList<const WbBaseNode *> WbMotor::findClosestDescendantNodesWithDedicatedWrenNo
     list << static_cast<WbBaseNode *>(it.next());
   return list;
 }
+
+void WbMotor::exportNodeFields(WbWriter &writer) const {
+  WbJointDevice::exportNodeFields(writer);
+
+  exportSFResourceField("sound", mSound, writer.relativeSoundsPath(), writer);
+}
+
+QStringList WbMotor::customExportedFields() const {
+  QStringList fields;
+  fields << "sound";
+  return fields;
+}

--- a/src/webots/nodes/WbMotor.hpp
+++ b/src/webots/nodes/WbMotor.hpp
@@ -100,6 +100,9 @@ protected:
   void enableMotorFeedback(int rate);
   virtual double computeFeedback() const = 0;
 
+  void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
+
 protected slots:
   void updateMaxForceOrTorque();
   void updateMinAndMaxPosition();

--- a/src/webots/nodes/WbSkin.cpp
+++ b/src/webots/nodes/WbSkin.cpp
@@ -527,6 +527,18 @@ void WbSkin::reset(const QString &id) {
   }
 }
 
+void WbSkin::exportNodeFields(WbWriter &writer) const {
+  WbBaseNode::exportNodeFields(writer);
+
+  exportSFResourceField("modelUrl", mModelUrl, writer.relativeMeshesPath(), writer);
+}
+
+QStringList WbSkin::customExportedFields() const {
+  QStringList fields;
+  fields << "modelUrl";
+  return fields;
+}
+
 void WbSkin::updateModel() {
   applyTranslationToWren();
   applyRotationToWren();

--- a/src/webots/nodes/WbSkin.hpp
+++ b/src/webots/nodes/WbSkin.hpp
@@ -67,6 +67,10 @@ public:
 signals:
   void wrenMaterialChanged();
 
+protected:
+  void exportNodeFields(WbWriter &writer) const override;
+  QStringList customExportedFields() const override;
+
 private:
   WbSkin &operator=(const WbSkin &);  // non copyable
   WbNode *clone() const override { return new WbSkin(*this); }

--- a/src/webots/nodes/WbTrackWheel.cpp
+++ b/src/webots/nodes/WbTrackWheel.cpp
@@ -108,6 +108,6 @@ QStringList WbTrackWheel::fieldsToSynchronizeWithW3d() const {
 void WbTrackWheel::exportNodeFields(WbWriter &writer) const {
   WbBaseNode::exportNodeFields(writer);
 
-  if (!writer.isW3d())
+  if (writer.isW3d())
     writer << " rotation=\'" << mRotation->value() << "\'";
 }

--- a/src/webots/nodes/WbTrackWheel.cpp
+++ b/src/webots/nodes/WbTrackWheel.cpp
@@ -106,9 +106,8 @@ QStringList WbTrackWheel::fieldsToSynchronizeWithW3d() const {
 }
 
 void WbTrackWheel::exportNodeFields(WbWriter &writer) const {
-  if (!writer.isW3d())
-    return;
-
   WbBaseNode::exportNodeFields(writer);
-  writer << " rotation=\'" << mRotation->value() << "\'";
+
+  if (!writer.isW3d())
+    writer << " rotation=\'" << mRotation->value() << "\'";
 }

--- a/src/webots/scene_tree/WbSceneTree.cpp
+++ b/src/webots/scene_tree/WbSceneTree.cpp
@@ -750,20 +750,6 @@ void WbSceneTree::convertProtoToBaseNode(bool rootOnly) {
       writer.setRootNode(NULL);
     currentNode->write(writer);
 
-    // relative urls that get exposed by the conversion need to be changed to remote ones
-    QRegularExpressionMatchIterator it = WbUrl::vrmlResourceRegex().globalMatch(nodeString);
-    while (it.hasNext()) {
-      const QRegularExpressionMatch match = it.next();
-      if (match.hasMatch()) {
-        QString asset = match.captured(0);
-        asset.replace("\"", "");
-        if (!WbUrl::isWeb(asset) && QDir::isRelativePath(asset)) {
-          QString newUrl = QString("\"%1\"").arg(WbUrl::combinePaths(asset, currentNode->proto()->url()));
-          nodeString.replace(QString("\"%1\"").arg(asset), newUrl.replace(WbStandardPaths::webotsHomePath(), "webots://"));
-        }
-      }
-    }
-
     const bool skipTemplateRegeneration =
       WbVrmlNodeUtilities::findUpperTemplateNeedingRegenerationFromField(parentField, parentNode);
     if (skipTemplateRegeneration)

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1244,6 +1244,20 @@ void WbNode::writeExport(WbWriter &writer) const {
   }
 }
 
+QString WbNode::exportResource(const QString &rawURL, const QString &resolvedURL, const QString &relativeResourcePath,
+                        WbWriter &writer) const {
+  if (WbUrl::isLocalUrl(resolvedURL))
+    return WbUrl::computeLocalAssetUrl(resolvedURL, writer.isW3d());
+  else if (WbUrl::isWeb(resolvedURL))
+    return resolvedURL;
+  else {
+    if (writer.isWritingToFile())
+      return WbUrl::exportResource(this, rawURL, resolvedURL, relativeResourcePath, writer);
+    else
+      return WbUrl::expressRelativeToWorld(resolvedURL);
+  }
+}
+
 bool WbNode::operator==(const WbNode &other) const {
   if (mModel != other.mModel || isProtoInstance() != other.isProtoInstance() ||
       (mProto && mProto->url() != other.mProto->url()) || mDefName != other.mDefName)

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1258,6 +1258,40 @@ QString WbNode::exportResource(const QString &rawURL, const QString &resolvedURL
   }
 }
 
+void WbNode::exportMFResourceField(const QString &fieldName, const WbMFString* value, const QString &relativeResourcePath, WbWriter &writer) const {
+  if (value->size() == 0) return;
+
+  const WbField *originalField = findField(fieldName, true);
+  assert(originalField && originalField->type() == WB_MF_STRING);
+
+  WbField copiedField(*originalField);
+  WbMFString *newValue = dynamic_cast<WbMFString *>(copiedField.value());
+
+  for (int i = 0; i < value->size(); ++i) {
+    const QString &rawURL = value->item(i);
+    const QString &resolvedURL = WbUrl::computePath(this, fieldName, rawURL);
+    newValue->setItem(i, exportResource(rawURL, resolvedURL, relativeResourcePath, writer));
+  }
+
+  copiedField.write(writer);
+}
+
+void WbNode::exportSFResourceField(const QString &fieldName, const WbSFString* value, const QString &relativeResourcePath, WbWriter &writer) const {
+  const QString &rawURL = value->value();
+  if (rawURL.isEmpty()) return;
+
+  const WbField *originalField = findField(fieldName, true);
+  assert(originalField && originalField->type() == WB_SF_STRING);
+
+  WbField copiedField(*originalField);
+  WbSFString *newValue = dynamic_cast<WbSFString *>(copiedField.value());
+
+  const QString &resolvedURL = WbUrl::computePath(this, fieldName, rawURL);
+  newValue->setValue(exportResource(rawURL, resolvedURL, relativeResourcePath, writer));
+
+  copiedField.write(writer);
+}
+
 bool WbNode::operator==(const WbNode &other) const {
   if (mModel != other.mModel || isProtoInstance() != other.isProtoInstance() ||
       (mProto && mProto->url() != other.mProto->url()) || mDefName != other.mDefName)

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1259,10 +1259,16 @@ QString WbNode::exportResource(const QString &rawURL, const QString &resolvedURL
 }
 
 void WbNode::exportMFResourceField(const QString &fieldName, const WbMFString* value, const QString &relativeResourcePath, WbWriter &writer) const {
-  if (value->size() == 0) return;
-
   const WbField *originalField = findField(fieldName, true);
   assert(originalField && originalField->type() == WB_MF_STRING);
+
+  // only w3c and proto exports need urls to be resolved
+  if (!(writer.isW3d() || writer.isProto())) {
+    originalField->write(writer);
+    return;
+  }
+
+  if (value->size() == 0) return;
 
   WbField copiedField(*originalField);
   WbMFString *newValue = dynamic_cast<WbMFString *>(copiedField.value());
@@ -1277,11 +1283,17 @@ void WbNode::exportMFResourceField(const QString &fieldName, const WbMFString* v
 }
 
 void WbNode::exportSFResourceField(const QString &fieldName, const WbSFString* value, const QString &relativeResourcePath, WbWriter &writer) const {
-  const QString &rawURL = value->value();
-  if (rawURL.isEmpty()) return;
-
   const WbField *originalField = findField(fieldName, true);
   assert(originalField && originalField->type() == WB_SF_STRING);
+
+  // only w3c and proto exports need urls to be resolved
+  if (!(writer.isW3d() || writer.isProto())) {
+    originalField->write(writer);
+    return;
+  }
+
+  const QString &rawURL = value->value();
+  if (rawURL.isEmpty()) return;
 
   WbField copiedField(*originalField);
   WbSFString *newValue = dynamic_cast<WbSFString *>(copiedField.value());

--- a/src/webots/vrml/WbNode.cpp
+++ b/src/webots/vrml/WbNode.cpp
@@ -1111,7 +1111,8 @@ void WbNode::exportNodeFields(WbWriter &writer) const {
     return;
 
   foreach (const WbField *f, fields()) {
-    if (!f->isDeprecated() && ((f->isW3d() || writer.isProto()) && f->singleType() != WB_SF_NODE))
+    if (!f->isDeprecated() && ((f->isW3d() || writer.isProto()) && f->singleType() != WB_SF_NODE) &&
+        !customExportedFields().contains(f->name()))
       f->write(writer);
   }
 }

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -317,6 +317,9 @@ protected:
   virtual void exportNodeFooter(WbWriter &writer) const;
   virtual void exportExternalSubProto(WbWriter &writer) const;
 
+  // fields which should not be handled by the default exportNodeFields function
+  virtual QStringList customExportedFields() const { return QStringList(); }
+
   // Helper to handle exporting fields with resources which reference external files
   QString exportResource(const QString &rawURL, const QString &resolvedURL, const QString &relativeResourcePath,
                           WbWriter &writer) const;

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -317,6 +317,10 @@ protected:
   virtual void exportNodeFooter(WbWriter &writer) const;
   virtual void exportExternalSubProto(WbWriter &writer) const;
 
+  // Helper to handle exporting fields with resources which reference external files
+  QString exportResource(const QString &rawURL, const QString &resolvedURL, const QString &relativeResourcePath,
+                          WbWriter &writer) const;
+
   // Methods related to URDF export
   const WbNode *findUrdfLinkRoot() const;  // Finds first upper Webots node that is considered as URDF link
   virtual bool isUrdfRootLink() const;     // Determines whether the Webots node is considered as URDF link as well

--- a/src/webots/vrml/WbNode.hpp
+++ b/src/webots/vrml/WbNode.hpp
@@ -320,6 +320,11 @@ protected:
   // Helper to handle exporting fields with resources which reference external files
   QString exportResource(const QString &rawURL, const QString &resolvedURL, const QString &relativeResourcePath,
                           WbWriter &writer) const;
+  // Wrappers for the most common use case (simply exporting a field with no additional processing)
+  void exportMFResourceField(const QString &fieldName, const WbMFString* value, const QString &relativeResourcePath,
+                              WbWriter &writer) const;
+  void exportSFResourceField(const QString &fieldName, const WbSFString* value, const QString &relativeResourcePath,
+                              WbWriter &writer) const;
 
   // Methods related to URDF export
   const WbNode *findUrdfLinkRoot() const;  // Finds first upper Webots node that is considered as URDF link

--- a/src/webots/vrml/WbUrl.cpp
+++ b/src/webots/vrml/WbUrl.cpp
@@ -58,18 +58,17 @@ QString WbUrl::missing(const QString &url) {
   return "";
 }
 
-QString WbUrl::computePath(const WbNode *node, const QString &field, const WbMFString *urlField, int index, bool showWarning,
-                          bool disableCache) {
+QString WbUrl::computePath(const WbNode *node, const QString &field, const WbMFString *urlField, int index, bool showWarning) {
   // check if mUrl is empty
   if (urlField->size() < 1)
     return "";
 
   // get the URL at specified index
   const QString &url = urlField->item(index);
-  return computePath(node, field, url, showWarning, disableCache);
+  return computePath(node, field, url, showWarning);
 }
 
-QString WbUrl::computePath(const WbNode *node, const QString &field, const QString &rawUrl, bool showWarning, bool disableCache) {
+QString WbUrl::computePath(const WbNode *node, const QString &field, const QString &rawUrl, bool showWarning) {
   QString url = resolveUrl(rawUrl);
   // check if the first URL is empty
   if (url.isEmpty()) {
@@ -96,7 +95,7 @@ QString WbUrl::computePath(const WbNode *node, const QString &field, const QStri
       // note: derived PROTO are a special case because instances of the intermediary ancestors from which it is defined don't
       // persist after the build process, hence why we keep track of the scope while building the node itself
       if (protoNode->proto()->isDerived()) {
-        if (!disableCache && WbFileUtil::isLocatedInDirectory(f->scope(), WbStandardPaths::cachedAssetsPath()))
+        if (WbFileUtil::isLocatedInDirectory(f->scope(), WbStandardPaths::cachedAssetsPath()))
           parentUrl = WbNetwork::instance()->getUrlFromEphemeralCache(f->scope());
         else
           parentUrl = f->scope();

--- a/src/webots/vrml/WbUrl.cpp
+++ b/src/webots/vrml/WbUrl.cpp
@@ -134,6 +134,9 @@ QString WbUrl::resolveUrl(const QString &rawUrl) {
 
 QString WbUrl::exportResource(const WbNode *node, const QString &url, const QString &sourcePath,
                               const QString &relativeResourcePath, const WbWriter &writer) {
+  // in addition to writing the node, we want to ensure that the resource file exists
+  // at the expected location. If not, we should copy it, possibly creating the expected
+  // directory structure.
   const QFileInfo urlFileInfo(url);
   const QString fileName = urlFileInfo.fileName();
   const QString expectedRelativePath = relativeResourcePath + fileName;

--- a/src/webots/vrml/WbUrl.hpp
+++ b/src/webots/vrml/WbUrl.hpp
@@ -30,9 +30,7 @@ namespace WbUrl {
   QString combinePaths(const QString &rawUrl, const QString &rawParentUrl);
 
   QString exportResource(const WbNode *node, const QString &url, const QString &sourcePath, const QString &relativeResourcePath,
-                         const WbWriter &writer, const bool isTexture = true);
-  QString exportTexture(const WbNode *node, const WbMFString *urlField, int index, const WbWriter &writer);
-  QString exportMesh(const WbNode *node, const WbMFString *urlField, int index, const WbWriter &writer);
+                         const WbWriter &writer);
 
   QString missing(const QString &url);
   const QString &missingTexture();

--- a/src/webots/vrml/WbWriter.hpp
+++ b/src/webots/vrml/WbWriter.hpp
@@ -91,6 +91,7 @@ public:
 
   static QString relativeTexturesPath() { return "textures/"; }
   static QString relativeMeshesPath() { return "meshes/"; }
+  static QString relativeSoundsPath() { return "sounds/"; }
 
 private:
   void setType();


### PR DESCRIPTION
**Description**
This PR unifies the various methods for re-relativizing resource urls when a node is exported to another format. This should fix a few bugs and make the code more uniform/easier to maintain in the future. Specifically:
* The string-based handling that was previously being used for proto exports has been removed. Instead, when exporting to a proto, nodes will use the same code that was previously used for w3d exports. This fixes the resolution of resource paths in nested protos (see #6851) and allows for a more-targeted system that only affects urls that are known to point to resources, excluding any extraneous paths that end up in the generated proto.
* The resource resolution/export code has been centralized in `WbNode` and the field export system has been updated to make it easier for nodes to specify custom field export code. This should make everything a bit more readable, and it fixes some cases where fields would be exported twice.
* A couple of other nodes (`WbCamera`, `WbContactProperties`, `WbMotor`, `WbSkin`) used various resources, but did not have any special export code. I've added it in. This means that these nodes will now download their resources when exported to w3d.
* Finally, there were a few locations where `WbUrl::exportResource` was called with the same raw and resolved url. ([1](https://github.com/cyberbotics/webots/blob/ec05c25bbddb4e34b19132828686e63b30004ab0/src/webots/nodes/WbBackground.cpp#L701) [2](https://github.com/cyberbotics/webots/blob/ec05c25bbddb4e34b19132828686e63b30004ab0/src/webots/nodes/WbBackground.cpp#L720) [3](https://github.com/cyberbotics/webots/blob/ec05c25bbddb4e34b19132828686e63b30004ab0/src/webots/nodes/WbCadShape.cpp#L607)) In unifying everything, I've updated the code to pass the actual raw url. Assuming I understand the code correctly, this should not cause any change in behavior as `WbUrl::exportResource` only uses the raw url to parse out the file name; not its path.

**Related Issues**
This pull-request fixes issue #6851 

**Tasks**
Add the list of tasks of this PR.
  - [ ] Update the documentation (if needed)
  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)

**Documentation**
https://cyberbotics.com/doc/guide/getting-started-with-webots?version=DeepBlueRobotics:fix-node-field-export  **TODO: Update documentation**
