### PR TITLE
Remove Movie Test Exclusion from Ubuntu 22.04

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -208,14 +208,12 @@ def generateWorldsList(groupName):
             # speaker test not working on github action because of missing sound drivers
             # robot window test cannot open a browser for the robot window in a headless environment
             #       on non-mac operating systems
-            # movie recording test not working on BETA Ubuntu 22.04 GitHub Action environment
             # billboard test not working in macos GitHub Action environment
             # billboard and robot window not working on windows GitHub Action environment.
             if (not filename.endswith('_temp.wbt') and
                     not ('GITHUB_ACTIONS' in os.environ and (
                         filename.endswith('speaker.wbt') or
                         filename.endswith('local_proto_with_texture.wbt') or
-                        (filename.endswith('supervisor_start_stop_movie.wbt') and is_ubuntu_22_04) or
                         (filename.endswith('billboard.wbt') and sys.platform == 'darwin') or
                         (filename.endswith('billboard.wbt') and sys.platform == 'win32') or
                         (filename.endswith('robot_window_html.wbt') and sys.platform == 'linux') or


### PR DESCRIPTION
**Description**
As discussed in [#6780 (comment)](https://github.com/cyberbotics/webots/pull/6780#pullrequestreview-3126168912), this PR removes the test exclusion for `supervisor_start_stop_movie.wbt` on Ubuntu 22.04. This actually removes the only use of `is_ubuntu_22_04` in the suite, which I think is neat. However, I've elected to leave the variable in until Ubuntu 22.04 support is phased out in case it becomes necessary. If maintainers want me to just remove it now, I can.