### PR TITLE
Fix `addTorque` and `addForceWithOffset` Python Implementations

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -19,6 +19,7 @@
     - Fixed a bug causing supervisors to occasionally read stale field values after the simulation was reset ([#6758](https://github.com/cyberbotics/webots/pull/6758)).
     - Fixed a bug causing Webots to occasionally crash when unloading a world ([#6857](https://github.com/cyberbotics/webots/pull/6857)).
     - Fixed a crash occurring when Python was not found on Windows ([#6870](https://github.com/cyberbotics/webots/pull/6870)).
+    - Fixed `addForceWithOffset` and `addTorque` doing the same thing as `addForce` in Python ([#6881](https://github.com/cyberbotics/webots/pull/6881)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/lib/controller/python/controller/node.py
+++ b/lib/controller/python/controller/node.py
@@ -218,11 +218,11 @@ class Node:
         wb.wb_supervisor_node_add_force(self._ref, (ctypes.c_double * 3)(*force), 1 if relative else 0)
 
     def addForceWithOffset(self, force: typing.List[float], offset: typing.List[float], relative: bool):
-        wb.wb_supervisor_node_add_force(self._ref, (ctypes.c_double * 3)(*force), (ctypes.c_double * 3)(*offset),
-                                        1 if relative else 0)
+        wb.wb_supervisor_node_add_force_with_offset(self._ref, (ctypes.c_double * 3)(*force), (ctypes.c_double * 3)(*offset),
+                                                    1 if relative else 0)
 
     def addTorque(self, torque: typing.List[float], relative: bool):
-        wb.wb_supervisor_node_add_force(self._ref, (ctypes.c_double * 4)(*torque), 1 if relative else 0)
+        wb.wb_supervisor_node_add_torque(self._ref, (ctypes.c_double * 3)(*torque), 1 if relative else 0)
 
     @property
     def DEF(self) -> str:


### PR DESCRIPTION
**Description**
These python methods call the wrong C-API methods. This PR fixes that.

**Related Issues**
This pull-request fixes issue #6879 and ~~maybe~~ #6345 ~~(some investigation needed)~~.

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)
