### PR TITLE
chore: add appstream metadata

### DIFF
--- a/scripts/new_version/new_version.sh
+++ b/scripts/new_version/new_version.sh
@@ -119,3 +119,7 @@ then
 
   echo "tests/cache/worlds/backwards_compatibility.wbt should not be modified by this script"
 fi
+# metainfo
+echo "Update metainfo file"
+$CURRENT_DIR/new_version_file.sh $old_version $new_version $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
+$CURRENT_DIR/new_version_file.sh "[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" "$(date +%F)" $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml

--- a/scripts/new_version/new_version.sh
+++ b/scripts/new_version/new_version.sh
@@ -120,6 +120,6 @@ then
   echo "tests/cache/worlds/backwards_compatibility.wbt should not be modified by this script"
 fi
 # metainfo
-echo "Update metainfo file"
+echo "Update metainfo file..."
 $CURRENT_DIR/new_version_file.sh $old_version $new_version $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
 $CURRENT_DIR/new_version_file.sh "[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" "$(date +%F)" $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml

--- a/scripts/new_version/new_version.sh
+++ b/scripts/new_version/new_version.sh
@@ -123,3 +123,7 @@ fi
 echo "Update metainfo file..."
 $CURRENT_DIR/new_version_file.sh $old_version $new_version $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
 $CURRENT_DIR/new_version_file.sh "[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}" "$(date +%F)" $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
+$CURRENT_DIR/new_version_file.sh "Copyright [0-9]\{4\}" "Copyright ${new_version_year}" $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
+if [ $new_version_year -ne $old_version_year ]; then
+  $CURRENT_DIR/new_version_file.sh "changelog-r${old_version_year}" "changelog-r${new_version_year}" $WEBOTS_HOME/scripts/packaging/webots.metainfo.xml
+fi

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -39,7 +39,9 @@
     <category>Education</category>
     <category>Robotics</category>
   </categories>
-  <content_rating type="oars-1.1"/>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
   <releases>
     <release version="R2025a" date="2025-02-04"></release>
   </releases>

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2025 Cyberbotics Ltd. -->
 <!--
   This metainfo file provides metadata about Webots for Flatpak distribution.
   It follows the AppStream specification and is required for publishing Webots

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.cyberbotics.webots</id>
+  <name>Webots</name>
+  <project_license>Apache-2.0</project_license>
+  <developer id="com.cyberbotics">
+    <name>Cyberbotics Ltd.</name>
+  </developer>
+  <summary>Webots Robot Simulator</summary>
+  <description>
+    <p>
+      Webots provides a complete development environment to model, program, and simulate robots, vehicles, and mechanical systems. It is a beginner friendly software that is meant to introduce newcomers to the world of robotics.
+    </p>
+    <p>
+      Webots was originally designed at EPFL in 1996 as a research tool for mobile robotics. In 1998, it began being developed and commercialized by Cyberbotics. In December 2018, Webots was open sourced. Since then, Cyberbotics continues to develop Webots thanks to paid customer support, training, and consulting for industry and academic research projects.
+    </p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <launchable type="desktop-id">com.cyberbotics.webots.desktop</launchable>
+  <url type="homepage">https://cyberbotics.com</url>
+  <url type="help">https://github.com/cyberbotics/webots/discussions</url>
+  <url type="bugtracker">https://github.com/cyberbotics/webots/issues</url>
+  <url type="contribute">https://github.com/cyberbotics/webots/blob/master/CONTRIBUTING.md</url>
+  <url type="donation">https://github.com/sponsors/cyberbotics</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Main window</caption>
+      <image>https://raw.githubusercontent.com/cyberbotics/webots/master/docs/guide/images/main_window.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Education</category>
+    <category>Robotics</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="R2025a" date="2025-02-04"></release>
+  </releases>
+</component>

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -44,6 +44,8 @@
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <releases>
-    <release version="R2025a" date="2025-02-04"></release>
+    <release version="R2025a" date="2025-02-04">
+      <url>https://cyberbotics.com/doc/reference/changelog-r2025</url>
+    </release>
   </releases>
 </component>

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This metainfo file provides metadata about Webots for Flatpak distribution.
+  It follows the AppStream specification and is required for publishing Webots
+  on Flathub.
+  See: https://github.com/flathub/com.cyberbotics.webots
+-->
 <component type="desktop-application">
   <id>com.cyberbotics.webots</id>
   <name>Webots</name>

--- a/scripts/packaging/webots.metainfo.xml
+++ b/scripts/packaging/webots.metainfo.xml
@@ -4,6 +4,7 @@
   This metainfo file provides metadata about Webots for Flatpak distribution.
   It follows the AppStream specification and is required for publishing Webots
   on Flathub.
+  See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines
   See: https://github.com/flathub/com.cyberbotics.webots
 -->
 <component type="desktop-application">


### PR DESCRIPTION
**Description**
Add appstream for `webots`. Recently I tried to build and run `webots` by flatpak. Yes, I did it and linux arm64 is also supported. I've submitted it to [flathub](https://github.com/flathub/flathub/pull/6852). Now it's being examined. appstream is needed by flatpak apps, and it tells the mata info of the app. It should be managed by upstream. https://github.com/flathub/flathub/pull/6852#discussion_r2293735935

**Related Issues**


**Tasks**
Add the list of tasks of this PR.
  - [x] for flatpak

**Documentation**
If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
https://cyberbotics.com/doc/guide/getting-started-with-webots?version=my_repo:my_branch
or
https://cyberbotics.com/doc/guide/getting-started-with-webots?version=my_branch (if the branch is on this repository)

**Screenshots**
If this pull-request includes any interesting visible result, add one or more screenshots.

**Additional context**
Add any other context about the pull-request here.
