### PR TITLE
Improve Timestep Algorithm

### DIFF
--- a/src/webots/engine/WbSimulationWorld.cpp
+++ b/src/webots/engine/WbSimulationWorld.cpp
@@ -191,8 +191,8 @@ void WbSimulationWorld::step() {
     // How long should we have slept to be in real-time?
     double idealSleepTime = timeStep - (elapsed - mSleepRealTime);
     // Limit to timeStep to avoid weird behavior on large pauses (e.g., on startup)
-    if (idealSleepTime > timeStep)
-      idealSleepTime = timeStep;
+    // We also can't wait less than 0 ms.
+    idealSleepTime = qBound(0.0, idealSleepTime, timeStep);
     // computing the mean of an history of several time values
     // improves significantly the stability of the algorithm.
     // Moreover it improves the stability of simulations where
@@ -205,8 +205,6 @@ void WbSimulationWorld::step() {
       mean += v;
     mean /= mIdealSleepTimeHistory.size();
     mSleepRealTime = mean;
-    if (mSleepRealTime < 0.0)
-      mSleepRealTime = 0.0;
 
     mTimer->start(mSleepRealTime);
   }

--- a/src/webots/engine/WbSimulationWorld.hpp
+++ b/src/webots/engine/WbSimulationWorld.hpp
@@ -78,7 +78,7 @@ private:
   QTimer *mTimer;
   QElapsedTimer mRealTimeTimer;
   double mSleepRealTime;
-  QList<int> mElapsedTimeHistory;
+  QList<double> mIdealSleepTimeHistory;
   QVector<WbNode *> mAddedNode;  // list of nodes added since the simulation started
 
   void storeLastSaveTime() override;


### PR DESCRIPTION
**Description**
This PR updates the timestep algorithm to calculate the mean of "ideal" delay times to determine how long to wait between timesteps rather than calculating the mean of elapsed times and calculating a delay based on that. This should remove the dependence of each data point on the current sleep time, reducing oscillations in the simulation speed. (See linked issue for more details.)

**Related Issues**
This pull-request fixes issue #6897.

**Tasks**
Add the list of tasks of this PR.
  - [ ] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)
