### PR TITLE
Set permissions on copied files to 0644

### DIFF
--- a/projects/robots/gctronic/e-puck/transfer/populate_xc16_directory.py
+++ b/projects/robots/gctronic/e-puck/transfer/populate_xc16_directory.py
@@ -98,6 +98,8 @@ for f in files:
         basename = os.path.basename(path)
         try:
             shutil.copy(path, os.path.join(dstdirpath, basename))
+            if platform.system() != 'Windows':
+                os.chmod(os.path.join(dstdirpath, basename), 0o644)
         except IOError as e:
             raise RuntimeError("Unable to copy file. %s" % e)
 


### PR DESCRIPTION
As requested.  I've made an explicit assumption that none of the files should be _directly_ executable on non-Windows systems (I'm not actually 100% sure why they're included so excuse my ignorance).  (I've also assumed that all platforms except windows actually support os.chmod).

**Related Issues**
This pull-request fixes issue #6782 
