### PR TITLE
Added a  Blender-style mouse mode for 3D viewport navigation

### DIFF
--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -48,6 +48,23 @@ Alternatively, the mouse wheel alone can also be used for zooming.
 > If you are on a desktop Mac with a single button mouse, hold the <kbd>⌥ option</kbd> key (<kbd>⌥ alt</kbd> on some keyboards) and press the mouse button to translate the camera according to the mouse motion.
 Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out and rotate the camera.
 
+#### Blender-style Mouse Mode
+
+Users coming from Blender, FreeCAD or similar 3D applications can switch the 3D
+viewport to a Blender-style navigation scheme via `Tools > Preferences > General`,
+field **Mouse mode**. When set to **Blender**, the middle mouse button drives the
+camera regardless of the modifier key:
+
+- **Middle drag** rotates (orbits) the viewpoint.
+- <kbd>Shift</kbd> + **middle drag** translates (pans) the viewpoint.
+- <kbd>Ctrl</kbd> + **middle drag** zooms (combined with rotation around the viewing axis, since Webots does not yet have a pure zoom drag).
+- The **mouse wheel** alone still zooms in and out, in both modes.
+
+The other shortcuts (<kbd>Shift</kbd> + left/right click to move solids,
+<kbd>Alt</kbd> + click to apply forces / torques, etc.) keep their default
+Webots semantics in both modes. The default value of this preference is
+**Webots**, so existing users see no change unless they opt in.
+
 ### Moving a Solid Object
 
 Currently Webots provides two different ways to move solid objects: axis-aligned handles and keyboard shortcuts.

--- a/docs/guide/the-3d-window.md
+++ b/docs/guide/the-3d-window.md
@@ -7,7 +7,7 @@ The bounding object of a selected solid is represented by white lines.
 These lines turn pink if the solid is colliding with another one and blue when the solid is idle, i.e., it comes to rest and it does not interact with any other active solid.
 Double-clicking on a [Robot](../reference/robot.md) opens the Robot Window.
 
-If an object has a solid subpart, then it is also possible to select only this subpart by clicking on it once the whole object is already selected, or by clicking on it while holding down the <kbd>alt</kbd> key.
+If an object has a solid subpart, then it is also possible to select only this subpart by clicking on it once the whole object is already selected, or by clicking on it while holding down the <kbd>alt</kbd> key (<kbd>⌥ option</kbd> on some Apple keyboards).
 Linux users should also hold down the <kbd>ctrl</kbd> key together with the <kbd>alt</kbd> key.
 
 #### Context Menu
@@ -50,20 +50,16 @@ Hold the <kbd>ctrl</kbd> key down and press the mouse button to zoom in and out 
 
 #### Blender-style Mouse Mode
 
-Users coming from Blender, FreeCAD or similar 3D applications can switch the 3D
-viewport to a Blender-style navigation scheme via `Tools > Preferences > General`,
-field **Mouse mode**. When set to **Blender**, the middle mouse button drives the
-camera regardless of the modifier key:
+Users coming from Blender, FreeCAD or similar 3D applications can switch the 3D viewport to a Blender-style navigation scheme via `Tools > Preferences > General`, field **Mouse mode**.
+When set to **Blender**, the middle mouse button drives the camera regardless of the modifier key:
 
 - **Middle drag** rotates (orbits) the viewpoint.
 - <kbd>Shift</kbd> + **middle drag** translates (pans) the viewpoint.
 - <kbd>Ctrl</kbd> + **middle drag** zooms (combined with rotation around the viewing axis, since Webots does not yet have a pure zoom drag).
 - The **mouse wheel** alone still zooms in and out, in both modes.
 
-The other shortcuts (<kbd>Shift</kbd> + left/right click to move solids,
-<kbd>Alt</kbd> + click to apply forces / torques, etc.) keep their default
-Webots semantics in both modes. The default value of this preference is
-**Webots**, so existing users see no change unless they opt in.
+The other shortcuts (<kbd>Shift</kbd> + left/right click to move solids, <kbd>Alt</kbd> + click to apply forces / torques, etc.) keep their default Webots semantics in both modes.
+The default value of this preference is **Webots**, so existing users see no change unless they opt in.
 
 ### Moving a Solid Object
 
@@ -125,9 +121,9 @@ Camera rotation can be useful when checking wether your force / torque vector ha
 By default for each Camera, Display and RangeFinder device, an overlay showing the recorded or displayed image is visible in the 3D view.
 The device type is indicated by the border color: magenta for Camera devices, cyan for Display devices and yellow for RangeFinder devices, see [this figure](#camera-display-and-rangefinder-overlays).
 This overlay can be moved to the desired position on the view by clicking on it and dragging the mouse.
-In order to resize the overlay the user has to click on the icon located at the bottom right corner and drag the mouse, during this action the original not scaled image size will be indicated using darker areas, as depicted in [this figure](#camera-overlay-resizing).
+In order to resize the overlay the user has to click on the icon located at the bottom right corner and drag the mouse, during this action the original not scaled image size will be indicated using a white rectangle.
 Additionally, a close button is available on the top right corner to hide the overlay.
-Once the [Robot](../reference/robot.md) is selected, it is also possible to show or hide the overlay images from the `Camera Devices`, `Display Devices` and `RangeFinder Devices` items in the `Overlays` menu or from the [context menu](#context-menu).
+Once the [Robot](../reference/robot.md) is selected, it is also possible to show or hide the overlay images from the `Camera Devices`, `Display Devices` and `RangeFinder Devices` items in the `Overlays` menu.
 
 %figure "Camera, Display and RangeFinder overlays"
 

--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -10,6 +10,7 @@
     - Webots now prints the cause when it fails to create a memory-mapped file for a camera node ([#6896](https://github.com/cyberbotics/webots/pull/6896)).
     - Made the timestep algorithm more consistent when running in realtime mode ([#6898](https://github.com/cyberbotics/webots/pull/6898)).
     - The `immersionProperties` field of the Clearpath Heron USV robot is now exported, so users can modify it without changing the proto file ([#6961](https://github.com/cyberbotics/webots/pull/6961)).
+    - Added a Blender-style mouse mode for 3D viewport navigation, selectable via Tools > Preferences > General ([#6971](https://github.com/cyberbotics/webots/pull/6971)).
   - Cleanup
     - **Removed `libController.a` and `libCppController.a` libraries on Windows. Please use `Controller.lib` and `CppController.lib` instead ([#6753](https://github.com/cyberbotics/webots/pull/6753)).**
   - Bug Fixes

--- a/src/webots/core/WbPreferences.cpp
+++ b/src/webots/core/WbPreferences.cpp
@@ -83,6 +83,10 @@ WbPreferences::WbPreferences(const QString &companyName, const QString &applicat
   setDefault("View3d/hideAllCameraOverlays", false);
   setDefault("View3d/hideAllRangeFinderOverlays", false);
   setDefault("View3d/hideAllDisplayOverlays", false);
+  // 3D viewport navigation scheme: "webots" (default) or "blender".
+  // In "blender" mode, middle-mouse drag orbits, Shift+middle pans, and Ctrl+middle zooms,
+  // matching the Blender / FreeCAD industry convention (see discussion #6966).
+  setDefault("View3d/mouseMode", "webots");
   setDefault("Network/cacheSize", 1024);
   setDefault("Network/uploadUrl", "https://webots.cloud");
   setDefault("RobotWindow/newBrowserWindow", false);

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -313,10 +313,9 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   mMouseModeCombo = new QComboBox(this);
   mMouseModeCombo->addItem(tr("Webots (default)"));
   mMouseModeCombo->addItem(tr("Blender"));
-  mMouseModeCombo->setToolTip(
-    tr("Selects the mouse navigation scheme used in the 3D view.\n"
-       "  - Webots (default): left = orbit, right = pan, middle = zoom + rotate, wheel = zoom.\n"
-       "  - Blender: middle = orbit, Shift+middle = pan, Ctrl+middle = zoom, wheel = zoom."));
+  mMouseModeCombo->setToolTip(tr("Selects the mouse navigation scheme used in the 3D view.\n"
+                                 "  - Webots (default): left = orbit, right = pan, middle = zoom + rotate, wheel = zoom.\n"
+                                 "  - Blender: middle = orbit, Shift+middle = pan, Ctrl+middle = zoom, wheel = zoom."));
 
   mNumberOfThreadsCombo = new QComboBox(this);
   int max = qMax(1, QThread::idealThreadCount());

--- a/src/webots/gui/WbPreferencesDialog.cpp
+++ b/src/webots/gui/WbPreferencesDialog.cpp
@@ -86,6 +86,7 @@ WbPreferencesDialog::WbPreferencesDialog(QWidget *parent, const QString &default
   // general tab
   int index = gStartupModes.indexOf(prefs->value("General/startupMode").toString());
   mStartupModeCombo->setCurrentIndex(index != -1 ? index : 0);
+  mMouseModeCombo->setCurrentIndex(prefs->value("View3d/mouseMode").toString().toLower() == "blender" ? 1 : 0);
   mEditorFontEdit->setText(prefs->value("Editor/font").toString());
   mNumberOfThreads = prefs->value("General/numberOfThreads", 1).toInt();
   mNumberOfThreadsCombo->setCurrentIndex(mNumberOfThreads - 1);
@@ -168,6 +169,7 @@ void WbPreferencesDialog::accept() {
                      prefs->value("OpenGL/GTAO").toInt() != mAmbientOcclusionCombo->currentIndex());
   // general tab
   prefs->setValue("General/startupMode", gStartupModes.value(mStartupModeCombo->currentIndex()));
+  prefs->setValue("View3d/mouseMode", mMouseModeCombo->currentIndex() == 1 ? "blender" : "webots");
   prefs->setValue("Editor/font", mEditorFontEdit->text());
   prefs->setValue("General/language", languageKey);
   prefs->setValue("General/theme", mValidThemeFilenames.at(mThemeCombo->currentIndex()));
@@ -307,6 +309,15 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
   foreach (const QString &mode, gStartupModes)
     mStartupModeCombo->addItem(mode);
 
+  // 3D viewport navigation scheme.
+  mMouseModeCombo = new QComboBox(this);
+  mMouseModeCombo->addItem(tr("Webots (default)"));
+  mMouseModeCombo->addItem(tr("Blender"));
+  mMouseModeCombo->setToolTip(
+    tr("Selects the mouse navigation scheme used in the 3D view.\n"
+       "  - Webots (default): left = orbit, right = pan, middle = zoom + rotate, wheel = zoom.\n"
+       "  - Blender: middle = orbit, Shift+middle = pan, Ctrl+middle = zoom, wheel = zoom."));
+
   mNumberOfThreadsCombo = new QComboBox(this);
   int max = qMax(1, QThread::idealThreadCount());
   int def = WbSysInfo::coreCount();
@@ -439,6 +450,10 @@ QWidget *WbPreferencesDialog::createGeneralTab() {
                                             "download\nat every startup. If available, it will inform you about it."));
   layout->addWidget(new QLabel(tr("Update policy:"), this), 13, 0);
   layout->addWidget(mCheckWebotsUpdateCheckBox, 13, 1);
+
+  // row 14
+  layout->addWidget(new QLabel(tr("Mouse mode:"), this), 14, 0);
+  layout->addWidget(mMouseModeCombo, 14, 1);
 
   setTabOrder(mStartupModeCombo, mEditorFontEdit);
   setTabOrder(mEditorFontEdit, chooseFontButton);

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -66,8 +66,8 @@ private:
   QComboBox *mNumberOfThreadsCombo;
 
   QDialogButtonBox *mButtonBox;
-  QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mAmbientOcclusionCombo, *mTextureQualityCombo,
-    *mTextureFilteringCombo;
+  QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mMouseModeCombo, *mAmbientOcclusionCombo,
+    *mTextureQualityCombo, *mTextureFilteringCombo;
   WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectPath, *mHttpProxyHostName, *mHttpProxyPort,
     *mHttpProxyUsername, *mHttpProxyPassword, *mUploadUrl, *mBrowserProgram;
   QCheckBox *mDisableSaveWarningCheckBox, *mThumnailCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox,

--- a/src/webots/gui/WbPreferencesDialog.hpp
+++ b/src/webots/gui/WbPreferencesDialog.hpp
@@ -66,8 +66,8 @@ private:
   QComboBox *mNumberOfThreadsCombo;
 
   QDialogButtonBox *mButtonBox;
-  QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mMouseModeCombo, *mAmbientOcclusionCombo,
-    *mTextureQualityCombo, *mTextureFilteringCombo;
+  QComboBox *mLanguageCombo, *mThemeCombo, *mStartupModeCombo, *mMouseModeCombo, *mAmbientOcclusionCombo, *mTextureQualityCombo,
+    *mTextureFilteringCombo;
   WbLineEdit *mEditorFontEdit, *mPythonCommand, *mMatlabCommand, *mExtraProjectPath, *mHttpProxyHostName, *mHttpProxyPort,
     *mHttpProxyUsername, *mHttpProxyPassword, *mUploadUrl, *mBrowserProgram;
   QCheckBox *mDisableSaveWarningCheckBox, *mThumnailCheckBox, *mCheckWebotsUpdateCheckBox, *mTelemetryCheckBox,

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1948,8 +1948,7 @@ void WbView3D::mouseMoveEvent(QMouseEvent *event) {
       distanceToPickPosition = viewpoint->position()->value().length();
     if (distanceToPickPosition < 0.001)
       distanceToPickPosition = 0.001;
-    const double scale =
-      distanceToPickPosition * 2 * tan(viewpoint->fieldOfView()->value() / 2) / std::max(width(), height());
+    const double scale = distanceToPickPosition * 2 * tan(viewpoint->fieldOfView()->value() / 2) / std::max(width(), height());
 
     if (event->modifiers() & Qt::ShiftModifier)
       mDragKinematics = new WbTranslateViewpointEvent(position, viewpoint, scale);

--- a/src/webots/gui/WbView3D.cpp
+++ b/src/webots/gui/WbView3D.cpp
@@ -1929,6 +1929,37 @@ void WbView3D::mouseMoveEvent(QMouseEvent *event) {
     return;
   }
 
+  // Optional Blender-style viewpoint navigation (discussion #6966).
+  // When enabled, the middle mouse button drives the camera regardless of Shift/Ctrl
+  // modifiers, matching the Blender / FreeCAD industry convention:
+  //   middle drag       -> orbit (rotate viewpoint)
+  //   Shift+middle drag -> pan   (translate viewpoint)
+  //   Ctrl+middle drag  -> zoom  (zoom + rotate, since no zoom-only drag class exists)
+  // Left/right buttons keep their Webots semantics (selection, force/torque, Shift+left
+  // to move solids, etc.) so existing object-manipulation shortcuts are preserved.
+  const bool blenderMouseMode =
+    WbPreferences::instance()->value("View3d/mouseMode").toString().compare("blender", Qt::CaseInsensitive) == 0;
+  if (blenderMouseMode && (event->buttons() & Qt::MiddleButton) &&
+      !mDisabledUserInteractionsMap.value(WbAction::LOCK_VIEWPOINT, false)) {
+    double distanceToPickPosition;
+    if (mPicker->selectedId() != -1)
+      distanceToPickPosition = (viewpoint->position()->value() - viewpoint->rotationCenter()).length();
+    else
+      distanceToPickPosition = viewpoint->position()->value().length();
+    if (distanceToPickPosition < 0.001)
+      distanceToPickPosition = 0.001;
+    const double scale =
+      distanceToPickPosition * 2 * tan(viewpoint->fieldOfView()->value() / 2) / std::max(width(), height());
+
+    if (event->modifiers() & Qt::ShiftModifier)
+      mDragKinematics = new WbTranslateViewpointEvent(position, viewpoint, scale);
+    else if (event->modifiers() & Qt::ControlModifier)
+      mDragKinematics = new WbZoomAndRotateViewpointEvent(position, viewpoint, 5 * scale);
+    else
+      mDragKinematics = new WbRotateViewpointEvent(position, viewpoint, mPicker->selectedId() != -1);
+    return;
+  }
+
   // Cases 1 SHIFT + CLICK
   // - LEFT CLICK  -> move the selected solid along horizontal plane
   // - RIGHT CLICK -> rotate the selected solid around world vertical axis


### PR DESCRIPTION
Introduces a View3d/mouseMode preference (default webots) that lets users switch the 3D-view navigation between the existing Webots scheme and a Blender / FreeCAD-style scheme.

In Blender mode:
  middle drag        -> orbit (rotate viewpoint)
  Shift + middle     -> pan   (translate viewpoint)
  Ctrl  + middle     -> zoom  (zoom + rotate, no pure zoom drag exists)
  wheel              -> zoom (unchanged)

Left/right buttons keep their Webots semantics in both modes, so the Shift+left/right object-move shortcuts and Alt+click force/torque shortcuts still work. The setting is exposed as a Mouse mode combo box in Tools > Preferences > General and documented in docs/guide/the-3d-window.md.

Addresses discussion #6966.
