### PR TITLE
Work around macOS 27 startup issues

### DIFF
--- a/src/controller/c/g_image.c
+++ b/src/controller/c/g_image.c
@@ -25,7 +25,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #define STBIW_WINDOWS_UTF8
 #include <stb_image.h>
-#include <stb_image_write.h>
+#include "stb_image_write.h"
 
 #include <webots/types.h>
 

--- a/src/webots/gui/WbTcpServer.cpp
+++ b/src/webots/gui/WbTcpServer.cpp
@@ -130,24 +130,37 @@ void WbTcpServer::create(int port) {
   // - a websocket on "/"
   // - texture images on the other urls. e.g. "/textures/dir/image.[jpg|png|hdr]"
 
-  // See if a server is already running on port by trying to connect to it.
-  // This is needed because in some environments QTcpServer::listen() uses a socket that is configured to reuse a port [1]
-  // and Qt does not provide a way to configure the socket before calling listen() [2].
-  // [1] https://doc.qt.io/qt-6/qabstractsocket.html#BindFlag-enum
-  // [2] https://stackoverflow.com/questions/47268023/how-to-set-so-reuseaddr-on-the-socket-used-by-qtcpserver
+  // =====================================================
+  // TEMPORARY PATCH FOR macOS 27
+  // -----------------------------------------------------
+  // Webots R2025a performs a pre-check by connecting to
+  // localhost:port and assumes the port is already in use
+  // if the connection succeeds.
+  //
+  // On macOS 27 this check appears to incorrectly report
+  // every port as occupied.
+  //
+  // We disable the pre-check and rely on the real
+  // QTcpServer::listen() call below.
+  // =====================================================
+
+  /*
   QTcpSocket socket;
   socket.connectToHost("localhost", port);
   if (socket.waitForConnected(100)) {
     socket.disconnectFromHost();
     throw tr("Port %1 is already in use").arg(port);
   }
+  */
 
   // Reference to let live QTcpSocket and QWebSocketServer on the same port using `QWebSocketServer::handleConnection()`:
   // - https://bugreports.qt.io/browse/QTBUG-54276
   mWebSocketServer = new QWebSocketServer("Webots Streaming Server", QWebSocketServer::NonSecureMode, this);
   mTcpServer = new QTcpServer();
+
   if (!mTcpServer->listen(QHostAddress::Any, port))
     throw tr("Cannot set the server in listen mode: %1").arg(mTcpServer->errorString());
+
   connect(mWebSocketServer, &QWebSocketServer::newConnection, this, &WbTcpServer::onNewWebSocketConnection);
   connect(mTcpServer, &QTcpServer::newConnection, this, &WbTcpServer::onNewTcpConnection);
   connect(WbSimulationState::instance(), &WbSimulationState::controllerReadRequestsCompleted, this,


### PR DESCRIPTION
This PR is related to issue https://github.com/cyberbotics/webots/issues/6976.

It contains two small changes that allowed Webots R2025a to build and run on macOS 27 Beta:

In WbTcpServer.cpp, the localhost TCP pre-check is disabled because it falsely reports all ports as already in use on macOS 27 Beta.
In g_image.c, stb_image_write.h is included with quotes instead of angle brackets to satisfy the newer macOS/Clang include behavior.
This has been tested by rebuilding Webots from source on Apple Silicon M1 Max. The patched build launches correctly, loads worlds, and runs controllers.

I understand that the TCP change may be considered a workaround rather than the final upstream fix. I am submitting this PR mainly to make the tested patch visible and easier to review.