### PR TITLE
Use C23 bool

### DIFF
--- a/include/controller/c/webots/types.h
+++ b/include/controller/c/webots/types.h
@@ -48,21 +48,7 @@ typedef struct WbFieldStructPrivate *WbFieldRef;
 #define INFINITY (1.0 / 0.0)
 #endif
 
-#ifndef bool
-#define bool char
-#endif
-
-#ifndef true
-// clang-format off
-#define true ((bool)1)
-// clang-format on
-#endif
-
-#ifndef false
-// clang-format off
-#define false ((bool)0)
-// clang-format on
-#endif
+#include <stdbool.h>
 
 #endif
 

--- a/projects/vehicles/controllers/autonomous_vehicle/autonomous_vehicle.c
+++ b/projects/vehicles/controllers/autonomous_vehicle/autonomous_vehicle.c
@@ -93,17 +93,14 @@ void set_autodrive(bool onoff) {
   if (autodrive == onoff)
     return;
   autodrive = onoff;
-  switch (autodrive) {
-    case false:
-      printf("switching to manual drive...\n");
-      printf("hit [A] to return to auto-drive.\n");
-      break;
-    case true:
-      if (has_camera)
-        printf("switching to auto-drive...\n");
-      else
-        printf("impossible to switch auto-drive on without camera...\n");
-      break;
+  if (autodrive) {
+    if (has_camera)
+      printf("switching to auto-drive...\n");
+    else
+      printf("impossible to switch auto-drive on without camera...\n");
+  } else {
+    printf("switching to manual drive...\n");
+    printf("hit [A] to return to auto-drive.\n");
   }
 }
 


### PR DESCRIPTION
**Description**
I'm using the Webots API using a custom Makefile to integrate into a project which is build using C23 standart.
But if I end up with 2 definition of bool, depending of the include I use in different c files. So I have conflict between "native' bool and Webots bool which is char.

**Additional context**
To get is right, and because I'm using gcc 14, I've found a defect, as indicated into the code as comment, but you can find disccution about that here : https://stackoverflow.com/questions/78581920/what-is-the-stdc-version-value-for-c23/78582932#78582932
