### PR TITLE
Fixed failing build on Windows CI

### DIFF
--- a/src/ode/Makefile
+++ b/src/ode/Makefile
@@ -39,9 +39,7 @@ endif
 FILES_TO_REMOVE = $(MAIN_TARGET_COPY) libode.a ode.a
 
 CFLAGS = -DdTRIMESH_ENABLED -DdTRIMESH_OPCODE -DODE_MT -DODE_LIB -DODE_THREADMODE_PTHREAD
-ifeq ($(OSTYPE),darwin)
-  CFLAGS += -Wno-unused-but-set-variable
-else
+ifneq ($(OSTYPE),darwin)
   CFLAGS += -Wno-misleading-indentation -Wno-nonnull-compare
 endif
 

--- a/src/ode/ode/src/ode_MT/clustering/cluster.cpp
+++ b/src/ode/ode/src/ode_MT/clustering/cluster.cpp
@@ -641,7 +641,9 @@ void dxClusteredWorldAndSpace::makeClusters()
     }
 
     }
+#ifndef dNODEBUG
     ODE_INFO("%d new nodes, %d old nodes\n", newNodeCount, oldNodeCount);
+#endif
 
     // Finally, separate clusters based on proximity of hashspace cells
     // if 2 neighboring cells in the hashspace have objects inside,
@@ -1222,10 +1224,11 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
         }
         }
     }
+#ifndef dNODEBUG
     ODE_PRINT("%d geoms updated\n", updateCount);
     ODE_PRINT("%d table additions\n", tableCount);
     ODE_PRINT("%d nodes reused\n", oldNodeCount);
-
+#endif
     return bCalculateNewSZ;
 }
 

--- a/src/ode/ode/src/ode_MT/clustering/cluster.cpp
+++ b/src/ode/ode/src/ode_MT/clustering/cluster.cpp
@@ -543,12 +543,17 @@ void dxClusteredWorldAndSpace::makeClusters()
     }
 
     clusterCount = 0;
+#ifndef dNODEBUG
+    // counters used only by the ODE_INFO/ODE_PRINT debug logging below
     int tableCount = 0;
     int firstaabbCount = 0;
     int oldNodeCount = 0, newNodeCount = 0;
+#endif
     // add each AABB to the hash table (may need to add it to up to 8 cells)
     for (aabb = first_aabb; aabb; aabb = aabb->next) {
+#ifndef dNODEBUG
     ++firstaabbCount;
+#endif
 
     ClusterNode *head = NULL;
     ClusterNode *tail = NULL;
@@ -569,7 +574,9 @@ void dxClusteredWorldAndSpace::makeClusters()
       // get the hash index
       dVector3 pos = { (dReal)xi, (dReal)yi, (dReal)zi};
       unsigned long hi = getVirtualAddress (pos) % sz;
+#ifndef dNODEBUG
       ++tableCount;
+#endif
 
       dxClusterNode *node = NULL;
       // first check to see if we have a free node
@@ -579,7 +586,9 @@ void dxClusteredWorldAndSpace::makeClusters()
           table[hi]->nextFreeNode = node->next;
 
           if (node->next) node->next->count = node->count + 1;
+#ifndef dNODEBUG
           ++oldNodeCount;
+#endif
       }
       // add a new node to the hash table if required
       else
@@ -592,7 +601,9 @@ void dxClusteredWorldAndSpace::makeClusters()
 
           node->next = table[hi];
           table[hi] = node;
+#ifndef dNODEBUG
           ++newNodeCount;
+#endif
       }
 
       node->x = xi;
@@ -636,13 +647,17 @@ void dxClusteredWorldAndSpace::makeClusters()
     // if 2 neighboring cells in the hashspace have objects inside,
     // they belong to the same cluster. In this way, we only need to traverse
     // the hashspace once and come with a list of clusters. Pretty fast.
+#ifndef dNODEBUG
     int nodeCount = 0;
+#endif
     for (int i = 0; i < sz; ++i)
     {
         dxClusterNode *node = table[i];
         if (node && node->isStatic==false && node->tagged == false  && table[i]->nextFreeNode != table[i])
         {
+#ifndef dNODEBUG
             ++nodeCount;
+#endif
             node->tagged = true;
 
             ClusterNode *head = NULL;
@@ -665,6 +680,7 @@ void dxClusteredWorldAndSpace::makeClusters()
 {
     ODE_INFO("Geom count: %d\n", algoN);
     ODE_INFO("Big box count: %d\n", bigboxCount);
+    ODE_INFO("AABB count: %d\n", firstaabbCount);
     ODE_INFO("Limits: (%f, %f), (%f, %f), (%f, %f)\n", xmin, xmax, ymin, ymax, zmin, zmax);
     ODE_INFO("%d out of %d table additions\n", tableCount, sz);
     ODE_IMPORTANT("dxClusterNode Count: %d\n", nodeCount);
@@ -1100,8 +1116,11 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
     }
 
     // then go through each cluster AABB and update dbounds and table
+#ifndef dNODEBUG
+    // counters used only by the ODE_PRINT debug logging below
     int tableCount = 0, newNodeCount = 0, oldNodeCount = 0;
     int updateCount = 0;
+#endif
     for (dxClusterNode *node = clusterAABBs[kid]; node; node = node->next)
     {
         dxClusterAABB *aabb = node->aabb;
@@ -1125,7 +1144,9 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
             joint = joint->next;
         }
 
+#ifndef dNODEBUG
         updateCount++;
+#endif
 
         // if geom was found, use absolute position of geom to update node aabb
         if (geom) // discretize AABB position to cell size
@@ -1156,7 +1177,9 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
           if (bCalculateNewSZ == true)
               ODE_PRINT("SCENE SIZE CHANGED! Aborting current frame\n");
 
+#ifndef dNODEBUG
           tableCount++;
+#endif
 
           dxClusterNode *node2 = NULL;
           // first check to see if we have a free node
@@ -1165,7 +1188,9 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
               node2 = clusterTables[kid][hi]->nextFreeNode;
               clusterTables[kid][hi]->nextFreeNode = node2->next;
 
+#ifndef dNODEBUG
               oldNodeCount++;
+#endif
           }
           else
           {
@@ -1178,7 +1203,9 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
 
               node2->next = clusterTables[kid][hi];
               clusterTables[kid][hi] = node2;
+#ifndef dNODEBUG
               newNodeCount++;
+#endif
           }
 
           node2->x = xi;
@@ -1197,6 +1224,7 @@ bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int kid)
     }
     ODE_PRINT("%d geoms updated\n", updateCount);
     ODE_PRINT("%d table additions\n", tableCount);
+    ODE_PRINT("%d nodes reused\n", oldNodeCount);
 
     return bCalculateNewSZ;
 }

--- a/src/ode/ode/src/ode_MT/util_MT.h
+++ b/src/ode/ode/src/ode_MT/util_MT.h
@@ -6,9 +6,24 @@
 #include "ode/collision_space.h"
 #include "ode/collision_trimesh.h"
 
+#ifdef dNODEBUG
 #define ODE_PRINT(...) do {} while(0)
 #define ODE_INFO(...) do {} while(0)
 #define ODE_IMPORTANT(...) do {} while(0)
+#else
+// Debug logging is disabled, but the arguments are still referenced in dead code that
+// the optimizer removes. This keeps variables used only for debug logging from being
+// reported as unused, without evaluating the arguments at runtime or producing output.
+inline void ode_debug_noop(...) {}
+#define ODE_PRINT(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
+#define ODE_INFO(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
+#define ODE_IMPORTANT(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
+// Display the debug messages through ODE's messaging facility (the same channel used by
+// dDEBUGMSG). Disabled in release builds (dNODEBUG), where these expand to no-ops.
+//#define ODE_PRINT(...) do { dMessage(d_ERR_UASSERT, __VA_ARGS__); } while(0)
+//#define ODE_INFO(...) do { dMessage(d_ERR_UASSERT, __VA_ARGS__); } while(0)
+//#define ODE_IMPORTANT(...) do { dMessage(d_ERR_UASSERT, __VA_ARGS__); } while(0)
+#endif
 
 typedef dWorldID dWorldCreateFunction();
 typedef dSpaceID dSpaceCreateFunction(dSpaceID);

--- a/src/ode/ode/src/ode_MT/util_MT.h
+++ b/src/ode/ode/src/ode_MT/util_MT.h
@@ -15,9 +15,9 @@
 // the optimizer removes. This keeps variables used only for debug logging from being
 // reported as unused, without evaluating the arguments at runtime or producing output.
 inline void ode_debug_noop(...) {}
-#define ODE_PRINT(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
-#define ODE_INFO(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
-#define ODE_IMPORTANT(...) do { if (false) ode_debug_noop(__VA_ARGS__); } while(0)
+#define ODE_PRINT(...) do { (void)(1 ? 0 : (ode_debug_noop(__VA_ARGS__), 0)); } while(0)
+#define ODE_INFO(...) do { (void)(1 ? 0 : (ode_debug_noop(__VA_ARGS__), 0)); } while(0)
+#define ODE_IMPORTANT(...) do { (void)(1 ? 0 : (ode_debug_noop(__VA_ARGS__), 0)); } while(0)
 // Display the debug messages through ODE's messaging facility (the same channel used by
 // dDEBUGMSG). Disabled in release builds (dNODEBUG), where these expand to no-ops.
 //#define ODE_PRINT(...) do { dMessage(d_ERR_UASSERT, __VA_ARGS__); } while(0)

--- a/src/ode/ode/src/ode_MT/util_MT.h
+++ b/src/ode/ode/src/ode_MT/util_MT.h
@@ -11,7 +11,7 @@
 #define ODE_INFO(...) do {} while(0)
 #define ODE_IMPORTANT(...) do {} while(0)
 #else
-// Debug logging is disabled, but the arguments are still referenced in dead code that
+// We've disabled ODE's debug logging, but the arguments are still referenced in dead code that
 // the optimizer removes. This keeps variables used only for debug logging from being
 // reported as unused, without evaluating the arguments at runtime or producing output.
 inline void ode_debug_noop(...) {}

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -914,9 +914,9 @@ unsigned int *WbDisplay::imageCopy(short int x, short int y, short int &w, short
         displayAlpha = SHIFT(displayPixel, 24);
         oneMinusDisplayAlpha = 0xFF - displayAlpha;
         cameraPixel = cameraImage[srcPixelIndex];
-        clippedImage[srcPixelIndex] = 0xFF000000;
+        clippedImage[j * w + i] = 0xFF000000;
         for (int k = 0; k < 3; k++)
-          clippedImage[srcPixelIndex] +=
+          clippedImage[j * w + i] +=
             (((oneMinusDisplayAlpha * SHIFT(cameraPixel, 8 * k) + displayAlpha * SHIFT(displayPixel, 8 * k)) / 0xFF) << 8 * k);
       }
     }

--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -905,11 +905,10 @@ unsigned int *WbDisplay::imageCopy(short int x, short int y, short int &w, short
   if (mAttachedCamera) {
     // blend camera background image and display image
     const unsigned int *const cameraImage = reinterpret_cast<const unsigned int *>(mAttachedCamera->constImage());
-    int destIndex = 0;
     int displayPixel, displayAlpha, oneMinusDisplayAlpha, cameraPixel;
     for (int j = 0; j < h; j++) {
       int srcRowIndex = (clippedY + j) * width();
-      for (int i = 0; i < w; i++, destIndex++) {
+      for (int i = 0; i < w; i++) {
         int srcPixelIndex = srcRowIndex + clippedX + i;
         displayPixel = mImage[srcPixelIndex];
         displayAlpha = SHIFT(displayPixel, 24);

--- a/src/webots/nodes/WbMuscle.cpp
+++ b/src/webots/nodes/WbMuscle.cpp
@@ -384,10 +384,8 @@ void WbMuscle::updateMeshCoordinates() {
 
   // set vertex coordinates and normals
   const WbMatrix3 rm = mMatrix.extracted3x3Matrix();
-  int vIndex = 0;
-  int nIndex = 0;
   // top vertices
-  for (int i = 0; i < SUBDIVISION; ++i, vIndex += 3, nIndex += 3) {
+  for (int i = 0; i < SUBDIVISION; ++i) {
     float vertex[3];
     (mMatrix * WbVector4(0, 0, 0, 1)).toVector3().toFloatArray(vertex);
     wr_dynamic_mesh_add_vertex(mMesh, vertex);
@@ -403,7 +401,7 @@ void WbMuscle::updateMeshCoordinates() {
   for (int j = 1; j < SUBDIVISION; ++j, y += dy) {
     const double d = y / h2;
     const double r = mRadius * sqrt(1 - d * d);
-    for (int i = 0; i <= SUBDIVISION; ++i, vIndex += 3, nIndex += 3) {
+    for (int i = 0; i <= SUBDIVISION; ++i) {
       const WbVector4 coord = WbVector4(r * gCircleCoordinates[i].x(), y + h2, r * gCircleCoordinates[i].y(), 1.0);
 
       float vertex[3];
@@ -415,7 +413,7 @@ void WbMuscle::updateMeshCoordinates() {
     }
   }
   // bottom vertices
-  for (int i = 0; i < SUBDIVISION; ++i, vIndex += 3, nIndex += 3) {
+  for (int i = 0; i < SUBDIVISION; ++i) {
     float vertex[3];
     (mMatrix * WbVector4(0, mHeight, 0, 1)).toVector3().toFloatArray(vertex);
     wr_dynamic_mesh_add_vertex(mMesh, vertex);


### PR DESCRIPTION
The build is failing (see [here](https://github.com/cyberbotics/webots/actions/runs/27583302967/job/81578037723)) because the new version of GCC detects a new warning which is considered as an error:

```console
ode/src/ode_MT/clustering/cluster.cpp: In member function 'void dxClusteredWorldAndSpace::makeClusters()':
ode/src/ode_MT/clustering/cluster.cpp:546:9: error: variable 'tableCount' set but not used [-Werror=unused-but-set-variable=]
  546 |     int tableCount = 0;
      |         ^~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:547:9: error: variable 'firstaabbCount' set but not used [-Werror=unused-but-set-variable=]
  547 |     int firstaabbCount = 0;
      |         ^~~~~~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:548:9: error: variable 'oldNodeCount' set but not used [-Werror=unused-but-set-variable=]
  548 |     int oldNodeCount = 0, newNodeCount = 0;
      |         ^~~~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:548:27: error: variable 'newNodeCount' set but not used [-Werror=unused-but-set-variable=]
  548 |     int oldNodeCount = 0, newNodeCount = 0;
      |                           ^~~~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:639:9: error: variable 'nodeCount' set but not used [-Werror=unused-but-set-variable=]
  639 |     int nodeCount = 0;
      |         ^~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp: In member function 'bool dxClusteredWorldAndSpace::updateClusterAABBsAndTable(int)':
ode/src/ode_MT/clustering/cluster.cpp:1103:9: error: variable 'tableCount' set but not used [-Werror=unused-but-set-variable=]
 1103 |     int tableCount = 0, newNodeCount = 0, oldNodeCount = 0;
      |         ^~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:1103:25: error: variable 'newNodeCount' set but not used [-Werror=unused-but-set-variable=]
 1103 |     int tableCount = 0, newNodeCount = 0, oldNodeCount = 0;
      |                         ^~~~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:1103:43: error: variable 'oldNodeCount' set but not used [-Werror=unused-but-set-variable=]
 1103 |     int tableCount = 0, newNodeCount = 0, oldNodeCount = 0;
      |                                           ^~~~~~~~~~~~
ode/src/ode_MT/clustering/cluster.cpp:1104:9: error: variable 'updateCount' set but not used [-Werror=unused-but-set-variable=]
 1104 |     int updateCount = 0;
      |         ^~~~~~~~~~~
```

This patch fixes the problem by using these variables only in debug mode, not in release mode.