### PR TITLE
Remove Unnecessary `termio.h` Include

### DIFF
--- a/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
+++ b/projects/robots/gctronic/e-puck/plugins/remote_controls/e-puck_bluetooth/Serial.cpp
@@ -43,10 +43,6 @@
 #include <IOKit/serial/IOSerialKeys.h>
 #include <IOKit/serial/ioss.h>
 #include <sys/param.h>
-
-#else  // __linux__
-#include <termio.h>
-
 #endif
 #endif
 


### PR DESCRIPTION
**Description**
As far as I can tell, `termio.h` has been superseded by `termios.h`. Newer versions of glibc have stopped including this library altogether, so removing this include is necessary to build on Ubuntu 26 and Fedora 44 (which include this newer version). Additionally, glibc versions going back as far as Ubuntu 22 appear to just define termio.h as
```c
#include <termios.h>
#include <sys/ioctl.h>
```
[ioctl only defines `ioctl()`](https://www.man7.org/linux/man-pages/man2/ioctl.2.html), which is unused in this file. Thus, this include is equivalent to only including `termios`, which is already done above, so this change should not impact functionally on any currently-supported systems.

**Related Issues**
This pull-request fixes issue #6982 