### PR TITLE
Fix Viewport Rendering on Systems with Fractional Scaling

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -30,6 +30,7 @@
     - OSM importer no longer crashes when run in 3d mode ([#6935](https://github.com/cyberbotics/webots/pull/6935)).
     - Fixed Java compilation deprecation warning and run-time warning ([#6936](https://github.com/cyberbotics/webots/pull/6936)).
     - Fixed controller signal handlers not restoring the original handler (e.g. CPython's) on exit ([#6945](https://github.com/cyberbotics/webots/pull/6945)).
+    - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/include/wren/viewport.h
+++ b/include/wren/viewport.h
@@ -36,7 +36,7 @@ void wr_viewport_set_clear_color_rgba(WrViewport *viewport, const float *color);
 void wr_viewport_set_polygon_mode(WrViewport *viewport, WrViewportPolygonMode mode);
 void wr_viewport_set_visibility_mask(WrViewport *viewport, int mask);
 void wr_viewport_set_size(WrViewport *viewport, int width, int height);
-void wr_viewport_set_pixel_ratio(WrViewport *viewport, int ratio);
+void wr_viewport_set_pixel_ratio(WrViewport *viewport, double ratio);
 void wr_viewport_set_camera(WrViewport *viewport, WrCamera *camera);
 void wr_viewport_set_frame_buffer(WrViewport *viewport, WrFrameBuffer *frame_buffer);
 

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -236,7 +236,7 @@ void WbRenderingDeviceWindow::initialize() {
 void WbRenderingDeviceWindow::render() {
   QOpenGLFunctions_3_3_Core *f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_3_3_Core>(mContext);
 
-  const int ratio = (int)devicePixelRatio();
+  const double ratio = devicePixelRatio();
   f->glViewport(0, 0, width() * ratio, height() * ratio);
 
   f->glClear(GL_COLOR_BUFFER_BIT);

--- a/src/webots/gui/WbRenderingDeviceWindow.cpp
+++ b/src/webots/gui/WbRenderingDeviceWindow.cpp
@@ -28,6 +28,8 @@
 #include <QtOpenGL/QOpenGLShaderProgram>
 #include <QtOpenGL/QOpenGLVersionFunctionsFactory>
 
+#include <cmath>
+
 static const char *gVertexShaderSource = "#version 330\n"
                                          "layout (location = 0) in vec4 posAttr;\n"
                                          "layout (location = 1) in vec2 uvAttr;\n"
@@ -237,7 +239,7 @@ void WbRenderingDeviceWindow::render() {
   QOpenGLFunctions_3_3_Core *f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_3_3_Core>(mContext);
 
   const double ratio = devicePixelRatio();
-  f->glViewport(0, 0, width() * ratio, height() * ratio);
+  f->glViewport(0, 0, std::ceil(width() * ratio), std::ceil(height() * ratio));
 
   f->glClear(GL_COLOR_BUFFER_BIT);
 

--- a/src/webots/gui/WbVideoRecorder.hpp
+++ b/src/webots/gui/WbVideoRecorder.hpp
@@ -37,7 +37,7 @@ public:
 
   static int displayRefresh() { return cDisplayRefresh; }
 
-  void setScreenPixelRatio(int ratio) { mScreenPixelRatio = ratio; }
+  void setScreenPixelRatio(double ratio) { mScreenPixelRatio = ratio; }
 
   // initialize recording parameters by GUI
   bool initRecording(WbSimulationView *view, double basicTimeStep);
@@ -72,7 +72,7 @@ private:
   int mLastFileNumber;
 
   QSize mVideoResolution;
-  int mScreenPixelRatio;
+  double mScreenPixelRatio;
   int mVideoQuality;
   double mVideoAcceleration;
   bool mShowCaption;

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -184,7 +184,7 @@ void WbWrenWindow::initialize() {
 }
 
 void WbWrenWindow::updateWrenViewportDimensions() {
-  const int ratio = (int)devicePixelRatio();
+  const double ratio = devicePixelRatio();
   wr_viewport_set_pixel_ratio(wr_scene_get_viewport(wr_scene_get_instance()), ratio);
   WbVideoRecorder::instance()->setScreenPixelRatio(ratio);
 }

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -382,8 +382,7 @@ void WbWrenWindow::updateFrameBuffer() {
     wr_texture_delete(WR_TEXTURE(mWrenDepthFrameBufferTexture));
 
   mWrenMainFrameBuffer = wr_frame_buffer_new();
-  const double frameBufferScaling = devicePixelRatio();
-  wr_frame_buffer_set_size(mWrenMainFrameBuffer, width() * frameBufferScaling, height() * frameBufferScaling);
+  wr_frame_buffer_set_size(mWrenMainFrameBuffer, width(), height());
 
   mWrenMainFrameBufferTexture = wr_texture_rtt_new();
   wr_texture_set_internal_format(WR_TEXTURE(mWrenMainFrameBufferTexture), WR_TEXTURE_INTERNAL_FORMAT_RGB16F);

--- a/src/webots/gui/WbWrenWindow.cpp
+++ b/src/webots/gui/WbWrenWindow.cpp
@@ -382,7 +382,8 @@ void WbWrenWindow::updateFrameBuffer() {
     wr_texture_delete(WR_TEXTURE(mWrenDepthFrameBufferTexture));
 
   mWrenMainFrameBuffer = wr_frame_buffer_new();
-  wr_frame_buffer_set_size(mWrenMainFrameBuffer, width(), height());
+  const double frameBufferScaling = devicePixelRatio();
+  wr_frame_buffer_set_size(mWrenMainFrameBuffer, width() * frameBufferScaling, height() * frameBufferScaling);
 
   mWrenMainFrameBufferTexture = wr_texture_rtt_new();
   wr_texture_set_internal_format(WR_TEXTURE(mWrenMainFrameBufferTexture), WR_TEXTURE_INTERNAL_FORMAT_RGB16F);

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -284,8 +284,8 @@ namespace wren {
         if (!offScreen && mCurrentViewport == mMainViewport && mCurrentViewport->frameBuffer()) {
           glstate::bindDrawFrameBuffer(0);
           mCurrentViewport->frameBuffer()->blit(0, true, false, false, 0, 0, 0, 0, 0, 0,
-                                                mCurrentViewport->width() * mCurrentViewport->pixelRatio(),
-                                                mCurrentViewport->height() * mCurrentViewport->pixelRatio());
+                                                round(mCurrentViewport->width() * mCurrentViewport->pixelRatio()),
+                                                round(mCurrentViewport->height() * mCurrentViewport->pixelRatio()));
         }
       }
 

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -284,8 +284,8 @@ namespace wren {
         if (!offScreen && mCurrentViewport == mMainViewport && mCurrentViewport->frameBuffer()) {
           glstate::bindDrawFrameBuffer(0);
           mCurrentViewport->frameBuffer()->blit(0, true, false, false, 0, 0, 0, 0, 0, 0,
-                                                round(mCurrentViewport->width() * mCurrentViewport->pixelRatio()),
-                                                round(mCurrentViewport->height() * mCurrentViewport->pixelRatio()));
+                                                ceil(mCurrentViewport->width() * mCurrentViewport->pixelRatio()),
+                                                ceil(mCurrentViewport->height() * mCurrentViewport->pixelRatio()));
         }
       }
 

--- a/src/wren/Scene.cpp
+++ b/src/wren/Scene.cpp
@@ -49,6 +49,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 #define INVERSE_LOG2 1.442695
@@ -284,8 +285,8 @@ namespace wren {
         if (!offScreen && mCurrentViewport == mMainViewport && mCurrentViewport->frameBuffer()) {
           glstate::bindDrawFrameBuffer(0);
           mCurrentViewport->frameBuffer()->blit(0, true, false, false, 0, 0, 0, 0, 0, 0,
-                                                ceil(mCurrentViewport->width() * mCurrentViewport->pixelRatio()),
-                                                ceil(mCurrentViewport->height() * mCurrentViewport->pixelRatio()));
+                                                std::ceil(mCurrentViewport->width() * mCurrentViewport->pixelRatio()),
+                                                std::ceil(mCurrentViewport->height() * mCurrentViewport->pixelRatio()));
         }
       }
 

--- a/src/wren/Viewport.cpp
+++ b/src/wren/Viewport.cpp
@@ -306,7 +306,7 @@ void wr_viewport_set_size(WrViewport *viewport, int width, int height) {
   reinterpret_cast<wren::Viewport *>(viewport)->setSize(width, height);
 }
 
-void wr_viewport_set_pixel_ratio(WrViewport *viewport, int ratio) {
+void wr_viewport_set_pixel_ratio(WrViewport *viewport, double ratio) {
   reinterpret_cast<wren::Viewport *>(viewport)->setPixelRatio(ratio);
 }
 

--- a/src/wren/Viewport.hpp
+++ b/src/wren/Viewport.hpp
@@ -39,7 +39,7 @@ namespace wren {
     void setPolygonMode(WrViewportPolygonMode polygonMode) { mPolygonMode = polygonMode; }
     void setVisbilityMask(int mask) { mVisibilityMask = mask; }
     void setSize(int width, int height);
-    void setPixelRatio(int ratio) { mPixelRatio = ratio; }
+    void setPixelRatio(double ratio) { mPixelRatio = ratio; }
     void setCamera(Camera *camera);
     void setFrameBuffer(FrameBuffer *frameBuffer);
     void enableShadows(bool enable) { mAreShadowsEnabled = enable; }
@@ -59,7 +59,7 @@ namespace wren {
 
     int width() const { return mWidth; }
     int height() const { return mHeight; }
-    int pixelRatio() const { return mPixelRatio; }
+    double pixelRatio() const { return mPixelRatio; }
     bool areShadowsEnabled() const { return mAreShadowsEnabled; }
     WrViewportPolygonMode polygonMode() const { return mPolygonMode; }
     int visibilityMask() const { return mVisibilityMask; }
@@ -90,7 +90,7 @@ namespace wren {
     int mVisibilityMask;
     int mWidth;
     int mHeight;
-    int mPixelRatio;
+    double mPixelRatio;
 
     Camera *mCamera;
     FrameBuffer *mFrameBuffer;


### PR DESCRIPTION
**Description**
This PR adds basic support for fractional scaling. It turns out that this code wasn't as intertwined as I thought, so this was actually able to be pretty fast. I've only done a couple of basic tests, but so far, I don't see any weird behavior.

Because we still have to ultimately convert to pixels, there may still be a 1-pixel misalignment between the viewport and the actual screen, but it's significantly better than before. In those cases, I've opted to oversize the viewport so that we don't get any black bars. (If we're going to be wrong, we might as well pick the option that looks good.) I think this is just an unavoidable artifact of fractional scaling, but hopefully, it shouldn't be too noticeable.

One thing I noticed in testing is that the resolution of the upscaled display is lower than it would be otherwise. This is because the internal framebuffer renders in unscaled coordinates and is then scaled-up to fit the frame. I tried just changing its size, but apparently something depends on that, so it didn't work. I also looked into changing the size of the entire viewport, but it looks like that will be difficult as it currently assumes that it's in Qt coordinates, so conversions from e.g. input events are not correctly converted. All that is to say, I think it's possible, but it will take some more work, so I think its best left for another day. Once this gets merged, I'll open an issue for tracking that.

**Related Issues**
This pull-request fixes issue #6956 ; We should probably reach out to the original submitters to see if this patch does actually fix the problem on all systems and doesn't introduce any game-breaking bugs before merging.
