### PR TITLE
Fix MacOS Sources Test

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -38,11 +38,31 @@ jobs:
         python: [3.9]
         include:
           - os: ubuntu-22.04
-            DEPENDENCIES_INSTALLATION: "wget https://github.com/danmar/cppcheck/archive/refs/tags/2.14.2.tar.gz; tar -xf 2.14.2.tar.gz -C ~/; mkdir -p ~/cppcheck-2.14.2/build; cd ~/cppcheck-2.14.2/build; cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; cmake --build . --config RelWithDebInfo; export PATH=~/cppcheck-2.14.2/build/bin:$PATH"
+            DEPENDENCIES_INSTALLATION: |
+              wget https://github.com/danmar/cppcheck/archive/refs/tags/2.14.2.tar.gz
+              tar -xf 2.14.2.tar.gz -C ~/
+              mkdir -p ~/cppcheck-2.14.2/build
+              cd ~/cppcheck-2.14.2/build
+              cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+              cmake --build . --config RelWithDebInfo
+              export PATH=~/cppcheck-2.14.2/build/bin:$PATH
           - os: macos-14
-            DEPENDENCIES_INSTALLATION: "brew tap-new --no-git $USER/local-cppcheck; brew extract --version=2.14.2 cppcheck $USER/local-cppcheck; brew install cppcheck@2.14.2; brew tap-new --no-git $USER/local-clang-format; brew extract --version=14.0.0 clang-format $USER/local-clang-format; brew install clang-format@14.0.0"
+            DEPENDENCIES_INSTALLATION: |
+              brew tap-new --no-git $USER/local-cppcheck
+              brew extract --version=2.14.2 cppcheck $USER/local-cppcheck
+              brew trust --formula $USER/local-cppcheck
+              brew install cppcheck@2.14.2
+              brew tap-new --no-git $USER/local-clang-format
+              brew extract --version=14.0.0 clang-format $USER/local-clang-format
+              brew trust --formula $USER/local-clang-format
+              brew install clang-format@14.0.0
           - os: windows-2022
-            DEPENDENCIES_INSTALLATION: "curl -LJO https://github.com/danmar/cppcheck/releases/download/2.14.1/cppcheck-2.14.1-x64-Setup.msi; powershell 'Start-Process msiexec -ArgumentList \"/quiet\",\"/passive\",\"/qn\",\"/i\",\"cppcheck-2.14.1-x64-Setup.msi\" -Wait'; choco uninstall -y llvm; choco install -y llvm --version=14.0.0; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: |
+              curl -LJO https://github.com/danmar/cppcheck/releases/download/2.14.1/cppcheck-2.14.1-x64-Setup.msi
+              powershell 'Start-Process msiexec -ArgumentList \"/quiet\",\"/passive\",\"/qn\",\"/i\",\"cppcheck-2.14.1-x64-Setup.msi\" -Wait'
+              choco uninstall -y llvm
+              choco install -y llvm --version=14.0.0
+              export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\"
     runs-on: ${{ matrix.os }}
     if: needs.job-skipper.outputs.should_skip != 'true'
     steps:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -59,10 +59,10 @@ jobs:
           - os: windows-2022
             DEPENDENCIES_INSTALLATION: |
               curl -LJO https://github.com/danmar/cppcheck/releases/download/2.14.1/cppcheck-2.14.1-x64-Setup.msi
-              powershell 'Start-Process msiexec -ArgumentList \"/quiet\",\"/passive\",\"/qn\",\"/i\",\"cppcheck-2.14.1-x64-Setup.msi\" -Wait'
+              powershell 'Start-Process msiexec -ArgumentList "/quiet","/passive","/qn","/i","cppcheck-2.14.1-x64-Setup.msi" -Wait'
               choco uninstall -y llvm
               choco install -y llvm --version=14.0.0
-              export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\"
+              export PATH=$PATH:"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin"
     runs-on: ${{ matrix.os }}
     if: needs.job-skipper.outputs.should_skip != 'true'
     steps:

--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -50,11 +50,11 @@ jobs:
             DEPENDENCIES_INSTALLATION: |
               brew tap-new --no-git $USER/local-cppcheck
               brew extract --version=2.14.2 cppcheck $USER/local-cppcheck
-              brew trust --formula $USER/local-cppcheck
+              brew trust --formula $USER/local-cppcheck/cppcheck@2.14.2
               brew install cppcheck@2.14.2
               brew tap-new --no-git $USER/local-clang-format
               brew extract --version=14.0.0 clang-format $USER/local-clang-format
-              brew trust --formula $USER/local-clang-format
+              brew trust --formula $USER/local-clang-format/clang-format@14.0.0
               brew install clang-format@14.0.0
           - os: windows-2022
             DEPENDENCIES_INSTALLATION: |

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -39,7 +39,7 @@ jobs:
             DEPENDENCIES_INSTALLATION: |
               brew install cppcheck
               brew tap-new --no-git $USER/local-clang-format
-              brew trust --formula $USER/local-clang-format
+              brew trust --formula $USER/local-clang-format/clang-format@14.0.0
               brew extract --version=14.0.0 clang-format $USER/local-clang-format
               brew install clang-format@14.0.0
           - os: windows-2022

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -47,7 +47,7 @@ jobs:
               choco install -y cppcheck || true
               choco uninstall -y llvm
               choco install -y llvm --version=14.0.0
-              export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\"
+              export PATH=$PATH:"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin"
     runs-on: ${{ matrix.os }}
     if: needs.job-skipper.outputs.should_skip != 'true'
     steps:

--- a/.github/workflows/tests_sources_with_latest_cppcheck.yml
+++ b/.github/workflows/tests_sources_with_latest_cppcheck.yml
@@ -36,9 +36,18 @@ jobs:
           - os: ubuntu-22.04
             DEPENDENCIES_INSTALLATION: "sudo apt -y install cppcheck"
           - os: macos-14
-            DEPENDENCIES_INSTALLATION: "brew install cppcheck; brew tap-new --no-git $USER/local-clang-format; brew extract --version=14.0.0 clang-format $USER/local-clang-format; brew install clang-format@14.0.0"
+            DEPENDENCIES_INSTALLATION: |
+              brew install cppcheck
+              brew tap-new --no-git $USER/local-clang-format
+              brew trust --formula $USER/local-clang-format
+              brew extract --version=14.0.0 clang-format $USER/local-clang-format
+              brew install clang-format@14.0.0
           - os: windows-2022
-            DEPENDENCIES_INSTALLATION: "choco install -y cppcheck || true; choco uninstall -y llvm; choco install -y llvm --version=14.0.0; export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\""
+            DEPENDENCIES_INSTALLATION: |
+              choco install -y cppcheck || true
+              choco uninstall -y llvm
+              choco install -y llvm --version=14.0.0
+              export PATH=$PATH:\"/c/Program Files/Cppcheck:/c/Program Files/LLVM/bin\"
     runs-on: ${{ matrix.os }}
     if: needs.job-skipper.outputs.should_skip != 'true'
     steps:


### PR DESCRIPTION
**Description**
The macos sources test was complaining about the custom brews we're using to pin clang and cppcheck being untrusted. Not sure why this is showing up now given that they were working earlier this week, and I don't see a recent runner update, but this PR adds the command to trust them. While I was in there, I also swapped those sections to use multiline strings for readability. I'll revert if it breaks anything.