### PR TITLE
Add Missing `QActionGroup` Creation

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -32,6 +32,7 @@
     - Fixed controller signal handlers not restoring the original handler (e.g. CPython's) on exit ([#6945](https://github.com/cyberbotics/webots/pull/6945)).
     - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).
     - USE nodes are now validated before being inserted into the Scene Tree. This fixes some crashes when loading invalid world files ([#6997](https://github.com/cyberbotics/webots/pull/6997)).
+    - Fixed a bug causing the "Plain/Wireframe Rendering" and "Follow Object > ..." buttons to incorrectly be shown as unchecked in certain circumstances ([#7000](https://github.com/cyberbotics/webots/pull/7000)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/src/webots/user_commands/WbActionManager.cpp
+++ b/src/webots/user_commands/WbActionManager.cpp
@@ -738,6 +738,7 @@ void WbActionManager::populateActions() {
   newAction->setCheckable(true);
   mActions[FOLLOW_PAN_AND_TILT] = newAction;
 
+  actionGroup = new QActionGroup(this);
   actionGroup->addAction(mActions[FOLLOW_NONE]);
   actionGroup->addAction(mActions[FOLLOW_TRACKING]);
   actionGroup->addAction(mActions[FOLLOW_MOUNTED]);


### PR DESCRIPTION
**Description**
Someone forgot to create a new `QActionGroup`, so the "Follow Object" buttons got put in the same group as the "Rendering Mode" options, so only one could be selected at a time. From what I can see though, this didn't trigger any events, so the only impacts were that some of the buttons were visually unchecked while they were active.

Also, Happy 7000th Issue/PR 🎉 🥳 🚀