### PR TITLE
Fix OSM importer crash on multiple layer values

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -28,7 +28,7 @@
     - Fixed `addForceWithOffset` and `addTorque` doing the same thing as `addForce` in Python ([#6881](https://github.com/cyberbotics/webots/pull/6881)).
     - Fixed Python controllers on Windows ([#6933](https://github.com/cyberbotics/webots/pull/6933)).
     - OSM importer no longer crashes when run in 3d mode ([#6935](https://github.com/cyberbotics/webots/pull/6935)).
-    - Fixed a crash in the OSM importer when a way has multiple layer values.
+    - Fixed a crash in the OSM importer when a way has multiple layer values ([#7005](https://github.com/cyberbotics/webots/pull/7005)).
     - Fixed Java compilation deprecation warning and run-time warning ([#6936](https://github.com/cyberbotics/webots/pull/6936)).
     - Fixed controller signal handlers not restoring the original handler (e.g. CPython's) on exit ([#6945](https://github.com/cyberbotics/webots/pull/6945)).
     - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).

--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -28,6 +28,7 @@
     - Fixed `addForceWithOffset` and `addTorque` doing the same thing as `addForce` in Python ([#6881](https://github.com/cyberbotics/webots/pull/6881)).
     - Fixed Python controllers on Windows ([#6933](https://github.com/cyberbotics/webots/pull/6933)).
     - OSM importer no longer crashes when run in 3d mode ([#6935](https://github.com/cyberbotics/webots/pull/6935)).
+    - Fixed a crash in the OSM importer when a way has multiple layer values.
     - Fixed Java compilation deprecation warning and run-time warning ([#6936](https://github.com/cyberbotics/webots/pull/6936)).
     - Fixed controller signal handlers not restoring the original handler (e.g. CPython's) on exit ([#6945](https://github.com/cyberbotics/webots/pull/6945)).
     - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).

--- a/resources/osm_importer/parser_objects.py
+++ b/resources/osm_importer/parser_objects.py
@@ -102,7 +102,7 @@ class Parser(object):
         self.wayRefList[osmId] = refs  # we need to store them because the can then be usefull when parsin 'relations'
 
         # dont take into acount underground structure
-        if float(tags.get('layer', '0')) < 0:
+        if min(float(layer) for layer in tags.get('layer', '0').split(';')) < 0:
             return
 
         if 'building' in tags or 'building:part' in tags:


### PR DESCRIPTION
**Description**

Handle semicolon-separated OpenStreetMap `layer` values when deciding whether a
way is underground. The importer now evaluates each numeric layer and preserves
its existing conservative behavior by skipping a way when any listed layer is
negative.

**Related Issues**

This pull request fixes issue #7004.

**Tasks**

- [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)
- [x] Preserve scalar `layer` behavior.
- [x] Handle all-negative, mixed, and all-positive layer lists.
- [x] Reproduce and verify the reported `layer="-1;-2"` input.

**Documentation**

No user-guide change is needed; the release changelog records the bug fix.

**Screenshots**

Not applicable.

**Additional context**

Validation performed locally on macOS:

```bash
# Real Parser.parse_file reproduction plus scalar/list edge cases
PYTHONPATH=resources/osm_importer uv run --no-project \
  --with lxml --with shapely --with webcolors --with pyproj python <regression-script>

uvx --from pycodestyle pycodestyle --max-line-length=128 \
  resources/osm_importer/parser_objects.py
uvx --from pyflakes pyflakes resources/osm_importer/parser_objects.py
python3 -m compileall -q resources/osm_importer/parser_objects.py
git diff --check
```

All checks and five scalar/list regression cases pass.
