### PR TITLE
Serve SVG files with the image/svg+xml MIME type

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -34,6 +34,7 @@
     - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).
     - USE nodes are now validated before being inserted into the Scene Tree. This fixes some crashes when loading invalid world files ([#6997](https://github.com/cyberbotics/webots/pull/6997)).
     - Fixed a bug causing the "Plain/Wireframe Rendering" and "Follow Object > ..." buttons to incorrectly be shown as unchecked in certain circumstances ([#7000](https://github.com/cyberbotics/webots/pull/7000)).
+    - SVG files are now served with the `image/svg+xml` MIME type instead of being rejected as an unsupported file type, so robot windows can use SVG images ([#XXXX](https://github.com/cyberbotics/webots/pull/XXXX)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -34,7 +34,7 @@
     - The viewport now renders correctly on systems with fractional scaling enabled ([#6991](https://github.com/cyberbotics/webots/pull/6991)).
     - USE nodes are now validated before being inserted into the Scene Tree. This fixes some crashes when loading invalid world files ([#6997](https://github.com/cyberbotics/webots/pull/6997)).
     - Fixed a bug causing the "Plain/Wireframe Rendering" and "Follow Object > ..." buttons to incorrectly be shown as unchecked in certain circumstances ([#7000](https://github.com/cyberbotics/webots/pull/7000)).
-    - SVG files are now served with the `image/svg+xml` MIME type instead of being rejected as an unsupported file type, so robot windows can use SVG images ([#XXXX](https://github.com/cyberbotics/webots/pull/XXXX)).
+    - SVG files are now served with the `image/svg+xml` MIME type instead of being rejected as an unsupported file type, so robot windows can use SVG images ([#7007](https://github.com/cyberbotics/webots/pull/7007)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/src/webots/core/WbHttpReply.cpp
+++ b/src/webots/core/WbHttpReply.cpp
@@ -78,6 +78,8 @@ QString WbHttpReply::mimeType(const QString &url, bool generic) {
   const QString extension = url.mid(url.lastIndexOf('.') + 1).toLower();
   if (extension == "png" || extension == "jpg" || extension == "jpeg" || extension == "ico")
     return QString("image/%1").arg(extension);
+  else if (extension == "svg")  // the MIME type is not simply "image/svg", hence the separate case
+    return "image/svg+xml";
   else if (extension == "html" || extension == "css")
     return QString("text/%1").arg(extension);
   else if (extension == "js")


### PR DESCRIPTION
WbHttpReply::mimeType() had no case for SVG, so it returned an empty string and WbTcpServer::sendTcpRequestReply() rejected every .svg request as an unsupported file type before it ever looked for the file. A robot window could therefore use PNG, JPEG and ICO images but got a 404 for any SVG shipped beside it.

SVG needs a case of its own rather than joining the png/jpg/jpeg/ico branch, whose type is built as "image/<extension>": the registered type is image/svg+xml, and Chromium will not render an SVG served as anything else.

**Tasks**
Add the list of tasks of this PR.
  - [x] Update the [changelog](https://github.com/cyberbotics/webots/blob/master/docs/reference/changelog-r2025.md)

