### PR TITLE
Fix negative identity quaternion conversion

### DIFF
--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -35,6 +35,7 @@
     - USE nodes are now validated before being inserted into the Scene Tree. This fixes some crashes when loading invalid world files ([#6997](https://github.com/cyberbotics/webots/pull/6997)).
     - Fixed a bug causing the "Plain/Wireframe Rendering" and "Follow Object > ..." buttons to incorrectly be shown as unchecked in certain circumstances ([#7000](https://github.com/cyberbotics/webots/pull/7000)).
     - SVG files are now served with the `image/svg+xml` MIME type instead of being rejected as an unsupported file type, so robot windows can use SVG images ([#7007](https://github.com/cyberbotics/webots/pull/7007)).
+    - Fixed a crash when entering a quaternion with a negative scalar and a zero vector in the rotation editor ([#6800](https://github.com/cyberbotics/webots/issues/6800)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/docs/reference/changelog-r2025.md
+++ b/docs/reference/changelog-r2025.md
@@ -35,7 +35,7 @@
     - USE nodes are now validated before being inserted into the Scene Tree. This fixes some crashes when loading invalid world files ([#6997](https://github.com/cyberbotics/webots/pull/6997)).
     - Fixed a bug causing the "Plain/Wireframe Rendering" and "Follow Object > ..." buttons to incorrectly be shown as unchecked in certain circumstances ([#7000](https://github.com/cyberbotics/webots/pull/7000)).
     - SVG files are now served with the `image/svg+xml` MIME type instead of being rejected as an unsupported file type, so robot windows can use SVG images ([#7007](https://github.com/cyberbotics/webots/pull/7007)).
-    - Fixed a crash when entering a quaternion with a negative scalar and a zero vector in the rotation editor ([#6800](https://github.com/cyberbotics/webots/issues/6800)).
+    - Fixed a crash when entering a quaternion with a negative scalar and a zero vector in the rotation editor ([#7009](https://github.com/cyberbotics/webots/pull/7009)).
 
 ## Webots R2025a
 Released on January 31st, 2025.

--- a/src/webots/maths/WbRotation.cpp
+++ b/src/webots/maths/WbRotation.cpp
@@ -29,8 +29,9 @@ void WbRotation::fromQuaternion(const WbQuaternion &q) {
     mAngle = 2.0 * M_PI;
   else
     mAngle = 2.0 * acos(q.w());
-  if (mAngle < WbPrecision::DOUBLE_EQUALITY_TOLERANCE) {
-    // if the angle is close to zero, then the direction of the axis is not important
+  const double axisLength = sqrt(q.x() * q.x() + q.y() * q.y() + q.z() * q.z());
+  if (mAngle < WbPrecision::DOUBLE_EQUALITY_TOLERANCE || axisLength < WbPrecision::DOUBLE_EQUALITY_TOLERANCE) {
+    // Both (1, 0, 0, 0) and (-1, 0, 0, 0) represent the identity rotation, whose axis is arbitrary.
     mX = 0.0;
     mY = 0.0;
     mZ = 1.0;
@@ -39,7 +40,7 @@ void WbRotation::fromQuaternion(const WbQuaternion &q) {
   }
 
   // normalise axes
-  const double inv = 1.0 / sqrt(q.x() * q.x() + q.y() * q.y() + q.z() * q.z());
+  const double inv = 1.0 / axisLength;
   mX = q.x() * inv;
   mY = q.y() * inv;
   mZ = q.z() * inv;


### PR DESCRIPTION
**Description**

Entering a quaternion such as `(-0.5, 0, 0, 0)` in the rotation editor normalizes it to `(-1, 0, 0, 0)`. This is a valid representation of the identity rotation, but `WbRotation::fromQuaternion()` previously converted its scalar component to an angle of `2π` and then attempted to normalize its zero-length vector component. The resulting division by zero produced NaN axis values that could later crash the scene tree or rendering path.

This change computes the quaternion vector length once and treats a normalized quaternion with no usable vector component as the identity rotation. Both positive and negative identity quaternions therefore produce the existing finite canonical representation `(0, 0, 1, 0)`. Non-degenerate negative-scalar quaternions continue through the existing axis-normalization path and retain their original rotation angle.

**Related Issues**

This pull request fixes issue #6800.

**Tasks**

- [x] Handle negative identity quaternions without dividing by zero.
- [x] Preserve the existing behavior for non-degenerate quaternions.
- [x] Update the changelog.
- [x] Validate the conversion with degenerate and non-degenerate inputs.
- [x] Run the project source-format and static-analysis checks.

**Documentation**

No user-facing documentation change is required. The fix is recorded in `docs/reference/changelog-r2025.md`.

**Screenshots**

Not applicable. The change prevents invalid numerical state rather than changing the expected visual output.

**Additional context**

Before the fix, a standalone C++ reproduction for `(-0.5, 0, 0, 0)` produced:

```text
nan nan nan 6.28319
```

After the fix, the regression probe covers:

- `(-0.5, 0, 0, 0)`
- `(-1, 1e-16, 0, 0)`
- `(1, 0, 0, 0)`
- a non-degenerate negative-scalar quaternion

All cases produce finite results, the three identity inputs use the canonical identity rotation, and the non-degenerate case retains its expected axis and `1.5π` angle.

Validation completed:

- standalone C++ regression probe with AddressSanitizer and UndefinedBehaviorSanitizer
- ClangFormat 14.0.6, matching the source CI major version
- repository `TestCppCheck` with Cppcheck 2.14.2
- `git diff --check`
