### PR TITLE
Use WorldInfo.basicTimeStep in new C and MATLAB controllers

### DIFF
--- a/resources/templates/controllers/template.c
+++ b/resources/templates/controllers/template.c
@@ -13,11 +13,6 @@
 #include <webots/robot.h>
 
 /*
- * You may want to add macros here.
- */
-#define TIME_STEP 64
-
-/*
  * This is the main program.
  * The arguments of the main function can be specified by the
  * "controllerArgs" field of the Robot node
@@ -25,6 +20,9 @@
 int main(int argc, char **argv) {
   /* necessary to initialize webots stuff */
   wb_robot_init();
+
+  /* get the time step of the current world. */
+  const int time_step = wb_robot_get_basic_time_step();
 
   /*
    * You should declare here WbDeviceTag variables for storing
@@ -34,10 +32,10 @@ int main(int argc, char **argv) {
    */
 
   /* main loop
-   * Perform simulation steps of TIME_STEP milliseconds
+   * Perform simulation steps of the current world's basic time step
    * and leave the loop when the simulation is over
    */
-  while (wb_robot_step(TIME_STEP) != -1) {
+  while (wb_robot_step(time_step) != -1) {
     /*
      * Read the sensors :
      * Enter here functions to read sensor data, like:

--- a/resources/templates/controllers/template.m
+++ b/resources/templates/controllers/template.m
@@ -11,7 +11,7 @@ function template
 %desktop;
 %keyboard;
 
-TIME_STEP = 64;
+TIME_STEP = wb_robot_get_basic_time_step();
 
 % get and enable devices, e.g.:
 %  camera = wb_robot_get_device('camera');

--- a/tests/sources/test_controller_templates.py
+++ b/tests/sources/test_controller_templates.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# Copyright 1996-2024 Cyberbotics Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for controller wizard templates."""
+
+import os
+import unittest
+
+
+class TestControllerTemplates(unittest.TestCase):
+    """Check that new controller templates follow the world basic time step."""
+
+    def setUp(self):
+        webots_home = os.path.normpath(os.environ['WEBOTS_HOME'])
+        self.templates_dir = os.path.join(webots_home, 'resources', 'templates', 'controllers')
+
+    def _read_template(self, filename):
+        with open(os.path.join(self.templates_dir, filename), encoding='utf-8') as file:
+            return file.read()
+
+    def test_c_template_uses_world_basic_time_step(self):
+        content = self._read_template('template.c')
+        self.assertIn('wb_robot_get_basic_time_step()', content)
+        self.assertNotIn('#define TIME_STEP 64', content)
+
+    def test_matlab_template_uses_world_basic_time_step(self):
+        content = self._read_template('template.m')
+        self.assertIn('TIME_STEP = wb_robot_get_basic_time_step();', content)
+        self.assertNotIn('TIME_STEP = 64;', content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Summary: use the world basic time step in the C and MATLAB controller templates copied by the new controller wizard; add a regression test. Testing: python -m unittest tests.sources.test_controller_templates