### PR TITLE
Rescan embedded display textures after live scene-tree edits

### DIFF
--- a/src/webots/nodes/WbDisplay.cpp
+++ b/src/webots/nodes/WbDisplay.cpp
@@ -26,6 +26,7 @@
 #include "WbRobot.hpp"
 #include "WbShape.hpp"
 #include "WbSimulationState.hpp"
+#include "WbSFNode.hpp"
 #include "WbStandardPaths.hpp"
 #include "WbWrenOpenGlContext.hpp"
 #include "WbWrenRenderingContext.hpp"
@@ -94,6 +95,7 @@ void WbDisplay::init() {
   mRequestImages = false;
   mAttachedCamera = NULL;
   mNeedToSetExternalTextures = false;
+  mIsUpdatingImageTextures = false;
 
   mDisplayFont = new WbDisplayFont();
   QString error = mDisplayFont->error();
@@ -140,7 +142,7 @@ void WbDisplay::clearImages() {
 
 void WbDisplay::preFinalize() {
   WbRenderingDevice::preFinalize();
-  findImageTextures();
+  updateImageTextures();
 }
 
 int WbDisplay::channelNumberFromPixelFormat(int pixelFormat) {
@@ -159,24 +161,41 @@ int WbDisplay::channelNumberFromPixelFormat(int pixelFormat) {
 }
 
 void WbDisplay::findImageTextures() {
-  mNeedToSetExternalTextures = true;
+  for (int i = 0; i < children().size(); ++i) {
+    WbNode *child = children().item(i);
+    if (child)
+      findImageTextures(child);
+  }
 
-  clearImageTextures();
+  for (int i = 0; i < mImageTextures.size(); ++i)
+    connect(mImageTextures.at(i), &QObject::destroyed, this, &WbDisplay::removeImageTexture, Qt::UniqueConnection);
 
-  if (children().size() < 1)
-    return;
+  // debug code - print the found materials
+  // foreach (WbImageTexture *texture, mImageTextures)
+  //   parsingWarn(QString("found image texture %1").arg(texture->usefulName()));
+}
 
-  WbNode *firstChild = children().item(0);
-  const WbShape *shape = dynamic_cast<WbShape *>(firstChild);
+void WbDisplay::findImageTextures(WbNode *node) {
+  const WbShape *shape = dynamic_cast<WbShape *>(node);
   if (shape) {
+    WbSFNode *appearanceField = shape->findSFNode("appearance");
+    if (appearanceField) {
+      mImageTextureConnections.append(
+        connect(appearanceField, &WbSFNode::changed, this, &WbDisplay::updateImageTextures, Qt::UniqueConnection));
+    }
+
     const WbAppearance *appearance = shape->appearance();
     const WbPbrAppearance *pbrAppearance = shape->pbrAppearance();
     if (appearance) {
+      mImageTextureConnections.append(
+        connect(appearance, &WbAppearance::changed, this, &WbDisplay::updateImageTextures, Qt::UniqueConnection));
       // cppcheck-suppress constVariablePointer
       WbImageTexture *theTexture = appearance->texture();
       if (theTexture)
         mImageTextures.push_back(theTexture);
     } else if (pbrAppearance) {
+      mImageTextureConnections.append(
+        connect(pbrAppearance, &WbPbrAppearance::changed, this, &WbDisplay::updateImageTextures, Qt::UniqueConnection));
       // cppcheck-suppress constVariablePointer
       WbImageTexture *theTexture = pbrAppearance->baseColorMap();
       if (theTexture)
@@ -185,18 +204,18 @@ void WbDisplay::findImageTextures() {
       if (theTexture)
         mImageTextures.push_back(theTexture);
     }
-  } else {
-    WbGroup *group = dynamic_cast<WbGroup *>(firstChild);
-    if (group)
-      findImageTextures(group);
+    return;
   }
 
-  for (int i = 0; i < mImageTextures.size(); ++i)
-    connect(mImageTextures.at(i), &QObject::destroyed, this, &WbDisplay::removeImageTexture);
+  WbGroup *group = dynamic_cast<WbGroup *>(node);
+  if (!group)
+    return;
 
-  // debug code - print the found materials
-  // foreach (WbImageTexture *texture, mImageTextures)
-  //   parsingWarn(QString("found image texture %1").arg(texture->usefulName()));
+  if (group->childrenField()) {
+    mImageTextureConnections.append(
+      connect(group->childrenField(), &WbMFNode::changed, this, &WbDisplay::updateImageTextures, Qt::UniqueConnection));
+  }
+  findImageTextures(group);
 }
 
 void WbDisplay::removeImageTexture(QObject *object) {
@@ -208,33 +227,33 @@ void WbDisplay::clearImageTextures() {
   mImageTextures.clear();
 }
 
+void WbDisplay::updateImageTextures() {
+  if (mIsUpdatingImageTextures)
+    return;
+
+  mIsUpdatingImageTextures = true;
+  mNeedToSetExternalTextures = true;
+
+  while (!mImageTextureConnections.isEmpty())
+    disconnect(mImageTextureConnections.takeLast());
+
+  if (childrenField()) {
+    mImageTextureConnections.append(
+      connect(childrenField(), &WbMFNode::changed, this, &WbDisplay::updateImageTextures, Qt::UniqueConnection));
+  }
+
+  clearImageTextures();
+  findImageTextures();
+
+  mIsUpdatingImageTextures = false;
+}
+
 void WbDisplay::findImageTextures(WbGroup *group) {
   WbMFNode::Iterator i(group->children());
   while (i.hasNext()) {
     WbNode *node = i.next();
-    const WbShape *shape = dynamic_cast<WbShape *>(node);
-    if (shape) {
-      const WbAppearance *appearance = shape->appearance();
-      const WbPbrAppearance *pbrAppearance = shape->pbrAppearance();
-      if (appearance) {
-        // cppcheck-suppress constVariablePointer
-        WbImageTexture *theTexture = appearance->texture();
-        if (theTexture)
-          mImageTextures.push_back(theTexture);
-      } else if (pbrAppearance) {
-        // cppcheck-suppress constVariablePointer
-        WbImageTexture *theTexture = pbrAppearance->baseColorMap();
-        if (theTexture)
-          mImageTextures.push_back(theTexture);
-        theTexture = pbrAppearance->emissiveColorMap();
-        if (theTexture)
-          mImageTextures.push_back(theTexture);
-      }
-    } else {
-      WbGroup *g = dynamic_cast<WbGroup *>(node);
-      if (g)
-        findImageTextures(g);
-    }
+    if (node)
+      findImageTextures(node);
   }
 }
 

--- a/src/webots/nodes/WbDisplay.hpp
+++ b/src/webots/nodes/WbDisplay.hpp
@@ -21,6 +21,7 @@ class WbCamera;
 class WbDisplayFont;
 class WbDisplayImage;
 class WbImageTexture;
+class WbNode;
 
 class QDataStream;
 
@@ -103,14 +104,18 @@ private:
   bool mUpdateRequired;
   WbCamera *mAttachedCamera;
   bool mNeedToSetExternalTextures;
+  bool mIsUpdatingImageTextures;
 
   void findImageTextures();
+  void findImageTextures(WbNode *node);
   void findImageTextures(WbGroup *group);
   void clearImageTextures();
   bool isAnyImageTextureFound() { return (bool)mImageTextures.size(); }
   QList<WbImageTexture *> mImageTextures;
+  QList<QMetaObject::Connection> mImageTextureConnections;
 
 private slots:
+  void updateImageTextures();
   void removeImageTexture(QObject *object);
   void removeExternalTextures();
   void detachCamera();

--- a/tests/api/controllers/display/display.c
+++ b/tests/api/controllers/display/display.c
@@ -2,6 +2,7 @@
 #include <webots/display.h>
 #include <webots/distance_sensor.h>
 #include <webots/robot.h>
+#include <webots/supervisor.h>
 
 #include "../../../lib/ts_assertion.h"
 #include "../../../lib/ts_utils.h"
@@ -156,6 +157,48 @@ int main(int argc, char **argv) {
   // after detaching the camera, the display is transparent
   // and the camera records the green plane behind the display
   quick_assert_color(camera, camera_width * 0.5, camera_height * 0.5, 0x0000CF00, "detach camera failed");
+
+  // check that embedded display textures are rediscovered after live appearance edits
+  reset_display(display);
+  wb_display_set_color(display, BLUE);
+  wb_display_fill_rectangle(display, 0, 0, display_width, display_height);
+  wb_robot_step(TIME_STEP);
+
+  quick_assert_color(camera, camera_width * 0.5, camera_height * 0.5, 0x0000CF, "embedded display precondition failed");
+
+  WbNodeRef embedded_shape = wb_supervisor_node_get_from_def("EMOTICONS_DISPLAY_SHAPE");
+  ts_assert_pointer_not_null(embedded_shape, "Failed to resolve the embedded display shape.");
+  WbFieldRef appearance_field = wb_supervisor_node_get_field(embedded_shape, "appearance");
+  ts_assert_pointer_not_null(appearance_field, "Failed to resolve the embedded display appearance field.");
+
+  wb_supervisor_field_remove_sf(appearance_field);
+  wb_robot_step(TIME_STEP);
+
+  wb_supervisor_field_import_sf_node_from_string(
+    appearance_field,
+    "Appearance { material Material { ambientIntensity 1 diffuseColor 1 1 1 } texture ImageTexture { filtering 0 } }");
+  wb_robot_step(TIME_STEP);
+
+  quick_assert_color(camera, camera_width * 0.5, camera_height * 0.5, 0x0000CF,
+                     "embedded display texture was not restored after importing a new appearance");
+
+  // check that deeper nested group edits also trigger embedded texture rediscovery
+  WbNodeRef embedded_group = wb_supervisor_node_get_from_def("EMOTICONS_DISPLAY_GROUP");
+  ts_assert_pointer_not_null(embedded_group, "Failed to resolve the embedded display group.");
+  WbFieldRef group_children_field = wb_supervisor_node_get_field(embedded_group, "children");
+  ts_assert_pointer_not_null(group_children_field, "Failed to resolve the embedded display group children field.");
+
+  wb_supervisor_field_remove_mf(group_children_field, 0);
+  wb_robot_step(TIME_STEP);
+
+  wb_supervisor_field_import_mf_node_from_string(
+    group_children_field, -1,
+    "Shape { appearance Appearance { material Material { ambientIntensity 1 diffuseColor 1 1 1 } texture "
+    "ImageTexture { filtering 0 } } geometry Plane { size 2 2 } }");
+  wb_robot_step(TIME_STEP);
+
+  quick_assert_color(camera, camera_width * 0.5, camera_height * 0.5, 0x0000CF,
+                     "embedded display texture was not restored after importing a nested group child");
 
   ts_send_success();
   return EXIT_SUCCESS;

--- a/tests/api/worlds/display.wbt
+++ b/tests/api/worlds/display.wbt
@@ -20,6 +20,7 @@ PointLight {
   intensity 0
 }
 Robot {
+  supervisor TRUE
   children [
     Pose {
       translation 0 0 -1.1
@@ -50,26 +51,32 @@ Robot {
       width 80
       height 80
     }
-    Display {
+    DEF EMOTICONS_DISPLAY Display {
       translation 0 0 -1
       rotation 1 0 0 1.57
       children [
         Pose {
+        }
+        DEF EMOTICONS_DISPLAY_POSE Pose {
           rotation 1 0 0 -1.57079632679
           children [
-            Shape {
-              appearance Appearance {
-                material Material {
-                  ambientIntensity 1
-                  diffuseColor 1 1 1
+            DEF EMOTICONS_DISPLAY_GROUP Group {
+              children [
+                DEF EMOTICONS_DISPLAY_SHAPE Shape {
+                  appearance Appearance {
+                    material Material {
+                      ambientIntensity 1
+                      diffuseColor 1 1 1
+                    }
+                    texture ImageTexture {
+                      filtering 0
+                    }
+                  }
+                  geometry Plane {
+                    size 2 2
+                  }
                 }
-                texture ImageTexture {
-                  filtering 0
-                }
-              }
-              geometry Plane {
-                size 2 2
-              }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary

- rescan embedded image textures when display descendants change at runtime
- track nested `Group` / `Pose` children and appearance changes with stale-safe Qt connections
- scan every top-level child instead of only the first
- extend the display API regression to remove and reinsert a nested texture-bearing shape without reloading the world

## Why

`WbDisplay` only discovered embedded displays during prefinalization. Live scene-tree edits therefore left new or replaced embedded textures undiscovered until the world reloaded, as reported in #6964.

## Verification

- MinGW controller syntax check
- recursive signal/lifetime review against `WbGroup` ownership
- `git diff --check`

The full Webots world test could not run locally and remains CI-bound.

Fixes #6964